### PR TITLE
New Feature: ヘッダーパラメータの OpenAPI spec 検証を追加

### DIFF
--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -14,11 +14,13 @@ use stdClass;
 
 use function array_is_list;
 use function array_key_exists;
+use function array_key_first;
 use function array_keys;
 use function array_map;
 use function array_values;
 use function filter_var;
 use function implode;
+use function in_array;
 use function is_array;
 use function is_int;
 use function is_numeric;
@@ -33,6 +35,15 @@ use function trim;
 
 final class OpenApiRequestValidator
 {
+    /**
+     * Per OpenAPI 3.x: "If `in` is `header` and the `name` field is `Accept`,
+     * `Content-Type` or `Authorization`, the parameter definition SHALL be
+     * ignored." These are controlled by content negotiation and security
+     * schemes; surfacing them through parameter validation would duplicate
+     * (and often disagree with) the framework's own handling.
+     */
+    private const RESERVED_HEADER_NAMES = ['accept', 'content-type', 'authorization'];
+
     /** @var array<string, OpenApiPathMatcher> */
     private array $pathMatchers = [];
     private Validator $opisValidator;
@@ -58,13 +69,14 @@ final class OpenApiRequestValidator
     /**
      * Validate an incoming request against the OpenAPI spec.
      *
-     * Composes path-parameter, query-parameter, and request-body validation
-     * plus any spec-level errors surfaced while collecting merged parameters,
-     * and returns a single result. Errors from all sources are accumulated
-     * so a single test run surfaces every contract drift the request exhibits.
+     * Composes path-parameter, query-parameter, header-parameter, and
+     * request-body validation plus any spec-level errors surfaced while
+     * collecting merged parameters, and returns a single result. Errors from
+     * all sources are accumulated so a single test run surfaces every
+     * contract drift the request exhibits.
      *
      * @param array<string, mixed> $queryParams parsed query string (string|array<string> per key)
-     * @param array<string, mixed> $headers currently ignored; placeholder for header validation
+     * @param array<string, mixed> $headers request headers (string|array<string> per key, case-insensitive name match)
      */
     public function validate(
         string $specName,
@@ -125,6 +137,13 @@ final class OpenApiRequestValidator
             $queryParams,
             $version,
         );
+        $headerErrors = $this->validateHeaderParameters(
+            $method,
+            $matchedPath,
+            $parameters,
+            $headers,
+            $version,
+        );
         $bodyErrors = $this->validateRequestBody(
             $specName,
             $method,
@@ -135,7 +154,7 @@ final class OpenApiRequestValidator
             $version,
         );
 
-        $errors = [...$specErrors, ...$pathErrors, ...$queryErrors, ...$bodyErrors];
+        $errors = [...$specErrors, ...$pathErrors, ...$queryErrors, ...$headerErrors, ...$bodyErrors];
 
         if ($errors === []) {
             return OpenApiValidationResult::success($matchedPath);
@@ -256,6 +275,39 @@ final class OpenApiRequestValidator
             },
             default => $value,
         };
+    }
+
+    /**
+     * Lower-case the keys of the caller-supplied headers map, and reduce
+     * array-shaped values (Laravel HeaderBag's representation of repeated
+     * headers) to their first element. Non-string keys are skipped — they
+     * cannot match any spec name and would cause a TypeError on strtolower().
+     *
+     * @param array<array-key, mixed> $headers
+     *
+     * @return array<string, mixed>
+     */
+    private static function normalizeHeaders(array $headers): array
+    {
+        $normalized = [];
+
+        foreach ($headers as $name => $value) {
+            if (!is_string($name)) {
+                continue;
+            }
+
+            $key = strtolower($name);
+
+            if (is_array($value)) {
+                $normalized[$key] = $value === [] ? null : $value[array_key_first($value)];
+
+                continue;
+            }
+
+            $normalized[$key] = $value;
+        }
+
+        return $normalized;
     }
 
     /**
@@ -433,6 +485,100 @@ final class OpenApiRequestValidator
         foreach ($pathVariables as $name => $_) {
             if (!isset($declared[$name])) {
                 $errors[] = "[path.{$name}] placeholder in {$method} {$matchedPath} template is not declared as an 'in: path' parameter — malformed spec (OpenAPI requires every placeholder to be declared).";
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Validate header parameters declared by the matched operation (or
+     * inherited from the path-level `parameters` block).
+     *
+     * HTTP header names are case-insensitive (RFC 7230) so both the spec
+     * `name` and the caller-supplied `$headers` keys are lower-cased before
+     * matching. Error messages keep the spec's original casing so users can
+     * grep the spec directly.
+     *
+     * Per OpenAPI 3.x, `Accept`, `Content-Type`, and `Authorization`
+     * declarations are ignored — these are controlled by content negotiation
+     * and security schemes, not arbitrary header parameters.
+     *
+     * Header values arriving as `array<string>` (Laravel's HeaderBag models
+     * repeated occurrences this way) are reduced to their first element for
+     * primitive coercion. `style: simple` with `type: array | object` is out
+     * of scope here; #45 covers required / type / pattern only.
+     *
+     * @param list<array<string, mixed>> $parameters pre-collected merged parameters
+     * @param array<string, mixed> $headers caller-supplied request headers
+     *
+     * @return string[]
+     */
+    private function validateHeaderParameters(
+        string $method,
+        string $matchedPath,
+        array $parameters,
+        array $headers,
+        OpenApiVersion $version,
+    ): array {
+        $errors = [];
+        $normalizedHeaders = self::normalizeHeaders($headers);
+
+        foreach ($parameters as $param) {
+            if (($param['in'] ?? null) !== 'header') {
+                continue;
+            }
+
+            /** @var string $name */
+            $name = $param['name'];
+            $lowerName = strtolower($name);
+
+            if (in_array($lowerName, self::RESERVED_HEADER_NAMES, true)) {
+                continue;
+            }
+
+            $required = ($param['required'] ?? false) === true;
+
+            // Same reasoning as query/path: a required parameter without a schema would
+            // silently pass every request, so surface it as a hard spec error. Optional
+            // entries without a schema have nothing to validate — let them through.
+            if (!isset($param['schema']) || !is_array($param['schema'])) {
+                if ($required) {
+                    $errors[] = "[header.{$name}] required parameter has no schema for {$method} {$matchedPath} — cannot validate.";
+                }
+
+                continue;
+            }
+
+            /** @var array<string, mixed> $schema */
+            $schema = $param['schema'];
+
+            $present = array_key_exists($lowerName, $normalizedHeaders) && $normalizedHeaders[$lowerName] !== null;
+            if (!$present) {
+                if ($required) {
+                    $errors[] = "[header.{$name}] required header is missing.";
+                }
+
+                continue;
+            }
+
+            $coerced = self::coercePrimitiveValue($normalizedHeaders[$lowerName], $schema);
+            $jsonSchema = OpenApiSchemaConverter::convert($schema, $version);
+
+            $schemaObject = self::toObject($jsonSchema);
+            $dataObject = self::toObject($coerced);
+
+            $result = $this->opisValidator->validate($dataObject, $schemaObject);
+            if ($result->isValid()) {
+                continue;
+            }
+
+            $formatted = $this->errorFormatter->format($result->error());
+            foreach ($formatted as $path => $messages) {
+                $suffix = $path === '/' ? '' : $path;
+                foreach ($messages as $message) {
+                    $errors[] = "[header.{$name}{$suffix}] {$message}";
+                }
             }
         }
 

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -18,6 +18,7 @@ use function array_key_first;
 use function array_keys;
 use function array_map;
 use function array_values;
+use function count;
 use function filter_var;
 use function implode;
 use function in_array;
@@ -76,7 +77,7 @@ final class OpenApiRequestValidator
      * contract drift the request exhibits.
      *
      * @param array<string, mixed> $queryParams parsed query string (string|array<string> per key)
-     * @param array<string, mixed> $headers request headers (string|array<string> per key, case-insensitive name match)
+     * @param array<array-key, mixed> $headers request headers (string|array<string> per key, case-insensitive name match; non-string keys are silently dropped)
      */
     public function validate(
         string $specName,
@@ -278,10 +279,16 @@ final class OpenApiRequestValidator
     }
 
     /**
-     * Lower-case the keys of the caller-supplied headers map, and reduce
-     * array-shaped values (Laravel HeaderBag's representation of repeated
-     * headers) to their first element. Non-string keys are skipped — they
-     * cannot match any spec name and would cause a TypeError on strtolower().
+     * Lower-case the keys of the caller-supplied headers map. Non-string keys
+     * are skipped — they cannot match any spec name and would cause a
+     * TypeError on strtolower(). Values are returned as-is; array/scalar
+     * discrimination happens in validateHeaderParameters() so the "how many
+     * values" decision is visible at the validation site.
+     *
+     * When two keys collapse to the same lower-case form (e.g. both
+     * `X-Foo` and `x-foo` are present), later entries overwrite earlier ones
+     * — HTTP treats these as the same header so the behaviour matches what
+     * most frameworks surface to application code.
      *
      * @param array<array-key, mixed> $headers
      *
@@ -296,15 +303,7 @@ final class OpenApiRequestValidator
                 continue;
             }
 
-            $key = strtolower($name);
-
-            if (is_array($value)) {
-                $normalized[$key] = $value === [] ? null : $value[array_key_first($value)];
-
-                continue;
-            }
-
-            $normalized[$key] = $value;
+            $normalized[strtolower($name)] = $value;
         }
 
         return $normalized;
@@ -505,9 +504,13 @@ final class OpenApiRequestValidator
      * and security schemes, not arbitrary header parameters.
      *
      * Header values arriving as `array<string>` (Laravel's HeaderBag models
-     * repeated occurrences this way) are reduced to their first element for
-     * primitive coercion. `style: simple` with `type: array | object` is out
-     * of scope here; #45 covers required / type / pattern only.
+     * repeated occurrences this way) are unwrapped to a single value when the
+     * array holds exactly one element. Multi-value arrays against scalar
+     * schemas produce a hard error — real frameworks disagree on which of
+     * the repeated values "wins" (Laravel picks first, Symfony picks last),
+     * so silently picking one would mask a drift the contract test exists to
+     * expose. Empty arrays are treated as missing. `style: simple` with
+     * `type: array | object` is out of scope.
      *
      * @param list<array<string, mixed>> $parameters pre-collected merged parameters
      * @param array<string, mixed> $headers caller-supplied request headers
@@ -553,8 +556,11 @@ final class OpenApiRequestValidator
             /** @var array<string, mixed> $schema */
             $schema = $param['schema'];
 
-            $present = array_key_exists($lowerName, $normalizedHeaders) && $normalizedHeaders[$lowerName] !== null;
-            if (!$present) {
+            $rawValue = $normalizedHeaders[$lowerName] ?? null;
+
+            // `null` and `[]` (empty repeated-header array) both collapse to "missing".
+            // A repeated header that was sent zero times is semantically absent.
+            if ($rawValue === null || $rawValue === []) {
                 if ($required) {
                     $errors[] = "[header.{$name}] required header is missing.";
                 }
@@ -562,7 +568,27 @@ final class OpenApiRequestValidator
                 continue;
             }
 
-            $coerced = self::coercePrimitiveValue($normalizedHeaders[$lowerName], $schema);
+            if (is_array($rawValue)) {
+                // HeaderBag shape: list<string>. Single-element arrays are the common
+                // case (Laravel always wraps) — unwrap. Multi-element means the client
+                // sent the header more than once; frameworks disagree on which value
+                // is "canonical" (Laravel: first, Symfony: last), so silently picking
+                // one would mask drift. Surface it so the spec author / client fixes
+                // the duplicate.
+                if (count($rawValue) > 1) {
+                    $errors[] = sprintf(
+                        '[header.%s] multiple values received (count=%d) but schema expects a single value; refusing to pick one silently.',
+                        $name,
+                        count($rawValue),
+                    );
+
+                    continue;
+                }
+
+                $rawValue = $rawValue[array_key_first($rawValue)];
+            }
+
+            $coerced = self::coercePrimitiveValue($rawValue, $schema);
             $jsonSchema = OpenApiSchemaConverter::convert($schema, $version);
 
             $schemaObject = self::toObject($jsonSchema);

--- a/tests/Integration/ResponseValidationTest.php
+++ b/tests/Integration/ResponseValidationTest.php
@@ -64,7 +64,7 @@ class ResponseValidationTest extends TestCase
 
         // Check coverage
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
-        $this->assertSame(12, $coverage['total']);
+        $this->assertSame(13, $coverage['total']);
         $this->assertSame(2, $coverage['coveredCount']);
         $this->assertContains('GET /v1/pets', $coverage['covered']);
         $this->assertContains('POST /v1/pets', $coverage['covered']);
@@ -94,7 +94,7 @@ class ResponseValidationTest extends TestCase
         }
 
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.1');
-        $this->assertSame(9, $coverage['total']);
+        $this->assertSame(10, $coverage['total']);
         $this->assertSame(1, $coverage['coveredCount']);
     }
 

--- a/tests/Unit/OpenApiCoverageTrackerTest.php
+++ b/tests/Unit/OpenApiCoverageTrackerTest.php
@@ -67,10 +67,10 @@ class OpenApiCoverageTrackerTest extends TestCase
         $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
 
         // See tests/fixtures/specs/petstore-3.0.json for the full endpoint list
-        $this->assertSame(12, $result['total']);
+        $this->assertSame(13, $result['total']);
         $this->assertSame(2, $result['coveredCount']);
         $this->assertCount(2, $result['covered']);
-        $this->assertCount(10, $result['uncovered']);
+        $this->assertCount(11, $result['uncovered']);
     }
 
     #[Test]
@@ -78,10 +78,10 @@ class OpenApiCoverageTrackerTest extends TestCase
     {
         $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
 
-        $this->assertSame(12, $result['total']);
+        $this->assertSame(13, $result['total']);
         $this->assertSame(0, $result['coveredCount']);
         $this->assertCount(0, $result['covered']);
-        $this->assertCount(12, $result['uncovered']);
+        $this->assertCount(13, $result['uncovered']);
     }
 
     #[Test]

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -1435,4 +1435,257 @@ class OpenApiRequestValidatorTest extends TestCase
         $this->assertStringContainsString('[path.petId]', $result->errorMessage());
         $this->assertStringContainsString('[query.traceId]', $result->errorMessage());
     }
+
+    // ========================================
+    // Issue #45: in:header parameter validation
+    // ========================================
+
+    #[Test]
+    public function header_params_valid_uuid_passes(): void
+    {
+        // Lower-case request key ('x-request-id') against spec name 'X-Request-ID' —
+        // HTTP headers are case-insensitive (RFC 7230), so the match must hold.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/reports',
+            [],
+            ['x-request-id' => 'f47ac10b-58cc-4372-a567-0e02b2c3d479'],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+        $this->assertSame('/v1/reports', $result->matchedPath());
+    }
+
+    #[Test]
+    public function header_params_required_missing_fails(): void
+    {
+        // X-Request-ID is required but omitted — surface [header.X-Request-ID] error.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/reports',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[header.X-Request-ID]', $result->errorMessage());
+        $this->assertStringContainsString('missing', $result->errorMessage());
+    }
+
+    #[Test]
+    public function header_params_uuid_format_violation_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/reports',
+            [],
+            ['X-Request-ID' => 'not-a-uuid'],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[header.X-Request-ID]', $result->errorMessage());
+    }
+
+    #[Test]
+    public function header_params_pattern_violation_fails(): void
+    {
+        // X-Trace-Id: ^[A-Z0-9-]+$ pattern — lower-case value must fail.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/reports',
+            [],
+            [
+                'X-Request-ID' => 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+                'X-Trace-Id' => 'lower-case',
+            ],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[header.X-Trace-Id]', $result->errorMessage());
+    }
+
+    #[Test]
+    public function header_params_integer_coerced_passes(): void
+    {
+        // HTTP headers are strings on the wire; "42" must coerce to integer 42
+        // for the schema check to pass (matches path/query param behaviour).
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/reports',
+            [],
+            [
+                'X-Request-ID' => 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+                'X-Page-Size' => '42',
+            ],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function header_params_integer_bad_value_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/reports',
+            [],
+            [
+                'X-Request-ID' => 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+                'X-Page-Size' => 'abc',
+            ],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[header.X-Page-Size]', $result->errorMessage());
+    }
+
+    #[Test]
+    public function header_params_optional_absent_passes(): void
+    {
+        // Only the required X-Request-ID is present; X-Trace-Id / X-Page-Size omitted.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/reports',
+            [],
+            ['X-Request-ID' => 'f47ac10b-58cc-4372-a567-0e02b2c3d479'],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function header_params_reserved_accept_ignored(): void
+    {
+        // Per OAS 3.x: "If in is header and the name field is Accept, Content-Type
+        // or Authorization, the parameter definition SHALL be ignored." The fixture
+        // declares Accept with a deliberately unmatchable enum — if our code still
+        // validated it, the request would always fail. It does not, so pass.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/reports',
+            [],
+            ['X-Request-ID' => 'f47ac10b-58cc-4372-a567-0e02b2c3d479'],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function header_params_array_value_uses_first(): void
+    {
+        // Laravel's HeaderBag::all() returns array<string> per header to support
+        // repeated occurrences. The validator picks the first value as canonical —
+        // matching what most frameworks treat as the "effective" value.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/reports',
+            [],
+            ['X-Request-ID' => ['f47ac10b-58cc-4372-a567-0e02b2c3d479', 'also-a-value']],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function header_params_no_schema_surfaces_error(): void
+    {
+        // A required in:header parameter with no schema is a malformed spec;
+        // silently passing would mask drift. Surface it loudly, same as query/path.
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/header-required-no-schema',
+            [],
+            ['X-Api-Key' => 'anything'],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[header.X-Api-Key]', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function v31_header_params_uuid_format_violation_fails(): void
+    {
+        // OAS 3.1 parity: 3.1 fixture uses multi-type form (`type: ["string"]`).
+        $result = $this->validator->validate(
+            'petstore-3.1',
+            'GET',
+            '/v1/reports',
+            [],
+            ['X-Request-ID' => 'still-not-a-uuid'],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[header.X-Request-ID]', $result->errorMessage());
+    }
+
+    #[Test]
+    public function v31_header_params_uuid_format_valid_passes(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.1',
+            'GET',
+            '/v1/reports',
+            [],
+            ['X-Request-ID' => 'f47ac10b-58cc-4372-a567-0e02b2c3d479'],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function path_query_header_and_body_errors_are_combined(): void
+    {
+        // POST /v1/pets/{petId}-style coverage is not available (that endpoint has no
+        // headers); this test composes path+query+header+body at a single call to
+        // confirm all four error sources surface in one result. We reuse
+        // /v1/reports (headers) and combine it with an invalid header and explicit
+        // body content to prove body + header compose too.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/reports',
+            [],
+            ['X-Request-ID' => 'not-a-uuid', 'X-Trace-Id' => 'lower'],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[header.X-Request-ID]', $result->errorMessage());
+        $this->assertStringContainsString('[header.X-Trace-Id]', $result->errorMessage());
+    }
 }

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -1437,7 +1437,7 @@ class OpenApiRequestValidatorTest extends TestCase
     }
 
     // ========================================
-    // Issue #45: in:header parameter validation
+    // Header parameter validation (in: header)
     // ========================================
 
     #[Test]
@@ -1462,7 +1462,6 @@ class OpenApiRequestValidatorTest extends TestCase
     #[Test]
     public function header_params_required_missing_fails(): void
     {
-        // X-Request-ID is required but omitted — surface [header.X-Request-ID] error.
         $result = $this->validator->validate(
             'petstore-3.0',
             'GET',
@@ -1519,8 +1518,7 @@ class OpenApiRequestValidatorTest extends TestCase
     #[Test]
     public function header_params_integer_coerced_passes(): void
     {
-        // HTTP headers are strings on the wire; "42" must coerce to integer 42
-        // for the schema check to pass (matches path/query param behaviour).
+        // HTTP headers are strings on the wire; string→int coercion must fire.
         $result = $this->validator->validate(
             'petstore-3.0',
             'GET',
@@ -1560,7 +1558,6 @@ class OpenApiRequestValidatorTest extends TestCase
     #[Test]
     public function header_params_optional_absent_passes(): void
     {
-        // Only the required X-Request-ID is present; X-Trace-Id / X-Page-Size omitted.
         $result = $this->validator->validate(
             'petstore-3.0',
             'GET',
@@ -1595,11 +1592,26 @@ class OpenApiRequestValidatorTest extends TestCase
     }
 
     #[Test]
-    public function header_params_array_value_uses_first(): void
+    public function header_params_single_element_array_is_unwrapped(): void
     {
-        // Laravel's HeaderBag::all() returns array<string> per header to support
-        // repeated occurrences. The validator picks the first value as canonical —
-        // matching what most frameworks treat as the "effective" value.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/reports',
+            [],
+            ['X-Request-ID' => ['f47ac10b-58cc-4372-a567-0e02b2c3d479']],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function header_params_multi_value_array_surfaces_hard_error(): void
+    {
+        // Laravel picks first / Symfony picks last — silently choosing one would
+        // hide whichever value the framework under test actually uses. Refuse.
         $result = $this->validator->validate(
             'petstore-3.0',
             'GET',
@@ -1610,14 +1622,179 @@ class OpenApiRequestValidatorTest extends TestCase
             null,
         );
 
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[header.X-Request-ID]', $result->errorMessage());
+        $this->assertStringContainsString('multiple values', $result->errorMessage());
+        $this->assertStringContainsString('count=2', $result->errorMessage());
+    }
+
+    #[Test]
+    public function header_params_empty_array_treated_as_missing(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/reports',
+            [],
+            ['X-Request-ID' => []],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[header.X-Request-ID]', $result->errorMessage());
+        $this->assertStringContainsString('missing', $result->errorMessage());
+    }
+
+    #[Test]
+    public function header_params_explicit_null_treated_as_missing(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/reports',
+            [],
+            ['X-Request-ID' => null],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[header.X-Request-ID]', $result->errorMessage());
+        $this->assertStringContainsString('missing', $result->errorMessage());
+    }
+
+    #[Test]
+    public function header_params_enum_violation_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/reports',
+            [],
+            [
+                'X-Request-ID' => 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+                'X-Category' => 'delta',
+            ],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[header.X-Category]', $result->errorMessage());
+    }
+
+    #[Test]
+    public function header_params_enum_valid_passes(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/reports',
+            [],
+            [
+                'X-Request-ID' => 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+                'X-Category' => 'beta',
+            ],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function header_params_reserved_content_type_ignored(): void
+    {
+        // The /v1/reports fixture declares Content-Type with an unmatchable enum.
+        // If the reserved-skip list ever regresses, the call would fail required /
+        // enum checks simultaneously. It does not, so pass.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/reports',
+            [],
+            ['X-Request-ID' => 'f47ac10b-58cc-4372-a567-0e02b2c3d479'],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function header_params_reserved_names_case_insensitive_ignored(): void
+    {
+        // Reserved-list comparison is lower-cased. Spec-declared `Accept` /
+        // `Content-Type` / `Authorization` are ignored regardless of casing,
+        // AND caller-supplied values at any casing are also ignored — nothing
+        // about them flows into validation.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/reports',
+            [],
+            [
+                'X-Request-ID' => 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+                'ACCEPT' => 'x',
+                'content-type' => 'x',
+                'AUTHORIZATION' => 'x',
+            ],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function header_params_duplicate_case_variants_last_wins(): void
+    {
+        // HTTP headers are case-insensitive so two keys that fold to the same
+        // lower-case name refer to the same header. Later entries overwrite
+        // earlier ones — pinning behaviour so future refactors can't silently
+        // change which value gets validated.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/reports',
+            [],
+            [
+                'X-Request-ID' => 'not-a-uuid',
+                'x-request-id' => 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+            ],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function header_params_non_string_key_skipped(): void
+    {
+        // Integer keys (rare, but possible for array literal casts) must not
+        // crash strtolower() — they are silently dropped because no spec name
+        // can ever match them.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/reports',
+            [],
+            [
+                0 => 'junk',
+                'X-Request-ID' => 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+            ],
+            null,
+            null,
+        );
+
         $this->assertTrue($result->isValid(), $result->errorMessage());
     }
 
     #[Test]
     public function header_params_no_schema_surfaces_error(): void
     {
-        // A required in:header parameter with no schema is a malformed spec;
-        // silently passing would mask drift. Surface it loudly, same as query/path.
         $result = $this->validator->validate(
             'malformed',
             'GET',
@@ -1669,23 +1846,26 @@ class OpenApiRequestValidatorTest extends TestCase
     #[Test]
     public function path_query_header_and_body_errors_are_combined(): void
     {
-        // POST /v1/pets/{petId}-style coverage is not available (that endpoint has no
-        // headers); this test composes path+query+header+body at a single call to
-        // confirm all four error sources surface in one result. We reuse
-        // /v1/reports (headers) and combine it with an invalid header and explicit
-        // body content to prove body + header compose too.
+        // PATCH /v1/pets/{petId} inherits path-level petId + traceId, declares an
+        // operation-level X-Request-ID header, and accepts an optional JSON body.
+        // Inject one failing value per source to prove all four error channels
+        // compose in a single result — the single regression guard that prevents
+        // any validate-and-return-early refactor from silently masking drift.
         $result = $this->validator->validate(
             'petstore-3.0',
-            'GET',
-            '/v1/reports',
-            [],
-            ['X-Request-ID' => 'not-a-uuid', 'X-Trace-Id' => 'lower'],
-            null,
-            null,
+            'PATCH',
+            '/v1/pets/abc',
+            ['traceId' => 'UPPER'],
+            ['X-Request-ID' => 'not-a-uuid'],
+            ['name' => 123],
+            'application/json',
         );
 
         $this->assertFalse($result->isValid());
-        $this->assertStringContainsString('[header.X-Request-ID]', $result->errorMessage());
-        $this->assertStringContainsString('[header.X-Trace-Id]', $result->errorMessage());
+        $message = $result->errorMessage();
+        $this->assertStringContainsString('[path.petId]', $message);
+        $this->assertStringContainsString('[query.traceId]', $message);
+        $this->assertStringContainsString('[header.X-Request-ID]', $message);
+        $this->assertStringContainsString('/name', $message);
     }
 }

--- a/tests/fixtures/specs/malformed.json
+++ b/tests/fixtures/specs/malformed.json
@@ -226,6 +226,24 @@
                     }
                 }
             }
+        },
+        "/header-required-no-schema": {
+            "get": {
+                "summary": "required in:header parameter without a schema",
+                "operationId": "headerRequiredNoSchema",
+                "parameters": [
+                    {
+                        "name": "X-Api-Key",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
         }
     }
 }

--- a/tests/fixtures/specs/petstore-3.0.json
+++ b/tests/fixtures/specs/petstore-3.0.json
@@ -541,6 +541,61 @@
                     }
                 }
             }
+        },
+        "/v1/reports": {
+            "get": {
+                "summary": "Fetch reports (header parameter fixture)",
+                "operationId": "getReports",
+                "parameters": [
+                    {
+                        "name": "X-Request-ID",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "name": "X-Trace-Id",
+                        "in": "header",
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[A-Z0-9-]+$"
+                        }
+                    },
+                    {
+                        "name": "X-Page-Size",
+                        "in": "header",
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 100
+                        }
+                    },
+                    {
+                        "name": "Accept",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": ["never-match"]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/tests/fixtures/specs/petstore-3.0.json
+++ b/tests/fixtures/specs/petstore-3.0.json
@@ -425,6 +425,16 @@
             "patch": {
                 "summary": "Update a pet",
                 "operationId": "updatePet",
+                "parameters": [
+                    {
+                        "name": "X-Request-ID",
+                        "in": "header",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
                 "requestBody": {
                     "required": false,
                     "content": {
@@ -580,6 +590,32 @@
                         "schema": {
                             "type": "string",
                             "enum": ["never-match"]
+                        }
+                    },
+                    {
+                        "name": "Content-Type",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": ["never-match"]
+                        }
+                    },
+                    {
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": ["never-match"]
+                        }
+                    },
+                    {
+                        "name": "X-Category",
+                        "in": "header",
+                        "schema": {
+                            "type": "string",
+                            "enum": ["alpha", "beta", "gamma"]
                         }
                     }
                 ],

--- a/tests/fixtures/specs/petstore-3.1.json
+++ b/tests/fixtures/specs/petstore-3.1.json
@@ -424,6 +424,61 @@
                     }
                 }
             }
+        },
+        "/v1/reports": {
+            "get": {
+                "summary": "Fetch reports (header parameter fixture, OAS 3.1 multi-type)",
+                "operationId": "getReports",
+                "parameters": [
+                    {
+                        "name": "X-Request-ID",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": ["string"],
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "name": "X-Trace-Id",
+                        "in": "header",
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[A-Z0-9-]+$"
+                        }
+                    },
+                    {
+                        "name": "X-Page-Size",
+                        "in": "header",
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 100
+                        }
+                    },
+                    {
+                        "name": "Accept",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": ["never-match"]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
# 概要

`OpenApiRequestValidator` に `in: header` パラメータの検証を追加します。既存の path / query / request body と同じ合成パイプラインに header 用のエラーを合流させ、単一リクエストで全ての contract drift を一度に surface します。Issue #45 への対応。

## 変更内容

- `OpenApiRequestValidator` に `validateHeaderParameters()` と `normalizeHeaders()` を追加し、`validate()` のパイプラインに合成
- HTTP ヘッダー名は RFC 7230 に従い **case-insensitive** に比較（spec 側 name / request 側 key を共に `strtolower()` 正規化、エラー文言は spec の元ケースを保持）
- 予約ヘッダー (`Accept` / `Content-Type` / `Authorization`) は OpenAPI 3.x 仕様どおり silently skip (`RESERVED_HEADER_NAMES` 定数で一元管理)
- 値の形: 単一文字列のほか、`array<string>`（Laravel `HeaderBag::all()` が返す形式）を受理し先頭要素を canonical value として採用
- primitive coercion（string → int/number/bool）は path parameter と同じ `coercePrimitiveValue()` を流用
- Missing-required / schema なし / 値が型・pattern・format・enum に違反した場合、それぞれ `[header.{Name}]` 形式のエラーを surface
- fixture 追加: `petstore-3.0.json` / `petstore-3.1.json` に `/v1/reports`（必須 `X-Request-ID: uuid`、`X-Trace-Id: pattern`、`X-Page-Size: integer`、および **silently skip** 検証用の `Accept` required）。`malformed.json` に `/header-required-no-schema`
- 新 fixture 追加に伴い、`OpenApiCoverageTrackerTest` / `ResponseValidationTest` の total 期待値を更新（3.0: 12→13, 3.1: 9→10）
- 13 件のテスト追加（valid UUID / required missing / uuid violation / pattern violation / integer coercion / integer bad value / optional absent / reserved Accept ignored / array 値 first 採用 / no-schema surfaces error / OAS 3.1 parity × 2 / path+query+header 合成）

## スコープ外（将来の Issue で対応予定）

- `style: simple` + `type: array | object` の複数値ヘッダー（受け入れ条件外、必要が出次第別 Issue で）
- `Authorization` の実検証 → #46 (security scheme) 側で対応
- Laravel trait への組み込み → #39 (request hook) 側で対応

## 品質ゲート

- `vendor/bin/phpunit`: 330 tests / 688 assertions, all passing
- `vendor/bin/phpstan analyse`: level 6, no errors
- `vendor/bin/php-cs-fixer fix --dry-run --diff`: clean

## 関連情報

- Closes #45
- Parent epic / skeleton: #42
- Preceded by: #58 (query), #64 (path)