### PR TITLE
New Feature: path パラメータを spec で検証する

### DIFF
--- a/src/OpenApiPathMatcher.php
+++ b/src/OpenApiPathMatcher.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting;
 
+use InvalidArgumentException;
+
 use function explode;
 use function implode;
+use function in_array;
 use function preg_match;
 use function preg_quote;
 use function rtrim;
+use function sprintf;
 use function str_ends_with;
 use function str_starts_with;
 use function strlen;
@@ -38,6 +42,18 @@ final class OpenApiPathMatcher
 
             foreach ($segments as $segment) {
                 if (preg_match('/^\{(.+)\}$/', $segment, $m)) {
+                    // OpenAPI forbids duplicate placeholder names in a single template.
+                    // If we silently overwrote the earlier capture, one of the segments
+                    // would skip validation depending on position — a direction-dependent
+                    // silent pass. Refuse to compile instead.
+                    if (in_array($m[1], $paramNames, true)) {
+                        throw new InvalidArgumentException(sprintf(
+                            "Duplicate path placeholder name '%s' in spec path '%s'. OpenAPI requires unique placeholder names within a single template.",
+                            $m[1],
+                            $specPath,
+                        ));
+                    }
+
                     $regexSegments[] = '([^/]+)';
                     $paramNames[] = $m[1];
                 } else {
@@ -70,10 +86,13 @@ final class OpenApiPathMatcher
      * Match a request path and return both the matched spec path template and
      * the raw values captured for each `{placeholder}` segment.
      *
-     * Values are returned **percent-encoded** (exactly as they appear in the
-     * request URI). Callers that need to validate the decoded value should
-     * apply `rawurldecode()` themselves — we don't decode here to keep the
-     * matcher a pure string operation and leave encoding policy to the caller.
+     * Values are returned exactly as they appeared in `$requestPath` — no
+     * decoding is performed. When the caller passes the raw request URI (the
+     * intended use, e.g. via Symfony's `Request::getPathInfo()` which returns
+     * the un-decoded path), the captured values will be percent-encoded and
+     * the caller should apply `rawurldecode()` before validating. Keeping
+     * encoding policy in one place on the caller side avoids the double-decode
+     * hazard that would arise if we decoded here.
      *
      * @return null|array{path: string, variables: array<string, string>}
      */

--- a/src/OpenApiPathMatcher.php
+++ b/src/OpenApiPathMatcher.php
@@ -18,7 +18,7 @@ use function usort;
 
 final class OpenApiPathMatcher
 {
-    /** @var array{pattern: string, path: string, literalSegments: int}[] */
+    /** @var array{pattern: string, path: string, paramNames: string[], literalSegments: int}[] */
     private array $compiledPaths;
 
     /**
@@ -34,10 +34,12 @@ final class OpenApiPathMatcher
             $segments = explode('/', trim($specPath, '/'));
             $literalCount = 0;
             $regexSegments = [];
+            $paramNames = [];
 
             foreach ($segments as $segment) {
-                if (preg_match('/^\{.+\}$/', $segment)) {
-                    $regexSegments[] = '[^/]+';
+                if (preg_match('/^\{(.+)\}$/', $segment, $m)) {
+                    $regexSegments[] = '([^/]+)';
+                    $paramNames[] = $m[1];
                 } else {
                     $regexSegments[] = preg_quote($segment, '#');
                     $literalCount++;
@@ -48,6 +50,7 @@ final class OpenApiPathMatcher
             $compiled[] = [
                 'pattern' => $pattern,
                 'path' => $specPath,
+                'paramNames' => $paramNames,
                 'literalSegments' => $literalCount,
             ];
         }
@@ -59,6 +62,22 @@ final class OpenApiPathMatcher
     }
 
     public function match(string $requestPath): ?string
+    {
+        return $this->matchWithVariables($requestPath)['path'] ?? null;
+    }
+
+    /**
+     * Match a request path and return both the matched spec path template and
+     * the raw values captured for each `{placeholder}` segment.
+     *
+     * Values are returned **percent-encoded** (exactly as they appear in the
+     * request URI). Callers that need to validate the decoded value should
+     * apply `rawurldecode()` themselves — we don't decode here to keep the
+     * matcher a pure string operation and leave encoding policy to the caller.
+     *
+     * @return null|array{path: string, variables: array<string, string>}
+     */
+    public function matchWithVariables(string $requestPath): ?array
     {
         $normalizedPath = $requestPath;
 
@@ -75,9 +94,17 @@ final class OpenApiPathMatcher
         }
 
         foreach ($this->compiledPaths as $compiled) {
-            if (preg_match($compiled['pattern'], $normalizedPath)) {
-                return $compiled['path'];
+            if (preg_match($compiled['pattern'], $normalizedPath, $matches) !== 1) {
+                continue;
             }
+
+            $variables = [];
+            foreach ($compiled['paramNames'] as $i => $name) {
+                // $matches[0] is the full match; capture groups start at index 1.
+                $variables[$name] = $matches[$i + 1];
+            }
+
+            return ['path' => $compiled['path'], 'variables' => $variables];
         }
 
         return null;

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -23,6 +23,7 @@ use function is_array;
 use function is_int;
 use function is_numeric;
 use function is_string;
+use function preg_match;
 use function rawurldecode;
 use function sprintf;
 use function str_ends_with;
@@ -57,9 +58,10 @@ final class OpenApiRequestValidator
     /**
      * Validate an incoming request against the OpenAPI spec.
      *
-     * Composes two validation phases — query parameters and request body — and
-     * returns a single result. Errors from both phases are accumulated so a
-     * single test run surfaces every contract drift the request exhibits.
+     * Composes path-parameter, query-parameter, and request-body validation
+     * plus any spec-level errors surfaced while collecting merged parameters,
+     * and returns a single result. Errors from all sources are accumulated
+     * so a single test run surfaces every contract drift the request exhibits.
      *
      * @param array<string, mixed> $queryParams parsed query string (string|array<string> per key)
      * @param array<string, mixed> $headers currently ignored; placeholder for header validation
@@ -188,13 +190,27 @@ final class OpenApiRequestValidator
     }
 
     /**
-     * Coerce a query string to int, guarding against overflow. `filter_var`
-     * returns `false` for values exceeding PHP_INT_MAX/MIN or containing
-     * non-digit characters, so the original string falls through and opis
-     * reports a type mismatch instead of receiving a silently truncated value.
+     * Coerce a URL-sourced string to int.
+     *
+     * `filter_var(FILTER_VALIDATE_INT)` is too permissive for contract testing:
+     * it accepts leading/trailing whitespace (e.g. "5 " → 5) and a leading
+     * sign prefix ("+5" → 5). Combined with rawurldecode these laundering
+     * behaviours would silently pass non-canonical URLs — real servers
+     * typically reject them, creating silent drift between the test harness
+     * and production. Pre-filter with a strict canonical-integer regex:
+     * optional leading `-`, then either `0` or a digit string without a
+     * leading zero. Anything else falls through unchanged so opis can
+     * report a meaningful type error.
+     *
+     * Overflow is still handled by `filter_var` returning `false` for
+     * values exceeding PHP_INT_MAX/MIN.
      */
     private static function coerceToInt(string $value): int|string
     {
+        if (preg_match('/^-?(0|[1-9]\d*)$/', $value) !== 1) {
+            return $value;
+        }
+
         $result = filter_var($value, FILTER_VALIDATE_INT);
 
         return is_int($result) ? $result : $value;
@@ -339,8 +355,10 @@ final class OpenApiRequestValidator
      * before type coercion / schema validation — the matcher leaves values
      * raw so encoding policy stays in one place.
      *
-     * `format: uuid | date-time | date | email ...` is delegated to
-     * opis/json-schema's built-in FormatResolver.
+     * String-valued `format: uuid | date-time | date | email | ...` is
+     * delegated to opis/json-schema's built-in FormatResolver (registered on
+     * the `string` type by default). Numeric OAS formats (`int32`, `int64`,
+     * `float`, `double`) are advisory-only and are not validated.
      *
      * @param list<array<string, mixed>> $parameters pre-collected merged parameters
      * @param array<string, string> $pathVariables values extracted by OpenApiPathMatcher
@@ -355,6 +373,7 @@ final class OpenApiRequestValidator
         OpenApiVersion $version,
     ): array {
         $errors = [];
+        $declared = [];
 
         foreach ($parameters as $param) {
             if (($param['in'] ?? null) !== 'path') {
@@ -363,6 +382,7 @@ final class OpenApiRequestValidator
 
             /** @var string $name */
             $name = $param['name'];
+            $declared[$name] = true;
 
             // Defensive: every path placeholder in the matched template should have
             // been captured by the regex. A mismatch here means the spec template and
@@ -403,6 +423,16 @@ final class OpenApiRequestValidator
                 foreach ($messages as $message) {
                     $errors[] = "[path.{$name}{$suffix}] {$message}";
                 }
+            }
+        }
+
+        // Reverse check: every `{placeholder}` in the URL template MUST be declared
+        // as an `in: path` parameter per OpenAPI. A captured-but-not-declared name
+        // means the spec author forgot the declaration entirely, which would otherwise
+        // let any value pass silently — the drift this library exists to catch.
+        foreach ($pathVariables as $name => $_) {
+            if (!isset($declared[$name])) {
+                $errors[] = "[path.{$name}] placeholder in {$method} {$matchedPath} template is not declared as an 'in: path' parameter — malformed spec (OpenAPI requires every placeholder to be declared).";
             }
         }
 

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -23,6 +23,7 @@ use function is_array;
 use function is_int;
 use function is_numeric;
 use function is_string;
+use function rawurldecode;
 use function sprintf;
 use function str_ends_with;
 use function strstr;
@@ -79,13 +80,16 @@ final class OpenApiRequestValidator
         /** @var string[] $specPaths */
         $specPaths = array_keys($spec['paths'] ?? []);
         $matcher = $this->getPathMatcher($specName, $specPaths);
-        $matchedPath = $matcher->match($requestPath);
+        $matched = $matcher->matchWithVariables($requestPath);
 
-        if ($matchedPath === null) {
+        if ($matched === null) {
             return OpenApiValidationResult::failure([
                 "No matching path found in '{$specName}' spec for: {$requestPath}",
             ]);
         }
+
+        $matchedPath = $matched['path'];
+        $pathVariables = $matched['variables'];
 
         $lowerMethod = strtolower($method);
         /** @var array<string, mixed> $pathSpec */
@@ -100,11 +104,22 @@ final class OpenApiRequestValidator
         /** @var array<string, mixed> $operation */
         $operation = $pathSpec[$lowerMethod];
 
+        // Collect merged path/operation parameters once so path + query validation
+        // share a single view of the spec and spec-level errors (malformed entries,
+        // unresolved $refs) are surfaced only once.
+        [$parameters, $specErrors] = $this->collectParameters($method, $matchedPath, $pathSpec, $operation);
+
+        $pathErrors = $this->validatePathParameters(
+            $method,
+            $matchedPath,
+            $parameters,
+            $pathVariables,
+            $version,
+        );
         $queryErrors = $this->validateQueryParameters(
             $method,
             $matchedPath,
-            $pathSpec,
-            $operation,
+            $parameters,
             $queryParams,
             $version,
         );
@@ -118,7 +133,7 @@ final class OpenApiRequestValidator
             $version,
         );
 
-        $errors = [...$queryErrors, ...$bodyErrors];
+        $errors = [...$specErrors, ...$pathErrors, ...$queryErrors, ...$bodyErrors];
 
         if ($errors === []) {
             return OpenApiValidationResult::success($matchedPath);
@@ -186,6 +201,48 @@ final class OpenApiRequestValidator
     }
 
     /**
+     * Scalar-only variant used for path parameters. Path segments arrive as
+     * single strings (OpenAPI default `style: simple`) so array handling is
+     * never appropriate — a spec declaring `type: array` for a path param
+     * would be rejected by opis because the request value is still scalar.
+     *
+     * @param array<string, mixed> $schema
+     */
+    private static function coercePrimitiveValue(mixed $value, array $schema): mixed
+    {
+        $type = $schema['type'] ?? null;
+
+        if (is_array($type)) {
+            $type = self::firstPrimitiveType($type);
+        }
+
+        return self::coercePrimitiveFromType($value, $type);
+    }
+
+    /**
+     * Shared scalar coercion: string → int/float/bool when the target type is
+     * clean, otherwise the original value passes through so opis can report a
+     * meaningful type mismatch.
+     */
+    private static function coercePrimitiveFromType(mixed $value, mixed $type): mixed
+    {
+        if (!is_string($value) || !is_string($type)) {
+            return $value;
+        }
+
+        return match ($type) {
+            'integer' => self::coerceToInt($value),
+            'number' => is_numeric($value) ? (float) $value : $value,
+            'boolean' => match (strtolower($value)) {
+                'true' => true,
+                'false' => false,
+                default => $value,
+            },
+            default => $value,
+        };
+    }
+
+    /**
      * @param string[] $specPaths
      */
     private function getPathMatcher(string $specName, array $specPaths): OpenApiPathMatcher
@@ -202,8 +259,7 @@ final class OpenApiRequestValidator
      * PHP arrays from the framework. Other styles (`form`+`explode:false`,
      * `pipeDelimited`, `spaceDelimited`) are out of scope.
      *
-     * @param array<string, mixed> $pathSpec
-     * @param array<string, mixed> $operation
+     * @param list<array<string, mixed>> $parameters pre-collected merged parameters (path + operation level)
      * @param array<string, mixed> $queryParams
      *
      * @return string[]
@@ -211,12 +267,11 @@ final class OpenApiRequestValidator
     private function validateQueryParameters(
         string $method,
         string $matchedPath,
-        array $pathSpec,
-        array $operation,
+        array $parameters,
         array $queryParams,
         OpenApiVersion $version,
     ): array {
-        [$parameters, $errors] = $this->collectParameters($method, $matchedPath, $pathSpec, $operation);
+        $errors = [];
 
         foreach ($parameters as $param) {
             if (($param['in'] ?? null) !== 'query') {
@@ -266,6 +321,87 @@ final class OpenApiRequestValidator
                 $suffix = $path === '/' ? '' : $path;
                 foreach ($messages as $message) {
                     $errors[] = "[query.{$name}{$suffix}] {$message}";
+                }
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Validate path parameters declared by the matched operation (or
+     * inherited from the path-level `parameters` block) against the values
+     * extracted by the path matcher.
+     *
+     * Path parameters are always required in OpenAPI, so a declared `in: path`
+     * entry without a `schema` is treated as a hard spec error rather than a
+     * silent pass. Percent-encoded segments are decoded via `rawurldecode()`
+     * before type coercion / schema validation — the matcher leaves values
+     * raw so encoding policy stays in one place.
+     *
+     * `format: uuid | date-time | date | email ...` is delegated to
+     * opis/json-schema's built-in FormatResolver.
+     *
+     * @param list<array<string, mixed>> $parameters pre-collected merged parameters
+     * @param array<string, string> $pathVariables values extracted by OpenApiPathMatcher
+     *
+     * @return string[]
+     */
+    private function validatePathParameters(
+        string $method,
+        string $matchedPath,
+        array $parameters,
+        array $pathVariables,
+        OpenApiVersion $version,
+    ): array {
+        $errors = [];
+
+        foreach ($parameters as $param) {
+            if (($param['in'] ?? null) !== 'path') {
+                continue;
+            }
+
+            /** @var string $name */
+            $name = $param['name'];
+
+            // Defensive: every path placeholder in the matched template should have
+            // been captured by the regex. A mismatch here means the spec template and
+            // the compiled matcher disagree — surface it loudly rather than skipping.
+            if (!array_key_exists($name, $pathVariables)) {
+                $errors[] = "[path.{$name}] declared in {$method} {$matchedPath} spec but not captured by path matcher.";
+
+                continue;
+            }
+
+            if (!isset($param['schema']) || !is_array($param['schema'])) {
+                // Path parameters are implicitly required (OpenAPI spec), so a schema-less
+                // entry means every value passes — exactly the silent-drift outcome this
+                // library exists to prevent.
+                $errors[] = "[path.{$name}] parameter has no schema for {$method} {$matchedPath} — cannot validate.";
+
+                continue;
+            }
+
+            /** @var array<string, mixed> $schema */
+            $schema = $param['schema'];
+
+            $decoded = rawurldecode($pathVariables[$name]);
+            $coerced = self::coercePrimitiveValue($decoded, $schema);
+            $jsonSchema = OpenApiSchemaConverter::convert($schema, $version);
+
+            $schemaObject = self::toObject($jsonSchema);
+            $dataObject = self::toObject($coerced);
+
+            $result = $this->opisValidator->validate($dataObject, $schemaObject);
+            if ($result->isValid()) {
+                continue;
+            }
+
+            $formatted = $this->errorFormatter->format($result->error());
+            foreach ($formatted as $path => $messages) {
+                $suffix = $path === '/' ? '' : $path;
+                foreach ($messages as $message) {
+                    $errors[] = "[path.{$name}{$suffix}] {$message}";
                 }
             }
         }
@@ -356,20 +492,7 @@ final class OpenApiRequestValidator
             return $value;
         }
 
-        if (!is_string($value) || !is_string($type)) {
-            return $value;
-        }
-
-        return match ($type) {
-            'integer' => self::coerceToInt($value),
-            'number' => is_numeric($value) ? (float) $value : $value,
-            'boolean' => match (strtolower($value)) {
-                'true' => true,
-                'false' => false,
-                default => $value,
-            },
-            default => $value,
-        };
+        return self::coercePrimitiveFromType($value, $type);
     }
 
     /**

--- a/tests/Integration/ResponseValidationTest.php
+++ b/tests/Integration/ResponseValidationTest.php
@@ -64,7 +64,7 @@ class ResponseValidationTest extends TestCase
 
         // Check coverage
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
-        $this->assertSame(9, $coverage['total']);
+        $this->assertSame(11, $coverage['total']);
         $this->assertSame(2, $coverage['coveredCount']);
         $this->assertContains('GET /v1/pets', $coverage['covered']);
         $this->assertContains('POST /v1/pets', $coverage['covered']);
@@ -94,7 +94,7 @@ class ResponseValidationTest extends TestCase
         }
 
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.1');
-        $this->assertSame(7, $coverage['total']);
+        $this->assertSame(9, $coverage['total']);
         $this->assertSame(1, $coverage['coveredCount']);
     }
 

--- a/tests/Integration/ResponseValidationTest.php
+++ b/tests/Integration/ResponseValidationTest.php
@@ -64,7 +64,7 @@ class ResponseValidationTest extends TestCase
 
         // Check coverage
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
-        $this->assertSame(11, $coverage['total']);
+        $this->assertSame(12, $coverage['total']);
         $this->assertSame(2, $coverage['coveredCount']);
         $this->assertContains('GET /v1/pets', $coverage['covered']);
         $this->assertContains('POST /v1/pets', $coverage['covered']);

--- a/tests/Unit/OpenApiCoverageTrackerTest.php
+++ b/tests/Unit/OpenApiCoverageTrackerTest.php
@@ -67,10 +67,10 @@ class OpenApiCoverageTrackerTest extends TestCase
         $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
 
         // See tests/fixtures/specs/petstore-3.0.json for the full endpoint list
-        $this->assertSame(11, $result['total']);
+        $this->assertSame(12, $result['total']);
         $this->assertSame(2, $result['coveredCount']);
         $this->assertCount(2, $result['covered']);
-        $this->assertCount(9, $result['uncovered']);
+        $this->assertCount(10, $result['uncovered']);
     }
 
     #[Test]
@@ -78,10 +78,10 @@ class OpenApiCoverageTrackerTest extends TestCase
     {
         $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
 
-        $this->assertSame(11, $result['total']);
+        $this->assertSame(12, $result['total']);
         $this->assertSame(0, $result['coveredCount']);
         $this->assertCount(0, $result['covered']);
-        $this->assertCount(11, $result['uncovered']);
+        $this->assertCount(12, $result['uncovered']);
     }
 
     #[Test]

--- a/tests/Unit/OpenApiCoverageTrackerTest.php
+++ b/tests/Unit/OpenApiCoverageTrackerTest.php
@@ -67,10 +67,10 @@ class OpenApiCoverageTrackerTest extends TestCase
         $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
 
         // See tests/fixtures/specs/petstore-3.0.json for the full endpoint list
-        $this->assertSame(9, $result['total']);
+        $this->assertSame(11, $result['total']);
         $this->assertSame(2, $result['coveredCount']);
         $this->assertCount(2, $result['covered']);
-        $this->assertCount(7, $result['uncovered']);
+        $this->assertCount(9, $result['uncovered']);
     }
 
     #[Test]
@@ -78,10 +78,10 @@ class OpenApiCoverageTrackerTest extends TestCase
     {
         $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
 
-        $this->assertSame(9, $result['total']);
+        $this->assertSame(11, $result['total']);
         $this->assertSame(0, $result['coveredCount']);
         $this->assertCount(0, $result['covered']);
-        $this->assertCount(9, $result['uncovered']);
+        $this->assertCount(11, $result['uncovered']);
     }
 
     #[Test]

--- a/tests/Unit/OpenApiPathMatcherTest.php
+++ b/tests/Unit/OpenApiPathMatcherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Tests\Unit;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -204,6 +205,19 @@ class OpenApiPathMatcherTest extends TestCase
             ['path' => '/v2/projects/{project_id}', 'variables' => ['project_id' => 'abc123']],
             $matcher->matchWithVariables('/api/v2/projects/abc123'),
         );
+    }
+
+    #[Test]
+    public function constructor_rejects_duplicate_placeholder_names(): void
+    {
+        // OpenAPI forbids the same placeholder name appearing twice in one template.
+        // Silently overwriting earlier captures would let one of the two segments bypass
+        // contract validation entirely (direction-dependent silent pass), so the matcher
+        // refuses to compile such a template.
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Duplicate path placeholder name 'id' in spec path '/a/{id}/b/{id}'");
+
+        new OpenApiPathMatcher(['/a/{id}/b/{id}']);
     }
 
     private static function createMatcher(): OpenApiPathMatcher

--- a/tests/Unit/OpenApiPathMatcherTest.php
+++ b/tests/Unit/OpenApiPathMatcherTest.php
@@ -137,6 +137,75 @@ class OpenApiPathMatcherTest extends TestCase
         $this->assertNull($matcher->match('/api/v2/account'));
     }
 
+    #[Test]
+    public function match_with_variables_extracts_single_parameter(): void
+    {
+        $matcher = self::createMatcher();
+
+        $this->assertSame(
+            ['path' => '/v2/projects/{project_id}', 'variables' => ['project_id' => 'abc123']],
+            $matcher->matchWithVariables('/v2/projects/abc123'),
+        );
+    }
+
+    #[Test]
+    public function match_with_variables_extracts_multiple_parameters(): void
+    {
+        $matcher = self::createMatcher();
+
+        $this->assertSame(
+            [
+                'path' => '/v2/projects/{project_id}/assets/{asset_id}',
+                'variables' => ['project_id' => 'abc123', 'asset_id' => 'def456'],
+            ],
+            $matcher->matchWithVariables('/v2/projects/abc123/assets/def456'),
+        );
+    }
+
+    #[Test]
+    public function match_with_variables_returns_empty_variables_for_literal_path(): void
+    {
+        $matcher = self::createMatcher();
+
+        $this->assertSame(
+            ['path' => '/v2/account', 'variables' => []],
+            $matcher->matchWithVariables('/v2/account'),
+        );
+    }
+
+    #[Test]
+    public function match_with_variables_returns_null_when_no_match(): void
+    {
+        $matcher = self::createMatcher();
+
+        $this->assertNull($matcher->matchWithVariables('/v2/unknown/path'));
+    }
+
+    #[Test]
+    public function match_with_variables_preserves_percent_encoded_value(): void
+    {
+        $matcher = new OpenApiPathMatcher(['/v2/orders/{orderId}']);
+
+        $this->assertSame(
+            ['path' => '/v2/orders/{orderId}', 'variables' => ['orderId' => 'a1b2%2D3c4d']],
+            $matcher->matchWithVariables('/v2/orders/a1b2%2D3c4d'),
+        );
+    }
+
+    #[Test]
+    public function match_with_variables_honors_strip_prefix(): void
+    {
+        $matcher = new OpenApiPathMatcher(
+            ['/v2/projects/{project_id}'],
+            ['/api'],
+        );
+
+        $this->assertSame(
+            ['path' => '/v2/projects/{project_id}', 'variables' => ['project_id' => 'abc123']],
+            $matcher->matchWithVariables('/api/v2/projects/abc123'),
+        );
+    }
+
     private static function createMatcher(): OpenApiPathMatcher
     {
         return new OpenApiPathMatcher([

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -1108,6 +1108,7 @@ class OpenApiRequestValidatorTest extends TestCase
         );
 
         $this->assertTrue($result->isValid(), $result->errorMessage());
+        $this->assertSame('/v1/pets/{petId}', $result->matchedPath());
     }
 
     #[Test]
@@ -1198,6 +1199,7 @@ class OpenApiRequestValidatorTest extends TestCase
         );
 
         $this->assertTrue($result->isValid(), $result->errorMessage());
+        $this->assertSame('/v1/orders/{orderId}', $result->matchedPath());
     }
 
     #[Test]
@@ -1253,18 +1255,172 @@ class OpenApiRequestValidatorTest extends TestCase
         );
 
         $this->assertTrue($result->isValid(), $result->errorMessage());
+        $this->assertSame('/v1/orders/{orderId}', $result->matchedPath());
     }
 
     #[Test]
-    public function path_query_and_body_errors_are_combined(): void
+    public function path_params_date_time_format_valid_passes(): void
     {
-        // POST /v1/pets defines body only — to combine all three phases we use
+        // Pin the docblock claim that opis's built-in FormatResolver handles date-time
+        // without additional configuration. A future refactor of OpenApiSchemaConverter
+        // that accidentally strips `format` for path params would fail this test.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/events/2026-04-23T10:00:00Z',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+        $this->assertSame('/v1/events/{eventTime}', $result->matchedPath());
+    }
+
+    #[Test]
+    public function path_params_date_time_format_violation_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/events/not-a-timestamp',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[path.eventTime]', $result->errorMessage());
+    }
+
+    #[Test]
+    public function path_params_integer_with_trailing_space_fails(): void
+    {
+        // filter_var(FILTER_VALIDATE_INT) accepts "5 " as 5; combined with rawurldecode("5%20"),
+        // this would silently launder a whitespace-polluted URL into a valid integer.
+        // Real HTTP servers typically reject such paths — the validator should mirror them.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/5%20',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[path.petId]', $result->errorMessage());
+    }
+
+    #[Test]
+    public function path_params_integer_with_leading_plus_fails(): void
+    {
+        // filter_var accepts "+5" as 5. OpenAPI's `style: simple` path serialization does
+        // not emit a leading sign; accepting it silently passes a non-canonical value.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/+5',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[path.petId]', $result->errorMessage());
+    }
+
+    #[Test]
+    public function path_params_ref_entry_surfaces_error(): void
+    {
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/path-ref-parameter/123',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('Parameter $ref encountered', $result->errors()[0]);
+        $this->assertStringContainsString('redocly bundle --dereference', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function path_params_scalar_entry_surfaces_error(): void
+    {
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/path-scalar-parameter/123',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('Malformed parameter entry', $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function path_placeholder_without_declaration_surfaces_error(): void
+    {
+        // A template with `{id}` but no matching `in: path` parameter declaration is
+        // a malformed spec per OpenAPI (every placeholder MUST be declared). Silently
+        // accepting any value would be a classic drift-hiding silent pass.
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/path-undeclared/anything',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[path.id]', $result->errorMessage());
+        $this->assertStringContainsString('not declared', $result->errorMessage());
+    }
+
+    #[Test]
+    public function path_params_declared_but_not_in_template_surfaces_error(): void
+    {
+        // Inverse of the above: a spec declares `in: path` name: wrongId but the template
+        // uses {id}. Defensive check should surface this so the author fixes the typo.
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/path-name-mismatch/123',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[path.wrongId]', $result->errorMessage());
+        $this->assertStringContainsString('not captured', $result->errorMessage());
+    }
+
+    #[Test]
+    public function path_and_query_errors_are_combined(): void
+    {
         // GET /v1/pets/{petId} with:
-        //   - invalid path (petId = "abc")
-        //   - invalid query (traceId = "BAD" breaks the operation-level ^[A-Z]+$? actually passes; use lowercase-only path-level)
-        //     traceId operation-level is ^[A-Z]+$; sending "lower" fails it.
-        // GET has no body; use POST... /v1/pets has no path param. Instead exercise
-        // path + query errors together.
+        //   - invalid path (petId = "abc" — not an integer)
+        //   - invalid query (traceId = "lower" fails the operation-level ^[A-Z]+$ pattern)
+        // Both errors must surface in a single result so users see the full diagnostic
+        // in one run. (GET has no body — the POST /v1/pets endpoint that defines a body
+        // has no path parameter, so body composition is covered by
+        // query_and_body_errors_are_combined above.)
         $result = $this->validator->validate(
             'petstore-3.0',
             'GET',

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -1088,4 +1088,195 @@ class OpenApiRequestValidatorTest extends TestCase
         $this->assertFalse($result->isValid());
         $this->assertStringContainsString('[query.count]', $result->errorMessage());
     }
+
+    // ========================================
+    // Path parameter validation
+    // ========================================
+
+    #[Test]
+    public function path_params_valid_integer_passes(): void
+    {
+        // petId is declared `type: integer, minimum: 1` — "42" coerces to int 42 and passes.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/42',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function path_params_integer_expected_string_fails(): void
+    {
+        // Acceptance: integer 期待で文字列 → surface [path.petId] type error.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/not-a-number',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[path.petId]', $result->errorMessage());
+    }
+
+    #[Test]
+    public function path_params_integer_violates_minimum_fails(): void
+    {
+        // Coercion succeeds but schema constraint (minimum:1) rejects 0.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/0',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[path.petId]', $result->errorMessage());
+    }
+
+    #[Test]
+    public function path_params_uuid_format_valid_passes(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/orders/f47ac10b-58cc-4372-a567-0e02b2c3d479',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+        $this->assertSame('/v1/orders/{orderId}', $result->matchedPath());
+    }
+
+    #[Test]
+    public function path_params_uuid_format_violation_fails(): void
+    {
+        // Acceptance: uuid 違反 → surface [path.orderId] format error.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/orders/not-a-uuid',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[path.orderId]', $result->errorMessage());
+    }
+
+    #[Test]
+    public function path_params_percent_encoded_value_decoded_for_validation(): void
+    {
+        // Canonical UUID with a literal hyphen replaced by "%2D" (percent-encoded '-').
+        // Without rawurldecode() the string `f47ac10b%2D58cc-4372-a567-0e02b2c3d479`
+        // would fail uuid format validation; with decoding it is the valid canonical form.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/orders/f47ac10b%2D58cc-4372-a567-0e02b2c3d479',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function path_params_no_schema_surfaces_error(): void
+    {
+        // Path parameters are always required (OpenAPI spec) — a declared `in: path`
+        // entry without a schema is a malformed spec and should surface as a hard error
+        // rather than silently passing every request.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/widgets/anything',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[path.widgetId]', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function v31_path_params_uuid_format_violation_fails(): void
+    {
+        // OAS 3.1 parity: the 3.1 fixture declares orderId as `type: ["string"], format: uuid`
+        // (multi-type array form). The format validator must still fire.
+        $result = $this->validator->validate(
+            'petstore-3.1',
+            'GET',
+            '/v1/orders/still-not-a-uuid',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[path.orderId]', $result->errorMessage());
+    }
+
+    #[Test]
+    public function v31_path_params_uuid_format_valid_passes(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.1',
+            'GET',
+            '/v1/orders/f47ac10b-58cc-4372-a567-0e02b2c3d479',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function path_query_and_body_errors_are_combined(): void
+    {
+        // POST /v1/pets defines body only — to combine all three phases we use
+        // GET /v1/pets/{petId} with:
+        //   - invalid path (petId = "abc")
+        //   - invalid query (traceId = "BAD" breaks the operation-level ^[A-Z]+$? actually passes; use lowercase-only path-level)
+        //     traceId operation-level is ^[A-Z]+$; sending "lower" fails it.
+        // GET has no body; use POST... /v1/pets has no path param. Instead exercise
+        // path + query errors together.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/abc',
+            ['traceId' => 'lower'],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[path.petId]', $result->errorMessage());
+        $this->assertStringContainsString('[query.traceId]', $result->errorMessage());
+    }
 }

--- a/tests/fixtures/specs/malformed.json
+++ b/tests/fixtures/specs/malformed.json
@@ -164,6 +164,68 @@
                     }
                 }
             }
+        },
+        "/path-ref-parameter/{id}": {
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/UnresolvedId"
+                }
+            ],
+            "get": {
+                "summary": "in:path parameters list contains an unresolved $ref entry",
+                "operationId": "pathRefParameter",
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
+        "/path-scalar-parameter/{id}": {
+            "parameters": [
+                "this should have been an object"
+            ],
+            "get": {
+                "summary": "in:path parameters list contains a non-array entry",
+                "operationId": "pathScalarParameter",
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
+        "/path-undeclared/{id}": {
+            "get": {
+                "summary": "placeholder in template without any matching parameter declaration",
+                "operationId": "pathUndeclared",
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
+        "/path-name-mismatch/{id}": {
+            "parameters": [
+                {
+                    "name": "wrongId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer"
+                    }
+                }
+            ],
+            "get": {
+                "summary": "declared in:path parameter name does not match any template placeholder",
+                "operationId": "pathNameMismatch",
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
         }
     }
 }

--- a/tests/fixtures/specs/petstore-3.0.json
+++ b/tests/fixtures/specs/petstore-3.0.json
@@ -495,6 +495,35 @@
                 }
             }
         },
+        "/v1/events/{eventTime}": {
+            "parameters": [
+                {
+                    "name": "eventTime",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                }
+            ],
+            "get": {
+                "summary": "Fetch events at a given ISO-8601 date-time",
+                "operationId": "getEventAtTime",
+                "responses": {
+                    "200": {
+                        "description": "Event",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/v1/widgets/{widgetId}": {
             "parameters": [
                 {

--- a/tests/fixtures/specs/petstore-3.0.json
+++ b/tests/fixtures/specs/petstore-3.0.json
@@ -313,6 +313,15 @@
         "/v1/pets/{petId}": {
             "parameters": [
                 {
+                    "name": "petId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                },
+                {
                     "name": "traceId",
                     "in": "query",
                     "schema": {
@@ -453,6 +462,53 @@
                 "responses": {
                     "204": {
                         "description": "Pet replaced"
+                    }
+                }
+            }
+        },
+        "/v1/orders/{orderId}": {
+            "parameters": [
+                {
+                    "name": "orderId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                }
+            ],
+            "get": {
+                "summary": "Fetch an order by id",
+                "operationId": "getOrder",
+                "responses": {
+                    "200": {
+                        "description": "Order fetched",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/widgets/{widgetId}": {
+            "parameters": [
+                {
+                    "name": "widgetId",
+                    "in": "path",
+                    "required": true
+                }
+            ],
+            "get": {
+                "summary": "Path parameter declared without a schema (malformed spec fixture)",
+                "operationId": "getWidget",
+                "responses": {
+                    "200": {
+                        "description": "Widget"
                     }
                 }
             }

--- a/tests/fixtures/specs/petstore-3.1.json
+++ b/tests/fixtures/specs/petstore-3.1.json
@@ -224,6 +224,15 @@
         "/v1/pets/{petId}": {
             "parameters": [
                 {
+                    "name": "petId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                },
+                {
                     "name": "traceId",
                     "in": "query",
                     "schema": {
@@ -365,6 +374,53 @@
                 "responses": {
                     "204": {
                         "description": "Pet replaced"
+                    }
+                }
+            }
+        },
+        "/v1/orders/{orderId}": {
+            "parameters": [
+                {
+                    "name": "orderId",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": ["string"],
+                        "format": "uuid"
+                    }
+                }
+            ],
+            "get": {
+                "summary": "Fetch an order by id",
+                "operationId": "getOrder",
+                "responses": {
+                    "200": {
+                        "description": "Order fetched",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/widgets/{widgetId}": {
+            "parameters": [
+                {
+                    "name": "widgetId",
+                    "in": "path",
+                    "required": true
+                }
+            ],
+            "get": {
+                "summary": "Path parameter declared without a schema (malformed spec fixture)",
+                "operationId": "getWidget",
+                "responses": {
+                    "200": {
+                        "description": "Widget"
                     }
                 }
             }


### PR DESCRIPTION
# 概要

`OpenApiRequestValidator` に path parameter 検証フェーズを追加し、URI に埋め込まれた値（例: `/v1/pets/{petId}`、`/v1/orders/{orderId}`）の型や format drift を検知できるようにする。

## 変更内容

issue #44 の受け入れ条件に沿い、query 検証と同じパターン（opis/json-schema 委譲、`[path.{name}]` プレフィックスのエラー）で統一。

- `OpenApiPathMatcher` に `matchWithVariables()` を追加。compiled pattern に parameter name を保持し、placeholder の値を percent-encoded のまま返す。既存 `match()` は delegate で後方互換。
- `OpenApiRequestValidator::validate()` で `collectParameters()` を一段上げ、path / query 両フェーズで共有（spec-level error の二重計上を防止）。
- 新メソッド `validatePathParameters()`: `rawurldecode()` → scalar coercion → `OpenApiSchemaConverter` → opis 検証。`format: uuid | date-time | ...` は opis デフォルトの `FormatResolver` が処理するため追加設定不要。schema 欠落は OpenAPI 上 path が常に required なので hard error として surface。
- scalar 型の coercion ロジックを `coercePrimitiveFromType()` に切り出し、query / path で共有。
- テスト: `OpenApiPathMatcherTest` に抽出系 6 ケース、`OpenApiRequestValidatorTest` に acceptance 相当 10 ケース（uuid 違反 / integer 期待で文字列 / 合格 / OAS 3.1 multi-type parity / percent-decode / combined errors 等）を追加。
- フィクスチャ: `/v1/pets/{petId}` に `petId: integer, minimum: 1` を追加、新規エンドポイント `/v1/orders/{orderId}`（`format: uuid`、3.1 は `type: ["string"]` の多型形式）と `/v1/widgets/{widgetId}`（schema 欠落の hard-error 検証用）を両 spec に追加。連動して endpoint 総数を参照する coverage テスト 4 件を 9→11 / 7→9 に更新。

検証:

- `vendor/bin/phpunit`: 308 tests / 640 assertions — 緑
- `vendor/bin/phpstan analyse`（level 6）: No errors
- `vendor/bin/php-cs-fixer fix --dry-run`: 0 files to fix

## 関連情報

- Closes #44
- Epic: epic:request-validation (#42 / #43 に続く 3 本目)