### PR TITLE
fix(request-validator): surface unresolved $ref in requestBody / content as hard error

### DIFF
--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -408,6 +408,19 @@ final class OpenApiRequestValidator
 
         /** @var array<string, mixed> $requestBodySpec */
         $requestBodySpec = $operation['requestBody'];
+
+        // Unresolved $ref at requestBody level: PHP parses it as an assoc array, so the
+        // existing is_array guard lets it through. Without this check, the subsequent
+        // `isset($requestBodySpec['content'])` returns false and the method silently
+        // returns success — the worst possible outcome for a contract-testing tool.
+        if (array_key_exists('$ref', $requestBodySpec)) {
+            $ref = is_string($requestBodySpec['$ref']) ? $requestBodySpec['$ref'] : '(non-string $ref)';
+
+            return [
+                "RequestBody \$ref encountered for {$method} {$matchedPath} ('{$ref}') — \$ref resolution is not supported. Pre-bundle the spec (e.g. redocly bundle --dereference).",
+            ];
+        }
+
         $required = ($requestBodySpec['required'] ?? false) === true;
 
         if (!isset($requestBodySpec['content'])) {
@@ -422,6 +435,33 @@ final class OpenApiRequestValidator
 
         /** @var array<string, array<string, mixed>> $content */
         $content = $requestBodySpec['content'];
+
+        // Unresolved $ref at content[mediaType] or content[mediaType].schema level.
+        // Without these checks, (a) mediaType-level $ref silently returns success because
+        // the `schema` key is absent, and (b) schema-level $ref reaches opis and throws
+        // UnresolvedReferenceException with an unhelpful message. Flagging all entries
+        // (not just the JSON-compatible one) catches broken specs regardless of which
+        // Content-Type the caller uses.
+        foreach ($content as $mediaType => $mediaTypeSpec) {
+            if (array_key_exists('$ref', $mediaTypeSpec)) {
+                $ref = is_string($mediaTypeSpec['$ref']) ? $mediaTypeSpec['$ref'] : '(non-string $ref)';
+
+                return [
+                    "RequestBody content['{$mediaType}'] \$ref encountered for {$method} {$matchedPath} ('{$ref}') — \$ref resolution is not supported. Pre-bundle the spec (e.g. redocly bundle --dereference).",
+                ];
+            }
+
+            if (isset($mediaTypeSpec['schema']) &&
+                is_array($mediaTypeSpec['schema']) &&
+                array_key_exists('$ref', $mediaTypeSpec['schema'])
+            ) {
+                $ref = is_string($mediaTypeSpec['schema']['$ref']) ? $mediaTypeSpec['schema']['$ref'] : '(non-string $ref)';
+
+                return [
+                    "RequestBody content['{$mediaType}'].schema \$ref encountered for {$method} {$matchedPath} ('{$ref}') — \$ref resolution is not supported. Pre-bundle the spec (e.g. redocly bundle --dereference).",
+                ];
+            }
+        }
 
         // When the actual request Content-Type is provided, handle content negotiation:
         // non-JSON types are checked for spec presence only, while JSON-compatible types

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -433,7 +433,7 @@ final class OpenApiRequestValidator
             ];
         }
 
-        /** @var array<string, array<string, mixed>> $content */
+        /** @var array<string, mixed> $content */
         $content = $requestBodySpec['content'];
 
         // Unresolved $ref at content[mediaType] or content[mediaType].schema level.
@@ -443,6 +443,16 @@ final class OpenApiRequestValidator
         // (not just the JSON-compatible one) catches broken specs regardless of which
         // Content-Type the caller uses.
         foreach ($content as $mediaType => $mediaTypeSpec) {
+            // The @var on $content narrows values to array, but PHPDoc is unchecked at
+            // runtime — a malformed spec like `content: {"application/json": "oops"}`
+            // would TypeError on array_key_exists below. Surface it as a loud spec error
+            // instead, matching the sibling guard on `requestBody.content` above.
+            if (!is_array($mediaTypeSpec)) {
+                return [
+                    "Malformed 'requestBody.content[\"{$mediaType}\"]' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+                ];
+            }
+
             if (array_key_exists('$ref', $mediaTypeSpec)) {
                 $ref = is_string($mediaTypeSpec['$ref']) ? $mediaTypeSpec['$ref'] : '(non-string $ref)';
 
@@ -542,7 +552,7 @@ final class OpenApiRequestValidator
      * syntax suffix (RFC 6838), such as "application/problem+json" and
      * "application/vnd.api+json". Matching is case-insensitive.
      *
-     * @param array<string, array<string, mixed>> $content
+     * @param array<string, mixed> $content
      */
     private function findJsonContentType(array $content): ?string
     {
@@ -575,7 +585,7 @@ final class OpenApiRequestValidator
      * type matches any content type key defined in the spec. Spec keys are
      * lower-cased before comparison.
      *
-     * @param array<string, array<string, mixed>> $content
+     * @param array<string, mixed> $content
      */
     private function isContentTypeInSpec(string $requestContentType, array $content): bool
     {

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -442,6 +442,43 @@ class OpenApiRequestValidatorTest extends TestCase
         $this->assertStringContainsString('redocly bundle --dereference', $result->errors()[0]);
     }
 
+    #[Test]
+    public function request_body_non_string_ref_surfaces_error(): void
+    {
+        $result = $this->validator->validate(
+            'malformed',
+            'POST',
+            '/non-string-ref-request-body',
+            [],
+            [],
+            ['name' => 'Rex'],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('RequestBody $ref encountered', $result->errors()[0]);
+        $this->assertStringContainsString('(non-string $ref)', $result->errors()[0]);
+        $this->assertStringContainsString('redocly bundle --dereference', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function scalar_content_media_type_returns_failure(): void
+    {
+        $result = $this->validator->validate(
+            'malformed',
+            'POST',
+            '/scalar-content-media-type',
+            [],
+            [],
+            ['foo' => 'bar'],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString("Malformed 'requestBody.content[\"application/json\"]'", $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+    }
+
     // ========================================
     // Constructor validation (mirrors response validator)
     // ========================================

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -385,6 +385,63 @@ class OpenApiRequestValidatorTest extends TestCase
         $this->assertStringContainsString("Malformed 'requestBody.content'", $result->errors()[0]);
     }
 
+    #[Test]
+    public function request_body_ref_surfaces_error(): void
+    {
+        $result = $this->validator->validate(
+            'malformed',
+            'POST',
+            '/ref-request-body',
+            [],
+            [],
+            ['name' => 'Rex'],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('RequestBody $ref encountered', $result->errors()[0]);
+        $this->assertStringContainsString('#/components/requestBodies/PetBody', $result->errors()[0]);
+        $this->assertStringContainsString('redocly bundle --dereference', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function request_body_content_media_type_ref_surfaces_error(): void
+    {
+        $result = $this->validator->validate(
+            'malformed',
+            'POST',
+            '/ref-content-media-type',
+            [],
+            [],
+            ['name' => 'Rex'],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString("RequestBody content['application/json'] \$ref encountered", $result->errors()[0]);
+        $this->assertStringContainsString('#/components/schemas/Pet', $result->errors()[0]);
+        $this->assertStringContainsString('redocly bundle --dereference', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function request_body_content_schema_ref_surfaces_error(): void
+    {
+        $result = $this->validator->validate(
+            'malformed',
+            'POST',
+            '/ref-content-schema',
+            [],
+            [],
+            ['name' => 'Rex'],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString("RequestBody content['application/json'].schema \$ref encountered", $result->errors()[0]);
+        $this->assertStringContainsString('#/components/schemas/Pet', $result->errors()[0]);
+        $this->assertStringContainsString('redocly bundle --dereference', $result->errors()[0]);
+    }
+
     // ========================================
     // Constructor validation (mirrors response validator)
     // ========================================

--- a/tests/fixtures/specs/malformed.json
+++ b/tests/fixtures/specs/malformed.json
@@ -79,6 +79,60 @@
                     }
                 }
             }
+        },
+        "/ref-request-body": {
+            "post": {
+                "summary": "requestBody is directly a $ref",
+                "operationId": "refRequestBody",
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/PetBody"
+                },
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
+        "/ref-content-media-type": {
+            "post": {
+                "summary": "content[mediaType] is directly a $ref",
+                "operationId": "refContentMediaType",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "$ref": "#/components/schemas/Pet"
+                        }
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
+        "/ref-content-schema": {
+            "post": {
+                "summary": "content[mediaType].schema is directly a $ref",
+                "operationId": "refContentSchema",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Pet"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
         }
     }
 }

--- a/tests/fixtures/specs/malformed.json
+++ b/tests/fixtures/specs/malformed.json
@@ -133,6 +133,37 @@
                     }
                 }
             }
+        },
+        "/non-string-ref-request-body": {
+            "post": {
+                "summary": "requestBody $ref value is not a string",
+                "operationId": "nonStringRefRequestBody",
+                "requestBody": {
+                    "$ref": ["not", "a", "string"]
+                },
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
+        "/scalar-content-media-type": {
+            "post": {
+                "summary": "content[mediaType] is a scalar (not an object)",
+                "operationId": "scalarContentMediaType",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": "this should have been an object"
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #60. Follow-up to PR #58: the same silent-failure-on-`$ref` pattern that PR #58 fixed for `parameters` remained in three places inside `validateRequestBody()`. All three are now surfaced as hard errors pointing at `redocly bundle --dereference`.

### Patterns fixed
1. **`requestBody` 直下の `$ref`** — passed the `is_array` guard (PHP assoc array), then the `isset($requestBodySpec['content'])` check returned `false` → silent success. **Worst case**: an invalid body (missing required fields) was reported as OK.
2. **`content[mediaType]` 直下の `$ref`** — `findJsonContentType` matched the key, then the `isset(...['schema'])` check returned `false` → silent success.
3. **`content[mediaType].schema` 直下の `$ref`** — reached opis and threw `Opis\JsonSchema\Exceptions\UnresolvedReferenceException` with an unhelpful stack trace.

### Error message format
Matches the PR #58 prefix/suffix convention and distinguishes the three locations to make spec debugging straightforward:

- `RequestBody $ref encountered for POST /x ('#/...') — $ref resolution is not supported. Pre-bundle the spec (e.g. redocly bundle --dereference).`
- `RequestBody content['application/json'] $ref encountered for POST /x (...) — ...`
- `RequestBody content['application/json'].schema $ref encountered for POST /x (...) — ...`

### Scope
Intentionally does NOT implement `$ref` resolution (separate epic). Does NOT touch `OpenApiResponseValidator` or header/cookie parameter handling (separate issues).

## Test plan
- [x] 3 new TDD tests under the "Malformed spec guards" section in `OpenApiRequestValidatorTest` — verified red before implementation, green after.
- [x] 3 new fixtures in `tests/fixtures/specs/malformed.json` (`/ref-request-body`, `/ref-content-media-type`, `/ref-content-schema`).
- [x] `vendor/bin/phpunit` — 290 tests, 609 assertions, all green (287 → 290).
- [x] `vendor/bin/phpstan analyse` — no errors.
- [x] `vendor/bin/php-cs-fixer fix --dry-run --diff` — no diffs.