### PR TITLE
feat(request-validator): validate query parameters against spec

### DIFF
--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -12,9 +12,15 @@ use Opis\JsonSchema\Validator;
 use stdClass;
 
 use function array_is_list;
+use function array_key_exists;
 use function array_keys;
+use function array_map;
+use function array_values;
 use function implode;
 use function is_array;
+use function is_numeric;
+use function is_string;
+use function preg_match;
 use function sprintf;
 use function str_ends_with;
 use function strstr;
@@ -46,10 +52,14 @@ final class OpenApiRequestValidator
     }
 
     /**
-     * Validate a request body against the OpenAPI spec's requestBody schema.
+     * Validate an incoming request against the OpenAPI spec.
      *
-     * @param array<string, mixed> $queryParams reserved for future use; ignored in this skeleton
-     * @param array<string, mixed> $headers reserved for future use; ignored in this skeleton
+     * Composes two validation phases — query parameters and request body — and
+     * returns a single result. Errors from both phases are accumulated so a
+     * single test run surfaces every contract drift the request exhibits.
+     *
+     * @param array<string, mixed> $queryParams parsed query string (string|array<string> per key)
+     * @param array<string, mixed> $headers reserved for future use; ignored in this phase
      */
     public function validate(
         string $specName,
@@ -76,6 +86,7 @@ final class OpenApiRequestValidator
         }
 
         $lowerMethod = strtolower($method);
+        /** @var array<string, mixed> $pathSpec */
         $pathSpec = $spec['paths'][$matchedPath] ?? [];
 
         if (!isset($pathSpec[$lowerMethod])) {
@@ -84,105 +95,24 @@ final class OpenApiRequestValidator
             ], $matchedPath);
         }
 
+        /** @var array<string, mixed> $operation */
         $operation = $pathSpec[$lowerMethod];
 
-        // OpenAPI: a missing requestBody means the operation accepts no body — treat as success.
-        if (!isset($operation['requestBody'])) {
+        $queryErrors = $this->validateQueryParameters($pathSpec, $operation, $queryParams, $version);
+        $bodyErrors = $this->validateRequestBody(
+            $specName,
+            $method,
+            $matchedPath,
+            $operation,
+            $requestBody,
+            $contentType,
+            $version,
+        );
+
+        $errors = [...$queryErrors, ...$bodyErrors];
+
+        if ($errors === []) {
             return OpenApiValidationResult::success($matchedPath);
-        }
-
-        // A present-but-non-array requestBody signals a malformed spec (e.g. unresolved $ref,
-        // stray scalar). Contract-testing tools should surface this, not mask it as "no body".
-        if (!is_array($operation['requestBody'])) {
-            return OpenApiValidationResult::failure([
-                "Malformed 'requestBody' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar. Likely an unresolved \$ref or broken spec.",
-            ], $matchedPath);
-        }
-
-        /** @var array<string, mixed> $requestBodySpec */
-        $requestBodySpec = $operation['requestBody'];
-        $required = ($requestBodySpec['required'] ?? false) === true;
-
-        if (!isset($requestBodySpec['content'])) {
-            return OpenApiValidationResult::success($matchedPath);
-        }
-
-        if (!is_array($requestBodySpec['content'])) {
-            return OpenApiValidationResult::failure([
-                "Malformed 'requestBody.content' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar. Likely an unresolved \$ref or broken spec.",
-            ], $matchedPath);
-        }
-
-        /** @var array<string, array<string, mixed>> $content */
-        $content = $requestBodySpec['content'];
-
-        // When the actual request Content-Type is provided, handle content negotiation:
-        // non-JSON types are checked for spec presence only, while JSON-compatible types
-        // fall through to schema validation against the first JSON media type in the spec.
-        if ($contentType !== null) {
-            $normalizedType = $this->normalizeMediaType($contentType);
-
-            if (!$this->isJsonContentType($normalizedType)) {
-                if ($this->isContentTypeInSpec($normalizedType, $content)) {
-                    return OpenApiValidationResult::success($matchedPath);
-                }
-
-                $defined = implode(', ', array_keys($content));
-
-                return OpenApiValidationResult::failure([
-                    "Request Content-Type '{$normalizedType}' is not defined for {$method} {$matchedPath} in '{$specName}' spec. Defined content types: {$defined}",
-                ], $matchedPath);
-            }
-
-            // JSON-compatible request: fall through to existing JSON schema validation.
-            // JSON types are treated as interchangeable (e.g. application/vnd.api+json
-            // validates against an application/json spec entry) because the schema is
-            // the same regardless of the specific JSON media type.
-        }
-
-        $jsonContentType = $this->findJsonContentType($content);
-
-        // If no JSON-compatible content type is defined, skip body validation.
-        // This validator only handles JSON schemas; non-JSON types (e.g. application/xml,
-        // application/octet-stream) are outside its scope.
-        if ($jsonContentType === null) {
-            return OpenApiValidationResult::success($matchedPath);
-        }
-
-        if (!isset($content[$jsonContentType]['schema'])) {
-            return OpenApiValidationResult::success($matchedPath);
-        }
-
-        if ($requestBody === null) {
-            if (!$required) {
-                return OpenApiValidationResult::success($matchedPath);
-            }
-
-            return OpenApiValidationResult::failure([
-                "Request body is empty but {$method} {$matchedPath} defines a required JSON request body schema in '{$specName}' spec.",
-            ], $matchedPath);
-        }
-
-        /** @var array<string, mixed> $schema */
-        $schema = $content[$jsonContentType]['schema'];
-        $jsonSchema = OpenApiSchemaConverter::convert($schema, $version);
-
-        $schemaObject = self::toObject($jsonSchema);
-        $dataObject = self::toObject($requestBody);
-
-        $result = $this->opisValidator->validate($dataObject, $schemaObject);
-
-        if ($result->isValid()) {
-            return OpenApiValidationResult::success($matchedPath);
-        }
-
-        $formattedErrors = $this->errorFormatter->format($result->error());
-
-        $errors = [];
-        foreach ($formattedErrors as $path => $messages) {
-            foreach ($messages as $message) {
-                $errors[] = "[{$path}] {$message}";
-            }
         }
 
         return OpenApiValidationResult::failure($errors, $matchedPath);
@@ -222,6 +152,280 @@ final class OpenApiRequestValidator
     private function getPathMatcher(string $specName, array $specPaths): OpenApiPathMatcher
     {
         return $this->pathMatchers[$specName] ??= new OpenApiPathMatcher($specPaths, OpenApiSpecLoader::getStripPrefixes());
+    }
+
+    /**
+     * Validate query parameters declared by the matched operation (or
+     * inherited from the path-level `parameters` block).
+     *
+     * Only `style: form` + `explode: true` (the OpenAPI default for `in: query`)
+     * is supported. Repeated keys (`?tags=a&tags=b`) are expected to arrive as
+     * PHP arrays from the framework. Other styles (`form`+`explode:false`,
+     * `pipeDelimited`, `spaceDelimited`) are out of scope.
+     *
+     * @param array<string, mixed> $pathSpec
+     * @param array<string, mixed> $operation
+     * @param array<string, mixed> $queryParams
+     *
+     * @return string[]
+     */
+    private function validateQueryParameters(
+        array $pathSpec,
+        array $operation,
+        array $queryParams,
+        OpenApiVersion $version,
+    ): array {
+        $parameters = $this->collectParameters($pathSpec, $operation);
+
+        $errors = [];
+        foreach ($parameters as $param) {
+            if (($param['in'] ?? null) !== 'query') {
+                continue;
+            }
+
+            /** @var string $name */
+            $name = $param['name'];
+
+            if (!isset($param['schema']) || !is_array($param['schema'])) {
+                // No schema → nothing to validate against; mirrors body behaviour.
+                continue;
+            }
+
+            /** @var array<string, mixed> $schema */
+            $schema = $param['schema'];
+            $required = ($param['required'] ?? false) === true;
+
+            $present = array_key_exists($name, $queryParams) && $queryParams[$name] !== null;
+            if (!$present) {
+                if ($required) {
+                    $errors[] = "[query.{$name}] required query parameter is missing.";
+                }
+
+                continue;
+            }
+
+            $coerced = $this->coerceQueryValue($queryParams[$name], $schema);
+            $jsonSchema = OpenApiSchemaConverter::convert($schema, $version);
+
+            $schemaObject = self::toObject($jsonSchema);
+            $dataObject = self::toObject($coerced);
+
+            $result = $this->opisValidator->validate($dataObject, $schemaObject);
+            if ($result->isValid()) {
+                continue;
+            }
+
+            $formatted = $this->errorFormatter->format($result->error());
+            foreach ($formatted as $path => $messages) {
+                foreach ($messages as $message) {
+                    $errors[] = "[query.{$name}{$path}] {$message}";
+                }
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Merge path-level and operation-level parameters. Operation-level entries
+     * override path-level ones with the same `name` + `in` (per OpenAPI spec).
+     * Malformed entries (missing or non-string `name`/`in`) are silently
+     * skipped — they cannot be uniquely identified for override matching.
+     *
+     * @param array<string, mixed> $pathSpec
+     * @param array<string, mixed> $operation
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function collectParameters(array $pathSpec, array $operation): array
+    {
+        $merged = [];
+
+        foreach ([$pathSpec['parameters'] ?? [], $operation['parameters'] ?? []] as $source) {
+            if (!is_array($source)) {
+                continue;
+            }
+
+            foreach ($source as $param) {
+                if (!is_array($param)) {
+                    continue;
+                }
+
+                if (!isset($param['in'], $param['name']) || !is_string($param['in']) || !is_string($param['name'])) {
+                    continue;
+                }
+
+                $key = $param['in'] . ':' . $param['name'];
+                $merged[$key] = $param;
+            }
+        }
+
+        return array_values($merged);
+    }
+
+    /**
+     * Conservatively coerce a query string value to the type declared by the
+     * schema. When the string is not a clean representation of the target
+     * type, the original value is returned unchanged so opis can surface a
+     * meaningful type error rather than silently passing.
+     *
+     * @param array<string, mixed> $schema
+     */
+    private function coerceQueryValue(mixed $value, array $schema): mixed
+    {
+        $type = $schema['type'] ?? null;
+
+        if ($type === 'array') {
+            if (!is_array($value)) {
+                $value = [$value];
+            }
+
+            $itemSchema = $schema['items'] ?? null;
+            if (is_array($itemSchema)) {
+                /** @var list<mixed> $value */
+                return array_map(fn(mixed $item): mixed => $this->coerceQueryValue($item, $itemSchema), $value);
+            }
+
+            return $value;
+        }
+
+        if (!is_string($value) || !is_string($type)) {
+            return $value;
+        }
+
+        return match ($type) {
+            'integer' => preg_match('/^-?\d+$/', $value) === 1 ? (int) $value : $value,
+            'number' => is_numeric($value) ? (float) $value : $value,
+            'boolean' => match (strtolower($value)) {
+                'true' => true,
+                'false' => false,
+                default => $value,
+            },
+            default => $value,
+        };
+    }
+
+    /**
+     * Validate the request body against the operation's `requestBody` schema.
+     *
+     * Returns an empty list when the body is acceptable (including when the
+     * spec defines no body, no content, no JSON content type, or no schema).
+     * Hard spec-level errors (malformed `requestBody` / `content`) are
+     * reported as standard error entries so they compose with query errors.
+     *
+     * @param array<string, mixed> $operation
+     *
+     * @return string[]
+     */
+    private function validateRequestBody(
+        string $specName,
+        string $method,
+        string $matchedPath,
+        array $operation,
+        mixed $requestBody,
+        ?string $contentType,
+        OpenApiVersion $version,
+    ): array {
+        // OpenAPI: a missing requestBody means the operation accepts no body — treat as success.
+        if (!isset($operation['requestBody'])) {
+            return [];
+        }
+
+        // A present-but-non-array requestBody signals a malformed spec (e.g. unresolved $ref,
+        // stray scalar). Contract-testing tools should surface this, not mask it as "no body".
+        if (!is_array($operation['requestBody'])) {
+            return [
+                "Malformed 'requestBody' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar. Likely an unresolved \$ref or broken spec.",
+            ];
+        }
+
+        /** @var array<string, mixed> $requestBodySpec */
+        $requestBodySpec = $operation['requestBody'];
+        $required = ($requestBodySpec['required'] ?? false) === true;
+
+        if (!isset($requestBodySpec['content'])) {
+            return [];
+        }
+
+        if (!is_array($requestBodySpec['content'])) {
+            return [
+                "Malformed 'requestBody.content' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar. Likely an unresolved \$ref or broken spec.",
+            ];
+        }
+
+        /** @var array<string, array<string, mixed>> $content */
+        $content = $requestBodySpec['content'];
+
+        // When the actual request Content-Type is provided, handle content negotiation:
+        // non-JSON types are checked for spec presence only, while JSON-compatible types
+        // fall through to schema validation against the first JSON media type in the spec.
+        if ($contentType !== null) {
+            $normalizedType = $this->normalizeMediaType($contentType);
+
+            if (!$this->isJsonContentType($normalizedType)) {
+                if ($this->isContentTypeInSpec($normalizedType, $content)) {
+                    return [];
+                }
+
+                $defined = implode(', ', array_keys($content));
+
+                return [
+                    "Request Content-Type '{$normalizedType}' is not defined for {$method} {$matchedPath} in '{$specName}' spec. Defined content types: {$defined}",
+                ];
+            }
+
+            // JSON-compatible request: fall through to existing JSON schema validation.
+            // JSON types are treated as interchangeable (e.g. application/vnd.api+json
+            // validates against an application/json spec entry) because the schema is
+            // the same regardless of the specific JSON media type.
+        }
+
+        $jsonContentType = $this->findJsonContentType($content);
+
+        // If no JSON-compatible content type is defined, skip body validation.
+        // This validator only handles JSON schemas; non-JSON types (e.g. application/xml,
+        // application/octet-stream) are outside its scope.
+        if ($jsonContentType === null) {
+            return [];
+        }
+
+        if (!isset($content[$jsonContentType]['schema'])) {
+            return [];
+        }
+
+        if ($requestBody === null) {
+            if (!$required) {
+                return [];
+            }
+
+            return [
+                "Request body is empty but {$method} {$matchedPath} defines a required JSON request body schema in '{$specName}' spec.",
+            ];
+        }
+
+        /** @var array<string, mixed> $schema */
+        $schema = $content[$jsonContentType]['schema'];
+        $jsonSchema = OpenApiSchemaConverter::convert($schema, $version);
+
+        $schemaObject = self::toObject($jsonSchema);
+        $dataObject = self::toObject($requestBody);
+
+        $result = $this->opisValidator->validate($dataObject, $schemaObject);
+
+        if ($result->isValid()) {
+            return [];
+        }
+
+        $formattedErrors = $this->errorFormatter->format($result->error());
+
+        $errors = [];
+        foreach ($formattedErrors as $path => $messages) {
+            foreach ($messages as $message) {
+                $errors[] = "[{$path}] {$message}";
+            }
+        }
+
+        return $errors;
     }
 
     /**

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting;
 
+use const FILTER_VALIDATE_INT;
 use const PHP_INT_MAX;
 
 use InvalidArgumentException;
@@ -16,11 +17,12 @@ use function array_key_exists;
 use function array_keys;
 use function array_map;
 use function array_values;
+use function filter_var;
 use function implode;
 use function is_array;
+use function is_int;
 use function is_numeric;
 use function is_string;
-use function preg_match;
 use function sprintf;
 use function str_ends_with;
 use function strstr;
@@ -59,7 +61,7 @@ final class OpenApiRequestValidator
      * single test run surfaces every contract drift the request exhibits.
      *
      * @param array<string, mixed> $queryParams parsed query string (string|array<string> per key)
-     * @param array<string, mixed> $headers reserved for future use; ignored in this phase
+     * @param array<string, mixed> $headers currently ignored; placeholder for header validation
      */
     public function validate(
         string $specName,
@@ -98,7 +100,14 @@ final class OpenApiRequestValidator
         /** @var array<string, mixed> $operation */
         $operation = $pathSpec[$lowerMethod];
 
-        $queryErrors = $this->validateQueryParameters($pathSpec, $operation, $queryParams, $version);
+        $queryErrors = $this->validateQueryParameters(
+            $method,
+            $matchedPath,
+            $pathSpec,
+            $operation,
+            $queryParams,
+            $version,
+        );
         $bodyErrors = $this->validateRequestBody(
             $specName,
             $method,
@@ -147,6 +156,36 @@ final class OpenApiRequestValidator
     }
 
     /**
+     * Pick the first primitive type from an OAS 3.1 multi-type declaration,
+     * skipping `null`. Returns `null` if no usable string type is found.
+     *
+     * @param array<int|string, mixed> $types
+     */
+    private static function firstPrimitiveType(array $types): ?string
+    {
+        foreach ($types as $candidate) {
+            if (is_string($candidate) && $candidate !== 'null') {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Coerce a query string to int, guarding against overflow. `filter_var`
+     * returns `false` for values exceeding PHP_INT_MAX/MIN or containing
+     * non-digit characters, so the original string falls through and opis
+     * reports a type mismatch instead of receiving a silently truncated value.
+     */
+    private static function coerceToInt(string $value): int|string
+    {
+        $result = filter_var($value, FILTER_VALIDATE_INT);
+
+        return is_int($result) ? $result : $value;
+    }
+
+    /**
      * @param string[] $specPaths
      */
     private function getPathMatcher(string $specName, array $specPaths): OpenApiPathMatcher
@@ -170,14 +209,15 @@ final class OpenApiRequestValidator
      * @return string[]
      */
     private function validateQueryParameters(
+        string $method,
+        string $matchedPath,
         array $pathSpec,
         array $operation,
         array $queryParams,
         OpenApiVersion $version,
     ): array {
-        $parameters = $this->collectParameters($pathSpec, $operation);
+        [$parameters, $errors] = $this->collectParameters($method, $matchedPath, $pathSpec, $operation);
 
-        $errors = [];
         foreach ($parameters as $param) {
             if (($param['in'] ?? null) !== 'query') {
                 continue;
@@ -185,15 +225,21 @@ final class OpenApiRequestValidator
 
             /** @var string $name */
             $name = $param['name'];
+            $required = ($param['required'] ?? false) === true;
 
+            // A required parameter with no schema is a clearly malformed spec — surface it
+            // rather than silently passing every request. Optional parameters with no schema
+            // have nothing to validate, so we let them through (matches the body validator).
             if (!isset($param['schema']) || !is_array($param['schema'])) {
-                // No schema → nothing to validate against; mirrors body behaviour.
+                if ($required) {
+                    $errors[] = "[query.{$name}] required parameter has no schema for {$method} {$matchedPath} — cannot validate.";
+                }
+
                 continue;
             }
 
             /** @var array<string, mixed> $schema */
             $schema = $param['schema'];
-            $required = ($param['required'] ?? false) === true;
 
             $present = array_key_exists($name, $queryParams) && $queryParams[$name] !== null;
             if (!$present) {
@@ -217,8 +263,9 @@ final class OpenApiRequestValidator
 
             $formatted = $this->errorFormatter->format($result->error());
             foreach ($formatted as $path => $messages) {
+                $suffix = $path === '/' ? '' : $path;
                 foreach ($messages as $message) {
-                    $errors[] = "[query.{$name}{$path}] {$message}";
+                    $errors[] = "[query.{$name}{$suffix}] {$message}";
                 }
             }
         }
@@ -229,17 +276,22 @@ final class OpenApiRequestValidator
     /**
      * Merge path-level and operation-level parameters. Operation-level entries
      * override path-level ones with the same `name` + `in` (per OpenAPI spec).
-     * Malformed entries (missing or non-string `name`/`in`) are silently
-     * skipped — they cannot be uniquely identified for override matching.
+     *
+     * Malformed entries are surfaced as errors rather than silently skipped,
+     * because for a contract-testing tool the absence of an error means
+     * "validated and OK" — silently dropping a parameter would leave drift
+     * invisible. `$ref` entries are flagged separately so users know the spec
+     * needs to be pre-bundled (we don't resolve refs).
      *
      * @param array<string, mixed> $pathSpec
      * @param array<string, mixed> $operation
      *
-     * @return list<array<string, mixed>>
+     * @return array{0: list<array<string, mixed>>, 1: string[]}
      */
-    private function collectParameters(array $pathSpec, array $operation): array
+    private function collectParameters(string $method, string $matchedPath, array $pathSpec, array $operation): array
     {
         $merged = [];
+        $errors = [];
 
         foreach ([$pathSpec['parameters'] ?? [], $operation['parameters'] ?? []] as $source) {
             if (!is_array($source)) {
@@ -248,10 +300,21 @@ final class OpenApiRequestValidator
 
             foreach ($source as $param) {
                 if (!is_array($param)) {
+                    $errors[] = "Malformed parameter entry for {$method} {$matchedPath}: expected object, got scalar.";
+
+                    continue;
+                }
+
+                if (array_key_exists('$ref', $param)) {
+                    $ref = is_string($param['$ref']) ? $param['$ref'] : '(non-string $ref)';
+                    $errors[] = "Parameter \$ref encountered for {$method} {$matchedPath} ('{$ref}') — \$ref resolution is not supported. Pre-bundle the spec (e.g. redocly bundle --dereference).";
+
                     continue;
                 }
 
                 if (!isset($param['in'], $param['name']) || !is_string($param['in']) || !is_string($param['name'])) {
+                    $errors[] = "Malformed parameter entry for {$method} {$matchedPath}: 'name' and 'in' must be strings.";
+
                     continue;
                 }
 
@@ -260,7 +323,7 @@ final class OpenApiRequestValidator
             }
         }
 
-        return array_values($merged);
+        return [array_values($merged), $errors];
     }
 
     /**
@@ -269,20 +332,24 @@ final class OpenApiRequestValidator
      * type, the original value is returned unchanged so opis can surface a
      * meaningful type error rather than silently passing.
      *
+     * For multi-type schemas (OAS 3.1 `type: ["integer", "null"]`) the first
+     * non-`null` primitive type is used as the coercion target.
+     *
      * @param array<string, mixed> $schema
      */
     private function coerceQueryValue(mixed $value, array $schema): mixed
     {
         $type = $schema['type'] ?? null;
 
+        if (is_array($type)) {
+            $type = self::firstPrimitiveType($type);
+        }
+
         if ($type === 'array') {
-            if (!is_array($value)) {
-                $value = [$value];
-            }
+            $value = is_array($value) ? array_values($value) : [$value];
 
             $itemSchema = $schema['items'] ?? null;
             if (is_array($itemSchema)) {
-                /** @var list<mixed> $value */
                 return array_map(fn(mixed $item): mixed => $this->coerceQueryValue($item, $itemSchema), $value);
             }
 
@@ -294,7 +361,7 @@ final class OpenApiRequestValidator
         }
 
         return match ($type) {
-            'integer' => preg_match('/^-?\d+$/', $value) === 1 ? (int) $value : $value,
+            'integer' => self::coerceToInt($value),
             'number' => is_numeric($value) ? (float) $value : $value,
             'boolean' => match (strtolower($value)) {
                 'true' => true,

--- a/tests/Integration/ResponseValidationTest.php
+++ b/tests/Integration/ResponseValidationTest.php
@@ -64,12 +64,13 @@ class ResponseValidationTest extends TestCase
 
         // Check coverage
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
-        $this->assertSame(8, $coverage['total']);
+        $this->assertSame(9, $coverage['total']);
         $this->assertSame(2, $coverage['coveredCount']);
         $this->assertContains('GET /v1/pets', $coverage['covered']);
         $this->assertContains('POST /v1/pets', $coverage['covered']);
         $this->assertContains('GET /v1/health', $coverage['uncovered']);
         $this->assertContains('GET /v1/logout', $coverage['uncovered']);
+        $this->assertContains('GET /v1/pets/search', $coverage['uncovered']);
         $this->assertContains('DELETE /v1/pets/{petId}', $coverage['uncovered']);
         $this->assertContains('GET /v1/pets/{petId}', $coverage['uncovered']);
         $this->assertContains('PATCH /v1/pets/{petId}', $coverage['uncovered']);
@@ -93,7 +94,7 @@ class ResponseValidationTest extends TestCase
         }
 
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.1');
-        $this->assertSame(6, $coverage['total']);
+        $this->assertSame(7, $coverage['total']);
         $this->assertSame(1, $coverage['coveredCount']);
     }
 

--- a/tests/Unit/OpenApiCoverageTrackerTest.php
+++ b/tests/Unit/OpenApiCoverageTrackerTest.php
@@ -67,10 +67,10 @@ class OpenApiCoverageTrackerTest extends TestCase
         $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
 
         // See tests/fixtures/specs/petstore-3.0.json for the full endpoint list
-        $this->assertSame(8, $result['total']);
+        $this->assertSame(9, $result['total']);
         $this->assertSame(2, $result['coveredCount']);
         $this->assertCount(2, $result['covered']);
-        $this->assertCount(6, $result['uncovered']);
+        $this->assertCount(7, $result['uncovered']);
     }
 
     #[Test]
@@ -78,10 +78,10 @@ class OpenApiCoverageTrackerTest extends TestCase
     {
         $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
 
-        $this->assertSame(8, $result['total']);
+        $this->assertSame(9, $result['total']);
         $this->assertSame(0, $result['coveredCount']);
         $this->assertCount(0, $result['covered']);
-        $this->assertCount(8, $result['uncovered']);
+        $this->assertCount(9, $result['uncovered']);
     }
 
     #[Test]

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -10,6 +10,10 @@ use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\OpenApiRequestValidator;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
 
+use function array_filter;
+use function str_contains;
+use function strtolower;
+
 class OpenApiRequestValidatorTest extends TestCase
 {
     private OpenApiRequestValidator $validator;
@@ -434,5 +438,278 @@ class OpenApiRequestValidatorTest extends TestCase
 
         $this->assertTrue($result->isValid());
         $this->assertSame('/v1/pets', $result->matchedPath());
+    }
+
+    // ========================================
+    // Query parameter validation
+    // ========================================
+
+    #[Test]
+    public function query_params_all_valid_passes(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/search',
+            ['limit' => '10', 'status' => 'available', 'tags' => ['a', 'b'], 'q' => 'abc'],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+        $this->assertSame('/v1/pets/search', $result->matchedPath());
+    }
+
+    #[Test]
+    public function query_params_required_missing_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/search',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[query.limit]', $result->errors()[0]);
+        $this->assertStringContainsString('required', strtolower($result->errors()[0]));
+    }
+
+    #[Test]
+    public function query_params_enum_violation_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/search',
+            ['limit' => '10', 'status' => 'unknown'],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[query.status', $result->errorMessage());
+    }
+
+    #[Test]
+    public function query_params_type_mismatch_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/search',
+            ['limit' => 'abc'],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[query.limit', $result->errorMessage());
+    }
+
+    #[Test]
+    public function query_params_array_passes(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/search',
+            ['limit' => '10', 'tags' => ['a', 'b', 'c']],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function query_params_array_single_value_wrapped_passes(): void
+    {
+        // ?tags=a — frameworks may pass this as a scalar string for array-typed params.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/search',
+            ['limit' => '10', 'tags' => 'a'],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function query_params_optional_missing_passes(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/search',
+            ['limit' => '10'],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function query_params_min_max_violation_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/search',
+            ['limit' => '999'],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[query.limit', $result->errorMessage());
+    }
+
+    #[Test]
+    public function query_params_pattern_violation_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/search',
+            ['limit' => '10', 'q' => 'hello world'],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[query.q', $result->errorMessage());
+    }
+
+    #[Test]
+    public function query_params_path_level_inherited(): void
+    {
+        // PATCH does not redeclare traceId, so the path-level rule (lowercase only) applies.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'PATCH',
+            '/v1/pets/123',
+            ['traceId' => 'ABC'],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[query.traceId', $result->errorMessage());
+    }
+
+    #[Test]
+    public function query_params_operation_overrides_path_level(): void
+    {
+        // GET redeclares traceId with uppercase-only pattern, overriding the path-level lowercase rule.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/123',
+            ['traceId' => 'ABC'],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function query_params_operation_override_still_validates(): void
+    {
+        // GET's override requires uppercase; lowercase must fail (proves the override is checked,
+        // not silently bypassed).
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/123',
+            ['traceId' => 'abc'],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[query.traceId', $result->errorMessage());
+    }
+
+    #[Test]
+    public function query_and_body_errors_are_combined(): void
+    {
+        // dryRun=maybe → query type-mismatch (not a boolean)
+        // body missing required "name" → body schema violation
+        // Both must surface in a single result so users see the full diagnostic in one run.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            ['dryRun' => 'maybe'],
+            [],
+            ['tag' => 'dog'],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[query.dryRun', $result->errorMessage());
+        // Body errors use opis JSON pointer paths (no "query." prefix); assert at least one such entry.
+        $bodyErrors = array_filter(
+            $result->errors(),
+            static fn(string $err): bool => !str_contains($err, '[query.'),
+        );
+        $this->assertNotEmpty($bodyErrors, 'expected at least one body validation error in combined result');
+    }
+
+    // ========================================
+    // OAS 3.1 query parity
+    // ========================================
+
+    #[Test]
+    public function v31_query_params_valid_passes(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.1',
+            'GET',
+            '/v1/pets/search',
+            ['limit' => '5', 'status' => 'pending', 'tags' => ['x']],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function v31_query_params_enum_violation_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.1',
+            'GET',
+            '/v1/pets/search',
+            ['limit' => '5', 'status' => 'unknown'],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[query.status', $result->errorMessage());
     }
 }

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -440,10 +440,6 @@ class OpenApiRequestValidatorTest extends TestCase
         $this->assertSame('/v1/pets', $result->matchedPath());
     }
 
-    // ========================================
-    // Query parameter validation
-    // ========================================
-
     #[Test]
     public function query_params_all_valid_passes(): void
     {
@@ -493,7 +489,7 @@ class OpenApiRequestValidatorTest extends TestCase
         );
 
         $this->assertFalse($result->isValid());
-        $this->assertStringContainsString('[query.status', $result->errorMessage());
+        $this->assertStringContainsString('[query.status]', $result->errorMessage());
     }
 
     #[Test]
@@ -510,7 +506,7 @@ class OpenApiRequestValidatorTest extends TestCase
         );
 
         $this->assertFalse($result->isValid());
-        $this->assertStringContainsString('[query.limit', $result->errorMessage());
+        $this->assertStringContainsString('[query.limit]', $result->errorMessage());
     }
 
     #[Test]
@@ -576,7 +572,7 @@ class OpenApiRequestValidatorTest extends TestCase
         );
 
         $this->assertFalse($result->isValid());
-        $this->assertStringContainsString('[query.limit', $result->errorMessage());
+        $this->assertStringContainsString('[query.limit]', $result->errorMessage());
     }
 
     #[Test]
@@ -593,7 +589,7 @@ class OpenApiRequestValidatorTest extends TestCase
         );
 
         $this->assertFalse($result->isValid());
-        $this->assertStringContainsString('[query.q', $result->errorMessage());
+        $this->assertStringContainsString('[query.q]', $result->errorMessage());
     }
 
     #[Test]
@@ -611,7 +607,7 @@ class OpenApiRequestValidatorTest extends TestCase
         );
 
         $this->assertFalse($result->isValid());
-        $this->assertStringContainsString('[query.traceId', $result->errorMessage());
+        $this->assertStringContainsString('[query.traceId]', $result->errorMessage());
     }
 
     #[Test]
@@ -647,7 +643,7 @@ class OpenApiRequestValidatorTest extends TestCase
         );
 
         $this->assertFalse($result->isValid());
-        $this->assertStringContainsString('[query.traceId', $result->errorMessage());
+        $this->assertStringContainsString('[query.traceId]', $result->errorMessage());
     }
 
     #[Test]
@@ -667,13 +663,264 @@ class OpenApiRequestValidatorTest extends TestCase
         );
 
         $this->assertFalse($result->isValid());
-        $this->assertStringContainsString('[query.dryRun', $result->errorMessage());
+        $this->assertStringContainsString('[query.dryRun]', $result->errorMessage());
         // Body errors use opis JSON pointer paths (no "query." prefix); assert at least one such entry.
         $bodyErrors = array_filter(
             $result->errors(),
             static fn(string $err): bool => !str_contains($err, '[query.'),
         );
         $this->assertNotEmpty($bodyErrors, 'expected at least one body validation error in combined result');
+    }
+
+    #[Test]
+    public function query_and_body_both_valid_passes(): void
+    {
+        // Mirror of the combined-error test: confirms the success path through
+        // the composed validate() with both phases active and contributing zero errors.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            ['dryRun' => 'true'],
+            [],
+            ['name' => 'Fido'],
+            'application/json',
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function query_params_boolean_true_coerced(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            ['dryRun' => 'true'],
+            [],
+            ['name' => 'Fido'],
+            'application/json',
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function query_params_boolean_false_coerced(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            ['dryRun' => 'false'],
+            [],
+            ['name' => 'Fido'],
+            'application/json',
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function query_params_number_passes(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/search',
+            ['limit' => '5', 'score' => '0.7'],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function query_params_number_invalid_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/search',
+            ['limit' => '5', 'score' => 'not-a-number'],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[query.score]', $result->errorMessage());
+    }
+
+    #[Test]
+    public function query_params_no_type_schema_passes(): void
+    {
+        // category schema declares only `enum`, no `type` — coercion must skip,
+        // and opis must accept the matching enum value untouched.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/search',
+            ['limit' => '5', 'category' => 'dog'],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function query_params_no_type_schema_enum_violation_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/search',
+            ['limit' => '5', 'category' => 'fish'],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[query.category]', $result->errorMessage());
+    }
+
+    #[Test]
+    public function query_params_explicit_null_treated_as_missing(): void
+    {
+        // Explicit null for a required parameter should hit the same branch as "absent".
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/search',
+            ['limit' => null],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[query.limit]', $result->errorMessage());
+        $this->assertStringContainsString('required', strtolower($result->errorMessage()));
+    }
+
+    #[Test]
+    public function query_params_explicit_null_optional_skipped(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/search',
+            ['limit' => '5', 'status' => null],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function query_params_integer_overflow_treated_as_string(): void
+    {
+        // Out-of-range integer must NOT silently truncate to PHP_INT_MAX — opis
+        // should see the original string and emit a type error.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/search',
+            ['limit' => '99999999999999999999'],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[query.limit]', $result->errorMessage());
+        $this->assertStringContainsString('type: integer', $result->errorMessage());
+    }
+
+    #[Test]
+    public function query_params_integer_negative_passes(): void
+    {
+        // The integer schema for `count` (3.1) has minimum: 0, so use a permissive
+        // schema-less coercion check via path-level traceId... actually use the
+        // integer-typed `limit` with a known-passing positive value to prove
+        // negative-prefix regex handling — exercised via integer-overflow test.
+        // This case asserts the "clean integer" branch: filter_var accepts "-5" → -5,
+        // and even though -5 fails minimum:1, it does NOT fail with a type error.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/search',
+            ['limit' => '-5'],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringNotContainsString('type: integer', $result->errorMessage());
+        $this->assertStringContainsString('greater', strtolower($result->errorMessage()));
+    }
+
+    #[Test]
+    public function query_params_ref_entry_surfaces_error(): void
+    {
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/ref-parameter',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('Parameter $ref encountered', $result->errors()[0]);
+        $this->assertStringContainsString('redocly bundle --dereference', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function query_params_scalar_entry_surfaces_error(): void
+    {
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/scalar-parameter',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('Malformed parameter entry', $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function query_params_required_no_schema_surfaces_error(): void
+    {
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/required-no-schema',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[query.token]', $result->errors()[0]);
+        $this->assertStringContainsString('no schema', $result->errors()[0]);
     }
 
     // ========================================
@@ -710,6 +957,41 @@ class OpenApiRequestValidatorTest extends TestCase
         );
 
         $this->assertFalse($result->isValid());
-        $this->assertStringContainsString('[query.status', $result->errorMessage());
+        $this->assertStringContainsString('[query.status]', $result->errorMessage());
+    }
+
+    #[Test]
+    public function v31_query_params_multi_type_coerced_passes(): void
+    {
+        // count has type: ["integer", "null"] — coerceQueryValue must pick "integer"
+        // as the coercion target so "42" → 42 passes the schema.
+        $result = $this->validator->validate(
+            'petstore-3.1',
+            'GET',
+            '/v1/pets/search',
+            ['limit' => '5', 'count' => '42'],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function v31_query_params_multi_type_invalid_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.1',
+            'GET',
+            '/v1/pets/search',
+            ['limit' => '5', 'count' => 'not-a-number'],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[query.count]', $result->errorMessage());
     }
 }

--- a/tests/fixtures/specs/malformed.json
+++ b/tests/fixtures/specs/malformed.json
@@ -31,6 +31,54 @@
                     }
                 }
             }
+        },
+        "/ref-parameter": {
+            "get": {
+                "summary": "parameters list contains an unresolved $ref entry",
+                "operationId": "refParameter",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/UnresolvedLimit"
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
+        "/scalar-parameter": {
+            "get": {
+                "summary": "parameters list contains a non-array entry",
+                "operationId": "scalarParameter",
+                "parameters": [
+                    "this should have been an object"
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
+        "/required-no-schema": {
+            "get": {
+                "summary": "required query parameter without a schema",
+                "operationId": "requiredNoSchema",
+                "parameters": [
+                    {
+                        "name": "token",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
         }
     }
 }

--- a/tests/fixtures/specs/petstore-3.0.json
+++ b/tests/fixtures/specs/petstore-3.0.json
@@ -241,6 +241,22 @@
                             "pattern": "^[A-Za-z0-9]+$",
                             "minLength": 1
                         }
+                    },
+                    {
+                        "name": "score",
+                        "in": "query",
+                        "schema": {
+                            "type": "number",
+                            "minimum": 0,
+                            "maximum": 1
+                        }
+                    },
+                    {
+                        "name": "category",
+                        "in": "query",
+                        "schema": {
+                            "enum": ["dog", "cat", "bird"]
+                        }
                     }
                 ],
                 "responses": {

--- a/tests/fixtures/specs/petstore-3.0.json
+++ b/tests/fixtures/specs/petstore-3.0.json
@@ -100,6 +100,15 @@
             "post": {
                 "summary": "Create a pet",
                 "operationId": "createPet",
+                "parameters": [
+                    {
+                        "name": "dryRun",
+                        "in": "query",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
                 "requestBody": {
                     "required": true,
                     "content": {
@@ -189,6 +198,73 @@
                 }
             }
         },
+        "/v1/pets/search": {
+            "get": {
+                "summary": "Search pets",
+                "operationId": "searchPets",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 100
+                        }
+                    },
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "enum": ["available", "pending", "sold"]
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "q",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[A-Za-z0-9]+$",
+                            "minLength": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Search results",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/v1/logout": {
             "get": {
                 "summary": "Logout page",
@@ -219,9 +295,29 @@
             }
         },
         "/v1/pets/{petId}": {
+            "parameters": [
+                {
+                    "name": "traceId",
+                    "in": "query",
+                    "schema": {
+                        "type": "string",
+                        "pattern": "^[a-z]+$"
+                    }
+                }
+            ],
             "get": {
                 "summary": "Info for a specific pet",
                 "operationId": "showPetById",
+                "parameters": [
+                    {
+                        "name": "traceId",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[A-Z]+$"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Expected response to a valid request",

--- a/tests/fixtures/specs/petstore-3.1.json
+++ b/tests/fixtures/specs/petstore-3.1.json
@@ -71,6 +71,15 @@
             "post": {
                 "summary": "Create a pet",
                 "operationId": "createPet",
+                "parameters": [
+                    {
+                        "name": "dryRun",
+                        "in": "query",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
                 "requestBody": {
                     "required": true,
                     "content": {
@@ -137,10 +146,97 @@
                 }
             }
         },
+        "/v1/pets/search": {
+            "get": {
+                "summary": "Search pets",
+                "operationId": "searchPets",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 100
+                        }
+                    },
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "enum": ["available", "pending", "sold"]
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "q",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[A-Za-z0-9]+$",
+                            "minLength": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Search results",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/v1/pets/{petId}": {
+            "parameters": [
+                {
+                    "name": "traceId",
+                    "in": "query",
+                    "schema": {
+                        "type": "string",
+                        "pattern": "^[a-z]+$"
+                    }
+                }
+            ],
             "get": {
                 "summary": "Info for a specific pet",
                 "operationId": "showPetById",
+                "parameters": [
+                    {
+                        "name": "traceId",
+                        "in": "query",
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[A-Z]+$"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Expected response to a valid request",

--- a/tests/fixtures/specs/petstore-3.1.json
+++ b/tests/fixtures/specs/petstore-3.1.json
@@ -189,6 +189,14 @@
                             "pattern": "^[A-Za-z0-9]+$",
                             "minLength": 1
                         }
+                    },
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "schema": {
+                            "type": ["integer", "null"],
+                            "minimum": 0
+                        }
                     }
                 ],
                 "responses": {


### PR DESCRIPTION
## Summary

- Builds on `OpenApiRequestValidator` (#42) so the previously-ignored `$queryParams` argument is now validated against the operation's (and inherited path-level) `parameters` block.
- Supports required / type / enum / format / pattern / minimum / maximum / minLength / maxLength via `opis/json-schema`, plus basic `style: form` + `explode: true` for arrays — the OpenAPI default for `in: query`.
- Errors from the query phase and the body phase are accumulated into a single `OpenApiValidationResult` so contract tests surface every drift in one run.

## Behaviour highlights

- **Parameter resolution**: path-level `parameters` apply to all operations; operation-level entries with the same `in:name` override them (per OpenAPI spec).
- **Type coercion**: query strings are coerced to `int` / `float` / `bool` only when they are clean representations (e.g. `^-?\d+$` for integer, literal `true`/`false` for boolean). When coercion would mask an error (`(int)"abc" === 0`), the original string is preserved so opis emits a meaningful type error.
- **Array handling**: `?tags=a&tags=b` arrives as a PHP array from Laravel/Symfony and is validated element-wise; a single scalar value (`?tags=a`) is wrapped into a one-element list to match `style: form, explode: true` semantics.
- **Backward compatible**: existing tests pass `[]` for `$queryParams` and continue to behave the same — added query parameters in fixtures are all optional except where a new test exercises them.
- **Combined diagnostics**: a request with both query and body violations now returns a single result whose `errors()` contains both `[query.<name>] ...` and JSON-pointer body messages.

## Out of scope (future issues per the epic)

- Path / header / cookie parameter validation → #44, #45.
- Security scheme validation → #46.
- `style: form` + `explode: false`, `pipeDelimited`, `spaceDelimited` styles.
- `$ref` resolution inside `parameters` (no resolver exists in the project today; consistent with body validation).
- Laravel trait integration (#39 hook).

## Test plan

- [x] `vendor/bin/phpunit tests/Unit/OpenApiRequestValidatorTest.php` — 13 new tests green (all 4 acceptance-criteria patterns plus optional-missing, array, single-value coercion, min-max, pattern, path-level inheritance, operation override (both directions), combined query+body errors, OAS 3.1 parity).
- [x] `vendor/bin/phpunit` — 271 / 271 green (fixture additions required coverage-count updates in `OpenApiCoverageTrackerTest` and `ResponseValidationTest`).
- [x] `vendor/bin/phpstan analyse` — clean at level 6.
- [x] `vendor/bin/php-cs-fixer fix --dry-run --diff` — clean.

Closes #43