### PR TITLE
feat: add OpenApiRequestValidator skeleton with body validation

### DIFF
--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting;
+
+use const PHP_INT_MAX;
+
+use InvalidArgumentException;
+use Opis\JsonSchema\Errors\ErrorFormatter;
+use Opis\JsonSchema\Validator;
+use stdClass;
+
+use function array_is_list;
+use function array_keys;
+use function implode;
+use function is_array;
+use function sprintf;
+use function str_ends_with;
+use function strstr;
+use function strtolower;
+use function trim;
+
+final class OpenApiRequestValidator
+{
+    /** @var array<string, OpenApiPathMatcher> */
+    private array $pathMatchers = [];
+    private Validator $opisValidator;
+    private ErrorFormatter $errorFormatter;
+
+    public function __construct(
+        private readonly int $maxErrors = 20,
+    ) {
+        if ($this->maxErrors < 0) {
+            throw new InvalidArgumentException(
+                sprintf('maxErrors must be 0 (unlimited) or a positive integer, got %d.', $this->maxErrors),
+            );
+        }
+
+        $resolvedMaxErrors = $this->maxErrors === 0 ? PHP_INT_MAX : $this->maxErrors;
+        $this->opisValidator = new Validator(
+            max_errors: $resolvedMaxErrors,
+            stop_at_first_error: $resolvedMaxErrors === 1,
+        );
+        $this->errorFormatter = new ErrorFormatter();
+    }
+
+    /**
+     * Validate a request body against the OpenAPI spec's requestBody schema.
+     *
+     * @param array<string, mixed> $queryParams reserved for future use; ignored in this skeleton
+     * @param array<string, mixed> $headers reserved for future use; ignored in this skeleton
+     */
+    public function validate(
+        string $specName,
+        string $method,
+        string $requestPath,
+        array $queryParams,
+        array $headers,
+        mixed $requestBody,
+        ?string $contentType = null,
+    ): OpenApiValidationResult {
+        $spec = OpenApiSpecLoader::load($specName);
+
+        $version = OpenApiVersion::fromSpec($spec);
+
+        /** @var string[] $specPaths */
+        $specPaths = array_keys($spec['paths'] ?? []);
+        $matcher = $this->getPathMatcher($specName, $specPaths);
+        $matchedPath = $matcher->match($requestPath);
+
+        if ($matchedPath === null) {
+            return OpenApiValidationResult::failure([
+                "No matching path found in '{$specName}' spec for: {$requestPath}",
+            ]);
+        }
+
+        $lowerMethod = strtolower($method);
+        $pathSpec = $spec['paths'][$matchedPath] ?? [];
+
+        if (!isset($pathSpec[$lowerMethod])) {
+            return OpenApiValidationResult::failure([
+                "Method {$method} not defined for path {$matchedPath} in '{$specName}' spec.",
+            ], $matchedPath);
+        }
+
+        $operation = $pathSpec[$lowerMethod];
+
+        // Operations without a requestBody entry do not require a body (per AC of issue #42).
+        if (!isset($operation['requestBody']) || !is_array($operation['requestBody'])) {
+            return OpenApiValidationResult::success($matchedPath);
+        }
+
+        /** @var array<string, mixed> $requestBodySpec */
+        $requestBodySpec = $operation['requestBody'];
+        $required = ($requestBodySpec['required'] ?? false) === true;
+
+        if (!isset($requestBodySpec['content']) || !is_array($requestBodySpec['content'])) {
+            return OpenApiValidationResult::success($matchedPath);
+        }
+
+        /** @var array<string, array<string, mixed>> $content */
+        $content = $requestBodySpec['content'];
+
+        // When the actual request Content-Type is provided, handle content negotiation:
+        // non-JSON types are checked for spec presence only, while JSON-compatible types
+        // fall through to schema validation against the first JSON media type in the spec.
+        if ($contentType !== null) {
+            $normalizedType = $this->normalizeMediaType($contentType);
+
+            if (!$this->isJsonContentType($normalizedType)) {
+                if ($this->isContentTypeInSpec($normalizedType, $content)) {
+                    return OpenApiValidationResult::success($matchedPath);
+                }
+
+                $defined = implode(', ', array_keys($content));
+
+                return OpenApiValidationResult::failure([
+                    "Request Content-Type '{$normalizedType}' is not defined for {$method} {$matchedPath} in '{$specName}' spec. Defined content types: {$defined}",
+                ], $matchedPath);
+            }
+        }
+
+        $jsonContentType = $this->findJsonContentType($content);
+
+        // If no JSON-compatible content type is defined, skip body validation.
+        // This validator only handles JSON schemas; non-JSON types (e.g. text/plain,
+        // application/xml) are outside its scope.
+        if ($jsonContentType === null) {
+            return OpenApiValidationResult::success($matchedPath);
+        }
+
+        if (!isset($content[$jsonContentType]['schema'])) {
+            return OpenApiValidationResult::success($matchedPath);
+        }
+
+        if ($requestBody === null) {
+            if (!$required) {
+                return OpenApiValidationResult::success($matchedPath);
+            }
+
+            return OpenApiValidationResult::failure([
+                "Request body is empty but {$method} {$matchedPath} defines a required JSON request body schema in '{$specName}' spec.",
+            ], $matchedPath);
+        }
+
+        /** @var array<string, mixed> $schema */
+        $schema = $content[$jsonContentType]['schema'];
+        $jsonSchema = OpenApiSchemaConverter::convert($schema, $version);
+
+        $schemaObject = self::toObject($jsonSchema);
+        $dataObject = self::toObject($requestBody);
+
+        $result = $this->opisValidator->validate($dataObject, $schemaObject);
+
+        if ($result->isValid()) {
+            return OpenApiValidationResult::success($matchedPath);
+        }
+
+        $formattedErrors = $this->errorFormatter->format($result->error());
+
+        $errors = [];
+        foreach ($formattedErrors as $path => $messages) {
+            foreach ($messages as $message) {
+                $errors[] = "[{$path}] {$message}";
+            }
+        }
+
+        return OpenApiValidationResult::failure($errors, $matchedPath);
+    }
+
+    /**
+     * Recursively convert PHP arrays to stdClass objects, matching the
+     * behaviour of json_decode(json_encode($data)) without the intermediate
+     * JSON string allocation.
+     */
+    private static function toObject(mixed $value): mixed
+    {
+        if (!is_array($value)) {
+            return $value;
+        }
+
+        if ($value === [] || array_is_list($value)) {
+            /** @var list<mixed> $value */
+            foreach ($value as $i => $item) {
+                $value[$i] = self::toObject($item);
+            }
+
+            return $value;
+        }
+
+        $object = new stdClass();
+        foreach ($value as $key => $item) {
+            $object->{$key} = self::toObject($item);
+        }
+
+        return $object;
+    }
+
+    /**
+     * @param string[] $specPaths
+     */
+    private function getPathMatcher(string $specName, array $specPaths): OpenApiPathMatcher
+    {
+        return $this->pathMatchers[$specName] ??= new OpenApiPathMatcher($specPaths, OpenApiSpecLoader::getStripPrefixes());
+    }
+
+    /**
+     * Find the first JSON-compatible content type from the request body spec.
+     *
+     * Matches "application/json" exactly and any type with a "+json" structured
+     * syntax suffix (RFC 6838), such as "application/problem+json" and
+     * "application/vnd.api+json". Matching is case-insensitive.
+     *
+     * @param array<string, array<string, mixed>> $content
+     */
+    private function findJsonContentType(array $content): ?string
+    {
+        foreach ($content as $contentType => $mediaType) {
+            $lower = strtolower($contentType);
+
+            if ($this->isJsonContentType($lower)) {
+                return $contentType;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Extract the media type portion before any parameters (e.g. charset),
+     * and return it lower-cased.
+     *
+     * Example: "text/html; charset=utf-8" → "text/html"
+     */
+    private function normalizeMediaType(string $contentType): string
+    {
+        $mediaType = strstr($contentType, ';', true);
+
+        return strtolower(trim($mediaType !== false ? $mediaType : $contentType));
+    }
+
+    /**
+     * Check whether the given (already normalised, lower-cased) request content
+     * type matches any content type key defined in the spec. Spec keys are
+     * lower-cased before comparison.
+     *
+     * @param array<string, array<string, mixed>> $content
+     */
+    private function isContentTypeInSpec(string $requestContentType, array $content): bool
+    {
+        foreach ($content as $specContentType => $mediaType) {
+            if (strtolower($specContentType) === $requestContentType) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * True for "application/json" or any "+json" structured syntax suffix (RFC 6838).
+     * Expects a lower-cased media type without parameters.
+     */
+    private function isJsonContentType(string $lowerContentType): bool
+    {
+        return $lowerContentType === 'application/json' || str_ends_with($lowerContentType, '+json');
+    }
+}

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -86,17 +86,31 @@ final class OpenApiRequestValidator
 
         $operation = $pathSpec[$lowerMethod];
 
-        // Operations without a requestBody entry do not require a body (per AC of issue #42).
-        if (!isset($operation['requestBody']) || !is_array($operation['requestBody'])) {
+        // OpenAPI: a missing requestBody means the operation accepts no body — treat as success.
+        if (!isset($operation['requestBody'])) {
             return OpenApiValidationResult::success($matchedPath);
+        }
+
+        // A present-but-non-array requestBody signals a malformed spec (e.g. unresolved $ref,
+        // stray scalar). Contract-testing tools should surface this, not mask it as "no body".
+        if (!is_array($operation['requestBody'])) {
+            return OpenApiValidationResult::failure([
+                "Malformed 'requestBody' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar. Likely an unresolved \$ref or broken spec.",
+            ], $matchedPath);
         }
 
         /** @var array<string, mixed> $requestBodySpec */
         $requestBodySpec = $operation['requestBody'];
         $required = ($requestBodySpec['required'] ?? false) === true;
 
-        if (!isset($requestBodySpec['content']) || !is_array($requestBodySpec['content'])) {
+        if (!isset($requestBodySpec['content'])) {
             return OpenApiValidationResult::success($matchedPath);
+        }
+
+        if (!is_array($requestBodySpec['content'])) {
+            return OpenApiValidationResult::failure([
+                "Malformed 'requestBody.content' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar. Likely an unresolved \$ref or broken spec.",
+            ], $matchedPath);
         }
 
         /** @var array<string, array<string, mixed>> $content */
@@ -119,13 +133,18 @@ final class OpenApiRequestValidator
                     "Request Content-Type '{$normalizedType}' is not defined for {$method} {$matchedPath} in '{$specName}' spec. Defined content types: {$defined}",
                 ], $matchedPath);
             }
+
+            // JSON-compatible request: fall through to existing JSON schema validation.
+            // JSON types are treated as interchangeable (e.g. application/vnd.api+json
+            // validates against an application/json spec entry) because the schema is
+            // the same regardless of the specific JSON media type.
         }
 
         $jsonContentType = $this->findJsonContentType($content);
 
         // If no JSON-compatible content type is defined, skip body validation.
-        // This validator only handles JSON schemas; non-JSON types (e.g. text/plain,
-        // application/xml) are outside its scope.
+        // This validator only handles JSON schemas; non-JSON types (e.g. application/xml,
+        // application/octet-stream) are outside its scope.
         if ($jsonContentType === null) {
             return OpenApiValidationResult::success($matchedPath);
         }

--- a/tests/Integration/ResponseValidationTest.php
+++ b/tests/Integration/ResponseValidationTest.php
@@ -64,7 +64,7 @@ class ResponseValidationTest extends TestCase
 
         // Check coverage
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
-        $this->assertSame(6, $coverage['total']);
+        $this->assertSame(7, $coverage['total']);
         $this->assertSame(2, $coverage['coveredCount']);
         $this->assertContains('GET /v1/pets', $coverage['covered']);
         $this->assertContains('POST /v1/pets', $coverage['covered']);
@@ -72,6 +72,7 @@ class ResponseValidationTest extends TestCase
         $this->assertContains('GET /v1/logout', $coverage['uncovered']);
         $this->assertContains('DELETE /v1/pets/{petId}', $coverage['uncovered']);
         $this->assertContains('GET /v1/pets/{petId}', $coverage['uncovered']);
+        $this->assertContains('PATCH /v1/pets/{petId}', $coverage['uncovered']);
     }
 
     #[Test]
@@ -91,7 +92,7 @@ class ResponseValidationTest extends TestCase
         }
 
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.1');
-        $this->assertSame(4, $coverage['total']);
+        $this->assertSame(5, $coverage['total']);
         $this->assertSame(1, $coverage['coveredCount']);
     }
 

--- a/tests/Integration/ResponseValidationTest.php
+++ b/tests/Integration/ResponseValidationTest.php
@@ -64,7 +64,7 @@ class ResponseValidationTest extends TestCase
 
         // Check coverage
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
-        $this->assertSame(7, $coverage['total']);
+        $this->assertSame(8, $coverage['total']);
         $this->assertSame(2, $coverage['coveredCount']);
         $this->assertContains('GET /v1/pets', $coverage['covered']);
         $this->assertContains('POST /v1/pets', $coverage['covered']);
@@ -73,6 +73,7 @@ class ResponseValidationTest extends TestCase
         $this->assertContains('DELETE /v1/pets/{petId}', $coverage['uncovered']);
         $this->assertContains('GET /v1/pets/{petId}', $coverage['uncovered']);
         $this->assertContains('PATCH /v1/pets/{petId}', $coverage['uncovered']);
+        $this->assertContains('PUT /v1/pets/{petId}', $coverage['uncovered']);
     }
 
     #[Test]
@@ -92,7 +93,7 @@ class ResponseValidationTest extends TestCase
         }
 
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.1');
-        $this->assertSame(5, $coverage['total']);
+        $this->assertSame(6, $coverage['total']);
         $this->assertSame(1, $coverage['coveredCount']);
     }
 

--- a/tests/Unit/OpenApiCoverageTrackerTest.php
+++ b/tests/Unit/OpenApiCoverageTrackerTest.php
@@ -67,10 +67,10 @@ class OpenApiCoverageTrackerTest extends TestCase
         $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
 
         // See tests/fixtures/specs/petstore-3.0.json for the full endpoint list
-        $this->assertSame(7, $result['total']);
+        $this->assertSame(8, $result['total']);
         $this->assertSame(2, $result['coveredCount']);
         $this->assertCount(2, $result['covered']);
-        $this->assertCount(5, $result['uncovered']);
+        $this->assertCount(6, $result['uncovered']);
     }
 
     #[Test]
@@ -78,10 +78,10 @@ class OpenApiCoverageTrackerTest extends TestCase
     {
         $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
 
-        $this->assertSame(7, $result['total']);
+        $this->assertSame(8, $result['total']);
         $this->assertSame(0, $result['coveredCount']);
         $this->assertCount(0, $result['covered']);
-        $this->assertCount(7, $result['uncovered']);
+        $this->assertCount(8, $result['uncovered']);
     }
 
     #[Test]

--- a/tests/Unit/OpenApiCoverageTrackerTest.php
+++ b/tests/Unit/OpenApiCoverageTrackerTest.php
@@ -67,10 +67,10 @@ class OpenApiCoverageTrackerTest extends TestCase
         $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
 
         // See tests/fixtures/specs/petstore-3.0.json for the full endpoint list
-        $this->assertSame(6, $result['total']);
+        $this->assertSame(7, $result['total']);
         $this->assertSame(2, $result['coveredCount']);
         $this->assertCount(2, $result['covered']);
-        $this->assertCount(4, $result['uncovered']);
+        $this->assertCount(5, $result['uncovered']);
     }
 
     #[Test]
@@ -78,10 +78,10 @@ class OpenApiCoverageTrackerTest extends TestCase
     {
         $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
 
-        $this->assertSame(6, $result['total']);
+        $this->assertSame(7, $result['total']);
         $this->assertSame(0, $result['coveredCount']);
         $this->assertCount(0, $result['covered']);
-        $this->assertCount(6, $result['uncovered']);
+        $this->assertCount(7, $result['uncovered']);
     }
 
     #[Test]

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -173,6 +173,7 @@ class OpenApiRequestValidatorTest extends TestCase
         );
 
         $this->assertTrue($result->isValid());
+        $this->assertSame('/v1/pets/{petId}', $result->matchedPath());
     }
 
     #[Test]
@@ -189,6 +190,9 @@ class OpenApiRequestValidatorTest extends TestCase
         );
 
         $this->assertFalse($result->isValid());
+        $this->assertNotEmpty($result->errors());
+        // Must reach schema validation, not short-circuit via the required-but-empty branch.
+        $this->assertStringNotContainsString('Request body is empty', $result->errorMessage());
     }
 
     // ========================================
@@ -198,6 +202,24 @@ class OpenApiRequestValidatorTest extends TestCase
     #[Test]
     public function v30_non_json_content_type_with_spec_match_succeeds(): void
     {
+        // Body intentionally violates the JSON pet schema (integer, not an object with "name").
+        // If the non-JSON short-circuit ever regresses into schema validation this will fail.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            [],
+            [],
+            12345,
+            'text/plain',
+        );
+
+        $this->assertTrue($result->isValid());
+    }
+
+    #[Test]
+    public function v30_non_json_content_type_spec_match_is_case_insensitive(): void
+    {
         $result = $this->validator->validate(
             'petstore-3.0',
             'POST',
@@ -205,7 +227,7 @@ class OpenApiRequestValidatorTest extends TestCase
             [],
             [],
             'raw pet body',
-            'text/plain',
+            'TEXT/PLAIN',
         );
 
         $this->assertTrue($result->isValid());
@@ -296,6 +318,67 @@ class OpenApiRequestValidatorTest extends TestCase
         );
 
         $this->assertFalse($result->isValid());
+        $this->assertNotEmpty($result->errors());
+    }
+
+    // ========================================
+    // Schema-less JSON content type
+    // ========================================
+
+    #[Test]
+    public function v30_json_content_type_without_schema_skips_validation(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'PUT',
+            '/v1/pets/123',
+            [],
+            [],
+            ['anything' => 'goes'],
+            'application/json',
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertSame('/v1/pets/{petId}', $result->matchedPath());
+    }
+
+    // ========================================
+    // Malformed spec guards
+    // ========================================
+
+    #[Test]
+    public function malformed_request_body_returns_failure(): void
+    {
+        $result = $this->validator->validate(
+            'malformed',
+            'POST',
+            '/scalar-request-body',
+            [],
+            [],
+            ['foo' => 'bar'],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString("Malformed 'requestBody'", $result->errors()[0]);
+        $this->assertStringContainsString('unresolved $ref or broken spec', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function malformed_content_returns_failure(): void
+    {
+        $result = $this->validator->validate(
+            'malformed',
+            'POST',
+            '/scalar-content',
+            [],
+            [],
+            ['foo' => 'bar'],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString("Malformed 'requestBody.content'", $result->errors()[0]);
     }
 
     // ========================================
@@ -309,6 +392,24 @@ class OpenApiRequestValidatorTest extends TestCase
         $this->expectExceptionMessage('maxErrors must be 0 (unlimited) or a positive integer, got -1.');
 
         new OpenApiRequestValidator(maxErrors: -1);
+    }
+
+    #[Test]
+    public function max_errors_one_limits_to_single_error(): void
+    {
+        $validator = new OpenApiRequestValidator(maxErrors: 1);
+        $result = $validator->validate(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            [],
+            [],
+            ['name' => 123, 'tag' => 456],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertCount(1, $result->errors());
     }
 
     // ========================================

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -1,0 +1,337 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\OpenApiRequestValidator;
+use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+
+class OpenApiRequestValidatorTest extends TestCase
+{
+    private OpenApiRequestValidator $validator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs');
+        $this->validator = new OpenApiRequestValidator();
+    }
+
+    protected function tearDown(): void
+    {
+        OpenApiSpecLoader::reset();
+        parent::tearDown();
+    }
+
+    // ========================================
+    // Acceptance criteria: valid / invalid / spec 未定義
+    // ========================================
+
+    #[Test]
+    public function v30_valid_request_body_passes(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            [],
+            [],
+            ['name' => 'Fido', 'tag' => 'dog'],
+            'application/json',
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertSame('/v1/pets', $result->matchedPath());
+    }
+
+    #[Test]
+    public function v30_invalid_request_body_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            [],
+            [],
+            ['tag' => 'dog'],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertNotEmpty($result->errors());
+    }
+
+    #[Test]
+    public function v30_no_request_body_spec_passes(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertSame('/v1/pets', $result->matchedPath());
+    }
+
+    // ========================================
+    // Path / method resolution failures
+    // ========================================
+
+    #[Test]
+    public function unknown_path_returns_failure(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'POST',
+            '/v1/unknown',
+            [],
+            [],
+            ['name' => 'Fido'],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('No matching path found', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function undefined_method_returns_failure(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'PUT',
+            '/v1/pets',
+            [],
+            [],
+            ['name' => 'Fido'],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('Method PUT not defined', $result->errors()[0]);
+    }
+
+    // ========================================
+    // Empty body behaviour (required vs optional)
+    // ========================================
+
+    #[Test]
+    public function v30_empty_body_when_required_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            [],
+            [],
+            null,
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('Request body is empty', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function v30_empty_body_when_not_required_passes(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'PATCH',
+            '/v1/pets/123',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertSame('/v1/pets/{petId}', $result->matchedPath());
+    }
+
+    #[Test]
+    public function v30_valid_body_when_not_required_passes(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'PATCH',
+            '/v1/pets/123',
+            [],
+            [],
+            ['name' => 'Rex'],
+            'application/json',
+        );
+
+        $this->assertTrue($result->isValid());
+    }
+
+    #[Test]
+    public function v30_invalid_body_when_not_required_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'PATCH',
+            '/v1/pets/123',
+            [],
+            [],
+            ['name' => 123],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+    }
+
+    // ========================================
+    // Content negotiation
+    // ========================================
+
+    #[Test]
+    public function v30_non_json_content_type_with_spec_match_succeeds(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            [],
+            [],
+            'raw pet body',
+            'text/plain',
+        );
+
+        $this->assertTrue($result->isValid());
+    }
+
+    #[Test]
+    public function v30_content_type_not_in_spec_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            [],
+            [],
+            'id,name',
+            'text/csv',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString("Request Content-Type 'text/csv' is not defined for", $result->errors()[0]);
+        $this->assertStringContainsString('application/json', $result->errors()[0]);
+        $this->assertStringContainsString('text/plain', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function v30_vendor_json_content_type_validates_schema(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            [],
+            [],
+            ['name' => 'Fido'],
+            'application/vnd.api+json',
+        );
+
+        $this->assertTrue($result->isValid());
+    }
+
+    #[Test]
+    public function v30_json_content_type_with_charset_validates_schema(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            [],
+            [],
+            ['name' => 'Fido'],
+            'application/json; charset=utf-8',
+        );
+
+        $this->assertTrue($result->isValid());
+    }
+
+    // ========================================
+    // OAS 3.1
+    // ========================================
+
+    #[Test]
+    public function v31_valid_request_body_passes(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.1',
+            'POST',
+            '/v1/pets',
+            [],
+            [],
+            ['name' => 'Fido', 'tag' => null],
+            'application/json',
+        );
+
+        $this->assertTrue($result->isValid());
+    }
+
+    #[Test]
+    public function v31_invalid_request_body_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.1',
+            'POST',
+            '/v1/pets',
+            [],
+            [],
+            ['tag' => 'dog'],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+    }
+
+    // ========================================
+    // Constructor validation (mirrors response validator)
+    // ========================================
+
+    #[Test]
+    public function negative_max_errors_throws_exception(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('maxErrors must be 0 (unlimited) or a positive integer, got -1.');
+
+        new OpenApiRequestValidator(maxErrors: -1);
+    }
+
+    // ========================================
+    // Strip prefix (reuses OpenApiPathMatcher behaviour)
+    // ========================================
+
+    #[Test]
+    public function v30_strip_prefixes_applied(): void
+    {
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs', ['/api']);
+
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'POST',
+            '/api/v1/pets',
+            [],
+            [],
+            ['name' => 'Fido'],
+            'application/json',
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertSame('/v1/pets', $result->matchedPath());
+    }
+}

--- a/tests/fixtures/specs/malformed.json
+++ b/tests/fixtures/specs/malformed.json
@@ -1,0 +1,36 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Malformed specs for negative tests",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/scalar-request-body": {
+            "post": {
+                "summary": "requestBody is a scalar (e.g. unresolved $ref)",
+                "operationId": "scalarRequestBody",
+                "requestBody": "this should have been an object",
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
+        "/scalar-content": {
+            "post": {
+                "summary": "requestBody.content is a scalar",
+                "operationId": "scalarContent",
+                "requestBody": {
+                    "required": true,
+                    "content": "this should have been an object"
+                },
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/fixtures/specs/petstore-3.0.json
+++ b/tests/fixtures/specs/petstore-3.0.json
@@ -100,6 +100,31 @@
             "post": {
                 "summary": "Create a pet",
                 "operationId": "createPet",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": ["name"],
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "tag": {
+                                        "type": "string",
+                                        "nullable": true
+                                    }
+                                }
+                            }
+                        },
+                        "text/plain": {
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
                 "responses": {
                     "201": {
                         "description": "Pet created",
@@ -273,6 +298,34 @@
                 "responses": {
                     "204": {
                         "description": "Pet deleted"
+                    }
+                }
+            },
+            "patch": {
+                "summary": "Update a pet",
+                "operationId": "updatePet",
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "tag": {
+                                        "type": "string",
+                                        "nullable": true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "Pet updated"
                     }
                 }
             }

--- a/tests/fixtures/specs/petstore-3.0.json
+++ b/tests/fixtures/specs/petstore-3.0.json
@@ -328,6 +328,21 @@
                         "description": "Pet updated"
                     }
                 }
+            },
+            "put": {
+                "summary": "Replace a pet (schema-less JSON body)",
+                "operationId": "replacePet",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {}
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "Pet replaced"
+                    }
+                }
             }
         }
     }

--- a/tests/fixtures/specs/petstore-3.1.json
+++ b/tests/fixtures/specs/petstore-3.1.json
@@ -71,6 +71,30 @@
             "post": {
                 "summary": "Create a pet",
                 "operationId": "createPet",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": ["name"],
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "tag": {
+                                        "type": ["string", "null"]
+                                    }
+                                }
+                            }
+                        },
+                        "text/plain": {
+                            "schema": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
                 "responses": {
                     "201": {
                         "description": "Pet created",
@@ -195,6 +219,33 @@
                 "responses": {
                     "204": {
                         "description": "Pet deleted"
+                    }
+                }
+            },
+            "patch": {
+                "summary": "Update a pet",
+                "operationId": "updatePet",
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "tag": {
+                                        "type": ["string", "null"]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "Pet updated"
                     }
                 }
             }

--- a/tests/fixtures/specs/petstore-3.1.json
+++ b/tests/fixtures/specs/petstore-3.1.json
@@ -248,6 +248,21 @@
                         "description": "Pet updated"
                     }
                 }
+            },
+            "put": {
+                "summary": "Replace a pet (schema-less JSON body)",
+                "operationId": "replacePet",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {}
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "Pet replaced"
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Adds `OpenApiRequestValidator` mirroring `OpenApiResponseValidator`, validating request bodies against `requestBody.content.{json}.schema` via `opis/json-schema` while reusing `OpenApiPathMatcher` and `OpenApiSchemaConverter`.
- Scope intentionally limited to JSON body validation per issue; `$queryParams` / `$headers` are accepted but unused (wired up in follow-up issues per the `request-validation` epic).
- Petstore fixtures gain a `requestBody` on `POST /v1/pets` (required) and a new `PATCH /v1/pets/{petId}` (required: false) to drive the new test cases.

## Behaviour highlights

- Operation without `requestBody` → `success` (per acceptance criterion).
- Respects `requestBody.required`: missing body is OK when not required, fails with a descriptive error when required.
- Content negotiation matches the response validator: non-JSON content types are checked for spec presence; `+json` suffixes validate against the JSON schema.
- Path / method resolution failures return the same message shapes as the response validator for consistency.

## Out of scope (future issues per the epic)

- Query / path / header / cookie / security validation.
- Laravel trait integration (#39 hook).
- Factoring out shared helpers between request & response validators — kept duplicated for now to avoid premature abstraction; revisit once a third consumer or #39 integration surfaces real pain.

## Test plan

- [x] `vendor/bin/phpunit tests/Unit/OpenApiRequestValidatorTest.php` — 17 new tests green
- [x] `vendor/bin/phpunit` — 251 / 251 green (fixture additions required coverage-count updates in `OpenApiCoverageTrackerTest` and `ResponseValidationTest`)
- [x] `vendor/bin/phpstan analyse` — clean
- [x] `vendor/bin/php-cs-fixer fix --dry-run --diff` — clean

## New test cases (overview)

- AC minimum: valid body / invalid body / no `requestBody` spec.
- Path / method failures (unknown path, undefined method).
- `required: true` + empty body → failure; `required: false` + empty body → success; invalid body on optional body → failure.
- Content negotiation: spec-matched non-JSON → success; unknown content type → failure listing defined types; `+json` suffix; `application/json; charset=utf-8`.
- OAS 3.1 variant (valid / invalid).
- Constructor validation (`maxErrors`), strip-prefix reuse.

Closes #42