### PR TITLE
Refactoring: OpenApiResponseValidator のキャッシュ最適化

### DIFF
--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -19,6 +19,14 @@ use function strtolower;
 trait ValidatesOpenApiSchema
 {
     use OpenApiSpecResolver;
+    private static ?OpenApiResponseValidator $cachedValidator = null;
+    private static int $cachedMaxErrors = -1;
+
+    public static function resetValidatorCache(): void
+    {
+        self::$cachedValidator = null;
+        self::$cachedMaxErrors = -1;
+    }
 
     protected function openApiSpec(): string
     {
@@ -61,10 +69,7 @@ trait ValidatesOpenApiSchema
 
         $contentType = $response->headers->get('Content-Type', '');
 
-        $maxErrors = config('openapi-contract-testing.max_errors', 20);
-        $validator = new OpenApiResponseValidator(
-            maxErrors: is_numeric($maxErrors) ? (int) $maxErrors : 20,
-        );
+        $validator = self::getOrCreateValidator();
         $result = $validator->validate(
             $specName,
             $resolvedMethod,
@@ -90,6 +95,19 @@ trait ValidatesOpenApiSchema
             "OpenAPI schema validation failed for {$resolvedMethod} {$resolvedPath} (spec: {$specName}):\n"
             . $result->errorMessage(),
         );
+    }
+
+    private static function getOrCreateValidator(): OpenApiResponseValidator
+    {
+        $maxErrors = config('openapi-contract-testing.max_errors', 20);
+        $resolvedMaxErrors = is_numeric($maxErrors) ? (int) $maxErrors : 20;
+
+        if (self::$cachedValidator === null || self::$cachedMaxErrors !== $resolvedMaxErrors) {
+            self::$cachedValidator = new OpenApiResponseValidator(maxErrors: $resolvedMaxErrors);
+            self::$cachedMaxErrors = $resolvedMaxErrors;
+        }
+
+        return self::$cachedValidator;
     }
 
     /** @return null|array<string, mixed> */

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -20,12 +20,12 @@ trait ValidatesOpenApiSchema
 {
     use OpenApiSpecResolver;
     private static ?OpenApiResponseValidator $cachedValidator = null;
-    private static int $cachedMaxErrors = -1;
+    private static ?int $cachedMaxErrors = null;
 
     public static function resetValidatorCache(): void
     {
         self::$cachedValidator = null;
-        self::$cachedMaxErrors = -1;
+        self::$cachedMaxErrors = null;
     }
 
     protected function openApiSpec(): string

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -23,6 +23,11 @@ use function trim;
 
 final class OpenApiResponseValidator
 {
+    /** @var array<string, OpenApiPathMatcher> */
+    private array $pathMatchers = [];
+    private Validator $opisValidator;
+    private ErrorFormatter $errorFormatter;
+
     public function __construct(
         private readonly int $maxErrors = 20,
     ) {
@@ -31,6 +36,13 @@ final class OpenApiResponseValidator
                 sprintf('maxErrors must be 0 (unlimited) or a positive integer, got %d.', $this->maxErrors),
             );
         }
+
+        $resolvedMaxErrors = $this->maxErrors === 0 ? PHP_INT_MAX : $this->maxErrors;
+        $this->opisValidator = new Validator(
+            max_errors: $resolvedMaxErrors,
+            stop_at_first_error: $resolvedMaxErrors === 1,
+        );
+        $this->errorFormatter = new ErrorFormatter();
     }
 
     public function validate(
@@ -47,7 +59,7 @@ final class OpenApiResponseValidator
 
         /** @var string[] $specPaths */
         $specPaths = array_keys($spec['paths'] ?? []);
-        $matcher = new OpenApiPathMatcher($specPaths, OpenApiSpecLoader::getStripPrefixes());
+        $matcher = $this->getPathMatcher($specName, $specPaths);
         $matchedPath = $matcher->match($requestPath);
 
         if ($matchedPath === null) {
@@ -135,19 +147,13 @@ final class OpenApiResponseValidator
         $schemaObject = self::toObject($jsonSchema);
         $dataObject = self::toObject($responseBody);
 
-        $resolvedMaxErrors = $this->maxErrors === 0 ? PHP_INT_MAX : $this->maxErrors;
-        $validator = new Validator(
-            max_errors: $resolvedMaxErrors,
-            stop_at_first_error: $resolvedMaxErrors === 1,
-        );
-        $result = $validator->validate($dataObject, $schemaObject);
+        $result = $this->opisValidator->validate($dataObject, $schemaObject);
 
         if ($result->isValid()) {
             return OpenApiValidationResult::success($matchedPath);
         }
 
-        $formatter = new ErrorFormatter();
-        $formattedErrors = $formatter->format($result->error());
+        $formattedErrors = $this->errorFormatter->format($result->error());
 
         $errors = [];
         foreach ($formattedErrors as $path => $messages) {
@@ -185,6 +191,14 @@ final class OpenApiResponseValidator
         }
 
         return $object;
+    }
+
+    /**
+     * @param string[] $specPaths
+     */
+    private function getPathMatcher(string $specName, array $specPaths): OpenApiPathMatcher
+    {
+        return $this->pathMatchers[$specName] ??= new OpenApiPathMatcher($specPaths, OpenApiSpecLoader::getStripPrefixes());
     }
 
     /**

--- a/tests/Unit/ValidatesOpenApiSchemaAttributeTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaAttributeTest.php
@@ -33,6 +33,7 @@ class ValidatesOpenApiSchemaAttributeTest extends TestCase
 
     protected function tearDown(): void
     {
+        self::resetValidatorCache();
         OpenApiSpecLoader::reset();
         OpenApiCoverageTracker::reset();
         parent::tearDown();

--- a/tests/Unit/ValidatesOpenApiSchemaDefaultSpecTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaDefaultSpecTest.php
@@ -41,6 +41,7 @@ class ValidatesOpenApiSchemaDefaultSpecTest extends TestCase
 
     protected function tearDown(): void
     {
+        self::resetValidatorCache();
         unset($GLOBALS['__openapi_testing_config']);
         OpenApiSpecLoader::reset();
         OpenApiCoverageTracker::reset();

--- a/tests/Unit/ValidatesOpenApiSchemaTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaTest.php
@@ -32,6 +32,7 @@ class ValidatesOpenApiSchemaTest extends TestCase
 
     protected function tearDown(): void
     {
+        self::resetValidatorCache();
         OpenApiSpecLoader::reset();
         OpenApiCoverageTracker::reset();
         parent::tearDown();


### PR DESCRIPTION
# 概要

`OpenApiResponseValidator::validate()` が呼ばれるたびに `OpenApiPathMatcher`・opis `Validator`・`ErrorFormatter` を毎回新規生成していた非効率を解消し、インスタンスレベル/静的キャッシュを導入。

## 変更内容

- `OpenApiResponseValidator`: `Validator` と `ErrorFormatter` をコンストラクタで1回だけ生成するようにし、`OpenApiPathMatcher` を spec 名ごとにキャッシュする `getPathMatcher()` を追加
- `ValidatesOpenApiSchema` trait: 静的キャッシュ (`$cachedValidator`) を導入し、`maxErrors` が変わらない限り同じバリデータインスタンスを再利用。テスト用に `resetValidatorCache()` を追加
- テスト3ファイルの `tearDown()` に `self::resetValidatorCache()` を追加してテスト間の分離を担保

## 関連情報

- PR #35 の `OpenApiSpecLoader` キャッシュ最適化に続くパフォーマンス改善