### PR TITLE
New Feature: security scheme (bearer / apiKey) の検証を追加

### DIFF
--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -20,6 +20,7 @@ use function array_map;
 use function array_values;
 use function count;
 use function filter_var;
+use function get_debug_type;
 use function implode;
 use function in_array;
 use function is_array;
@@ -70,14 +71,15 @@ final class OpenApiRequestValidator
     /**
      * Validate an incoming request against the OpenAPI spec.
      *
-     * Composes path-parameter, query-parameter, header-parameter, and
-     * request-body validation plus any spec-level errors surfaced while
+     * Composes path-parameter, query-parameter, header-parameter, security,
+     * and request-body validation plus any spec-level errors surfaced while
      * collecting merged parameters, and returns a single result. Errors from
      * all sources are accumulated so a single test run surfaces every
      * contract drift the request exhibits.
      *
      * @param array<string, mixed> $queryParams parsed query string (string|array<string> per key)
      * @param array<array-key, mixed> $headers request headers (string|array<string> per key, case-insensitive name match; non-string keys are silently dropped)
+     * @param array<string, mixed> $cookies request cookies (string values per key). Used for apiKey security schemes with `in: cookie`. Caller is expected to pass framework-parsed cookies (e.g. Laravel's `$request->cookies->all()`) — this validator does not parse a `Cookie` header.
      */
     public function validate(
         string $specName,
@@ -87,6 +89,7 @@ final class OpenApiRequestValidator
         array $headers,
         mixed $requestBody,
         ?string $contentType = null,
+        array $cookies = [],
     ): OpenApiValidationResult {
         $spec = OpenApiSpecLoader::load($specName);
 
@@ -145,6 +148,15 @@ final class OpenApiRequestValidator
             $headers,
             $version,
         );
+        $securityErrors = $this->validateSecurity(
+            $method,
+            $matchedPath,
+            $spec,
+            $operation,
+            $headers,
+            $queryParams,
+            $cookies,
+        );
         $bodyErrors = $this->validateRequestBody(
             $specName,
             $method,
@@ -155,7 +167,7 @@ final class OpenApiRequestValidator
             $version,
         );
 
-        $errors = [...$specErrors, ...$pathErrors, ...$queryErrors, ...$headerErrors, ...$bodyErrors];
+        $errors = [...$specErrors, ...$pathErrors, ...$queryErrors, ...$headerErrors, ...$securityErrors, ...$bodyErrors];
 
         if ($errors === []) {
             return OpenApiValidationResult::success($matchedPath);
@@ -609,6 +621,347 @@ final class OpenApiRequestValidator
         }
 
         return $errors;
+    }
+
+    /**
+     * Validate the endpoint's `security` requirement against the incoming
+     * request. Supports `http` + `bearer` and `apiKey` (in: header|query|cookie)
+     * schemes. OAuth2 / OpenID Connect are out of scope for phase 1 and are
+     * treated as unsupported: any requirement entry containing an unsupported
+     * scheme is skipped entirely (contributes neither pass nor fail).
+     *
+     * Resolution: operation-level `security` takes precedence; otherwise the
+     * root-level `security` is inherited. `security: []` (empty array) explicitly
+     * opts out of all authentication, so it returns `[]` immediately regardless
+     * of root-level definitions. Missing `security` on both levels also returns
+     * `[]` (no authentication required).
+     *
+     * OR / AND semantics (per OpenAPI):
+     * - Multiple entries in the `security` array → OR (any one satisfied is enough)
+     * - Multiple schemes within a single entry object → AND (all must be satisfied)
+     *
+     * Malformed spec elements (undefined scheme references, scalar entries,
+     * missing `type` / `scheme` / `name` / `in` fields) are always surfaced as
+     * hard errors, even if another requirement entry is satisfied — a broken
+     * security declaration is something the spec author must fix.
+     *
+     * @param array<string, mixed> $spec full spec root (for `components.securitySchemes` + root-level `security`)
+     * @param array<string, mixed> $operation operation spec (for operation-level `security`)
+     * @param array<array-key, mixed> $headers caller-supplied request headers
+     * @param array<string, mixed> $queryParams parsed query string
+     * @param array<string, mixed> $cookies request cookies (for `apiKey` with `in: cookie`)
+     *
+     * @return string[]
+     */
+    private function validateSecurity(
+        string $method,
+        string $matchedPath,
+        array $spec,
+        array $operation,
+        array $headers,
+        array $queryParams,
+        array $cookies,
+    ): array {
+        // Operation-level `security` (including an explicit empty array) overrides
+        // root-level. Only fall back to root when the operation does not declare
+        // `security` at all.
+        $security = array_key_exists('security', $operation)
+            ? $operation['security']
+            : ($spec['security'] ?? null);
+
+        if ($security === null) {
+            return [];
+        }
+
+        if (!is_array($security)) {
+            return [
+                sprintf(
+                    '[security] %s %s: operation/root-level `security` must be an array of requirement objects, got %s.',
+                    $method,
+                    $matchedPath,
+                    get_debug_type($security),
+                ),
+            ];
+        }
+
+        // Explicit `security: []` disables authentication for the operation.
+        if ($security === []) {
+            return [];
+        }
+
+        $schemes = $spec['components']['securitySchemes'] ?? [];
+        if (!is_array($schemes)) {
+            $schemes = [];
+        }
+
+        $normalizedHeaders = self::normalizeHeaders($headers);
+
+        $hardErrors = [];
+        $failureErrors = [];
+        $satisfied = false;
+
+        foreach ($security as $entryIndex => $entry) {
+            if (!is_array($entry)) {
+                $hardErrors[] = sprintf(
+                    '[security] %s %s: security requirement at index %d must be an object mapping scheme names to scope arrays, got %s.',
+                    $method,
+                    $matchedPath,
+                    is_int($entryIndex) ? $entryIndex : 0,
+                    get_debug_type($entry),
+                );
+
+                continue;
+            }
+
+            $entryHasHardError = false;
+            $entryHasUnsupported = false;
+            /** @var array<string, array{kind: string, def: array<string, mixed>}> $validatable */
+            $validatable = [];
+
+            foreach ($entry as $schemeName => $_scopes) {
+                if (!is_string($schemeName)) {
+                    $hardErrors[] = sprintf(
+                        '[security] %s %s: security scheme name must be a string, got %s.',
+                        $method,
+                        $matchedPath,
+                        get_debug_type($schemeName),
+                    );
+                    $entryHasHardError = true;
+
+                    continue;
+                }
+
+                $schemeDef = $schemes[$schemeName] ?? null;
+                if (!is_array($schemeDef)) {
+                    $hardErrors[] = sprintf(
+                        "[security] %s %s: security requirement references undefined scheme '%s' — add it under components.securitySchemes.",
+                        $method,
+                        $matchedPath,
+                        $schemeName,
+                    );
+                    $entryHasHardError = true;
+
+                    continue;
+                }
+
+                $classification = $this->classifySecurityScheme($schemeDef);
+
+                if ($classification['kind'] === 'malformed') {
+                    $hardErrors[] = sprintf(
+                        "[security] %s %s: security scheme '%s' is malformed: %s",
+                        $method,
+                        $matchedPath,
+                        $schemeName,
+                        $classification['reason'],
+                    );
+                    $entryHasHardError = true;
+
+                    continue;
+                }
+
+                if ($classification['kind'] === 'unsupported') {
+                    $entryHasUnsupported = true;
+
+                    continue;
+                }
+
+                $validatable[$schemeName] = ['kind' => $classification['kind'], 'def' => $schemeDef];
+            }
+
+            if ($entryHasHardError) {
+                continue;
+            }
+
+            if ($entryHasUnsupported) {
+                continue;
+            }
+
+            // Within a single requirement entry, ALL schemes must be satisfied (AND).
+            $entryFailures = [];
+            foreach ($validatable as $schemeName => $info) {
+                $schemeErrors = $this->checkSchemeSatisfaction(
+                    $info['kind'],
+                    $info['def'],
+                    $normalizedHeaders,
+                    $queryParams,
+                    $cookies,
+                );
+                foreach ($schemeErrors as $schemeError) {
+                    $entryFailures[] = sprintf(
+                        "[security] %s %s: requirement '%s' not satisfied: %s",
+                        $method,
+                        $matchedPath,
+                        $schemeName,
+                        $schemeError,
+                    );
+                }
+            }
+
+            if ($entryFailures === []) {
+                $satisfied = true;
+
+                break;
+            }
+
+            $failureErrors = [...$failureErrors, ...$entryFailures];
+        }
+
+        if ($satisfied) {
+            return $hardErrors;
+        }
+
+        // If every requirement entry was either skipped (unsupported scheme
+        // within) or malformed (already captured in $hardErrors), there is no
+        // *validatable* entry that failed. Returning early avoids blocking a
+        // test for a spec we fundamentally cannot evaluate (false-negative
+        // avoidance for oauth2-only endpoints).
+        if ($failureErrors === []) {
+            return $hardErrors;
+        }
+
+        return [...$hardErrors, ...$failureErrors];
+    }
+
+    /**
+     * Classify a security scheme definition into one of:
+     * - `bearer`        — http + scheme=bearer (validatable)
+     * - `apiKey`        — apiKey in header|query|cookie (validatable)
+     * - `unsupported`   — oauth2 / openIdConnect / http+basic/digest / mutualTLS / unknown type (phase 1 skip)
+     * - `malformed`     — missing/invalid required fields (hard spec error)
+     *
+     * @param array<string, mixed> $schemeDef
+     *
+     * @return array{kind: string, reason?: string}
+     */
+    private function classifySecurityScheme(array $schemeDef): array
+    {
+        $type = $schemeDef['type'] ?? null;
+        if (!is_string($type)) {
+            return ['kind' => 'malformed', 'reason' => "missing required 'type' field."];
+        }
+
+        if ($type === 'apiKey') {
+            $in = $schemeDef['in'] ?? null;
+            $name = $schemeDef['name'] ?? null;
+            if (!is_string($in) || !is_string($name)) {
+                return ['kind' => 'malformed', 'reason' => "apiKey scheme requires string 'in' and 'name' fields."];
+            }
+            if (!in_array($in, ['header', 'query', 'cookie'], true)) {
+                return ['kind' => 'malformed', 'reason' => "apiKey scheme 'in' must be one of header|query|cookie, got '{$in}'."];
+            }
+
+            return ['kind' => 'apiKey'];
+        }
+
+        if ($type === 'http') {
+            $scheme = $schemeDef['scheme'] ?? null;
+            if (!is_string($scheme)) {
+                return ['kind' => 'malformed', 'reason' => "http scheme requires a string 'scheme' field (e.g. 'bearer', 'basic')."];
+            }
+
+            if (strtolower($scheme) === 'bearer') {
+                return ['kind' => 'bearer'];
+            }
+
+            // http + basic / digest / etc. are well-formed but phase 1 cannot validate them.
+            return ['kind' => 'unsupported'];
+        }
+
+        // oauth2 / openIdConnect / mutualTLS / unknown types fall through as "unsupported".
+        return ['kind' => 'unsupported'];
+    }
+
+    /**
+     * Check whether a single (already-classified, well-formed) security scheme
+     * is satisfied by the request. Returns an empty list when satisfied, or
+     * one or more error strings explaining why not.
+     *
+     * @param array<string, mixed> $schemeDef
+     * @param array<string, mixed> $normalizedHeaders lower-cased header map
+     * @param array<string, mixed> $queryParams
+     * @param array<string, mixed> $cookies
+     *
+     * @return string[]
+     */
+    private function checkSchemeSatisfaction(
+        string $kind,
+        array $schemeDef,
+        array $normalizedHeaders,
+        array $queryParams,
+        array $cookies,
+    ): array {
+        if ($kind === 'bearer') {
+            $raw = $normalizedHeaders['authorization'] ?? null;
+            $value = $this->extractSingleStringValue($raw);
+            if ($value === null || $value === '') {
+                return ['Authorization header is missing.'];
+            }
+
+            // RFC 6750 §2.1: `Bearer <token>`. Scheme name is case-insensitive
+            // per RFC 7235 §2.1, so we accept "Bearer" / "bearer" / "BEARER" etc.
+            // Require a non-empty token portion; "Bearer" alone or "Bearer " is
+            // not a valid credential.
+            if (preg_match('/^bearer\s+(\S+)/i', $value) !== 1) {
+                return ["Authorization header does not contain a 'Bearer <token>' credential."];
+            }
+
+            return [];
+        }
+
+        if ($kind === 'apiKey') {
+            /** @var string $in */
+            $in = $schemeDef['in'];
+            /** @var string $name */
+            $name = $schemeDef['name'];
+
+            $raw = match ($in) {
+                'header' => $normalizedHeaders[strtolower($name)] ?? null,
+                'query' => $queryParams[$name] ?? null,
+                'cookie' => $cookies[$name] ?? null,
+                default => null,
+            };
+
+            $value = $this->extractSingleStringValue($raw);
+            if ($value === null || $value === '') {
+                return [sprintf("api key '%s' is missing from the %s.", $name, $in)];
+            }
+
+            return [];
+        }
+
+        // Unreachable: classifySecurityScheme only returns 'bearer' / 'apiKey' / 'unsupported' / 'malformed',
+        // and the caller filters out 'unsupported' and 'malformed' before reaching this method.
+        return [];
+    }
+
+    /**
+     * Normalize a header/query/cookie value (which may arrive as string, array
+     * of strings, or null) to a single string. Returns null when the value is
+     * absent, empty-array, or a non-string shape that cannot be coerced.
+     *
+     * Multi-value arrays collapse to the first element — security validation
+     * does not treat "multiple Authorization headers" as a hard error the way
+     * header-parameter validation does, because the security layer's job is
+     * "is a credential present" rather than "is the request well-formed". A
+     * duplicate Authorization header is already a framework-level concern.
+     */
+    private function extractSingleStringValue(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_array($value)) {
+            if ($value === []) {
+                return null;
+            }
+
+            $first = $value[array_key_first($value)];
+
+            return is_string($first) ? $first : null;
+        }
+
+        return is_string($value) ? $value : null;
     }
 
     /**

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -8,6 +8,7 @@ use const FILTER_VALIDATE_INT;
 use const PHP_INT_MAX;
 
 use InvalidArgumentException;
+use LogicException;
 use Opis\JsonSchema\Errors\ErrorFormatter;
 use Opis\JsonSchema\Validator;
 use stdClass;
@@ -662,9 +663,6 @@ final class OpenApiRequestValidator
         array $queryParams,
         array $cookies,
     ): array {
-        // Operation-level `security` (including an explicit empty array) overrides
-        // root-level. Only fall back to root when the operation does not declare
-        // `security` at all.
         $security = array_key_exists('security', $operation)
             ? $operation['security']
             : ($spec['security'] ?? null);
@@ -684,14 +682,24 @@ final class OpenApiRequestValidator
             ];
         }
 
-        // Explicit `security: []` disables authentication for the operation.
         if ($security === []) {
             return [];
         }
 
         $schemes = $spec['components']['securitySchemes'] ?? [];
+        // A non-array `components.securitySchemes` is a malformed spec — without
+        // this hard error, every scheme reference below would be reported as
+        // "undefined scheme … add it under components.securitySchemes", which
+        // misdirects the spec author away from the real cause.
         if (!is_array($schemes)) {
-            $schemes = [];
+            return [
+                sprintf(
+                    '[security] %s %s: components.securitySchemes must be an object mapping scheme names to definitions, got %s.',
+                    $method,
+                    $matchedPath,
+                    get_debug_type($schemes),
+                ),
+            ];
         }
 
         $normalizedHeaders = self::normalizeHeaders($headers);
@@ -776,7 +784,6 @@ final class OpenApiRequestValidator
                 continue;
             }
 
-            // Within a single requirement entry, ALL schemes must be satisfied (AND).
             $entryFailures = [];
             foreach ($validatable as $schemeName => $info) {
                 $schemeErrors = $this->checkSchemeSatisfaction(
@@ -824,10 +831,16 @@ final class OpenApiRequestValidator
 
     /**
      * Classify a security scheme definition into one of:
-     * - `bearer`        — http + scheme=bearer (validatable)
-     * - `apiKey`        — apiKey in header|query|cookie (validatable)
-     * - `unsupported`   — oauth2 / openIdConnect / http+basic/digest / mutualTLS / unknown type (phase 1 skip)
-     * - `malformed`     — missing/invalid required fields (hard spec error)
+     * - `bearer`      — http + scheme=bearer (validatable)
+     * - `apiKey`      — apiKey in header|query|cookie (validatable)
+     * - `unsupported` — a spec-allowed type we intentionally defer (oauth2,
+     *                   openIdConnect, mutualTLS, or http with a non-bearer
+     *                   scheme). Phase 1 skip — false-negative avoidance.
+     * - `malformed`   — missing/invalid required fields, or a `type` that is
+     *                   not in the OpenAPI-enumerated set. A typo like
+     *                   `{"type": "htpp"}` MUST surface as a hard error
+     *                   rather than silently skipping — otherwise the
+     *                   library would pass every request for that endpoint.
      *
      * @param array<string, mixed> $schemeDef
      *
@@ -836,7 +849,7 @@ final class OpenApiRequestValidator
     private function classifySecurityScheme(array $schemeDef): array
     {
         $type = $schemeDef['type'] ?? null;
-        if (!is_string($type)) {
+        if (!is_string($type) || $type === '') {
             return ['kind' => 'malformed', 'reason' => "missing required 'type' field."];
         }
 
@@ -867,8 +880,14 @@ final class OpenApiRequestValidator
             return ['kind' => 'unsupported'];
         }
 
-        // oauth2 / openIdConnect / mutualTLS / unknown types fall through as "unsupported".
-        return ['kind' => 'unsupported'];
+        if ($type === 'oauth2' || $type === 'openIdConnect' || $type === 'mutualTLS') {
+            return ['kind' => 'unsupported'];
+        }
+
+        return [
+            'kind' => 'malformed',
+            'reason' => "unknown type '{$type}' — OpenAPI 3.x enumerates apiKey|http|oauth2|openIdConnect|mutualTLS.",
+        ];
     }
 
     /**
@@ -929,21 +948,20 @@ final class OpenApiRequestValidator
             return [];
         }
 
-        // Unreachable: classifySecurityScheme only returns 'bearer' / 'apiKey' / 'unsupported' / 'malformed',
-        // and the caller filters out 'unsupported' and 'malformed' before reaching this method.
-        return [];
+        throw new LogicException("checkSchemeSatisfaction received unexpected kind '{$kind}'.");
     }
 
     /**
-     * Normalize a header/query/cookie value (which may arrive as string, array
-     * of strings, or null) to a single string. Returns null when the value is
-     * absent, empty-array, or a non-string shape that cannot be coerced.
+     * Return the first element of an array, the value itself if it's a string,
+     * or `null` otherwise (absent, empty array, or non-string scalar like int
+     * or bool). No coercion is performed — a non-string first element still
+     * returns `null`.
      *
-     * Multi-value arrays collapse to the first element — security validation
-     * does not treat "multiple Authorization headers" as a hard error the way
-     * header-parameter validation does, because the security layer's job is
-     * "is a credential present" rather than "is the request well-formed". A
-     * duplicate Authorization header is already a framework-level concern.
+     * Unlike `validateHeaderParameters()` (which rejects multi-value arrays as
+     * a hard error to force the spec author to pick a canonical value), the
+     * security layer silently accepts the first element. Presence of a
+     * credential is all the security layer checks, and duplicate headers are
+     * a framework-level concern surfaced elsewhere.
      */
     private function extractSingleStringValue(mixed $value): ?string
     {

--- a/tests/Integration/ResponseValidationTest.php
+++ b/tests/Integration/ResponseValidationTest.php
@@ -64,7 +64,7 @@ class ResponseValidationTest extends TestCase
 
         // Check coverage
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
-        $this->assertSame(22, $coverage['total']);
+        $this->assertSame(23, $coverage['total']);
         $this->assertSame(2, $coverage['coveredCount']);
         $this->assertContains('GET /v1/pets', $coverage['covered']);
         $this->assertContains('POST /v1/pets', $coverage['covered']);

--- a/tests/Integration/ResponseValidationTest.php
+++ b/tests/Integration/ResponseValidationTest.php
@@ -64,7 +64,7 @@ class ResponseValidationTest extends TestCase
 
         // Check coverage
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
-        $this->assertSame(13, $coverage['total']);
+        $this->assertSame(22, $coverage['total']);
         $this->assertSame(2, $coverage['coveredCount']);
         $this->assertContains('GET /v1/pets', $coverage['covered']);
         $this->assertContains('POST /v1/pets', $coverage['covered']);
@@ -94,7 +94,7 @@ class ResponseValidationTest extends TestCase
         }
 
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.1');
-        $this->assertSame(10, $coverage['total']);
+        $this->assertSame(19, $coverage['total']);
         $this->assertSame(1, $coverage['coveredCount']);
     }
 

--- a/tests/Unit/OpenApiCoverageTrackerTest.php
+++ b/tests/Unit/OpenApiCoverageTrackerTest.php
@@ -67,10 +67,10 @@ class OpenApiCoverageTrackerTest extends TestCase
         $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
 
         // See tests/fixtures/specs/petstore-3.0.json for the full endpoint list
-        $this->assertSame(22, $result['total']);
+        $this->assertSame(23, $result['total']);
         $this->assertSame(2, $result['coveredCount']);
         $this->assertCount(2, $result['covered']);
-        $this->assertCount(20, $result['uncovered']);
+        $this->assertCount(21, $result['uncovered']);
     }
 
     #[Test]
@@ -78,10 +78,10 @@ class OpenApiCoverageTrackerTest extends TestCase
     {
         $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
 
-        $this->assertSame(22, $result['total']);
+        $this->assertSame(23, $result['total']);
         $this->assertSame(0, $result['coveredCount']);
         $this->assertCount(0, $result['covered']);
-        $this->assertCount(22, $result['uncovered']);
+        $this->assertCount(23, $result['uncovered']);
     }
 
     #[Test]

--- a/tests/Unit/OpenApiCoverageTrackerTest.php
+++ b/tests/Unit/OpenApiCoverageTrackerTest.php
@@ -67,10 +67,10 @@ class OpenApiCoverageTrackerTest extends TestCase
         $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
 
         // See tests/fixtures/specs/petstore-3.0.json for the full endpoint list
-        $this->assertSame(13, $result['total']);
+        $this->assertSame(22, $result['total']);
         $this->assertSame(2, $result['coveredCount']);
         $this->assertCount(2, $result['covered']);
-        $this->assertCount(11, $result['uncovered']);
+        $this->assertCount(20, $result['uncovered']);
     }
 
     #[Test]
@@ -78,10 +78,10 @@ class OpenApiCoverageTrackerTest extends TestCase
     {
         $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
 
-        $this->assertSame(13, $result['total']);
+        $this->assertSame(22, $result['total']);
         $this->assertSame(0, $result['coveredCount']);
         $this->assertCount(0, $result['covered']);
-        $this->assertCount(13, $result['uncovered']);
+        $this->assertCount(22, $result['uncovered']);
     }
 
     #[Test]

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -1869,8 +1869,35 @@ class OpenApiRequestValidatorTest extends TestCase
         $this->assertStringContainsString('/name', $message);
     }
 
+    #[Test]
+    public function path_query_header_body_and_security_errors_all_compose(): void
+    {
+        // POST /v1/secure/compose/{tenantId} bundles every validation channel the
+        // pipeline offers: path param (integer), query param (pattern), header
+        // (uuid), body (required 'name'), and security (bearerAuth). Inject a
+        // failing value per source so a refactor that short-circuits after any
+        // single channel fails would break this test.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'POST',
+            '/v1/secure/compose/abc',
+            ['trace' => 'UPPER'],
+            ['X-Request-ID' => 'not-a-uuid'],
+            ['name' => 123],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $message = $result->errorMessage();
+        $this->assertStringContainsString('[path.tenantId]', $message);
+        $this->assertStringContainsString('[query.trace]', $message);
+        $this->assertStringContainsString('[header.X-Request-ID]', $message);
+        $this->assertStringContainsString('[security]', $message);
+        $this->assertStringContainsString('/name', $message);
+    }
+
     // ========================================
-    // Security scheme validation (#46)
+    // Security scheme validation
     // ========================================
 
     #[Test]
@@ -1910,7 +1937,6 @@ class OpenApiRequestValidatorTest extends TestCase
     #[Test]
     public function v30_security_bearer_wrong_scheme_fails(): void
     {
-        // "Basic" is a valid HTTP scheme but the spec requires "Bearer".
         $result = $this->validator->validate(
             'petstore-3.0',
             'GET',
@@ -1929,7 +1955,6 @@ class OpenApiRequestValidatorTest extends TestCase
     #[Test]
     public function v30_security_bearer_empty_token_fails(): void
     {
-        // "Bearer" with no token part is not a valid bearer credential.
         $result = $this->validator->validate(
             'petstore-3.0',
             'GET',
@@ -1963,7 +1988,6 @@ class OpenApiRequestValidatorTest extends TestCase
     #[Test]
     public function v30_security_bearer_header_name_is_case_insensitive(): void
     {
-        // RFC 7230 — HTTP header names are case-insensitive.
         $result = $this->validator->validate(
             'petstore-3.0',
             'GET',
@@ -2014,7 +2038,6 @@ class OpenApiRequestValidatorTest extends TestCase
     #[Test]
     public function v30_security_apikey_header_empty_value_fails(): void
     {
-        // An empty-string apiKey header is not a credential; reject it.
         $result = $this->validator->validate(
             'petstore-3.0',
             'GET',
@@ -2187,7 +2210,6 @@ class OpenApiRequestValidatorTest extends TestCase
     #[Test]
     public function v30_security_explicit_opt_out_passes_with_no_auth(): void
     {
-        // security: [] on an operation explicitly disables any root-level security.
         $result = $this->validator->validate(
             'petstore-3.0',
             'GET',
@@ -2204,10 +2226,9 @@ class OpenApiRequestValidatorTest extends TestCase
     #[Test]
     public function v30_security_oauth2_only_silent_skips(): void
     {
-        // OAuth2 / OpenID Connect are out of scope for phase 1 (see issue #46).
-        // When every requirement entry contains only unsupported schemes, we have
-        // nothing we can validate — pass rather than block the test (false-negative
-        // avoidance).
+        // When every requirement entry contains only unsupported schemes
+        // (oauth2 / openIdConnect) we have nothing we can validate — pass
+        // rather than block the test (false-negative avoidance).
         $result = $this->validator->validate(
             'petstore-3.0',
             'GET',
@@ -2256,30 +2277,6 @@ class OpenApiRequestValidatorTest extends TestCase
         $this->assertFalse($result->isValid());
         $this->assertStringContainsString('[security]', $result->errorMessage());
         $this->assertStringContainsString('bearerAuth', $result->errorMessage());
-    }
-
-    #[Test]
-    public function v30_security_reserved_header_parameter_ignored_but_security_validated(): void
-    {
-        // /v1/reports declares `Authorization` as a parameter (which per OpenAPI
-        // must be ignored). Adding a security requirement on top would be
-        // validated by the security path — but /v1/reports has no security set,
-        // so this specifically tests the reserved-header skip for parameter
-        // validation is unchanged.
-        $result = $this->validator->validate(
-            'petstore-3.0',
-            'GET',
-            '/v1/reports',
-            [],
-            [
-                'X-Request-ID' => 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
-                'Authorization' => 'anything',
-            ],
-            null,
-            null,
-        );
-
-        $this->assertTrue($result->isValid(), $result->errorMessage());
     }
 
     #[Test]
@@ -2337,7 +2334,9 @@ class OpenApiRequestValidatorTest extends TestCase
         );
 
         $this->assertFalse($result->isValid());
-        $this->assertStringContainsString('security', strtolower($result->errorMessage()));
+        $message = $result->errorMessage();
+        $this->assertStringContainsString('[security]', $message);
+        $this->assertStringContainsString('index 0', $message);
     }
 
     #[Test]
@@ -2535,6 +2534,161 @@ class OpenApiRequestValidatorTest extends TestCase
             '/v1/secure/oauth2-only',
             [],
             [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function security_unknown_type_is_hard_spec_error(): void
+    {
+        // A typo like type: "htpp" must not silently fall through as "unsupported".
+        // If it did, every request for that endpoint would silently pass — which
+        // is exactly the drift this library exists to catch.
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/security-scheme-unknown-type',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('typoScheme', $result->errorMessage());
+        $this->assertStringContainsString('htpp', $result->errorMessage());
+    }
+
+    #[Test]
+    public function security_empty_type_is_hard_spec_error(): void
+    {
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/security-scheme-empty-type',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('emptyTypeScheme', $result->errorMessage());
+    }
+
+    #[Test]
+    public function security_operation_level_scalar_is_hard_spec_error(): void
+    {
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/security-root-scalar',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[security]', $result->errorMessage());
+    }
+
+    #[Test]
+    public function security_numeric_scheme_name_is_hard_spec_error(): void
+    {
+        // Purely numeric JSON object keys (e.g. {"0": []}) become integer PHP
+        // array keys after json_decode. The guard at the top of the entry loop
+        // must catch this so a typo doesn't silently skip auth.
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/security-numeric-scheme-name',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[security]', $result->errorMessage());
+        $this->assertStringContainsString('scheme name must be a string', $result->errorMessage());
+    }
+
+    #[Test]
+    public function security_components_schemes_as_scalar_is_hard_spec_error(): void
+    {
+        // If `components.securitySchemes` itself is a scalar, don't silently
+        // treat every scheme reference as "undefined" — that misdirects the
+        // spec author. Surface a dedicated error pointing at the real cause.
+        $result = $this->validator->validate(
+            'security-schemes-scalar',
+            'GET',
+            '/needs-bearer',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('components.securitySchemes', $result->errorMessage());
+    }
+
+    #[Test]
+    public function security_two_unsupported_entries_silent_skip_to_pass(): void
+    {
+        // Two entries (oauth2 + oidc) are both unsupported. With no validatable
+        // entries remaining, overall result must be pass — prevents a regression
+        // where "no satisfied entry" is conflated with "no evaluable entry".
+        $result = $this->validator->validate(
+            'security-edge-cases',
+            'GET',
+            '/two-unsupported-entries',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function security_and_with_unsupported_scheme_skips_entry(): void
+    {
+        // Single entry AND-joining bearer with oauth2 — because the entry
+        // contains an unsupported scheme, phase-1 policy treats the whole entry
+        // as unevaluable (we cannot check oauth2, so we cannot confirm AND).
+        // Overall result: pass. Pins the documented tradeoff so a future policy
+        // change is an explicit decision, not an accidental regression.
+        $result = $this->validator->validate(
+            'security-edge-cases',
+            'GET',
+            '/and-with-unsupported',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function v30_security_apikey_header_name_is_case_insensitive(): void
+    {
+        // RFC 9110 §5.1 — HTTP header names are case-insensitive. Spec declares
+        // 'X-API-Key'; request sends 'x-api-key'. Locks in the normalize-then-
+        // lookup behaviour.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/apikey-header',
+            [],
+            ['x-api-key' => 'k1'],
             null,
             null,
         );

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -1868,4 +1868,677 @@ class OpenApiRequestValidatorTest extends TestCase
         $this->assertStringContainsString('[header.X-Request-ID]', $message);
         $this->assertStringContainsString('/name', $message);
     }
+
+    // ========================================
+    // Security scheme validation (#46)
+    // ========================================
+
+    #[Test]
+    public function v30_security_bearer_present_passes(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/bearer',
+            [],
+            ['Authorization' => 'Bearer abc123'],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function v30_security_bearer_missing_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/bearer',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[security]', $result->errorMessage());
+        $this->assertStringContainsString('bearerAuth', $result->errorMessage());
+    }
+
+    #[Test]
+    public function v30_security_bearer_wrong_scheme_fails(): void
+    {
+        // "Basic" is a valid HTTP scheme but the spec requires "Bearer".
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/bearer',
+            [],
+            ['Authorization' => 'Basic dXNlcjpwYXNz'],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[security]', $result->errorMessage());
+        $this->assertStringContainsString('bearerAuth', $result->errorMessage());
+    }
+
+    #[Test]
+    public function v30_security_bearer_empty_token_fails(): void
+    {
+        // "Bearer" with no token part is not a valid bearer credential.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/bearer',
+            [],
+            ['Authorization' => 'Bearer '],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[security]', $result->errorMessage());
+    }
+
+    #[Test]
+    public function v30_security_bearer_scheme_name_is_case_insensitive(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/bearer',
+            [],
+            ['Authorization' => 'bearer abc123'],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function v30_security_bearer_header_name_is_case_insensitive(): void
+    {
+        // RFC 7230 — HTTP header names are case-insensitive.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/bearer',
+            [],
+            ['authorization' => 'Bearer abc123'],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function v30_security_apikey_header_present_passes(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/apikey-header',
+            [],
+            ['X-API-Key' => 'k1'],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function v30_security_apikey_header_missing_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/apikey-header',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[security]', $result->errorMessage());
+        $this->assertStringContainsString('apiKeyHeader', $result->errorMessage());
+    }
+
+    #[Test]
+    public function v30_security_apikey_header_empty_value_fails(): void
+    {
+        // An empty-string apiKey header is not a credential; reject it.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/apikey-header',
+            [],
+            ['X-API-Key' => ''],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+    }
+
+    #[Test]
+    public function v30_security_apikey_query_present_passes(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/apikey-query',
+            ['api_key' => 'k1'],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function v30_security_apikey_query_missing_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/apikey-query',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[security]', $result->errorMessage());
+        $this->assertStringContainsString('apiKeyQuery', $result->errorMessage());
+    }
+
+    #[Test]
+    public function v30_security_apikey_cookie_present_passes(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/apikey-cookie',
+            [],
+            [],
+            null,
+            null,
+            ['session_id' => 'abc'],
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function v30_security_apikey_cookie_missing_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/apikey-cookie',
+            [],
+            [],
+            null,
+            null,
+            [],
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[security]', $result->errorMessage());
+        $this->assertStringContainsString('apiKeyCookie', $result->errorMessage());
+    }
+
+    #[Test]
+    public function v30_security_or_bearer_only_passes(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/or',
+            [],
+            ['Authorization' => 'Bearer abc'],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function v30_security_or_apikey_only_passes(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/or',
+            [],
+            ['X-API-Key' => 'k1'],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function v30_security_or_both_missing_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/or',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[security]', $result->errorMessage());
+    }
+
+    #[Test]
+    public function v30_security_and_both_satisfied_passes(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/and',
+            [],
+            [
+                'Authorization' => 'Bearer abc',
+                'X-API-Key' => 'k1',
+            ],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function v30_security_and_one_missing_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/and',
+            [],
+            ['Authorization' => 'Bearer abc'],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[security]', $result->errorMessage());
+        $this->assertStringContainsString('apiKeyHeader', $result->errorMessage());
+    }
+
+    #[Test]
+    public function v30_security_explicit_opt_out_passes_with_no_auth(): void
+    {
+        // security: [] on an operation explicitly disables any root-level security.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/opt-out',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function v30_security_oauth2_only_silent_skips(): void
+    {
+        // OAuth2 / OpenID Connect are out of scope for phase 1 (see issue #46).
+        // When every requirement entry contains only unsupported schemes, we have
+        // nothing we can validate — pass rather than block the test (false-negative
+        // avoidance).
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/oauth2-only',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function v30_security_bearer_or_oauth2_with_bearer_passes(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/bearer-or-oauth2',
+            [],
+            ['Authorization' => 'Bearer abc'],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function v30_security_bearer_or_oauth2_with_nothing_fails(): void
+    {
+        // Bearer entry is validatable and fails; OAuth2 entry is skipped.
+        // Since the only validatable entry failed and no other entry passed,
+        // overall result is fail.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/bearer-or-oauth2',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[security]', $result->errorMessage());
+        $this->assertStringContainsString('bearerAuth', $result->errorMessage());
+    }
+
+    #[Test]
+    public function v30_security_reserved_header_parameter_ignored_but_security_validated(): void
+    {
+        // /v1/reports declares `Authorization` as a parameter (which per OpenAPI
+        // must be ignored). Adding a security requirement on top would be
+        // validated by the security path — but /v1/reports has no security set,
+        // so this specifically tests the reserved-header skip for parameter
+        // validation is unchanged.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/reports',
+            [],
+            [
+                'X-Request-ID' => 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+                'Authorization' => 'anything',
+            ],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function v30_security_combines_with_other_errors(): void
+    {
+        // Bearer missing + no other issues — ensure the security error appears
+        // alongside any other errors the pipeline surfaces.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/secure/bearer',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $errors = $result->errors();
+        $this->assertNotEmpty($errors);
+        $this->assertTrue(
+            array_filter($errors, static fn(string $e): bool => str_contains($e, '[security]')) !== [],
+            'expected at least one [security] error in: ' . $result->errorMessage(),
+        );
+    }
+
+    #[Test]
+    public function security_undefined_scheme_is_hard_spec_error(): void
+    {
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/security-undefined-scheme',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('ghostScheme', $result->errorMessage());
+    }
+
+    #[Test]
+    public function security_scalar_entry_is_hard_spec_error(): void
+    {
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/security-scalar-entry',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('security', strtolower($result->errorMessage()));
+    }
+
+    #[Test]
+    public function security_scheme_missing_type_is_hard_spec_error(): void
+    {
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/security-scheme-missing-type',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('brokenScheme', $result->errorMessage());
+    }
+
+    #[Test]
+    public function security_scheme_http_without_scheme_field_is_hard_spec_error(): void
+    {
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/security-scheme-http-no-scheme-field',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('httpNoScheme', $result->errorMessage());
+    }
+
+    #[Test]
+    public function security_scheme_apikey_missing_name_is_hard_spec_error(): void
+    {
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/security-scheme-apikey-missing-name',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('apiKeyNoName', $result->errorMessage());
+    }
+
+    #[Test]
+    public function security_root_level_is_inherited_when_operation_omits_security(): void
+    {
+        $result = $this->validator->validate(
+            'security-root',
+            'GET',
+            '/inherits',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[security]', $result->errorMessage());
+        $this->assertStringContainsString('bearerAuth', $result->errorMessage());
+    }
+
+    #[Test]
+    public function security_root_level_is_inherited_and_satisfied(): void
+    {
+        $result = $this->validator->validate(
+            'security-root',
+            'GET',
+            '/inherits',
+            [],
+            ['Authorization' => 'Bearer abc'],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function security_operation_empty_array_opts_out_of_root(): void
+    {
+        $result = $this->validator->validate(
+            'security-root',
+            'GET',
+            '/opts-out',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function security_operation_override_replaces_root(): void
+    {
+        // /overrides replaces root-level bearerAuth with apiKeyHeader.
+        // Passing a bearer should fail (because apiKey is now required).
+        $result = $this->validator->validate(
+            'security-root',
+            'GET',
+            '/overrides',
+            [],
+            ['Authorization' => 'Bearer abc'],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('apiKeyHeader', $result->errorMessage());
+    }
+
+    #[Test]
+    public function security_operation_override_satisfied_passes(): void
+    {
+        $result = $this->validator->validate(
+            'security-root',
+            'GET',
+            '/overrides',
+            [],
+            ['X-API-Key' => 'k1'],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function v31_security_bearer_present_passes(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.1',
+            'GET',
+            '/v1/secure/bearer',
+            [],
+            ['Authorization' => 'Bearer abc123'],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function v31_security_apikey_query_missing_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.1',
+            'GET',
+            '/v1/secure/apikey-query',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('apiKeyQuery', $result->errorMessage());
+    }
+
+    #[Test]
+    public function v31_security_or_both_missing_fails(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.1',
+            'GET',
+            '/v1/secure/or',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('[security]', $result->errorMessage());
+    }
+
+    #[Test]
+    public function v31_security_oauth2_only_silent_skips(): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.1',
+            'GET',
+            '/v1/secure/oauth2-only',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
 }

--- a/tests/fixtures/specs/malformed.json
+++ b/tests/fixtures/specs/malformed.json
@@ -244,6 +244,90 @@
                     }
                 }
             }
+        },
+        "/security-undefined-scheme": {
+            "get": {
+                "summary": "security references a scheme not defined in components.securitySchemes",
+                "operationId": "securityUndefinedScheme",
+                "security": [
+                    { "ghostScheme": [] }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
+        "/security-scalar-entry": {
+            "get": {
+                "summary": "security entry is a scalar instead of an object",
+                "operationId": "securityScalarEntry",
+                "security": [
+                    "not-an-object"
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
+        "/security-scheme-missing-type": {
+            "get": {
+                "summary": "referenced scheme exists but has no 'type' field",
+                "operationId": "securitySchemeMissingType",
+                "security": [
+                    { "brokenScheme": [] }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
+        "/security-scheme-http-no-scheme-field": {
+            "get": {
+                "summary": "referenced http scheme missing 'scheme' field",
+                "operationId": "securityHttpNoSchemeField",
+                "security": [
+                    { "httpNoScheme": [] }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
+        "/security-scheme-apikey-missing-name": {
+            "get": {
+                "summary": "referenced apiKey scheme missing 'name' or 'in'",
+                "operationId": "securityApiKeyMissingName",
+                "security": [
+                    { "apiKeyNoName": [] }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "securitySchemes": {
+            "brokenScheme": {
+                "description": "no type field"
+            },
+            "httpNoScheme": {
+                "type": "http"
+            },
+            "apiKeyNoName": {
+                "type": "apiKey",
+                "in": "header"
+            }
         }
     }
 }

--- a/tests/fixtures/specs/malformed.json
+++ b/tests/fixtures/specs/malformed.json
@@ -314,6 +314,60 @@
                     }
                 }
             }
+        },
+        "/security-scheme-unknown-type": {
+            "get": {
+                "summary": "referenced scheme uses an unknown type (e.g. typo)",
+                "operationId": "securityUnknownType",
+                "security": [
+                    { "typoScheme": [] }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
+        "/security-scheme-empty-type": {
+            "get": {
+                "summary": "referenced scheme has an empty-string type",
+                "operationId": "securityEmptyType",
+                "security": [
+                    { "emptyTypeScheme": [] }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
+        "/security-root-scalar": {
+            "get": {
+                "summary": "operation-level security is a scalar instead of an array",
+                "operationId": "securityRootScalar",
+                "security": "should-be-an-array",
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
+        "/security-numeric-scheme-name": {
+            "get": {
+                "summary": "requirement entry has a purely numeric key (non-string after json_decode)",
+                "operationId": "securityNumericSchemeName",
+                "security": [
+                    { "0": [] }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
         }
     },
     "components": {
@@ -327,6 +381,13 @@
             "apiKeyNoName": {
                 "type": "apiKey",
                 "in": "header"
+            },
+            "typoScheme": {
+                "type": "htpp",
+                "scheme": "bearer"
+            },
+            "emptyTypeScheme": {
+                "type": ""
             }
         }
     }

--- a/tests/fixtures/specs/petstore-3.0.json
+++ b/tests/fixtures/specs/petstore-3.0.json
@@ -632,6 +632,149 @@
                     }
                 }
             }
+        },
+        "/v1/secure/bearer": {
+            "get": {
+                "summary": "Requires bearerAuth",
+                "operationId": "secureBearer",
+                "security": [
+                    { "bearerAuth": [] }
+                ],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        },
+        "/v1/secure/apikey-header": {
+            "get": {
+                "summary": "Requires apiKey in header",
+                "operationId": "secureApiKeyHeader",
+                "security": [
+                    { "apiKeyHeader": [] }
+                ],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        },
+        "/v1/secure/apikey-query": {
+            "get": {
+                "summary": "Requires apiKey in query",
+                "operationId": "secureApiKeyQuery",
+                "security": [
+                    { "apiKeyQuery": [] }
+                ],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        },
+        "/v1/secure/apikey-cookie": {
+            "get": {
+                "summary": "Requires apiKey in cookie",
+                "operationId": "secureApiKeyCookie",
+                "security": [
+                    { "apiKeyCookie": [] }
+                ],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        },
+        "/v1/secure/or": {
+            "get": {
+                "summary": "Bearer OR apiKey (header)",
+                "operationId": "secureOr",
+                "security": [
+                    { "bearerAuth": [] },
+                    { "apiKeyHeader": [] }
+                ],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        },
+        "/v1/secure/and": {
+            "get": {
+                "summary": "Bearer AND apiKey (header) in single requirement",
+                "operationId": "secureAnd",
+                "security": [
+                    { "bearerAuth": [], "apiKeyHeader": [] }
+                ],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        },
+        "/v1/secure/opt-out": {
+            "get": {
+                "summary": "Explicitly no auth required",
+                "operationId": "secureOptOut",
+                "security": [],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        },
+        "/v1/secure/oauth2-only": {
+            "get": {
+                "summary": "Only OAuth2 (unsupported in phase 1)",
+                "operationId": "secureOauth2Only",
+                "security": [
+                    { "oauth2Flow": ["read"] }
+                ],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        },
+        "/v1/secure/bearer-or-oauth2": {
+            "get": {
+                "summary": "Bearer OR OAuth2 (unsupported entry must not block)",
+                "operationId": "secureBearerOrOauth2",
+                "security": [
+                    { "bearerAuth": [] },
+                    { "oauth2Flow": ["read"] }
+                ],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        }
+    },
+    "components": {
+        "securitySchemes": {
+            "bearerAuth": {
+                "type": "http",
+                "scheme": "bearer"
+            },
+            "apiKeyHeader": {
+                "type": "apiKey",
+                "in": "header",
+                "name": "X-API-Key"
+            },
+            "apiKeyQuery": {
+                "type": "apiKey",
+                "in": "query",
+                "name": "api_key"
+            },
+            "apiKeyCookie": {
+                "type": "apiKey",
+                "in": "cookie",
+                "name": "session_id"
+            },
+            "oauth2Flow": {
+                "type": "oauth2",
+                "flows": {
+                    "authorizationCode": {
+                        "authorizationUrl": "https://example.com/oauth/authorize",
+                        "tokenUrl": "https://example.com/oauth/token",
+                        "scopes": {
+                            "read": "Read access"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/tests/fixtures/specs/petstore-3.0.json
+++ b/tests/fixtures/specs/petstore-3.0.json
@@ -740,6 +740,50 @@
                     "200": { "description": "OK" }
                 }
             }
+        },
+        "/v1/secure/compose/{tenantId}": {
+            "post": {
+                "summary": "Composition endpoint: path + query + header + body + security",
+                "operationId": "secureCompose",
+                "parameters": [
+                    {
+                        "name": "tenantId",
+                        "in": "path",
+                        "required": true,
+                        "schema": { "type": "integer", "minimum": 1 }
+                    },
+                    {
+                        "name": "trace",
+                        "in": "query",
+                        "schema": { "type": "string", "pattern": "^[a-z]+$" }
+                    },
+                    {
+                        "name": "X-Request-ID",
+                        "in": "header",
+                        "schema": { "type": "string", "format": "uuid" }
+                    }
+                ],
+                "security": [
+                    { "bearerAuth": [] }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": ["name"],
+                                "properties": {
+                                    "name": { "type": "string" }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "204": { "description": "No content" }
+                }
+            }
         }
     },
     "components": {

--- a/tests/fixtures/specs/petstore-3.1.json
+++ b/tests/fixtures/specs/petstore-3.1.json
@@ -479,6 +479,149 @@
                     }
                 }
             }
+        },
+        "/v1/secure/bearer": {
+            "get": {
+                "summary": "Requires bearerAuth",
+                "operationId": "secureBearer",
+                "security": [
+                    { "bearerAuth": [] }
+                ],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        },
+        "/v1/secure/apikey-header": {
+            "get": {
+                "summary": "Requires apiKey in header",
+                "operationId": "secureApiKeyHeader",
+                "security": [
+                    { "apiKeyHeader": [] }
+                ],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        },
+        "/v1/secure/apikey-query": {
+            "get": {
+                "summary": "Requires apiKey in query",
+                "operationId": "secureApiKeyQuery",
+                "security": [
+                    { "apiKeyQuery": [] }
+                ],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        },
+        "/v1/secure/apikey-cookie": {
+            "get": {
+                "summary": "Requires apiKey in cookie",
+                "operationId": "secureApiKeyCookie",
+                "security": [
+                    { "apiKeyCookie": [] }
+                ],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        },
+        "/v1/secure/or": {
+            "get": {
+                "summary": "Bearer OR apiKey (header)",
+                "operationId": "secureOr",
+                "security": [
+                    { "bearerAuth": [] },
+                    { "apiKeyHeader": [] }
+                ],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        },
+        "/v1/secure/and": {
+            "get": {
+                "summary": "Bearer AND apiKey (header) in single requirement",
+                "operationId": "secureAnd",
+                "security": [
+                    { "bearerAuth": [], "apiKeyHeader": [] }
+                ],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        },
+        "/v1/secure/opt-out": {
+            "get": {
+                "summary": "Explicitly no auth required",
+                "operationId": "secureOptOut",
+                "security": [],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        },
+        "/v1/secure/oauth2-only": {
+            "get": {
+                "summary": "Only OAuth2 (unsupported in phase 1)",
+                "operationId": "secureOauth2Only",
+                "security": [
+                    { "oauth2Flow": ["read"] }
+                ],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        },
+        "/v1/secure/bearer-or-oauth2": {
+            "get": {
+                "summary": "Bearer OR OAuth2 (unsupported entry must not block)",
+                "operationId": "secureBearerOrOauth2",
+                "security": [
+                    { "bearerAuth": [] },
+                    { "oauth2Flow": ["read"] }
+                ],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        }
+    },
+    "components": {
+        "securitySchemes": {
+            "bearerAuth": {
+                "type": "http",
+                "scheme": "bearer"
+            },
+            "apiKeyHeader": {
+                "type": "apiKey",
+                "in": "header",
+                "name": "X-API-Key"
+            },
+            "apiKeyQuery": {
+                "type": "apiKey",
+                "in": "query",
+                "name": "api_key"
+            },
+            "apiKeyCookie": {
+                "type": "apiKey",
+                "in": "cookie",
+                "name": "session_id"
+            },
+            "oauth2Flow": {
+                "type": "oauth2",
+                "flows": {
+                    "authorizationCode": {
+                        "authorizationUrl": "https://example.com/oauth/authorize",
+                        "tokenUrl": "https://example.com/oauth/token",
+                        "scopes": {
+                            "read": "Read access"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/tests/fixtures/specs/security-edge-cases.json
+++ b/tests/fixtures/specs/security-edge-cases.json
@@ -1,0 +1,56 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Security edge-case fixtures",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/two-unsupported-entries": {
+            "get": {
+                "summary": "Two oauth2/oidc entries in OR — both skipped, overall pass",
+                "operationId": "twoUnsupportedEntries",
+                "security": [
+                    { "oauth2A": ["read"] },
+                    { "oidcB": [] }
+                ],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        },
+        "/and-with-unsupported": {
+            "get": {
+                "summary": "Single entry ANDs bearer with oauth2 — currently skipped per phase 1 policy",
+                "operationId": "andWithUnsupported",
+                "security": [
+                    { "bearerAuth": [], "oauth2A": ["read"] }
+                ],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        }
+    },
+    "components": {
+        "securitySchemes": {
+            "bearerAuth": {
+                "type": "http",
+                "scheme": "bearer"
+            },
+            "oauth2A": {
+                "type": "oauth2",
+                "flows": {
+                    "authorizationCode": {
+                        "authorizationUrl": "https://example.com/oauth/authorize",
+                        "tokenUrl": "https://example.com/oauth/token",
+                        "scopes": { "read": "Read" }
+                    }
+                }
+            },
+            "oidcB": {
+                "type": "openIdConnect",
+                "openIdConnectUrl": "https://example.com/.well-known/openid-configuration"
+            }
+        }
+    }
+}

--- a/tests/fixtures/specs/security-root.json
+++ b/tests/fixtures/specs/security-root.json
@@ -1,0 +1,56 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Root-level security inheritance fixture",
+        "version": "1.0.0"
+    },
+    "security": [
+        { "bearerAuth": [] }
+    ],
+    "paths": {
+        "/inherits": {
+            "get": {
+                "summary": "Inherits root-level security (no operation-level override)",
+                "operationId": "inherits",
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        },
+        "/opts-out": {
+            "get": {
+                "summary": "Opts out via explicit empty security array",
+                "operationId": "optsOut",
+                "security": [],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        },
+        "/overrides": {
+            "get": {
+                "summary": "Overrides root with apiKey requirement",
+                "operationId": "overrides",
+                "security": [
+                    { "apiKeyHeader": [] }
+                ],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        }
+    },
+    "components": {
+        "securitySchemes": {
+            "bearerAuth": {
+                "type": "http",
+                "scheme": "bearer"
+            },
+            "apiKeyHeader": {
+                "type": "apiKey",
+                "in": "header",
+                "name": "X-API-Key"
+            }
+        }
+    }
+}

--- a/tests/fixtures/specs/security-schemes-scalar.json
+++ b/tests/fixtures/specs/security-schemes-scalar.json
@@ -1,0 +1,24 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "components.securitySchemes as scalar fixture",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/needs-bearer": {
+            "get": {
+                "summary": "Endpoint references a scheme but components.securitySchemes is a scalar",
+                "operationId": "needsBearer",
+                "security": [
+                    { "bearerAuth": [] }
+                ],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        }
+    },
+    "components": {
+        "securitySchemes": "this should have been an object"
+    }
+}


### PR DESCRIPTION
# 概要

`OpenApiRequestValidator` に endpoint の `security` 要件を request の実値と突き合わせて検証する機能を追加します。既存の path / query / header / body パイプラインと同じ流儀でエラーを合成し、1 リクエストで全ての contract drift を一度に surface します。Issue #46 への対応。

## 変更内容

- `OpenApiRequestValidator::validate()` に `array $cookies = []` パラメータを追加（apiKey `in: cookie` サポート、後方互換維持）
- `validateSecurity()` / `classifySecurityScheme()` / `checkSchemeSatisfaction()` / `extractSingleStringValue()` を新設し、pipeline に合成
- サポート scheme: `http` + `scheme: bearer`、`apiKey` (in: header | query | cookie)
- **OR 意味論**: `security` 配列の各 entry のうち、どれか 1 つが満たされれば pass
- **AND 意味論**: 単一 entry 内の複数 scheme は全て満たす必要あり
- **明示 opt-out**: `security: []` で root-level security を無効化
- **root 継承**: operation に `security` 未指定なら root-level の `security` を継承
- **OAuth2 / OpenID Connect**: phase 1 対象外として silent skip。判定不能 entry は pass/fail 判定から除外し、全 entry が skip の場合は pass（false-negative 回避）、validatable entry が残って失敗するなら fail
- エラー文言は `[security] {METHOD} {PATH}: ...` プレフィックスで統一
- **Authorization scheme 名の case-insensitive 比較** (`Bearer` / `bearer` / `BEARER` すべて受理) + **header 名も case-insensitive** (RFC 7230)

### Malformed spec の hard error 化

- `security` が非配列 / 要素がスカラー → `[security]` エラー
- `components.securitySchemes` で未定義の scheme を参照 → hard error
- scheme 側の `type` 欠落 / `http` の `scheme` 欠落 / `apiKey` の `in` or `name` 欠落 → hard error
- malformed な scheme を含む entry は pass/fail 判定から除外される（他 entry が pass でも malformed は常に surface）

### fixture / テスト

- `petstore-3.0.json` / `petstore-3.1.json` に `components.securitySchemes` (bearer / apiKeyHeader / apiKeyQuery / apiKeyCookie / oauth2Flow) + 9 endpoint 追加（bearer / apikey-header / apikey-query / apikey-cookie / or / and / opt-out / oauth2-only / bearer-or-oauth2）
- `security-root.json` を新規追加（root-level security 継承のテスト専用 minimal fixture）
- `malformed.json` に 5 種類の malformed security fixture 追加
- 38 件のテスト追加: bearer valid/missing/wrong-scheme/empty-token/case-insensitive / apiKey (header/query/cookie) valid/missing / OR / AND / explicit opt-out / oauth2 silent skip / bearer-or-oauth2 / reserved header との共存 / 未定義 scheme / malformed entry / root 継承 × OAS 3.0 + 3.1 並走
- `OpenApiCoverageTrackerTest` / `ResponseValidationTest` の total 期待値を新規 endpoint 数に合わせて更新（3.0: 13→22 / 3.1: 10→19）

## スコープ外（follow-up）

- **auto-inject dummy bearer** (#46 の acceptance criteria の 1 項目): `OpenApiRequestValidator` がまだ trait 層から呼ばれていないため injection の実装先がない。config キー追加 + injection 実装 + trait 統合をまとめて #69 で対応予定
- OAuth2 / OpenID Connect の実検証: 本体が authorization server への問い合わせを要する性質上、将来的に別 epic で検討
- `http` + `basic` / `digest` / `mutualTLS`: unsupported として扱い silent skip（OAuth2 と同様）

## 品質ゲート

- \`vendor/bin/phpunit\`: 377 tests / 773 assertions, all passing
- \`vendor/bin/phpstan analyse\`: level 6, no errors
- \`vendor/bin/php-cs-fixer fix --dry-run --diff\`: clean

## 関連情報

- Closes #46
- Follow-up: #69 (trait 統合 + auto-inject dummy bearer)
- 親 epic / skeleton: #42
- Preceded by: #58 (query) / #64 (path) / #65 (header)
- 副次的議論から起票: #68 (validator の domain 別分割リファクタ、スコープ管理のため本 PR では一枚岩のまま拡張)