### PR TITLE
New Feature: ValidatesOpenApiSchema trait に auto_assert オプションを追加し、HTTP レスポンスを自動検証

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ return [
     // Maximum number of validation errors to report per response.
     // 0 = unlimited (reports all errors).
     'max_errors' => 20,
+
+    // Automatically validate every TestResponse produced by Laravel HTTP
+    // helpers (get(), post(), etc.) against the OpenAPI spec. Defaults to
+    // false for backward compatibility.
+    'auto_assert' => false,
 ];
 ```
 
@@ -222,6 +227,39 @@ $validator = new OpenApiResponseValidator(maxErrors: 1);
 ```
 
 For Laravel, set the `max_errors` key in `config/openapi-contract-testing.php`.
+
+#### Auto-assert every response
+
+Forgetting `$this->assertResponseMatchesOpenApiSchema($response)` in a test means the contract is silently unchecked. Enable `auto_assert` to validate every response produced by Laravel's HTTP helpers automatically — just include the trait:
+
+```php
+// config/openapi-contract-testing.php
+return [
+    'default_spec' => 'front',
+    'auto_assert'  => true,
+];
+```
+
+```php
+use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
+
+class GetPetsTest extends TestCase
+{
+    use ValidatesOpenApiSchema;
+
+    public function test_list_pets(): void
+    {
+        // Contract is checked automatically — no explicit assert call needed.
+        $this->get('/api/v1/pets')->assertOk();
+    }
+}
+```
+
+Notes:
+
+- Defaults to `false` so existing test suites keep their explicit-assert behavior.
+- Auto-assert hooks into `createTestResponse()`, which is only invoked by Laravel's `MakesHttpRequests`. Responses you construct manually (outside `$this->get()`, `$this->post()`, etc.) are not touched.
+- Calling `$this->assertResponseMatchesOpenApiSchema($response)` on a response that auto-assert already validated is a no-op (idempotent), so mixing both styles is safe.
 
 ## Coverage Report
 

--- a/README.md
+++ b/README.md
@@ -258,8 +258,11 @@ class GetPetsTest extends TestCase
 Notes:
 
 - Defaults to `false` so existing test suites keep their explicit-assert behavior.
-- Auto-assert hooks into `createTestResponse()`, which is only invoked by Laravel's `MakesHttpRequests`. Responses you construct manually (outside `$this->get()`, `$this->post()`, etc.) are not touched.
-- Calling `$this->assertResponseMatchesOpenApiSchema($response)` on a response that auto-assert already validated is a no-op (idempotent), so mixing both styles is safe.
+- Auto-assert hooks into `MakesHttpRequests::createTestResponse()`. Responses you construct manually (outside `$this->get()`, `$this->post()`, etc.) are not touched.
+- Idempotency is keyed on the `(spec, method, path)` tuple. Calling `assertResponseMatchesOpenApiSchema($response)` after auto-assert with the matching signature is a no-op. Calling it with a different `method`/`path` — or a different `#[OpenApiSpec]` — runs validation again.
+- When auto-assert fails, the exception is thrown from inside `$this->get(...)`, so any chained assertion on the same line (`$this->get(...)->assertOk()`) will not run. This is usually what you want — the schema failure takes precedence over status-code checks.
+- `auto_assert` accepts boolean-compatible values (`true`/`false`/`"1"`/`"0"`/`"true"`/`"false"`) so `'auto_assert' => env('OPENAPI_AUTO_ASSERT')` works. Unrecognized values fail the test loudly with a clear message, not silently.
+- Streamed responses (`StreamedResponse`, binary downloads) cause `getContent()` to return `false`, which fails auto-assert with a clear message. If you use `auto_assert=true` on tests that exercise streams, scope the config change per-test or fall back to explicit manual asserts.
 
 ## Coverage Report
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.94",
-        "illuminate/testing": "^11.0 || ^12.0",
+        "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
         "phpstan/phpstan": "^2.0",
         "symfony/http-foundation": "^6.4 || ^7.0 || ^8.0"
     },

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -4,19 +4,28 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Laravel;
 
+use const FILTER_NULL_ON_FAILURE;
+use const FILTER_VALIDATE_BOOLEAN;
+
 use Illuminate\Testing\TestResponse;
 use JsonException;
 use Studio\OpenApiContractTesting\HttpMethod;
 use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\OpenApiResponseValidator;
 use Studio\OpenApiContractTesting\OpenApiSpecResolver;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use WeakMap;
 
+use function filter_var;
+use function get_debug_type;
 use function is_numeric;
 use function is_string;
+use function sprintf;
 use function str_contains;
 use function strtolower;
+use function strtoupper;
+use function var_export;
 
 trait ValidatesOpenApiSchema
 {
@@ -24,7 +33,7 @@ trait ValidatesOpenApiSchema
     private static ?OpenApiResponseValidator $cachedValidator = null;
     private static ?int $cachedMaxErrors = null;
 
-    /** @var null|WeakMap<TestResponse, true> */
+    /** @var null|WeakMap<TestResponse, array<string, true>> */
     private static ?WeakMap $validatedResponses = null;
 
     public static function resetValidatorCache(): void
@@ -35,16 +44,25 @@ trait ValidatesOpenApiSchema
     }
 
     /**
-     * Overrides Illuminate\Foundation\Testing\TestCase::createTestResponse so
-     * every HTTP test call runs schema validation when auto_assert is enabled.
+     * Overrides Laravel's MakesHttpRequests::createTestResponse hook so every
+     * HTTP test call runs schema validation when auto_assert is enabled.
      * When the library is used outside Laravel, this method is never called.
      *
+     * Method and path are resolved from the Request passed in by Laravel
+     * rather than from app('request'), so auto-assert stays independent of
+     * container state and sees the exact values the framework dispatched.
+     *
      * @param Response $response
+     * @param null|Request $request
      */
     protected function createTestResponse($response, $request = null): TestResponse
     {
         $testResponse = parent::createTestResponse($response, $request);
-        $this->maybeAutoAssertOpenApiSchema($testResponse);
+
+        $method = $request !== null ? HttpMethod::tryFrom(strtoupper($request->getMethod())) : null;
+        $path = $request?->getPathInfo();
+
+        $this->maybeAutoAssertOpenApiSchema($testResponse, $method, $path);
 
         return $testResponse;
     }
@@ -54,11 +72,7 @@ trait ValidatesOpenApiSchema
         ?HttpMethod $method = null,
         ?string $path = null,
     ): void {
-        if (config('openapi-contract-testing.auto_assert') !== true) {
-            return;
-        }
-
-        if (self::isAlreadyValidated($response)) {
+        if (!$this->isAutoAssertEnabled()) {
             return;
         }
 
@@ -86,10 +100,8 @@ trait ValidatesOpenApiSchema
         ?HttpMethod $method = null,
         ?string $path = null,
     ): void {
-        if (self::isAlreadyValidated($response)) {
-            return;
-        }
-        self::markValidated($response);
+        $resolvedMethod = $method !== null ? $method->value : app('request')->getMethod();
+        $resolvedPath = $path ?? app('request')->getPathInfo();
 
         $specName = $this->resolveOpenApiSpec();
         if ($specName === '') {
@@ -101,8 +113,16 @@ trait ValidatesOpenApiSchema
             );
         }
 
-        $resolvedMethod = $method !== null ? $method->value : app('request')->getMethod();
-        $resolvedPath = $path ?? app('request')->getPathInfo();
+        // Idempotency key includes the spec so that validating the same
+        // response against a different spec (or a different method/path on
+        // the same spec) still runs — auto-assert's no-op only applies to
+        // exact repeats.
+        $signature = $specName . ':' . $resolvedMethod . ' ' . $resolvedPath;
+
+        if (self::isAlreadyValidated($response, $signature)) {
+            return;
+        }
+        self::markValidated($response, $signature);
 
         $content = $response->getContent();
         if ($content === false) {
@@ -124,6 +144,8 @@ trait ValidatesOpenApiSchema
         // Record coverage for any matched endpoint, including those where body
         // validation was skipped (e.g. non-JSON content types). "Covered" means
         // the endpoint was exercised in a test, not that its body was validated.
+        // Note: under auto_assert, this records coverage for every Laravel HTTP
+        // call — including responses with no explicit contract-test intent.
         if ($result->matchedPath() !== null) {
             OpenApiCoverageTracker::record(
                 $specName,
@@ -139,16 +161,18 @@ trait ValidatesOpenApiSchema
         );
     }
 
-    private static function isAlreadyValidated(TestResponse $response): bool
+    private static function isAlreadyValidated(TestResponse $response, string $signature): bool
     {
         return self::$validatedResponses !== null &&
-            isset(self::$validatedResponses[$response]);
+            isset(self::$validatedResponses[$response][$signature]);
     }
 
-    private static function markValidated(TestResponse $response): void
+    private static function markValidated(TestResponse $response, string $signature): void
     {
         self::$validatedResponses ??= new WeakMap();
-        self::$validatedResponses[$response] = true;
+        $signatures = self::$validatedResponses[$response] ?? [];
+        $signatures[$signature] = true;
+        self::$validatedResponses[$response] = $signatures;
     }
 
     private static function getOrCreateValidator(): OpenApiResponseValidator
@@ -162,6 +186,30 @@ trait ValidatesOpenApiSchema
         }
 
         return self::$cachedValidator;
+    }
+
+    private function isAutoAssertEnabled(): bool
+    {
+        $raw = config('openapi-contract-testing.auto_assert', false);
+
+        if ($raw === true) {
+            return true;
+        }
+        if ($raw === false || $raw === null) {
+            return false;
+        }
+
+        $parsed = filter_var($raw, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+        if ($parsed === null) {
+            $this->fail(sprintf(
+                'openapi-contract-testing.auto_assert must be a boolean (or a boolean-compatible value '
+                . 'like "true"/"false"/"1"/"0"), got %s: %s.',
+                get_debug_type($raw),
+                var_export($raw, true),
+            ));
+        }
+
+        return $parsed;
     }
 
     /** @return null|array<string, mixed> */

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -10,6 +10,8 @@ use Studio\OpenApiContractTesting\HttpMethod;
 use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\OpenApiResponseValidator;
 use Studio\OpenApiContractTesting\OpenApiSpecResolver;
+use Symfony\Component\HttpFoundation\Response;
+use WeakMap;
 
 use function is_numeric;
 use function is_string;
@@ -22,10 +24,45 @@ trait ValidatesOpenApiSchema
     private static ?OpenApiResponseValidator $cachedValidator = null;
     private static ?int $cachedMaxErrors = null;
 
+    /** @var null|WeakMap<TestResponse, true> */
+    private static ?WeakMap $validatedResponses = null;
+
     public static function resetValidatorCache(): void
     {
         self::$cachedValidator = null;
         self::$cachedMaxErrors = null;
+        self::$validatedResponses = null;
+    }
+
+    /**
+     * Overrides Illuminate\Foundation\Testing\TestCase::createTestResponse so
+     * every HTTP test call runs schema validation when auto_assert is enabled.
+     * When the library is used outside Laravel, this method is never called.
+     *
+     * @param Response $response
+     */
+    protected function createTestResponse($response, $request = null): TestResponse
+    {
+        $testResponse = parent::createTestResponse($response, $request);
+        $this->maybeAutoAssertOpenApiSchema($testResponse);
+
+        return $testResponse;
+    }
+
+    protected function maybeAutoAssertOpenApiSchema(
+        TestResponse $response,
+        ?HttpMethod $method = null,
+        ?string $path = null,
+    ): void {
+        if (config('openapi-contract-testing.auto_assert') !== true) {
+            return;
+        }
+
+        if (self::isAlreadyValidated($response)) {
+            return;
+        }
+
+        $this->assertResponseMatchesOpenApiSchema($response, $method, $path);
     }
 
     protected function openApiSpec(): string
@@ -49,6 +86,11 @@ trait ValidatesOpenApiSchema
         ?HttpMethod $method = null,
         ?string $path = null,
     ): void {
+        if (self::isAlreadyValidated($response)) {
+            return;
+        }
+        self::markValidated($response);
+
         $specName = $this->resolveOpenApiSpec();
         if ($specName === '') {
             $this->fail(
@@ -95,6 +137,18 @@ trait ValidatesOpenApiSchema
             "OpenAPI schema validation failed for {$resolvedMethod} {$resolvedPath} (spec: {$specName}):\n"
             . $result->errorMessage(),
         );
+    }
+
+    private static function isAlreadyValidated(TestResponse $response): bool
+    {
+        return self::$validatedResponses !== null &&
+            isset(self::$validatedResponses[$response]);
+    }
+
+    private static function markValidated(TestResponse $response): void
+    {
+        self::$validatedResponses ??= new WeakMap();
+        self::$validatedResponses[$response] = true;
     }
 
     private static function getOrCreateValidator(): OpenApiResponseValidator

--- a/src/Laravel/config.php
+++ b/src/Laravel/config.php
@@ -8,4 +8,10 @@ return [
     // Maximum number of validation errors to report per response.
     // 0 = unlimited (reports all errors).
     'max_errors' => 20,
+
+    // When true, every TestResponse produced by Laravel HTTP test helpers
+    // (get(), post(), etc.) is validated against the OpenAPI spec at creation
+    // time, without requiring an explicit assertResponseMatchesOpenApiSchema()
+    // call in each test. Defaults to false for backward compatibility.
+    'auto_assert' => false,
 ];

--- a/tests/Helpers/LaravelConfigMock.php
+++ b/tests/Helpers/LaravelConfigMock.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Laravel;
 
-use Throwable;
+use Illuminate\Container\Container;
 
 use function array_key_exists;
-use function function_exists;
+use function class_exists;
 
 /**
  * Namespace-level config() mock for unit testing.
@@ -29,11 +29,16 @@ use function function_exists;
  * Resolution order:
  * 1. A unit-test override in $GLOBALS['__openapi_testing_config'] wins — unit
  *    tests set this explicitly to control what the trait sees.
- * 2. Otherwise, defer to the real framework helper when an app is running
- *    (integration tests using orchestra/testbench). The global helper is
- *    invoked via a variable function to bypass both PHP namespace resolution
- *    (which would recurse into this mock) and cs-fixer's global_namespace_import
- *    rule (which would strip a leading backslash and break the call).
+ * 2. When a Laravel container is bootstrapped and has a "config" binding (i.e.
+ *    integration tests using orchestra/testbench), delegate to the framework's
+ *    config() helper via a variable function. The variable call avoids both
+ *    PHP namespace resolution (which would recurse into this mock) and any
+ *    future auto-import of the global \config() by cs-fixer's
+ *    global_namespace_import rule (which would add a "use function config;"
+ *    and re-break this mock for the same reason as a manual import).
+ * 3. Otherwise (pure unit tests with no booted app), return the provided
+ *    default. The container-bound check avoids swallowing real binding errors:
+ *    only an unbootstrapped container falls through here.
  */
 function config(string $key, mixed $default = null): mixed
 {
@@ -44,14 +49,10 @@ function config(string $key, mixed $default = null): mixed
         return $GLOBALS['__openapi_testing_config'][$key];
     }
 
-    if (function_exists('config')) {
+    if (class_exists(Container::class) && Container::getInstance()->bound('config')) {
         $globalConfig = 'config';
 
-        try {
-            return $globalConfig($key, $default);
-        } catch (Throwable) {
-            return $default;
-        }
+        return $globalConfig($key, $default);
     }
 
     return $default;

--- a/tests/Helpers/LaravelConfigMock.php
+++ b/tests/Helpers/LaravelConfigMock.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Laravel;
 
+use Throwable;
+
+use function array_key_exists;
+use function function_exists;
+
 /**
  * Namespace-level config() mock for unit testing.
  *
@@ -21,9 +26,33 @@ namespace Studio\OpenApiContractTesting\Laravel;
  * in ValidatesOpenApiSchema.php (i.e., no "use function config" import).
  * Adding such an import would bypass namespace resolution and break this mock.
  *
- * Test values are read from $GLOBALS['__openapi_testing_config'].
+ * Resolution order:
+ * 1. A unit-test override in $GLOBALS['__openapi_testing_config'] wins — unit
+ *    tests set this explicitly to control what the trait sees.
+ * 2. Otherwise, defer to the real framework helper when an app is running
+ *    (integration tests using orchestra/testbench). The global helper is
+ *    invoked via a variable function to bypass both PHP namespace resolution
+ *    (which would recurse into this mock) and cs-fixer's global_namespace_import
+ *    rule (which would strip a leading backslash and break the call).
  */
 function config(string $key, mixed $default = null): mixed
 {
-    return $GLOBALS['__openapi_testing_config'][$key] ?? $default;
+    if (
+        isset($GLOBALS['__openapi_testing_config']) &&
+        array_key_exists($key, $GLOBALS['__openapi_testing_config'])
+    ) {
+        return $GLOBALS['__openapi_testing_config'][$key];
+    }
+
+    if (function_exists('config')) {
+        $globalConfig = 'config';
+
+        try {
+            return $globalConfig($key, $default);
+        } catch (Throwable) {
+            return $default;
+        }
+    }
+
+    return $default;
 }

--- a/tests/Integration/Laravel/AutoAssertIntegrationTest.php
+++ b/tests/Integration/Laravel/AutoAssertIntegrationTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Integration\Laravel;
+
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\Test;
+use Studio\OpenApiContractTesting\Laravel\OpenApiContractTestingServiceProvider;
+use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
+use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+
+use function dirname;
+
+/**
+ * Full Laravel integration test proving that applying the
+ * ValidatesOpenApiSchema trait with auto_assert=true is sufficient for
+ * $this->get() / post() / etc. to trigger OpenAPI validation — no explicit
+ * assertResponseMatchesOpenApiSchema() call required.
+ */
+class AutoAssertIntegrationTest extends TestCase
+{
+    use ValidatesOpenApiSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(dirname(__DIR__, 2) . '/fixtures/specs');
+        OpenApiCoverageTracker::reset();
+        config()->set('openapi-contract-testing.default_spec', 'petstore-3.0');
+    }
+
+    protected function tearDown(): void
+    {
+        self::resetValidatorCache();
+        OpenApiSpecLoader::reset();
+        OpenApiCoverageTracker::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function auto_assert_true_validates_http_response_without_explicit_call(): void
+    {
+        config()->set('openapi-contract-testing.auto_assert', true);
+
+        // No explicit assertResponseMatchesOpenApiSchema call — trait alone
+        // must trigger validation when auto_assert=true.
+        $response = $this->get('/v1/pets');
+
+        $response->assertOk();
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayHasKey('petstore-3.0', $covered);
+        $this->assertArrayHasKey('GET /v1/pets', $covered['petstore-3.0']);
+    }
+
+    #[Test]
+    public function auto_assert_true_raises_assertion_error_on_schema_mismatch(): void
+    {
+        config()->set('openapi-contract-testing.auto_assert', true);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('OpenAPI schema validation failed');
+
+        // Auto-assert must surface the mismatch without an explicit assert.
+        $this->get('/v1/pets?bad=1');
+    }
+
+    #[Test]
+    public function auto_assert_false_does_not_validate_automatically(): void
+    {
+        config()->set('openapi-contract-testing.auto_assert', false);
+
+        // Invalid body but auto_assert=false — no exception, no coverage.
+        $response = $this->get('/v1/pets?bad=1');
+
+        $response->assertOk();
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayNotHasKey('petstore-3.0', $covered);
+    }
+
+    #[Test]
+    public function auto_assert_not_set_defaults_to_skip(): void
+    {
+        // auto_assert not explicitly set — config merge default (false) applies.
+        $response = $this->get('/v1/pets?bad=1');
+
+        $response->assertOk();
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayNotHasKey('petstore-3.0', $covered);
+    }
+
+    #[Test]
+    public function explicit_and_auto_assert_are_idempotent(): void
+    {
+        config()->set('openapi-contract-testing.auto_assert', true);
+
+        // Auto-assert runs during $this->get(). A subsequent explicit call on
+        // the same response must not re-run validation nor re-record coverage.
+        $response = $this->get('/v1/pets');
+        $this->assertResponseMatchesOpenApiSchema($response);
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertCount(1, $covered['petstore-3.0'] ?? []);
+    }
+
+    /** @return array<int, class-string> */
+    protected function getPackageProviders($app): array
+    {
+        return [OpenApiContractTestingServiceProvider::class];
+    }
+
+    protected function defineRoutes($router): void
+    {
+        Route::get('/v1/pets', static function () {
+            $bad = request()->query('bad') === '1';
+
+            return response()->json(
+                $bad
+                    ? ['wrong_key' => 'value']
+                    : ['data' => [['id' => 1, 'name' => 'Fido', 'tag' => null]]],
+            );
+        });
+    }
+}

--- a/tests/Integration/Laravel/AutoAssertIntegrationTest.php
+++ b/tests/Integration/Laravel/AutoAssertIntegrationTest.php
@@ -11,15 +11,18 @@ use PHPUnit\Framework\Attributes\Test;
 use Studio\OpenApiContractTesting\Laravel\OpenApiContractTestingServiceProvider;
 use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
 use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\OpenApiSpec;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
 
 use function dirname;
 
 /**
- * Full Laravel integration test proving that applying the
- * ValidatesOpenApiSchema trait with auto_assert=true is sufficient for
- * $this->get() / post() / etc. to trigger OpenAPI validation — no explicit
- * assertResponseMatchesOpenApiSchema() call required.
+ * Exercises the full `$this->get()` / `$this->post()` → Laravel kernel →
+ * `MakesHttpRequests::createTestResponse` → trait override pipeline under a
+ * real Testbench app. Complements the unit tests (which call
+ * `maybeAutoAssertOpenApiSchema` directly) by proving the framework-boundary
+ * integration — the trait-provided `createTestResponse` actually wins over
+ * the one Laravel merges in from `MakesHttpRequests`.
  */
 class AutoAssertIntegrationTest extends TestCase
 {
@@ -43,14 +46,11 @@ class AutoAssertIntegrationTest extends TestCase
     }
 
     #[Test]
-    public function auto_assert_true_validates_http_response_without_explicit_call(): void
+    public function auto_assert_true_validates_get_response(): void
     {
         config()->set('openapi-contract-testing.auto_assert', true);
 
-        // No explicit assertResponseMatchesOpenApiSchema call — trait alone
-        // must trigger validation when auto_assert=true.
         $response = $this->get('/v1/pets');
-
         $response->assertOk();
 
         $covered = OpenApiCoverageTracker::getCovered();
@@ -59,55 +59,108 @@ class AutoAssertIntegrationTest extends TestCase
     }
 
     #[Test]
-    public function auto_assert_true_raises_assertion_error_on_schema_mismatch(): void
+    public function auto_assert_true_validates_post_response(): void
+    {
+        // Pins POST specifically: the hook is verb-agnostic in theory, but a
+        // regression that guards createTestResponse behind `method === 'GET'`
+        // would otherwise go undetected.
+        config()->set('openapi-contract-testing.auto_assert', true);
+
+        $response = $this->postJson('/v1/pets', ['name' => 'Buddy']);
+        $response->assertCreated();
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayHasKey('POST /v1/pets', $covered['petstore-3.0'] ?? []);
+    }
+
+    #[Test]
+    public function auto_assert_true_raises_on_schema_mismatch(): void
     {
         config()->set('openapi-contract-testing.auto_assert', true);
 
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('OpenAPI schema validation failed');
 
-        // Auto-assert must surface the mismatch without an explicit assert.
         $this->get('/v1/pets?bad=1');
     }
 
     #[Test]
-    public function auto_assert_false_does_not_validate_automatically(): void
+    public function auto_assert_false_does_not_validate(): void
     {
         config()->set('openapi-contract-testing.auto_assert', false);
 
-        // Invalid body but auto_assert=false — no exception, no coverage.
         $response = $this->get('/v1/pets?bad=1');
-
         $response->assertOk();
 
-        $covered = OpenApiCoverageTracker::getCovered();
-        $this->assertArrayNotHasKey('petstore-3.0', $covered);
+        $this->assertArrayNotHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
     }
 
     #[Test]
     public function auto_assert_not_set_defaults_to_skip(): void
     {
-        // auto_assert not explicitly set — config merge default (false) applies.
         $response = $this->get('/v1/pets?bad=1');
-
         $response->assertOk();
 
-        $covered = OpenApiCoverageTracker::getCovered();
-        $this->assertArrayNotHasKey('petstore-3.0', $covered);
+        $this->assertArrayNotHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
     }
 
     #[Test]
-    public function explicit_and_auto_assert_are_idempotent(): void
+    public function auto_assert_with_invalid_config_value_fails_loudly(): void
+    {
+        // Common user mistake: config value is a non-boolean-compatible value
+        // (e.g. typo in a cast). The trait must surface this as a clear test
+        // failure rather than silently treating it as "off".
+        config()->set('openapi-contract-testing.auto_assert', 'definitely-not-a-bool');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('auto_assert must be a boolean');
+
+        $this->get('/v1/pets');
+    }
+
+    #[Test]
+    public function auto_assert_accepts_string_true_as_truthy(): void
+    {
+        // env('X') returns strings — `'auto_assert' => env('AUTO_ASSERT')`
+        // would yield "true" (not boolean true). FILTER_VALIDATE_BOOLEAN
+        // treats this as truthy, so the user isn't punished for common
+        // env-var wiring.
+        config()->set('openapi-contract-testing.auto_assert', 'true');
+
+        $response = $this->get('/v1/pets');
+        $response->assertOk();
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayHasKey('GET /v1/pets', $covered['petstore-3.0'] ?? []);
+    }
+
+    #[Test]
+    public function explicit_assert_after_auto_assert_is_idempotent(): void
     {
         config()->set('openapi-contract-testing.auto_assert', true);
 
-        // Auto-assert runs during $this->get(). A subsequent explicit call on
-        // the same response must not re-run validation nor re-record coverage.
         $response = $this->get('/v1/pets');
         $this->assertResponseMatchesOpenApiSchema($response);
 
         $covered = OpenApiCoverageTracker::getCovered();
         $this->assertCount(1, $covered['petstore-3.0'] ?? []);
+    }
+
+    #[Test]
+    #[OpenApiSpec('petstore-3.1')]
+    public function method_level_attribute_resolves_spec_for_auto_assert(): void
+    {
+        // default_spec is set to petstore-3.0 in setUp, but this method is
+        // decorated with #[OpenApiSpec('petstore-3.1')] — auto-assert must
+        // respect the attribute and record coverage under 3.1, not 3.0.
+        config()->set('openapi-contract-testing.auto_assert', true);
+
+        $response = $this->get('/v1/pets');
+        $response->assertOk();
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayHasKey('petstore-3.1', $covered);
+        $this->assertArrayNotHasKey('petstore-3.0', $covered);
     }
 
     /** @return array<int, class-string> */
@@ -127,5 +180,10 @@ class AutoAssertIntegrationTest extends TestCase
                     : ['data' => [['id' => 1, 'name' => 'Fido', 'tag' => null]]],
             );
         });
+
+        Route::post('/v1/pets', static fn() => response()->json(
+            ['data' => ['id' => 42, 'name' => 'Buddy', 'tag' => null]],
+            201,
+        ));
     }
 }

--- a/tests/Unit/ValidatesOpenApiSchemaAutoAssertTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaAutoAssertTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use const JSON_THROW_ON_ERROR;
+
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\HttpMethod;
+use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
+use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\Tests\Helpers\CreatesTestResponse;
+
+use function count;
+use function json_encode;
+
+// Load namespace-level config() mock before the trait resolves the function call.
+require_once __DIR__ . '/../Helpers/LaravelConfigMock.php';
+
+class ValidatesOpenApiSchemaAutoAssertTest extends TestCase
+{
+    use CreatesTestResponse;
+    use ValidatesOpenApiSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs');
+        OpenApiCoverageTracker::reset();
+        $GLOBALS['__openapi_testing_config'] = [
+            'openapi-contract-testing.default_spec' => 'petstore-3.0',
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        self::resetValidatorCache();
+        unset($GLOBALS['__openapi_testing_config']);
+        OpenApiSpecLoader::reset();
+        OpenApiCoverageTracker::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function config_file_defaults_auto_assert_to_false(): void
+    {
+        $config = require __DIR__ . '/../../src/Laravel/config.php';
+
+        $this->assertArrayHasKey('auto_assert', $config);
+        $this->assertFalse($config['auto_assert']);
+    }
+
+    #[Test]
+    public function auto_assert_true_validates_valid_response_without_error(): void
+    {
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_assert'] = true;
+
+        $body = (string) json_encode(
+            ['data' => [['id' => 1, 'name' => 'Fido', 'tag' => null]]],
+            JSON_THROW_ON_ERROR,
+        );
+        $response = $this->makeTestResponse($body, 200);
+
+        $this->maybeAutoAssertOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayHasKey('petstore-3.0', $covered);
+        $this->assertArrayHasKey('GET /v1/pets', $covered['petstore-3.0']);
+    }
+
+    #[Test]
+    public function auto_assert_true_raises_assertion_error_for_invalid_response(): void
+    {
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_assert'] = true;
+
+        $body = (string) json_encode(['wrong_key' => 'value'], JSON_THROW_ON_ERROR);
+        $response = $this->makeTestResponse($body, 200);
+
+        $this->expectException(AssertionFailedError::class);
+
+        $this->maybeAutoAssertOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+    }
+
+    #[Test]
+    public function auto_assert_false_skips_validation_for_invalid_response(): void
+    {
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_assert'] = false;
+
+        $body = (string) json_encode(['wrong_key' => 'value'], JSON_THROW_ON_ERROR);
+        $response = $this->makeTestResponse($body, 200);
+
+        // No exception expected — validation is skipped.
+        $this->maybeAutoAssertOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayNotHasKey('petstore-3.0', $covered);
+    }
+
+    #[Test]
+    public function auto_assert_not_set_skips_validation_for_invalid_response(): void
+    {
+        // No auto_assert config key present — default should be false.
+        $body = (string) json_encode(['wrong_key' => 'value'], JSON_THROW_ON_ERROR);
+        $response = $this->makeTestResponse($body, 200);
+
+        $this->maybeAutoAssertOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayNotHasKey('petstore-3.0', $covered);
+    }
+
+    #[Test]
+    public function double_manual_assert_is_idempotent(): void
+    {
+        $body = (string) json_encode(
+            ['data' => [['id' => 1, 'name' => 'Fido', 'tag' => null]]],
+            JSON_THROW_ON_ERROR,
+        );
+        $response = $this->makeTestResponse($body, 200);
+
+        $this->assertResponseMatchesOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+        $this->assertResponseMatchesOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayHasKey('petstore-3.0', $covered);
+        $this->assertCount(
+            1,
+            $covered['petstore-3.0'],
+            'Coverage entries should not be duplicated when the same response is validated twice.',
+        );
+    }
+
+    #[Test]
+    public function manual_assert_then_auto_assert_is_idempotent(): void
+    {
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_assert'] = true;
+
+        $body = (string) json_encode(
+            ['data' => [['id' => 1, 'name' => 'Fido', 'tag' => null]]],
+            JSON_THROW_ON_ERROR,
+        );
+        $response = $this->makeTestResponse($body, 200);
+
+        $this->assertResponseMatchesOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+
+        $coveredBefore = OpenApiCoverageTracker::getCovered();
+        $countBefore = count($coveredBefore['petstore-3.0'] ?? []);
+
+        // A subsequent auto-assert on the same response must not re-validate or
+        // re-record coverage.
+        $this->maybeAutoAssertOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+
+        $coveredAfter = OpenApiCoverageTracker::getCovered();
+        $this->assertCount($countBefore, $coveredAfter['petstore-3.0'] ?? []);
+    }
+
+    #[Test]
+    public function auto_assert_then_manual_assert_does_not_raise_for_invalid_response(): void
+    {
+        // When auto-assert has already failed (and been caught), a manual
+        // assert on the same response instance should no-op so the same error
+        // is not reported twice. We simulate this by recording the response as
+        // validated via a successful auto-assert first, then calling the
+        // manual API — which would normally raise on a subsequent mismatch —
+        // expecting no exception because the response is already marked.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_assert'] = true;
+
+        $body = (string) json_encode(
+            ['data' => [['id' => 1, 'name' => 'Fido', 'tag' => null]]],
+            JSON_THROW_ON_ERROR,
+        );
+        $response = $this->makeTestResponse($body, 200);
+
+        $this->maybeAutoAssertOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+        // Calling manual assert afterwards must not throw or add another
+        // coverage entry.
+        $this->assertResponseMatchesOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertCount(1, $covered['petstore-3.0'] ?? []);
+    }
+}

--- a/tests/Unit/ValidatesOpenApiSchemaAutoAssertTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaAutoAssertTest.php
@@ -94,7 +94,6 @@ class ValidatesOpenApiSchemaAutoAssertTest extends TestCase
         $body = (string) json_encode(['wrong_key' => 'value'], JSON_THROW_ON_ERROR);
         $response = $this->makeTestResponse($body, 200);
 
-        // No exception expected — validation is skipped.
         $this->maybeAutoAssertOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
 
         $covered = OpenApiCoverageTracker::getCovered();
@@ -104,7 +103,6 @@ class ValidatesOpenApiSchemaAutoAssertTest extends TestCase
     #[Test]
     public function auto_assert_not_set_skips_validation_for_invalid_response(): void
     {
-        // No auto_assert config key present — default should be false.
         $body = (string) json_encode(['wrong_key' => 'value'], JSON_THROW_ON_ERROR);
         $response = $this->makeTestResponse($body, 200);
 
@@ -115,7 +113,45 @@ class ValidatesOpenApiSchemaAutoAssertTest extends TestCase
     }
 
     #[Test]
-    public function double_manual_assert_is_idempotent(): void
+    public function auto_assert_with_non_bool_value_fails_loudly(): void
+    {
+        // A user who mis-configures auto_assert (e.g. via env without cast)
+        // should see a loud failure, not a silent skip.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_assert'] = 'yolo';
+
+        $body = (string) json_encode(
+            ['data' => [['id' => 1, 'name' => 'Fido', 'tag' => null]]],
+            JSON_THROW_ON_ERROR,
+        );
+        $response = $this->makeTestResponse($body, 200);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('auto_assert must be a boolean');
+
+        $this->maybeAutoAssertOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+    }
+
+    #[Test]
+    public function auto_assert_with_truthy_string_validates(): void
+    {
+        // env('X') returns strings; "true" must be treated as truthy so that
+        // `'auto_assert' => env('AUTO_ASSERT')` (the idiomatic Laravel
+        // pattern) works without an explicit cast.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_assert'] = 'true';
+
+        $body = (string) json_encode(
+            ['data' => [['id' => 1, 'name' => 'Fido', 'tag' => null]]],
+            JSON_THROW_ON_ERROR,
+        );
+        $response = $this->makeTestResponse($body, 200);
+
+        $this->maybeAutoAssertOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+
+        $this->assertArrayHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
+    }
+
+    #[Test]
+    public function double_manual_assert_with_same_signature_is_idempotent(): void
     {
         $body = (string) json_encode(
             ['data' => [['id' => 1, 'name' => 'Fido', 'tag' => null]]],
@@ -128,15 +164,11 @@ class ValidatesOpenApiSchemaAutoAssertTest extends TestCase
 
         $covered = OpenApiCoverageTracker::getCovered();
         $this->assertArrayHasKey('petstore-3.0', $covered);
-        $this->assertCount(
-            1,
-            $covered['petstore-3.0'],
-            'Coverage entries should not be duplicated when the same response is validated twice.',
-        );
+        $this->assertCount(1, $covered['petstore-3.0']);
     }
 
     #[Test]
-    public function manual_assert_then_auto_assert_is_idempotent(): void
+    public function manual_then_auto_assert_with_same_signature_is_idempotent(): void
     {
         $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_assert'] = true;
 
@@ -147,27 +179,19 @@ class ValidatesOpenApiSchemaAutoAssertTest extends TestCase
         $response = $this->makeTestResponse($body, 200);
 
         $this->assertResponseMatchesOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+        $countBefore = count(OpenApiCoverageTracker::getCovered()['petstore-3.0'] ?? []);
 
-        $coveredBefore = OpenApiCoverageTracker::getCovered();
-        $countBefore = count($coveredBefore['petstore-3.0'] ?? []);
-
-        // A subsequent auto-assert on the same response must not re-validate or
-        // re-record coverage.
         $this->maybeAutoAssertOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
 
-        $coveredAfter = OpenApiCoverageTracker::getCovered();
-        $this->assertCount($countBefore, $coveredAfter['petstore-3.0'] ?? []);
+        $this->assertCount($countBefore, OpenApiCoverageTracker::getCovered()['petstore-3.0'] ?? []);
     }
 
     #[Test]
-    public function auto_assert_then_manual_assert_does_not_raise_for_invalid_response(): void
+    public function auto_then_manual_assert_with_same_signature_does_not_duplicate_coverage(): void
     {
-        // When auto-assert has already failed (and been caught), a manual
-        // assert on the same response instance should no-op so the same error
-        // is not reported twice. We simulate this by recording the response as
-        // validated via a successful auto-assert first, then calling the
-        // manual API — which would normally raise on a subsequent mismatch —
-        // expecting no exception because the response is already marked.
+        // After a successful auto-assert, a manual call with the matching
+        // (method, path) signature must no-op — no second validator run,
+        // no second coverage entry.
         $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_assert'] = true;
 
         $body = (string) json_encode(
@@ -177,11 +201,27 @@ class ValidatesOpenApiSchemaAutoAssertTest extends TestCase
         $response = $this->makeTestResponse($body, 200);
 
         $this->maybeAutoAssertOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
-        // Calling manual assert afterwards must not throw or add another
-        // coverage entry.
         $this->assertResponseMatchesOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
 
-        $covered = OpenApiCoverageTracker::getCovered();
-        $this->assertCount(1, $covered['petstore-3.0'] ?? []);
+        $this->assertCount(1, OpenApiCoverageTracker::getCovered()['petstore-3.0'] ?? []);
+    }
+
+    #[Test]
+    public function manual_assert_with_different_method_path_re_validates_same_response(): void
+    {
+        // Idempotency is keyed on (spec, method, path) — a second call with
+        // different (method, path) must re-validate, not silently no-op.
+        // We prove this by making the second call one that SHOULD fail:
+        // if idempotency wrongly skipped it, no exception would be raised.
+        //
+        // The empty 204 body validates against DELETE /v1/pets/{petId} but
+        // does NOT satisfy GET /v1/pets (which expects a JSON body). Before
+        // the tuple-keyed fix, this second call was silently skipped.
+        $response = $this->makeTestResponse('', 204);
+
+        $this->assertResponseMatchesOpenApiSchema($response, HttpMethod::DELETE, '/v1/pets/123');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->assertResponseMatchesOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
     }
 }


### PR DESCRIPTION
# 概要

`ValidatesOpenApiSchema` trait に `config('openapi-contract-testing.auto_assert')` を追加し、`true` に設定すると Laravel テストの HTTP 呼び出し（`$this->get()`, `$this->post()` など）が生成する `TestResponse` をスキーマと自動照合するようにした。各テストに `$this->assertResponseMatchesOpenApiSchema($response)` を明示的に書く必要がなくなり、契約検証の書き忘れを防げる。デフォルトは `false` で後方互換。

## 変更内容

- `src/Laravel/config.php` に `auto_assert`（デフォルト `false`）を追加
- `ValidatesOpenApiSchema` trait で `Illuminate\Foundation\Testing\TestCase::createTestResponse()` を override し、`auto_assert=true` かつ未検証のレスポンスに対して検証を発火
- `WeakMap<TestResponse, true>` ベースの idempotency ガードを `assertResponseMatchesOpenApiSchema()` 冒頭に追加。自動検証 + 明示検証を混在させても二重実行・二重報告されない
- `tests/Unit/ValidatesOpenApiSchemaAutoAssertTest.php` を新規追加（8 ケース：config デフォルト・ON/OFF 挙動・冪等性）
- `tests/Integration/Laravel/AutoAssertIntegrationTest.php` を新規追加（5 ケース：`orchestra/testbench` で本物の Laravel 環境を起動し、`$this->get('/v1/pets')` のみで auto-assert が走ることを E2E 検証）
- `composer.json`: dev dep を `illuminate/testing` から `orchestra/testbench: ^9.0 || ^10.0 || ^11.0` に入れ替え（`TestResponse` は testbench が引き込む `laravel/framework` から供給される）
- `tests/Helpers/LaravelConfigMock.php`: Laravel アプリが bootstrap されている場合は本物の `config()` ヘルパーに委譲するよう調整。ユニットテストでは従来通り `$GLOBALS` からモック値を読む
- `README.md` に `auto_assert` 設定の説明と使用例を追加

### 設計上の判断

Issue のヒントには「`TestResponse::macro` で `assertStatus` を wrap」とあったが、`Illuminate\Support\Traits\Macroable::__call()` は存在しないメソッドしか捕捉しないため、実メソッドである `assertStatus()` / `assertOk()` を macro で上書きすることは不可能。代わりに `createTestResponse()` を trait で override する方式を採用した。この方式では:

- 1 HTTP 呼び出し = 1 検証という自然な idempotency が得られる
- 既存 assertion メソッドの挙動を壊さない
- `assertStatus` 呼び出しより早いタイミングで検証が走るため、エラー報告のタイミングは劣化しない

### 破壊的変更

- dev dependency のみ: `illuminate/testing` → `orchestra/testbench`（ライブラリ利用者（production 依存）には影響なし）

### 受け入れ条件対応

- [x] trait を `use` するだけで自動検証が走る（`AutoAssertIntegrationTest::auto_assert_true_validates_http_response_without_explicit_call` で証明）
- [x] `auto_assert=false` で検証されない（`auto_assert_false_does_not_validate_automatically`）
- [x] 既存 `assertResponseMatchesOpenApiSchema()` を残し、二重呼び出しで冪等（`double_manual_assert_is_idempotent`、`explicit_and_auto_assert_are_idempotent`）
- [x] `config('openapi-contract-testing.auto_assert')` で切替可能、デフォルト `false`

### 検証

- PHPUnit: 199 tests / 404 assertions（既存 186 + unit 8 + integration 5）全 pass
- PHPStan: no errors
- PHP-CS-Fixer: no violations

## 関連情報

- Closes #39