### PR TITLE
New Feature: Add PHP 8.4 and PHPUnit 13 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,11 @@ jobs:
           - php: '8.3'
             phpunit: '12'
           - php: '8.4'
+            phpunit: '11'
+          - php: '8.4'
             phpunit: '12'
+          - php: '8.4'
+            phpunit: '13'
 
     steps:
       - uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "^8.2",
         "opis/json-schema": "^2.6",
-        "phpunit/phpunit": "^11.0 || ^12.0"
+        "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.94",


### PR DESCRIPTION
# 概要

PHP 8.4 および PHPUnit 13 に対応し、CIマトリクスを拡充。

## 変更内容

- `composer.json`: `phpunit/phpunit` の制約に `^13.0` を追加
- `.github/workflows/ci.yml`: CIマトリクスに以下の組み合わせを追加
  - PHP 8.4 + PHPUnit 11
  - PHP 8.4 + PHPUnit 13

### CIマトリクス（変更後）

| PHP | PHPUnit |
|-----|---------|
| 8.2 | 11 |
| 8.3 | 11 |
| 8.3 | 12 |
| 8.4 | 11 |
| 8.4 | 12 |
| 8.4 | 13 |

## 関連情報

- PHPUnit 13 リリースノート: https://phpunit.de/announcements/phpunit-13.html
- PHPUnit 13 は PHP 8.4 以上が必須