### PR TITLE
Document: specファイルに--dereferencedフラグが必要であることを明記

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ composer require --dev studio-design/openapi-contract-testing
 This package expects a **bundled** (all `$ref`s resolved) JSON spec file. Use [Redocly CLI](https://redocly.com/docs/cli/commands/bundle/) to bundle:
 
 ```bash
-npx @redocly/cli bundle openapi/root.yaml -o openapi/bundled/front.json
+npx @redocly/cli bundle openapi/root.yaml --dereferenced -o openapi/bundled/front.json
 ```
+
+> **Important:** The `--dereferenced` flag is required. Without it, `$ref` pointers (e.g., `#/components/schemas/...`) are preserved in the output, causing `UnresolvedReferenceException` at validation time. The underlying JSON Schema validator (`opis/json-schema`) does not resolve OpenAPI `$ref` references.
 
 ### 2. Configure PHPUnit extension
 


### PR DESCRIPTION
# 概要

Redocly CLIのbundleコマンド例に `--dereferenced` フラグを追加し、フラグが必要な理由を説明する注意書きを追加。

## 変更内容

`opis/json-schema` は standalone な JSON Schema バリデータであり、OpenAPI 固有の `$ref` 参照を解決できない。そのため、specファイルは事前に全ての `$ref` をインライン解決した状態で提供する必要がある。

- Redocly CLI bundleコマンドに `--dereferenced` フラグを追加
- フラグが必要な理由を説明するblockquote（注意書き）を追加

## 関連情報

- Closes #9