### PR TITLE
New Feature: PHP 8.4 / PHPUnit 13 サポート追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Install dependencies
+composer install
+
+# Run all tests
+vendor/bin/phpunit
+
+# Run a single test file
+vendor/bin/phpunit tests/Unit/OpenApiSchemaConverterTest.php
+
+# Run a single test method
+vendor/bin/phpunit --filter test_method_name
+
+# Run by test suite (Unit or Integration)
+vendor/bin/phpunit --testsuite Unit
+
+# Static analysis (level 6)
+vendor/bin/phpstan analyse
+
+# Code style fix
+vendor/bin/php-cs-fixer fix
+
+# Code style check (dry run)
+vendor/bin/php-cs-fixer fix --dry-run --diff
+```
+
+## Architecture
+
+This is a PHP library (`wadakatu/openapi-contract-testing`) that validates API responses against OpenAPI 3.0/3.1 specs during PHPUnit tests and tracks endpoint coverage.
+
+### Validation Flow
+
+1. **`OpenApiSpecLoader`** — Static singleton that loads and caches bundled JSON spec files from a configured base path. Specs are referenced by name (e.g., `"front"` loads `front.json`).
+2. **`OpenApiPathMatcher`** — Matches actual request paths (e.g., `/v1/pets/123`) against spec paths with parameters (e.g., `/v1/pets/{petId}`). Handles prefix stripping (e.g., `/api`) and sorts by literal segment count for most-specific-first matching.
+3. **`OpenApiSchemaConverter`** — Converts OpenAPI schemas to JSON Schema Draft 07 (required by `opis/json-schema`). Handles OAS 3.0 `nullable` → type arrays, OAS 3.1 `prefixItems` → `items`, and removes OAS-only / Draft 2020-12 keys.
+4. **`OpenApiResponseValidator`** — Orchestrates the above: loads spec → matches path → converts schema → validates response body via `opis/json-schema`. Returns `OpenApiValidationResult`.
+
+### PHPUnit Extension & Coverage
+
+- **`OpenApiCoverageExtension`** — PHPUnit extension configured in `phpunit.xml`. Reads `spec_base_path`, `strip_prefixes`, and `specs` parameters. Registers an `ExecutionFinishedSubscriber` that prints a coverage report.
+- **`OpenApiCoverageTracker`** — Static tracker that records validated endpoints during test runs and computes coverage against the full spec.
+
+### Laravel Integration
+
+- **`ValidatesOpenApiSchema`** trait — Used in Laravel test cases. Provides `assertResponseMatchesOpenApiSchema()` which auto-resolves method/path from the current request and records coverage.
+
+### Key Enums
+
+- **`OpenApiVersion`** (`V3_0` | `V3_1`) — Auto-detected from spec's `openapi` field.
+- **`HttpMethod`** — GET, POST, PUT, PATCH, DELETE.
+
+## Code Style
+
+Enforced by PHP-CS-Fixer (`.php-cs-fixer.dist.php`):
+- `declare(strict_types=1)` in all files
+- PER-CS2.0 base ruleset with `@PHP8x2Migration`
+- PHPUnit test methods use `snake_case`
+- Strict comparisons (`===`/`!==`) enforced
+- Explicit `use function` / `use const` imports (global namespace import)
+- Class elements ordered: traits → constants → static properties → properties → constructor → public static methods → public → protected → private
+
+## CI Matrix
+
+Tests run across PHP 8.2–8.4 with PHPUnit 11–13. PHP 8.2 + PHPUnit 12 is excluded (incompatible). PHPStan runs on PHP 8.3, PHP-CS-Fixer on PHP 8.2.


### PR DESCRIPTION
# 概要

PHP 8.4 および PHPUnit 13 のサポートを追加し、CI マトリクスを拡充しました。

## 変更内容

- `composer.json` の `phpunit/phpunit` 制約に `^13.0` を追加
- CI マトリクスに PHP 8.4 + PHPUnit 11 / 13 の組み合わせを追加
- `CLAUDE.md` を追加（Claude Code 向けのプロジェクトガイド）

## 関連情報

- なし