### PR TITLE
Bugfix: CIマトリックスからPHP 8.2 / PHPUnit 12の互換性のない組み合わせを削除

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ jobs:
         include:
           - php: '8.2'
             phpunit: '11'
-          - php: '8.2'
-            phpunit: '12'
           - php: '8.3'
             phpunit: '11'
           - php: '8.3'


### PR DESCRIPTION
# 概要

PHPUnit 12はPHP >= 8.3を要求するため、CIマトリックスに含まれていたPHP 8.2 / PHPUnit 12の組み合わせが失敗していました。この互換性のないエントリを削除してCIを修正します。

## 変更内容

- `.github/workflows/ci.yml` のテストマトリックスから `PHP 8.2 / PHPUnit 12` のエントリを削除
- 修正後のマトリックス:
  - PHP 8.2 / PHPUnit 11
  - PHP 8.3 / PHPUnit 11
  - PHP 8.3 / PHPUnit 12
  - PHP 8.4 / PHPUnit 12

## 関連情報

- CIの失敗ログ: `phpunit/phpunit[12.5.8, ..., 12.5.14] require php >=8.3 -> your php version (8.2.30) does not satisfy that requirement.`