### PR TITLE
New Feature: 5xx レスポンスをデフォルトでバリデーション対象外にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,9 +263,10 @@ $validator = new OpenApiResponseValidator(skipResponseCodes: ['5\d\d']);
 Notes:
 
 - Patterns are regex strings **without** `/` delimiters or `^$` anchors; they are anchored automatically, so `5\d\d` matches exactly `500`–`599` (not `5000`).
-- The skip check runs **before** the "Status code not defined" check, so a skipped code suppresses both missing-from-spec failures and schema mismatches. This makes the rule simple and predictable regardless of whether the code happens to be documented.
-- Skipped endpoints count as covered — the endpoint was exercised, just not schema-validated against the body. This mirrors how non-JSON content types and schema-less `204` responses are already handled.
-- `OpenApiValidationResult::isSkipped()` is exposed for callers who want to distinguish a skip from a genuine success.
+- The skip check sits **between** the "path / method not in spec" checks and the "status code not defined" / schema-validation checks. A skipped code therefore suppresses both status-code failure modes (undocumented code AND body mismatch for a documented code), but typos in the request path or method still fail loudly.
+- Skipped endpoints count as covered — the endpoint was exercised, just not schema-validated. Coverage semantics here match how non-JSON content types and schema-less `204` responses are handled, but `OpenApiValidationResult::isSkipped()` returns `true` **only** for status-code skips; the other no-body-validation branches still return a plain `success()`.
+- `OpenApiValidationResult::isSkipped()` is exposed for callers who want to distinguish a skip from a genuine success. `skipReason()` identifies the matched pattern.
+- **Observability trade-off**: a real regression that causes an unrelated `500` will not fail this assertion. Keep your HTTP-level assertions (`$response->assertOk()`, status-code expectations in the test) alongside the contract check so a stray 5xx still surfaces — the contract assertion alone is not a substitute for status-code assertions on happy paths.
 
 #### Auto-assert every response
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Validate your API responses against your OpenAPI specification during testing, a
 - **OpenAPI 3.0 & 3.1 support** — Automatic version detection from the `openapi` field
 - **Response validation** — Validates response bodies against JSON Schema (Draft 07 via opis/json-schema). Supports `application/json` and any `+json` content type (e.g., `application/problem+json`)
 - **Content negotiation** — Accepts the actual response `Content-Type` to handle mixed-content specs. Non-JSON responses (e.g., `text/html`, `application/xml`) are verified for spec presence without body validation; JSON-compatible responses are fully schema-validated
+- **Skip-by-status-code** — Configurable regex list of status codes whose bodies are not validated (default: every `5xx`), reflecting the common convention of not documenting production error responses in the spec
 - **Endpoint coverage tracking** — Unique PHPUnit extension that reports which spec endpoints are covered by tests
 - **Path matching** — Handles parameterized paths (`/pets/{petId}`) with configurable prefix stripping
 - **Laravel adapter** — Optional trait for seamless integration with Laravel's `TestResponse`
@@ -90,6 +91,12 @@ return [
     // helpers (get(), post(), etc.) against the OpenAPI spec. Defaults to
     // false for backward compatibility.
     'auto_assert' => false,
+
+    // Regex patterns (without delimiters or anchors) matched against the
+    // response status code. Matching codes short-circuit body validation —
+    // the test passes and the endpoint is still recorded as covered.
+    // Defaults to skipping every 5xx. Set to [] to validate every code.
+    'skip_response_codes' => ['5\d\d'],
 ];
 ```
 
@@ -227,6 +234,38 @@ $validator = new OpenApiResponseValidator(maxErrors: 1);
 ```
 
 For Laravel, set the `max_errors` key in `config/openapi-contract-testing.php`.
+
+#### Skipping responses by status code
+
+Production error responses (typically `5xx`) are often deliberately left out of the OpenAPI spec. Without special handling, a test that hits a `500` would fail twice: once from the underlying bug, and again from "Status code 500 not defined". To avoid that noise, every `5xx` response is **skipped by default** — body validation is not performed, the assertion passes, and the endpoint is still recorded as covered.
+
+Override via `skip_response_codes` in `config/openapi-contract-testing.php`:
+
+```php
+return [
+    // Default — skip all 5xx
+    'skip_response_codes' => ['5\d\d'],
+
+    // Widen to also skip all 4xx
+    'skip_response_codes' => ['4\d\d', '5\d\d'],
+
+    // Disable entirely — validate every status code
+    'skip_response_codes' => [],
+];
+```
+
+Or pass directly to `OpenApiResponseValidator`:
+
+```php
+$validator = new OpenApiResponseValidator(skipResponseCodes: ['5\d\d']);
+```
+
+Notes:
+
+- Patterns are regex strings **without** `/` delimiters or `^$` anchors; they are anchored automatically, so `5\d\d` matches exactly `500`–`599` (not `5000`).
+- The skip check runs **before** the "Status code not defined" check, so a skipped code suppresses both missing-from-spec failures and schema mismatches. This makes the rule simple and predictable regardless of whether the code happens to be documented.
+- Skipped endpoints count as covered — the endpoint was exercised, just not schema-validated against the body. This mirrors how non-JSON content types and schema-less `204` responses are already handled.
+- `OpenApiValidationResult::isSkipped()` is exposed for callers who want to distinguish a skip from a genuine success.
 
 #### Auto-assert every response
 
@@ -478,10 +517,12 @@ $result = $validator->validate(
     responseContentType: 'application/json',
 );
 
-$result->isValid();      // bool
+$result->isValid();      // bool (true for both successes AND skipped results)
+$result->isSkipped();    // bool (true when the status code matched skip_response_codes)
 $result->errors();       // string[]
 $result->errorMessage(); // string (joined errors)
 $result->matchedPath();  // ?string (e.g., '/v1/pets/{petId}')
+$result->skipReason();   // ?string (non-null when skipped)
 ```
 
 ### `OpenApiSpecLoader`

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -24,6 +24,7 @@ use WeakMap;
 use function filter_var;
 use function fwrite;
 use function get_debug_type;
+use function is_array;
 use function is_numeric;
 use function is_string;
 use function sprintf;
@@ -39,6 +40,9 @@ trait ValidatesOpenApiSchema
     use SkipOpenApiResolver;
     private static ?OpenApiResponseValidator $cachedValidator = null;
     private static ?int $cachedMaxErrors = null;
+
+    /** @var null|string[] */
+    private static ?array $cachedSkipResponseCodes = null;
 
     /** @var null|WeakMap<TestResponse, array<string, true>> */
     private static ?WeakMap $validatedResponses = null;
@@ -68,6 +72,7 @@ trait ValidatesOpenApiSchema
     {
         self::$cachedValidator = null;
         self::$cachedMaxErrors = null;
+        self::$cachedSkipResponseCodes = null;
         self::$validatedResponses = null;
     }
 
@@ -227,7 +232,7 @@ trait ValidatesOpenApiSchema
 
         $contentType = $response->headers->get('Content-Type', '');
 
-        $validator = self::getOrCreateValidator();
+        $validator = $this->getOrCreateValidator();
         $result = $validator->validate(
             $specName,
             $resolvedMethod,
@@ -271,17 +276,55 @@ trait ValidatesOpenApiSchema
         self::$validatedResponses[$response] = $signatures;
     }
 
-    private static function getOrCreateValidator(): OpenApiResponseValidator
+    private function getOrCreateValidator(): OpenApiResponseValidator
     {
         $maxErrors = config('openapi-contract-testing.max_errors', 20);
         $resolvedMaxErrors = is_numeric($maxErrors) ? (int) $maxErrors : 20;
 
-        if (self::$cachedValidator === null || self::$cachedMaxErrors !== $resolvedMaxErrors) {
-            self::$cachedValidator = new OpenApiResponseValidator(maxErrors: $resolvedMaxErrors);
+        $resolvedSkipCodes = $this->resolveSkipResponseCodes();
+
+        if (
+            self::$cachedValidator === null ||
+            self::$cachedMaxErrors !== $resolvedMaxErrors ||
+            self::$cachedSkipResponseCodes !== $resolvedSkipCodes
+        ) {
+            self::$cachedValidator = new OpenApiResponseValidator(
+                maxErrors: $resolvedMaxErrors,
+                skipResponseCodes: $resolvedSkipCodes,
+            );
             self::$cachedMaxErrors = $resolvedMaxErrors;
+            self::$cachedSkipResponseCodes = $resolvedSkipCodes;
         }
 
         return self::$cachedValidator;
+    }
+
+    /** @return string[] */
+    private function resolveSkipResponseCodes(): array
+    {
+        $raw = config('openapi-contract-testing.skip_response_codes', OpenApiResponseValidator::DEFAULT_SKIP_RESPONSE_CODES);
+
+        if (!is_array($raw)) {
+            $this->fail(sprintf(
+                'openapi-contract-testing.skip_response_codes must be an array of regex patterns, got %s: %s.',
+                get_debug_type($raw),
+                var_export($raw, true),
+            ));
+        }
+
+        $patterns = [];
+        foreach ($raw as $index => $pattern) {
+            if (!is_string($pattern)) {
+                $this->fail(sprintf(
+                    'openapi-contract-testing.skip_response_codes[%s] must be a string regex pattern, got %s.',
+                    (string) $index,
+                    get_debug_type($pattern),
+                ));
+            }
+            $patterns[] = $pattern;
+        }
+
+        return $patterns;
     }
 
     private function emitSkipOpenApiWarning(SkipOpenApi $attribute): void

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -321,6 +321,12 @@ trait ValidatesOpenApiSchema
                     get_debug_type($pattern),
                 ));
             }
+            if ($pattern === '') {
+                $this->fail(sprintf(
+                    'openapi-contract-testing.skip_response_codes[%s] must not be an empty string.',
+                    (string) $index,
+                ));
+            }
             $patterns[] = $pattern;
         }
 

--- a/src/Laravel/config.php
+++ b/src/Laravel/config.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Studio\OpenApiContractTesting\OpenApiResponseValidator;
+
 return [
     'default_spec' => '',
 
@@ -14,4 +16,12 @@ return [
     // time, without requiring an explicit assertResponseMatchesOpenApiSchema()
     // call in each test. Defaults to false for backward compatibility.
     'auto_assert' => false,
+
+    // Regex patterns (without delimiters or anchors) matched against the
+    // response status code. Matching codes short-circuit body validation and
+    // return a "skipped" result — the test is not failed, and the endpoint is
+    // still recorded as covered. The default skips every 5xx because specs
+    // typically do not document production error responses.
+    // Set to [] to disable and validate every status code against the spec.
+    'skip_response_codes' => OpenApiResponseValidator::DEFAULT_SKIP_RESPONSE_CODES,
 ];

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -15,6 +15,7 @@ use function array_is_list;
 use function array_keys;
 use function implode;
 use function is_array;
+use function preg_match;
 use function sprintf;
 use function str_ends_with;
 use function strstr;
@@ -23,19 +24,39 @@ use function trim;
 
 final class OpenApiResponseValidator
 {
+    /**
+     * Regex patterns (without delimiters or anchors) that match response status
+     * codes which should skip body validation. The default of `5\d\d` reflects
+     * the common convention of not documenting production 5xx in specs.
+     */
+    public const DEFAULT_SKIP_RESPONSE_CODES = ['5\d\d'];
+
     /** @var array<string, OpenApiPathMatcher> */
     private array $pathMatchers = [];
     private Validator $opisValidator;
     private ErrorFormatter $errorFormatter;
 
+    /** @var string[] Anchored regex patterns ready for preg_match. */
+    private readonly array $skipPatterns;
+
+    /**
+     * @param string[] $skipResponseCodes Regex patterns (without delimiters or
+     *                                    anchors) matched against the response status code as a string. A hit
+     *                                    short-circuits validation and returns an `OpenApiValidationResult::skipped()`
+     *                                    — isValid() stays true, isSkipped() becomes true, and the matched
+     *                                    path is still reported so coverage is recorded.
+     */
     public function __construct(
         private readonly int $maxErrors = 20,
+        array $skipResponseCodes = self::DEFAULT_SKIP_RESPONSE_CODES,
     ) {
         if ($this->maxErrors < 0) {
             throw new InvalidArgumentException(
                 sprintf('maxErrors must be 0 (unlimited) or a positive integer, got %d.', $this->maxErrors),
             );
         }
+
+        $this->skipPatterns = self::compileSkipPatterns($skipResponseCodes);
 
         $resolvedMaxErrors = $this->maxErrors === 0 ? PHP_INT_MAX : $this->maxErrors;
         $this->opisValidator = new Validator(
@@ -79,6 +100,17 @@ final class OpenApiResponseValidator
 
         $statusCodeStr = (string) $statusCode;
         $responses = $pathSpec[$lowerMethod]['responses'] ?? [];
+
+        // Skip-by-status-code: applied before the "Status code not defined"
+        // branch so that callers can suppress both outcomes (no-spec-entry AND
+        // schema mismatch) for codes they explicitly don't want to validate,
+        // e.g. production-only 5xx responses that aren't documented in the spec.
+        if ($this->matchesSkipPattern($statusCodeStr)) {
+            return OpenApiValidationResult::skipped(
+                $matchedPath,
+                sprintf('status %s matched skip pattern', $statusCodeStr),
+            );
+        }
 
         if (!isset($responses[$statusCodeStr])) {
             return OpenApiValidationResult::failure([
@@ -166,6 +198,31 @@ final class OpenApiResponseValidator
     }
 
     /**
+     * @param string[] $patterns
+     *
+     * @return string[]
+     */
+    private static function compileSkipPatterns(array $patterns): array
+    {
+        $compiled = [];
+
+        foreach ($patterns as $index => $pattern) {
+            $anchored = '/^(?:' . $pattern . ')$/';
+
+            $ok = @preg_match($anchored, '');
+            if ($ok === false) {
+                throw new InvalidArgumentException(
+                    sprintf('skipResponseCodes[%s] is not a valid regex pattern: %s', (string) $index, $pattern),
+                );
+            }
+
+            $compiled[] = $anchored;
+        }
+
+        return $compiled;
+    }
+
+    /**
      * Recursively convert PHP arrays to stdClass objects, matching the
      * behaviour of json_decode(json_encode($data)) without the intermediate
      * JSON string allocation.
@@ -191,6 +248,17 @@ final class OpenApiResponseValidator
         }
 
         return $object;
+    }
+
+    private function matchesSkipPattern(string $statusCode): bool
+    {
+        foreach ($this->skipPatterns as $pattern) {
+            if (preg_match($pattern, $statusCode) === 1) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -15,6 +15,7 @@ use function array_is_list;
 use function array_keys;
 use function implode;
 use function is_array;
+use function preg_last_error_msg;
 use function preg_match;
 use function sprintf;
 use function str_ends_with;
@@ -36,7 +37,7 @@ final class OpenApiResponseValidator
     private Validator $opisValidator;
     private ErrorFormatter $errorFormatter;
 
-    /** @var string[] Anchored regex patterns ready for preg_match. */
+    /** @var array<string, string> Raw pattern (as supplied) => anchored pattern ready for preg_match. */
     private readonly array $skipPatterns;
 
     /**
@@ -102,13 +103,15 @@ final class OpenApiResponseValidator
         $responses = $pathSpec[$lowerMethod]['responses'] ?? [];
 
         // Skip-by-status-code: applied before the "Status code not defined"
-        // branch so that callers can suppress both outcomes (no-spec-entry AND
-        // schema mismatch) for codes they explicitly don't want to validate,
-        // e.g. production-only 5xx responses that aren't documented in the spec.
-        if ($this->matchesSkipPattern($statusCodeStr)) {
+        // branch so a configured skip suppresses both status-code-level failure
+        // modes — "this code isn't in the spec's responses map" AND "this code
+        // IS documented but the body doesn't match its schema". Earlier checks
+        // (path / method not in spec) still fail loudly so typos stay visible.
+        $matchingPattern = $this->matchingSkipPattern($statusCodeStr);
+        if ($matchingPattern !== null) {
             return OpenApiValidationResult::skipped(
                 $matchedPath,
-                sprintf('status %s matched skip pattern', $statusCodeStr),
+                sprintf('status %s matched skip pattern %s', $statusCodeStr, $matchingPattern),
             );
         }
 
@@ -198,25 +201,40 @@ final class OpenApiResponseValidator
     }
 
     /**
+     * Keys keyed by the user-provided pattern (raw, without delimiters/anchors)
+     * so skipReason can echo what the caller wrote rather than the internal
+     * anchored form.
+     *
      * @param string[] $patterns
      *
-     * @return string[]
+     * @return array<string, string> raw pattern => anchored pattern
      */
     private static function compileSkipPatterns(array $patterns): array
     {
         $compiled = [];
 
         foreach ($patterns as $index => $pattern) {
+            if ($pattern === '') {
+                throw new InvalidArgumentException(
+                    sprintf('skipResponseCodes[%s] must not be an empty string.', (string) $index),
+                );
+            }
+
             $anchored = '/^(?:' . $pattern . ')$/';
 
             $ok = @preg_match($anchored, '');
             if ($ok === false) {
                 throw new InvalidArgumentException(
-                    sprintf('skipResponseCodes[%s] is not a valid regex pattern: %s', (string) $index, $pattern),
+                    sprintf(
+                        'skipResponseCodes[%s] is not a valid regex pattern "%s": %s',
+                        (string) $index,
+                        $pattern,
+                        preg_last_error_msg(),
+                    ),
                 );
             }
 
-            $compiled[] = $anchored;
+            $compiled[$pattern] = $anchored;
         }
 
         return $compiled;
@@ -250,15 +268,22 @@ final class OpenApiResponseValidator
         return $object;
     }
 
-    private function matchesSkipPattern(string $statusCode): bool
+    /**
+     * Returns the raw pattern (as supplied by the caller) that matched, or
+     * null if no pattern matched. `preg_match` returning false (runtime
+     * failure) is impossible in practice because compileSkipPatterns already
+     * probed each pattern successfully against the empty string and the
+     * subject here is always a short status-code string.
+     */
+    private function matchingSkipPattern(string $statusCode): ?string
     {
-        foreach ($this->skipPatterns as $pattern) {
-            if (preg_match($pattern, $statusCode) === 1) {
-                return true;
+        foreach ($this->skipPatterns as $raw => $anchored) {
+            if (preg_match($anchored, $statusCode) === 1) {
+                return $raw;
             }
         }
 
-        return false;
+        return null;
     }
 
     /**

--- a/src/OpenApiValidationResult.php
+++ b/src/OpenApiValidationResult.php
@@ -15,6 +15,8 @@ final class OpenApiValidationResult
         private readonly bool $valid,
         private readonly array $errors = [],
         private readonly ?string $matchedPath = null,
+        private readonly bool $skipped = false,
+        private readonly ?string $skipReason = null,
     ) {}
 
     public static function success(?string $matchedPath = null): self
@@ -28,9 +30,25 @@ final class OpenApiValidationResult
         return new self(false, $errors, $matchedPath);
     }
 
+    /**
+     * Represents a response whose body was intentionally not validated (e.g. a
+     * 5xx production error that the spec does not document). isValid() stays
+     * true so the assertion does not fail the test; isSkipped() distinguishes
+     * the case from a genuine successful match for callers that care.
+     */
+    public static function skipped(?string $matchedPath = null, ?string $reason = null): self
+    {
+        return new self(true, [], $matchedPath, true, $reason);
+    }
+
     public function isValid(): bool
     {
         return $this->valid;
+    }
+
+    public function isSkipped(): bool
+    {
+        return $this->skipped;
     }
 
     /** @return string[] */
@@ -47,5 +65,10 @@ final class OpenApiValidationResult
     public function matchedPath(): ?string
     {
         return $this->matchedPath;
+    }
+
+    public function skipReason(): ?string
+    {
+        return $this->skipReason;
     }
 }

--- a/src/OpenApiValidationResult.php
+++ b/src/OpenApiValidationResult.php
@@ -9,9 +9,14 @@ use function implode;
 final class OpenApiValidationResult
 {
     /**
+     * Private so the three factories (success / failure / skipped) are the
+     * only way to construct a result. This prevents illegal combinations such
+     * as `valid=false, skipped=true` or `valid=true, errors=['x']` — the
+     * factories enforce every invariant the type depends on.
+     *
      * @param string[] $errors
      */
-    public function __construct(
+    private function __construct(
         private readonly bool $valid,
         private readonly array $errors = [],
         private readonly ?string $matchedPath = null,
@@ -33,8 +38,9 @@ final class OpenApiValidationResult
     /**
      * Represents a response whose body was intentionally not validated (e.g. a
      * 5xx production error that the spec does not document). isValid() stays
-     * true so the assertion does not fail the test; isSkipped() distinguishes
-     * the case from a genuine successful match for callers that care.
+     * true so callers that gate on it (e.g. PHPUnit assertions) treat the
+     * result as non-failing; isSkipped() distinguishes it from a genuine
+     * successful schema match.
      */
     public static function skipped(?string $matchedPath = null, ?string $reason = null): self
     {

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -73,6 +73,20 @@ class OpenApiResponseValidatorTest extends TestCase
         yield 'empty nested object' => [['data' => []]];
     }
 
+    /**
+     * @return iterable<string, array{int, bool}>
+     */
+    public static function provideSkip_boundary_casesCases(): iterable
+    {
+        // Pin the exact 5xx boundary so that a future tweak to the default
+        // pattern (e.g. accidental `5\d+` instead of `5\d\d`) cannot silently
+        // widen or narrow the skip window.
+        yield '499 is not skipped' => [499, false];
+        yield '500 is skipped' => [500, true];
+        yield '599 is skipped' => [599, true];
+        yield '600 is not skipped' => [600, false];
+    }
+
     // ========================================
     // OAS 3.0 tests
     // ========================================
@@ -319,6 +333,9 @@ class OpenApiResponseValidatorTest extends TestCase
     {
         // Anchoring matters: "50" must not match "500". Without anchors, a
         // pattern like "50" would accidentally skip any code starting with 50.
+        // Also assert that validation still proceeds normally — petstore-3.0
+        // defines 500 with an empty application/json schema, so the result is
+        // a regular success, not a skip.
         $validator = new OpenApiResponseValidator(skipResponseCodes: ['50']);
 
         $result = $validator->validate(
@@ -330,6 +347,69 @@ class OpenApiResponseValidatorTest extends TestCase
         );
 
         $this->assertFalse($result->isSkipped());
+        $this->assertTrue($result->isValid());
+    }
+
+    #[Test]
+    #[DataProvider('provideSkip_boundary_casesCases')]
+    public function skip_boundary_cases(int $statusCode, bool $expectSkipped): void
+    {
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            $statusCode,
+            null,
+        );
+
+        $this->assertSame($expectSkipped, $result->isSkipped());
+    }
+
+    #[Test]
+    public function v31_5xx_response_is_skipped_by_default(): void
+    {
+        // petstore-3.1 does NOT define 503; skip must still fire under OAS 3.1
+        // so a future move of the skip check past version-specific schema
+        // conversion doesn't silently regress.
+        $result = $this->validator->validate(
+            'petstore-3.1',
+            'GET',
+            '/v1/pets',
+            503,
+            ['error' => 'service unavailable'],
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertTrue($result->isSkipped());
+        $this->assertSame('/v1/pets', $result->matchedPath());
+    }
+
+    #[Test]
+    public function multiple_skip_patterns_are_ored(): void
+    {
+        // Regression guard: the foreach in matchingSkipPattern must try every
+        // configured pattern, not short-circuit on the first.
+        $validator = new OpenApiResponseValidator(skipResponseCodes: ['4\d\d', '5\d\d']);
+
+        $result404 = $validator->validate('petstore-3.0', 'GET', '/v1/pets', 404, null);
+        $result500 = $validator->validate('petstore-3.0', 'GET', '/v1/pets', 500, null);
+
+        $this->assertTrue($result404->isSkipped());
+        $this->assertTrue($result500->isSkipped());
+    }
+
+    #[Test]
+    public function skip_reason_includes_matched_pattern(): void
+    {
+        // skipReason() carries enough detail to audit which configured pattern
+        // fired, not just which status code triggered — useful when running
+        // with multiple distinct patterns.
+        $validator = new OpenApiResponseValidator(skipResponseCodes: ['4\d\d', '5\d\d']);
+
+        $result = $validator->validate('petstore-3.0', 'GET', '/v1/pets', 503, null);
+
+        $this->assertTrue($result->isSkipped());
+        $this->assertSame('status 503 matched skip pattern 5\d\d', $result->skipReason());
     }
 
     #[Test]
@@ -337,8 +417,38 @@ class OpenApiResponseValidatorTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('skipResponseCodes');
+        $this->expectExceptionMessage('(unclosed');
 
         new OpenApiResponseValidator(skipResponseCodes: ['(unclosed']);
+    }
+
+    #[Test]
+    public function invalid_skip_pattern_error_includes_preg_detail(): void
+    {
+        try {
+            new OpenApiResponseValidator(skipResponseCodes: ['(unclosed']);
+            $this->fail('Expected InvalidArgumentException was not thrown.');
+        } catch (InvalidArgumentException $e) {
+            // The message carries both the offending raw pattern and a
+            // preg_last_error_msg() trailer (wording varies across PHP
+            // versions — "Internal error", "missing )", etc.). Assert both
+            // structural pieces are present rather than locking to a
+            // specific PCRE wording.
+            $this->assertStringContainsString('(unclosed', $e->getMessage());
+            $this->assertMatchesRegularExpression('/: \S/', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function empty_skip_pattern_is_rejected(): void
+    {
+        // An empty pattern is never legitimate for status-code matching
+        // (status codes are always non-empty), so reject it at construction
+        // instead of silently accepting a regex that matches nothing.
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('must not be an empty string');
+
+        new OpenApiResponseValidator(skipResponseCodes: ['']);
     }
 
     // ========================================

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -199,6 +199,149 @@ class OpenApiResponseValidatorTest extends TestCase
     }
 
     // ========================================
+    // Skip-by-status-code tests
+    // ========================================
+
+    #[Test]
+    public function v30_500_response_is_skipped_by_default(): void
+    {
+        // petstore-3.0 defines 500 with an empty schema. The default skip
+        // pattern must short-circuit even when the status code is defined,
+        // so tests exercising production-only error paths stay green.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            500,
+            ['error' => 'something went wrong'],
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertTrue($result->isSkipped());
+        $this->assertSame('/v1/pets', $result->matchedPath());
+    }
+
+    #[Test]
+    public function v30_503_response_is_skipped_by_default(): void
+    {
+        // petstore-3.0 does NOT define 503. The default skip pattern must
+        // suppress the normal "Status code 503 not defined" failure so that
+        // unexpected 5xx in test environments doesn't produce extra noise.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            503,
+            ['error' => 'service unavailable'],
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertTrue($result->isSkipped());
+        $this->assertSame('/v1/pets', $result->matchedPath());
+    }
+
+    #[Test]
+    public function v30_499_response_is_not_skipped_by_default(): void
+    {
+        // 499 is outside the 5xx default pattern — validation should proceed
+        // to the normal "Status code not defined" failure for this spec.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            499,
+            ['error' => 'client closed request'],
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertFalse($result->isSkipped());
+        $this->assertStringContainsString('Status code 499 not defined', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function v30_299_response_is_not_skipped_by_default(): void
+    {
+        // 299 is a 2xx, not in the default 5xx skip window. It must fall
+        // through to the existing "not defined" failure.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            299,
+            ['data' => []],
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertFalse($result->isSkipped());
+        $this->assertStringContainsString('Status code 299 not defined', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function skip_response_codes_can_be_disabled(): void
+    {
+        // Opting out of the default skip list means 5xx behaves like any
+        // other status code again — a 503 not in the spec becomes a failure.
+        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+
+        $result = $validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            503,
+            ['error' => 'service unavailable'],
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertFalse($result->isSkipped());
+        $this->assertStringContainsString('Status code 503 not defined', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function custom_skip_response_codes_pattern(): void
+    {
+        // Users can widen the skip set to cover 4xx or a specific code.
+        $validator = new OpenApiResponseValidator(skipResponseCodes: ['4\d\d', '5\d\d']);
+
+        $result = $validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            404,
+            null,
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertTrue($result->isSkipped());
+    }
+
+    #[Test]
+    public function skip_pattern_is_anchored(): void
+    {
+        // Anchoring matters: "50" must not match "500". Without anchors, a
+        // pattern like "50" would accidentally skip any code starting with 50.
+        $validator = new OpenApiResponseValidator(skipResponseCodes: ['50']);
+
+        $result = $validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            500,
+            null,
+        );
+
+        $this->assertFalse($result->isSkipped());
+    }
+
+    #[Test]
+    public function invalid_skip_pattern_throws(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('skipResponseCodes');
+
+        new OpenApiResponseValidator(skipResponseCodes: ['(unclosed']);
+    }
+
+    // ========================================
     // OAS 3.0 JSON-compatible content type tests
     // ========================================
 
@@ -293,7 +436,13 @@ class OpenApiResponseValidatorTest extends TestCase
     #[Test]
     public function v30_json_content_type_without_schema_skips_validation(): void
     {
-        $result = $this->validator->validate(
+        // Bypass the 5xx default skip so we exercise the "content entry with
+        // no schema" path specifically (petstore-3.0 defines 500 with an empty
+        // application/json object). With the default skip list, the 5xx check
+        // would short-circuit before reaching the schema-less branch.
+        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+
+        $result = $validator->validate(
             'petstore-3.0',
             'GET',
             '/v1/pets',
@@ -302,6 +451,7 @@ class OpenApiResponseValidatorTest extends TestCase
         );
 
         $this->assertTrue($result->isValid());
+        $this->assertFalse($result->isSkipped());
         $this->assertSame('/v1/pets', $result->matchedPath());
     }
 

--- a/tests/Unit/OpenApiValidationResultTest.php
+++ b/tests/Unit/OpenApiValidationResultTest.php
@@ -16,6 +16,7 @@ class OpenApiValidationResultTest extends TestCase
         $result = OpenApiValidationResult::success('/v1/pets');
 
         $this->assertTrue($result->isValid());
+        $this->assertFalse($result->isSkipped());
         $this->assertSame([], $result->errors());
         $this->assertSame('', $result->errorMessage());
         $this->assertSame('/v1/pets', $result->matchedPath());
@@ -27,6 +28,7 @@ class OpenApiValidationResultTest extends TestCase
         $result = OpenApiValidationResult::success();
 
         $this->assertTrue($result->isValid());
+        $this->assertFalse($result->isSkipped());
         $this->assertNull($result->matchedPath());
     }
 
@@ -37,6 +39,7 @@ class OpenApiValidationResultTest extends TestCase
         $result = OpenApiValidationResult::failure($errors);
 
         $this->assertFalse($result->isValid());
+        $this->assertFalse($result->isSkipped());
         $this->assertSame($errors, $result->errors());
         $this->assertNull($result->matchedPath());
     }
@@ -47,5 +50,42 @@ class OpenApiValidationResultTest extends TestCase
         $result = OpenApiValidationResult::failure(['Error 1', 'Error 2']);
 
         $this->assertSame("Error 1\nError 2", $result->errorMessage());
+    }
+
+    #[Test]
+    public function skipped_creates_skipped_result(): void
+    {
+        $result = OpenApiValidationResult::skipped('/v1/pets', 'status 500 matched skip pattern');
+
+        // isValid() remains true so the assertion surface does not fail the test,
+        // but isSkipped() distinguishes the case from a genuine success.
+        $this->assertTrue($result->isValid());
+        $this->assertTrue($result->isSkipped());
+        $this->assertSame([], $result->errors());
+        $this->assertSame('', $result->errorMessage());
+        $this->assertSame('/v1/pets', $result->matchedPath());
+        $this->assertSame('status 500 matched skip pattern', $result->skipReason());
+    }
+
+    #[Test]
+    public function skipped_without_reason(): void
+    {
+        $result = OpenApiValidationResult::skipped('/v1/pets');
+
+        $this->assertTrue($result->isValid());
+        $this->assertTrue($result->isSkipped());
+        $this->assertSame('/v1/pets', $result->matchedPath());
+        $this->assertNull($result->skipReason());
+    }
+
+    #[Test]
+    public function skipped_without_matched_path(): void
+    {
+        $result = OpenApiValidationResult::skipped();
+
+        $this->assertTrue($result->isValid());
+        $this->assertTrue($result->isSkipped());
+        $this->assertNull($result->matchedPath());
+        $this->assertNull($result->skipReason());
     }
 }

--- a/tests/Unit/OpenApiValidationResultTest.php
+++ b/tests/Unit/OpenApiValidationResultTest.php
@@ -55,7 +55,7 @@ class OpenApiValidationResultTest extends TestCase
     #[Test]
     public function skipped_creates_skipped_result(): void
     {
-        $result = OpenApiValidationResult::skipped('/v1/pets', 'status 500 matched skip pattern');
+        $result = OpenApiValidationResult::skipped('/v1/pets', 'status 500 matched skip pattern 5\d\d');
 
         // isValid() remains true so the assertion surface does not fail the test,
         // but isSkipped() distinguishes the case from a genuine success.
@@ -64,7 +64,7 @@ class OpenApiValidationResultTest extends TestCase
         $this->assertSame([], $result->errors());
         $this->assertSame('', $result->errorMessage());
         $this->assertSame('/v1/pets', $result->matchedPath());
-        $this->assertSame('status 500 matched skip pattern', $result->skipReason());
+        $this->assertSame('status 500 matched skip pattern 5\d\d', $result->skipReason());
     }
 
     #[Test]

--- a/tests/Unit/ValidatesOpenApiSchemaAutoAssertTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaAutoAssertTest.php
@@ -224,4 +224,42 @@ class ValidatesOpenApiSchemaAutoAssertTest extends TestCase
         $this->expectException(AssertionFailedError::class);
         $this->assertResponseMatchesOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
     }
+
+    #[Test]
+    public function auto_assert_does_not_fail_on_undocumented_5xx(): void
+    {
+        // End-to-end guard for the 5xx default skip under auto_assert: a
+        // production-style 503 that the spec does not document must pass
+        // through the full createTestResponse → maybeAutoAssert → validator
+        // chain without raising AssertionFailedError, and the endpoint must
+        // still be recorded as covered.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_assert'] = true;
+
+        $body = (string) json_encode(['error' => 'service unavailable'], JSON_THROW_ON_ERROR);
+        $response = $this->makeTestResponse($body, 503);
+
+        $this->maybeAutoAssertOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayHasKey('petstore-3.0', $covered);
+        $this->assertArrayHasKey('GET /v1/pets', $covered['petstore-3.0']);
+    }
+
+    #[Test]
+    public function auto_assert_still_fails_5xx_when_skip_disabled(): void
+    {
+        // Opting out of skip via config restores the "not defined" failure
+        // under auto_assert — confirms the cache-key extension makes the
+        // config change observable without a manual cache reset.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_assert'] = true;
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.skip_response_codes'] = [];
+
+        $body = (string) json_encode(['error' => 'service unavailable'], JSON_THROW_ON_ERROR);
+        $response = $this->makeTestResponse($body, 503);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Status code 503 not defined');
+
+        $this->maybeAutoAssertOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+    }
 }

--- a/tests/Unit/ValidatesOpenApiSchemaDefaultSpecTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaDefaultSpecTest.php
@@ -192,4 +192,86 @@ class ValidatesOpenApiSchemaDefaultSpecTest extends TestCase
             $this->assertGreaterThan(1, count($errorLines));
         }
     }
+
+    // ========================================
+    // skip_response_codes config tests
+    // ========================================
+
+    #[Test]
+    public function default_skip_response_codes_config_skips_5xx_responses(): void
+    {
+        // With no explicit config, the default from config.php (['5\d\d']) must
+        // apply: a 503 that is not in the spec must NOT fail the assertion.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.default_spec'] = 'petstore-3.0';
+
+        $body = (string) json_encode(['error' => 'service unavailable'], JSON_THROW_ON_ERROR);
+        $response = $this->makeTestResponse($body, 503);
+
+        $this->assertResponseMatchesOpenApiSchema(
+            $response,
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+
+        // Skipped endpoints still count as covered — the endpoint was exercised
+        // even though the body wasn't schema-checked.
+        $this->assertArrayHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
+    }
+
+    #[Test]
+    public function skip_response_codes_config_can_be_disabled(): void
+    {
+        // Empty array means "validate every status code" — a 503 not in the
+        // spec must fall through to the usual "Status code not defined" failure.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.default_spec'] = 'petstore-3.0';
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.skip_response_codes'] = [];
+
+        $body = (string) json_encode(['error' => 'service unavailable'], JSON_THROW_ON_ERROR);
+        $response = $this->makeTestResponse($body, 503);
+
+        try {
+            $this->assertResponseMatchesOpenApiSchema(
+                $response,
+                HttpMethod::GET,
+                '/v1/pets',
+            );
+            $this->fail('Expected AssertionFailedError was not thrown.');
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString('Status code 503 not defined', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function custom_skip_response_codes_config_widens_skip_set(): void
+    {
+        // Users can widen the skip to include 4xx by overriding the config.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.default_spec'] = 'petstore-3.0';
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.skip_response_codes'] = ['4\d\d', '5\d\d'];
+
+        $response = $this->makeTestResponse('{}', 404);
+
+        $this->assertResponseMatchesOpenApiSchema(
+            $response,
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+    }
+
+    #[Test]
+    public function non_array_skip_response_codes_config_fails_with_clear_message(): void
+    {
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.default_spec'] = 'petstore-3.0';
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.skip_response_codes'] = '5\d\d';
+
+        $response = $this->makeTestResponse('{}', 500);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('openapi-contract-testing.skip_response_codes must be an array');
+
+        $this->assertResponseMatchesOpenApiSchema(
+            $response,
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+    }
 }

--- a/tests/Unit/ValidatesOpenApiSchemaDefaultSpecTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaDefaultSpecTest.php
@@ -213,9 +213,13 @@ class ValidatesOpenApiSchemaDefaultSpecTest extends TestCase
             '/v1/pets',
         );
 
-        // Skipped endpoints still count as covered — the endpoint was exercised
-        // even though the body wasn't schema-checked.
-        $this->assertArrayHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
+        // Skipped endpoints still count as covered with the correct key — the
+        // endpoint was exercised even though the body wasn't schema-checked.
+        // Asserting the full "METHOD path" key (not just the spec name) guards
+        // against a regression where skipped() stops passing through matchedPath.
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayHasKey('petstore-3.0', $covered);
+        $this->assertArrayHasKey('GET /v1/pets', $covered['petstore-3.0']);
     }
 
     #[Test]
@@ -267,6 +271,46 @@ class ValidatesOpenApiSchemaDefaultSpecTest extends TestCase
 
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage('openapi-contract-testing.skip_response_codes must be an array');
+
+        $this->assertResponseMatchesOpenApiSchema(
+            $response,
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+    }
+
+    #[Test]
+    public function non_string_skip_response_codes_entry_fails_with_clear_message(): void
+    {
+        // Integer status codes look tempting (`['skip_response_codes' => [500]]`)
+        // but would silently break the regex-matching contract. Fail loudly.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.default_spec'] = 'petstore-3.0';
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.skip_response_codes'] = [500];
+
+        $response = $this->makeTestResponse('{}', 500);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('openapi-contract-testing.skip_response_codes[0] must be a string regex pattern');
+
+        $this->assertResponseMatchesOpenApiSchema(
+            $response,
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+    }
+
+    #[Test]
+    public function empty_string_skip_response_codes_entry_fails_with_clear_message(): void
+    {
+        // An empty pattern compiles to /^(?:)$/ which silently matches nothing —
+        // it should fail loudly at config time instead of becoming dead config.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.default_spec'] = 'petstore-3.0';
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.skip_response_codes'] = [''];
+
+        $response = $this->makeTestResponse('{}', 500);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('openapi-contract-testing.skip_response_codes[0] must not be an empty string');
 
         $this->assertResponseMatchesOpenApiSchema(
             $response,


### PR DESCRIPTION
# 概要

プロダクションで発生しうる 5xx レスポンスは OpenAPI spec に書かない運用が一般的だが、現状は spec 未定義 status code で `failure("Status code not defined")` が出るため、予期せぬ 500 が発生したテストが別の原因でも落ちてノイズになる。5xx をデフォルトでスキップし、`OpenApiValidationResult::skipped()` state で識別可能にする（Issue #47）。

## 変更内容

`OpenApiValidationResult` に `skipped` state を新設し、`OpenApiResponseValidator` に status code の regex パターンで skip 判定を導入した。Laravel アダプタ側では config `skip_response_codes`（デフォルト `['5\d\d']`）を介して制御できるようにし、既存の `max_errors` と同じ仕組みで validator キャッシュキーに反映している。

- `src/OpenApiValidationResult.php`: `::skipped()` factory / `isSkipped()` / `skipReason()` を追加。`isValid()` は skip 時も true を返してアサーションを通す
- `src/OpenApiResponseValidator.php`: `skipResponseCodes` コンストラクタ引数（デフォルト `['5\d\d']`）を追加。regex はコンストラクタで anchor 付きで検証し、不正パターンは `InvalidArgumentException`。skip 判定は `failure("Status code X not defined")` の直前に挿入（Issue の実装ヒントに従う）
- `src/Laravel/config.php`: `skip_response_codes` キーを追加
- `src/Laravel/ValidatesOpenApiSchema.php`: config 読み込み・型検証、validator キャッシュキー拡張
- `tests/Unit/OpenApiValidationResultTest.php`: skipped state のテスト 3 本 + 既存テストに `isSkipped()` 回帰アサート
- `tests/Unit/OpenApiResponseValidatorTest.php`: 500/503/499/299・override 無効化・custom pattern（4xx 追加）・anchoring 検証・invalid regex の 7 テスト追加。既存 `v30_json_content_type_without_schema_skips_validation` は 500 を使うため `skipResponseCodes: []` で挙動を維持
- `tests/Unit/ValidatesOpenApiSchemaDefaultSpecTest.php`: config 経由の伝播テスト 4 本（デフォルト skip / 無効化 / 拡張 / 型エラー）
- `README.md`: Features 行追加、新セクション「Skipping responses by status code」、API リファレンスに `isSkipped()` / `skipReason()` 追記

### 設計メモ

- skip 判定は status code が spec に定義されているかどうかに**関わらず**先に走る。ルールを単純・予測可能にするため、500 が spec に書かれていてもデフォルトではスキップされる
- coverage tracker は既存挙動 (`matchedPath` があれば record) のまま。skip 時も `matchedPath` を返すので、README の既存表現「body validation was skipped (e.g. non-JSON content types)」と整合して「endpoint は exercise された」扱いになる
- regex パターンは `/^(?:...)$/` で自動 anchor。`50` が `500` にヒットする事故を防ぐ

### 品質ゲート

- PHPUnit: 400/400 PASS
- PHPStan level 6: No errors
- php-cs-fixer: クリーン

## 関連情報

- Closes #47