### PR TITLE
New Feature: Renovate設定の追加による依存関係の自動更新

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Group GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "automerge": true
+    },
+    {
+      "description": "Automerge dev dependency minor/patch updates",
+      "matchDepTypes": ["require-dev"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "dev dependencies (non-major)",
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
# 概要

Renovate botの設定ファイルを追加し、依存関係の自動更新を有効化します。

## 変更内容

- `renovate.json` を追加
  - `config:recommended` をベースに設定
  - PRに `dependencies` ラベルを自動付与
  - GitHub Actions の更新をグループ化 + automerge
  - dev依存 (php-cs-fixer, phpstan, illuminate/testing) の minor/patch をグループ化 + automerge
  - production依存 (opis/json-schema, phpunit) は個別PRで慎重にレビュー

## 関連情報

- Closes #6 (旧Renovate設定PR)
- [Renovate Docs](https://docs.renovatebot.com/)