### PR TITLE
New Feature: リクエスト単位で検証をスキップする withoutValidation() API を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,42 @@ Notes:
 - If a test is marked `#[SkipOpenApi]` and still calls `assertResponseMatchesOpenApiSchema()` explicitly, an advisory warning is written to `STDERR` and a user deprecation is raised to flag the contradictory intent. The assertion is not suppressed — fix the cause by removing either the attribute or the explicit call.
 - The attribute is resolved via reflection on the direct class only; a class-level `#[SkipOpenApi]` on an abstract parent is **not** inherited by subclasses. Apply the attribute on each concrete test class (or per method) instead.
 
+#### Per-request skip with `withoutValidation()`
+
+When only a single request should skip validation — e.g., exercising a legacy endpoint during a staged migration — use the fluent `withoutValidation()` API instead of annotating the whole method:
+
+```php
+class PetApiTest extends TestCase
+{
+    use ValidatesOpenApiSchema;
+
+    public function test_legacy_endpoint(): void
+    {
+        // Only this HTTP call skips validation.
+        $this->withoutValidation()
+            ->get('/v1/pets/legacy')
+            ->assertOk();
+
+        // The next call is validated as usual.
+        $this->get('/v1/pets')->assertOk();
+    }
+}
+```
+
+Three scopes are available:
+
+- `withoutValidation()` — skip both request and response validation
+- `withoutResponseValidation()` — skip response validation only
+- `withoutRequestValidation()` — skip request validation only (forward-looking hook; request validation itself is not yet implemented)
+
+Notes:
+
+- The flag applies to **exactly one HTTP call**. It is consumed on the next `$this->get()` / `$this->post()` / etc., then automatically resets — a second consecutive call validates normally.
+- Scoped to auto-assert only, like `#[SkipOpenApi]`. An explicit `assertResponseMatchesOpenApiSchema()` call still runs regardless of the flag.
+- No coverage is recorded for the skipped request.
+- Each method returns `$this`, so both `$this->withoutValidation()->get(...)` and the step-by-step form (`$this->withoutValidation(); $this->get(...);`) work.
+- `withoutRequestValidation()` currently has no observable effect because request validation has not landed yet — the method exists so tests can adopt the intended API surface today without a later rewrite.
+
 ## Coverage Report
 
 After running tests, the PHPUnit extension prints a coverage report. The output format is controlled by the `console_output` parameter (or `OPENAPI_CONSOLE_OUTPUT` environment variable).

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -101,7 +101,13 @@ trait ValidatesOpenApiSchema
         return $this;
     }
 
-    /** Skips response validation for the next HTTP call only. */
+    /**
+     * Skips response validation for the next HTTP call only. The flag
+     * self-resets after one auto-assert attempt.
+     *
+     * Scoped to auto-assert only, matching the convention established by
+     * #[SkipOpenApi] and `withoutValidation()`.
+     */
     public function withoutResponseValidation(): static
     {
         $this->skipNextResponseValidation = true;

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -56,11 +56,57 @@ trait ValidatesOpenApiSchema
      */
     private static $skipWarningHandler;
 
+    // Per-request skip flags set by withoutRequestValidation() /
+    // withoutResponseValidation() / withoutValidation(). Consumed (and reset)
+    // on the next auto-assert attempt, so the flag covers exactly one HTTP
+    // call. Instance-level because PHPUnit builds a fresh TestCase per
+    // method — this gives us natural per-test isolation.
+    private bool $skipNextRequestValidation = false;
+    private bool $skipNextResponseValidation = false;
+
     public static function resetValidatorCache(): void
     {
         self::$cachedValidator = null;
         self::$cachedMaxErrors = null;
         self::$validatedResponses = null;
+    }
+
+    /**
+     * Skips both request and response validation for the next HTTP call only.
+     * The flag self-resets after one auto-assert attempt, so subsequent calls
+     * are validated as usual.
+     *
+     * Scoped to auto-assert only — explicit calls to
+     * assertResponseMatchesOpenApiSchema() still run, matching the convention
+     * already established by #[SkipOpenApi].
+     */
+    public function withoutValidation(): static
+    {
+        $this->skipNextRequestValidation = true;
+        $this->skipNextResponseValidation = true;
+
+        return $this;
+    }
+
+    /**
+     * Skips request validation for the next HTTP call only. Currently a
+     * forward-looking hook: request validation itself lands in #43, and this
+     * method wires up the flag ahead of time so callers can already write the
+     * intended API surface.
+     */
+    public function withoutRequestValidation(): static
+    {
+        $this->skipNextRequestValidation = true;
+
+        return $this;
+    }
+
+    /** Skips response validation for the next HTTP call only. */
+    public function withoutResponseValidation(): static
+    {
+        $this->skipNextResponseValidation = true;
+
+        return $this;
     }
 
     /**
@@ -92,7 +138,19 @@ trait ValidatesOpenApiSchema
         ?HttpMethod $method = null,
         ?string $path = null,
     ): void {
+        // Consume per-request skip flags unconditionally, so they track the
+        // HTTP call boundary regardless of auto_assert state. Without this,
+        // a flag set before an auto_assert=false call would silently leak
+        // into the next call after auto_assert flips on.
+        $skipResponse = $this->skipNextResponseValidation;
+        $this->skipNextRequestValidation = false;
+        $this->skipNextResponseValidation = false;
+
         if (!$this->isAutoAssertEnabled()) {
+            return;
+        }
+
+        if ($skipResponse) {
             return;
         }
 

--- a/tests/Integration/Laravel/AutoAssertIntegrationTest.php
+++ b/tests/Integration/Laravel/AutoAssertIntegrationTest.php
@@ -194,6 +194,64 @@ class AutoAssertIntegrationTest extends TestCase
         $this->assertArrayNotHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
     }
 
+    #[Test]
+    public function without_validation_skips_next_http_call_only(): void
+    {
+        // Proves the fluent chain works through Laravel's actual HTTP helpers:
+        // withoutValidation() returns $this, then get() on the same instance
+        // sees the flag. The /v1/pets?bad=1 route returns a spec-violating
+        // body — auto-assert would otherwise fail.
+        config()->set('openapi-contract-testing.auto_assert', true);
+
+        $response = $this->withoutValidation()->get('/v1/pets?bad=1');
+        $response->assertOk();
+
+        // No coverage from the skipped call.
+        $this->assertArrayNotHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
+    }
+
+    #[Test]
+    public function without_validation_flag_resets_after_one_http_call(): void
+    {
+        // Core guarantee from issue #41. First call consumes the flag; the
+        // second identical call must re-validate and fail. Without proper
+        // reset, the second call would silently pass.
+        config()->set('openapi-contract-testing.auto_assert', true);
+
+        $this->withoutValidation()->get('/v1/pets?bad=1')->assertOk();
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('OpenAPI schema validation failed');
+
+        $this->get('/v1/pets?bad=1');
+    }
+
+    #[Test]
+    public function without_response_validation_skips_next_http_call(): void
+    {
+        config()->set('openapi-contract-testing.auto_assert', true);
+
+        $response = $this->withoutResponseValidation()->get('/v1/pets?bad=1');
+        $response->assertOk();
+
+        $this->assertArrayNotHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
+    }
+
+    #[Test]
+    public function without_request_validation_still_runs_response_auto_assert(): void
+    {
+        // withoutRequestValidation is a forward-looking hook — it must NOT
+        // suppress the response-side validation that already runs today. The
+        // /v1/pets?bad=1 body violates the spec, so auto-assert should still
+        // fail.
+        config()->set('openapi-contract-testing.auto_assert', true);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('OpenAPI schema validation failed');
+
+        $this->withoutRequestValidation()->get('/v1/pets?bad=1');
+    }
+
     /** @return array<int, class-string> */
     protected function getPackageProviders($app): array
     {

--- a/tests/Unit/ValidatesOpenApiSchemaWithoutValidationTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaWithoutValidationTest.php
@@ -13,6 +13,7 @@ use Studio\OpenApiContractTesting\HttpMethod;
 use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
 use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\SkipOpenApi;
 use Studio\OpenApiContractTesting\Tests\Helpers\CreatesTestResponse;
 
 use function json_encode;
@@ -158,6 +159,54 @@ class ValidatesOpenApiSchemaWithoutValidationTest extends TestCase
 
         $this->expectException(AssertionFailedError::class);
         $this->assertResponseMatchesOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+    }
+
+    #[Test]
+    public function explicit_assert_after_without_validation_skip_still_validates_and_records(): void
+    {
+        // The skip flag suppresses auto-assert (including markValidated), so
+        // a later explicit assertResponseMatchesOpenApiSchema() on the same
+        // TestResponse must run validation from scratch and record coverage.
+        // Without this, the WeakMap idempotency check could mistakenly swallow
+        // the explicit call if the auto-assert path had silently marked the
+        // response as validated despite skipping.
+        $body = (string) json_encode(
+            ['data' => [['id' => 1, 'name' => 'Fido', 'tag' => null]]],
+            JSON_THROW_ON_ERROR,
+        );
+        $response = $this->makeTestResponse($body, 200);
+
+        $this->withoutValidation();
+        $this->maybeAutoAssertOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+
+        // Coverage not recorded by the skip.
+        $this->assertArrayNotHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
+
+        // Explicit call runs validation and records coverage.
+        $this->assertResponseMatchesOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayHasKey('petstore-3.0', $covered);
+        $this->assertArrayHasKey('GET /v1/pets', $covered['petstore-3.0']);
+    }
+
+    #[Test]
+    #[SkipOpenApi]
+    public function without_validation_combined_with_skip_attribute_both_agree_to_skip(): void
+    {
+        // Both the per-request flag and the class/method-level attribute
+        // express "skip this". The flag is consumed before the attribute
+        // check, so the attribute branch is never exercised — but the
+        // observable result (no validation, no coverage) is identical. This
+        // pins the ordering invariant: combining the two switches must not
+        // produce divergent or surprising behavior.
+        $body = (string) json_encode(['wrong_key' => 'value'], JSON_THROW_ON_ERROR);
+        $response = $this->makeTestResponse($body, 200);
+
+        $this->withoutValidation();
+        $this->maybeAutoAssertOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+
+        $this->assertArrayNotHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
     }
 
     #[Test]

--- a/tests/Unit/ValidatesOpenApiSchemaWithoutValidationTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaWithoutValidationTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use const JSON_THROW_ON_ERROR;
+
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\HttpMethod;
+use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
+use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\Tests\Helpers\CreatesTestResponse;
+
+use function json_encode;
+
+// Load namespace-level config() mock before the trait resolves the function call.
+require_once __DIR__ . '/../Helpers/LaravelConfigMock.php';
+
+/**
+ * Covers the per-request skip API from issue #41:
+ * `withoutValidation()`, `withoutRequestValidation()`, `withoutResponseValidation()`.
+ *
+ * The flag is consumed on the next auto-assert attempt (simulated here by a
+ * direct call to maybeAutoAssertOpenApiSchema, which is what createTestResponse
+ * delegates to). End-to-end integration through Laravel's HTTP helpers lives
+ * in AutoAssertIntegrationTest.
+ */
+class ValidatesOpenApiSchemaWithoutValidationTest extends TestCase
+{
+    use CreatesTestResponse;
+    use ValidatesOpenApiSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs');
+        OpenApiCoverageTracker::reset();
+        $GLOBALS['__openapi_testing_config'] = [
+            'openapi-contract-testing.default_spec' => 'petstore-3.0',
+            'openapi-contract-testing.auto_assert' => true,
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        self::resetValidatorCache();
+        unset($GLOBALS['__openapi_testing_config']);
+        OpenApiSpecLoader::reset();
+        OpenApiCoverageTracker::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function without_validation_skips_next_auto_assert(): void
+    {
+        // Body intentionally violates the spec. If the flag is not honored,
+        // maybeAutoAssertOpenApiSchema would raise AssertionFailedError.
+        $body = (string) json_encode(['wrong_key' => 'value'], JSON_THROW_ON_ERROR);
+        $response = $this->makeTestResponse($body, 200);
+
+        $this->withoutValidation();
+        $this->maybeAutoAssertOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+
+        // Flag skipped validation AND coverage recording — matching how
+        // #[SkipOpenApi] behaves, so per-request opt-out is consistent with
+        // the attribute-level opt-out.
+        $this->assertArrayNotHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
+    }
+
+    #[Test]
+    public function without_response_validation_skips_next_auto_assert(): void
+    {
+        $body = (string) json_encode(['wrong_key' => 'value'], JSON_THROW_ON_ERROR);
+        $response = $this->makeTestResponse($body, 200);
+
+        $this->withoutResponseValidation();
+        $this->maybeAutoAssertOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+
+        $this->assertArrayNotHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
+    }
+
+    #[Test]
+    public function without_request_validation_does_not_skip_response_auto_assert(): void
+    {
+        // withoutRequestValidation is a forward-looking hook — it wires up the
+        // flag consumption path so #43's request-side validator can read it,
+        // but must NOT suppress the response-side auto-assert that already
+        // exists today.
+        $body = (string) json_encode(
+            ['data' => [['id' => 1, 'name' => 'Fido', 'tag' => null]]],
+            JSON_THROW_ON_ERROR,
+        );
+        $response = $this->makeTestResponse($body, 200);
+
+        $this->withoutRequestValidation();
+        $this->maybeAutoAssertOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+
+        // Response auto-assert ran → coverage recorded.
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayHasKey('petstore-3.0', $covered);
+        $this->assertArrayHasKey('GET /v1/pets', $covered['petstore-3.0']);
+    }
+
+    #[Test]
+    public function without_validation_resets_after_one_call(): void
+    {
+        // Core guarantee from issue #41: the flag covers exactly the next
+        // HTTP call, then resets. A second call with an invalid body must
+        // fail — proving the flag did NOT persist.
+        $validBody = (string) json_encode(
+            ['data' => [['id' => 1, 'name' => 'Fido', 'tag' => null]]],
+            JSON_THROW_ON_ERROR,
+        );
+        $invalidBody = (string) json_encode(['wrong_key' => 'value'], JSON_THROW_ON_ERROR);
+
+        $this->withoutValidation();
+        $this->maybeAutoAssertOpenApiSchema(
+            $this->makeTestResponse($validBody, 200),
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+
+        // Flag is now consumed — second call re-validates.
+        $this->expectException(AssertionFailedError::class);
+        $this->maybeAutoAssertOpenApiSchema(
+            $this->makeTestResponse($invalidBody, 200),
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+    }
+
+    #[Test]
+    public function without_validation_returns_self_for_fluent_chain(): void
+    {
+        // Lets tests write `$this->withoutValidation()->get('/v1/pets')` — the
+        // primary ergonomic reason for having these methods at all.
+        $this->assertSame($this, $this->withoutValidation());
+        $this->assertSame($this, $this->withoutRequestValidation());
+        $this->assertSame($this, $this->withoutResponseValidation());
+    }
+
+    #[Test]
+    public function without_validation_does_not_affect_explicit_assert(): void
+    {
+        // Explicit assertResponseMatchesOpenApiSchema() is the user's direct
+        // intent. It must run regardless of the skip flag — matching
+        // #[SkipOpenApi]'s convention. The flag is consumed only on the
+        // HTTP-call boundary (maybeAutoAssertOpenApiSchema).
+        $body = (string) json_encode(['wrong_key' => 'value'], JSON_THROW_ON_ERROR);
+        $response = $this->makeTestResponse($body, 200);
+
+        $this->withoutValidation();
+
+        $this->expectException(AssertionFailedError::class);
+        $this->assertResponseMatchesOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+    }
+
+    #[Test]
+    public function without_validation_consumes_flag_even_when_auto_assert_disabled(): void
+    {
+        // If the flag leaked past an auto_assert=false HTTP call, toggling
+        // auto_assert on mid-test would silently skip the wrong request.
+        // Consumption must happen at the boundary regardless of config state.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_assert'] = false;
+
+        $this->withoutValidation();
+        $this->maybeAutoAssertOpenApiSchema(
+            $this->makeTestResponse('', 200),
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+
+        // Now enable auto-assert and send an invalid body — must throw,
+        // proving the flag was already consumed by the previous call.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_assert'] = true;
+        $invalidBody = (string) json_encode(['wrong_key' => 'value'], JSON_THROW_ON_ERROR);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->maybeAutoAssertOpenApiSchema(
+            $this->makeTestResponse($invalidBody, 200),
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+    }
+}


### PR DESCRIPTION
# 概要

auto-assert を有効にしたまま「この 1 リクエストだけスキップしたい」ケースに応える per-request skip API を Laravel trait に追加します。既存の `#[SkipOpenApi]`（メソッド/クラス単位の永続スキップ）と棲み分け、段階的移行などの過渡期ユースケースを fluent チェインでカバーします。

## 変更内容

`ValidatesOpenApiSchema` trait に 3 つの fluent メソッドを追加し、次の 1 HTTP 呼び出しだけ auto-assert をスキップする挙動を実装しました。

- `withoutValidation(): static` — リクエスト/レスポンス両方をスキップ
- `withoutResponseValidation(): static` — レスポンスのみスキップ
- `withoutRequestValidation(): static` — リクエストのみスキップ（#43 の request validation 実装までは no-op、将来の API 面を先行して固定）
- フラグは instance プロパティで管理し、`maybeAutoAssertOpenApiSchema()` の先頭で auto_assert の状態に関わらず必ず consume。これにより config が mid-test で切り替わった場合でもフラグが次の呼び出しへリークしないことを保証
- スコープは auto-assert のみ。明示的な `assertResponseMatchesOpenApiSchema()` は常に実行される（`#[SkipOpenApi]` と一貫した挙動）
- Unit 7 ケース（各スコープ / リセット / self 返却 / explicit call 非影響 / auto_assert 無効時の consume）と Integration 4 ケース（Testbench 経由の `\$this->withoutValidation()->get()` チェイン）を追加
- README に "Per-request skip with \`withoutValidation()\`" セクションを追記し、`#[SkipOpenApi]` との使い分け、リセット挙動、forward-looking な `withoutRequestValidation()` の位置付けを明記

### 検証

- `vendor/bin/phpunit`: 232 tests / 488 assertions すべて pass
- `vendor/bin/phpstan analyse` (level 6): 0 errors
- `vendor/bin/php-cs-fixer fix --dry-run`: 0 issues

## 関連情報

- Closes #41
- Blocked by #39 (auto-assert / closed & merged)
- Forward-compat hook for #43 (request validation)