### PR TITLE
feat(validates-openapi-schema): add per-request skipResponseCode() fluent API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Validate your API responses against your OpenAPI specification during testing, a
 - **OpenAPI 3.0 & 3.1 support** — Automatic version detection from the `openapi` field
 - **Response validation** — Validates response bodies against JSON Schema (Draft 07 via opis/json-schema). Supports `application/json` and any `+json` content type (e.g., `application/problem+json`)
 - **Content negotiation** — Accepts the actual response `Content-Type` to handle mixed-content specs. Non-JSON responses (e.g., `text/html`, `application/xml`) are verified for spec presence without body validation; JSON-compatible responses are fully schema-validated
-- **Skip-by-status-code** — Configurable regex list of status codes whose bodies are not validated (default: every `5xx`), reflecting the common convention of not documenting production error responses in the spec
+- **Skip-by-status-code** — Configurable regex list of status codes whose bodies are not validated (default: every `5xx`), reflecting the common convention of not documenting production error responses in the spec. Also available per-request via the fluent `skipResponseCode()` API
 - **Endpoint coverage tracking** — Unique PHPUnit extension that reports which spec endpoints are covered by tests
 - **Path matching** — Handles parameterized paths (`/pets/{petId}`) with configurable prefix stripping
 - **Laravel adapter** — Optional trait for seamless integration with Laravel's `TestResponse`
@@ -367,6 +367,39 @@ Notes:
 - Scoped to auto-assert only, like `#[SkipOpenApi]`. An explicit `assertResponseMatchesOpenApiSchema()` call still runs regardless of the flag.
 - No coverage is recorded for the skipped request.
 - Each method returns `$this`, so both `$this->withoutValidation()->get(...)` and the step-by-step form (`$this->withoutValidation(); $this->get(...);`) work.
+
+#### Per-request status-code skip with `skipResponseCode()`
+
+`withoutValidation()` is all-or-nothing for a request. When you only need to suppress a specific status code — e.g., a flaky `404` while a fixture is being repaired — `skipResponseCode()` adds a one-off skip on top of the config-level set:
+
+```php
+class PetApiTest extends TestCase
+{
+    use ValidatesOpenApiSchema;
+
+    public function test_endpoint_returning_a_documented_404(): void
+    {
+        // Only this call treats 404 as a skip; other calls keep the default behavior.
+        $this->skipResponseCode(404)
+            ->get('/v1/pets/missing')
+            ->assertNotFound();
+    }
+}
+```
+
+Argument shapes:
+
+- **`int`** — exact match, anchored. `skipResponseCode(500)` matches `"500"` only, never `"5000"` or `"50"`.
+- **`string`** — regex pattern (anchored automatically). `skipResponseCode('4\d\d')` matches the entire `4xx` range.
+- **`array`** — expanded one level. Mixed types are allowed: `skipResponseCode([404, '5\d\d'])`.
+- **Variadic** — multiple positional arguments work too: `skipResponseCode(404, 500, '5\d\d')`.
+
+Notes:
+
+- **Merged** with `skip_response_codes` from config — per-request codes ADD to the config set rather than replacing it. With the default config, `skipResponseCode(404)` skips both `404` and every `5xx`.
+- **One HTTP call**: same consumption model as `withoutValidation()`. The codes are consumed on the next auto-assert attempt and reset, so the next call falls back to the config-level set.
+- **Auto-assert only**. Explicit `assertResponseMatchesOpenApiSchema()` calls ignore per-request codes — explicit calls are the user's direct intent.
+- **Chainable**: returns `$this`. Multiple chained calls accumulate (`$this->skipResponseCode(404)->skipResponseCode(503)` registers both).
 - `withoutRequestValidation()` currently has no observable effect because request validation has not landed yet — the method exists so tests can adopt the intended API surface today without a later rewrite.
 
 ## Coverage Report

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -10,6 +10,7 @@ use const FILTER_VALIDATE_BOOLEAN;
 use const STDERR;
 
 use Illuminate\Testing\TestResponse;
+use InvalidArgumentException;
 use JsonException;
 use Studio\OpenApiContractTesting\HttpMethod;
 use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
@@ -73,8 +74,8 @@ trait ValidatesOpenApiSchema
     // Per-request additional response-code skip patterns set by
     // skipResponseCode(). Merged with the config-level skip set when building
     // the validator, then consumed (reset) on the next auto-assert attempt.
-    // Patterns are stored raw (without delimiters/anchors) so the existing
-    // OpenApiResponseValidator::compileSkipPatterns() pipeline can anchor them.
+    // Patterns are stored raw (without delimiters/anchors); the validator
+    // anchors them when compiling.
     /** @var string[] */
     private array $skipNextResponseCodes = [];
 
@@ -136,28 +137,58 @@ trait ValidatesOpenApiSchema
      * then consumed (reset) after one call — matching the per-request
      * consumption model of withoutValidation().
      *
-     * - int: exact match (the existing skip-pattern compiler anchors it to
-     *   `^(?:500)$`, so `500` only matches `"500"`).
-     * - string: regex pattern (anchored by the compiler).
-     * - array: expanded one level; each element is treated as int or string
-     *   per the above.
+     * - int: exact match (anchored for exact match, so `500` matches only "500").
+     * - string: regex pattern (anchored automatically).
+     * - array: expanded one level; each element must be int or string.
+     *   Nested arrays are rejected with a clear error message rather than a
+     *   raw TypeError.
      *
-     * Scoped to auto-assert only, matching withoutValidation()'s convention.
-     * Explicit assertResponseMatchesOpenApiSchema() calls are the user's
-     * direct intent and ignore this flag.
+     * Scoped to auto-assert only. Explicit calls to
+     * assertResponseMatchesOpenApiSchema() emit an advisory warning because
+     * the per-request flag is silently ignored there.
      *
      * @param array<int|string>|int|string ...$codes
+     *
+     * @throws InvalidArgumentException when no codes are supplied, when an
+     *                                  array argument is nested, or when an
+     *                                  array element is not int|string.
      */
     public function skipResponseCode(array|int|string ...$codes): static
     {
-        foreach ($codes as $code) {
+        if ($codes === []) {
+            throw new InvalidArgumentException(
+                'skipResponseCode() requires at least one code.',
+            );
+        }
+
+        $normalized = [];
+        foreach ($codes as $index => $code) {
             if (is_array($code)) {
-                foreach ($code as $inner) {
-                    $this->skipNextResponseCodes[] = self::normalizeSkipCode($inner);
+                foreach ($code as $innerIndex => $inner) {
+                    if (!is_int($inner) && !is_string($inner)) {
+                        throw new InvalidArgumentException(sprintf(
+                            'skipResponseCode() array elements must be int or string; got %s at position [%d][%s]. '
+                            . 'Nested arrays are not supported.',
+                            get_debug_type($inner),
+                            $index,
+                            (string) $innerIndex,
+                        ));
+                    }
+                    $normalized[] = self::normalizeSkipCode($inner);
                 }
             } else {
-                $this->skipNextResponseCodes[] = self::normalizeSkipCode($code);
+                $normalized[] = self::normalizeSkipCode($code);
             }
+        }
+
+        if ($normalized === []) {
+            throw new InvalidArgumentException(
+                'skipResponseCode() requires at least one code, but all supplied arrays were empty.',
+            );
+        }
+
+        foreach ($normalized as $code) {
+            $this->skipNextResponseCodes[] = $code;
         }
 
         return $this;
@@ -237,12 +268,9 @@ trait ValidatesOpenApiSchema
     }
 
     /**
-     * @param string[] $extraSkipResponseCodes Additional skip patterns merged
-     *                                         into the validator's skip set for this call only. Populated by
-     *                                         maybeAutoAssertOpenApiSchema() from the per-request
-     *                                         skipResponseCode() flag. Empty for explicit user calls — the flag
-     *                                         is scoped to auto-assert only, matching withoutValidation()'s
-     *                                         convention.
+     * @param string[] $extraSkipResponseCodes Additional skip patterns for
+     *                                         this call only; populated by maybeAutoAssertOpenApiSchema().
+     *                                         Empty for explicit user calls.
      */
     protected function assertResponseMatchesOpenApiSchema(
         TestResponse $response,
@@ -253,6 +281,15 @@ trait ValidatesOpenApiSchema
         $skipAttribute = $this->findSkipOpenApiAttribute();
         if ($skipAttribute !== null) {
             $this->emitSkipOpenApiWarning($skipAttribute);
+        }
+
+        // Pending per-request skip codes with no auto-assert in sight: the
+        // user set skipResponseCode() but is calling explicit assert, which
+        // ignores the flag by design. Warn and consume so the flag doesn't
+        // leak into a later HTTP call and surprise the user.
+        if ($extraSkipResponseCodes === [] && $this->skipNextResponseCodes !== []) {
+            $this->emitSkipResponseCodeWarning();
+            $this->skipNextResponseCodes = [];
         }
 
         $resolvedMethod = $method !== null ? $method->value : app('request')->getMethod();
@@ -430,6 +467,24 @@ trait ValidatesOpenApiSchema
             $reason !== '' ? sprintf('(reason: %s)', var_export($reason, true)) : '',
         );
 
+        $this->dispatchSkipWarning($message);
+    }
+
+    private function emitSkipResponseCodeWarning(): void
+    {
+        $message = sprintf(
+            '%s::%s set skipResponseCode() before calling assertResponseMatchesOpenApiSchema() explicitly. '
+            . 'Per-request skip codes apply only to auto-assert; the explicit assertion ignores them. '
+            . 'Remove the skipResponseCode() call or rely on auto-assert to clarify intent.',
+            static::class,
+            $this->name(), // @phpstan-ignore method.notFound
+        );
+
+        $this->dispatchSkipWarning($message);
+    }
+
+    private function dispatchSkipWarning(string $message): void
+    {
         $handler = self::$skipWarningHandler;
         if ($handler !== null) {
             $handler($message);

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -21,10 +21,12 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use WeakMap;
 
+use function array_merge;
 use function filter_var;
 use function fwrite;
 use function get_debug_type;
 use function is_array;
+use function is_int;
 use function is_numeric;
 use function is_string;
 use function sprintf;
@@ -67,6 +69,14 @@ trait ValidatesOpenApiSchema
     // method — this gives us natural per-test isolation.
     private bool $skipNextRequestValidation = false;
     private bool $skipNextResponseValidation = false;
+
+    // Per-request additional response-code skip patterns set by
+    // skipResponseCode(). Merged with the config-level skip set when building
+    // the validator, then consumed (reset) on the next auto-assert attempt.
+    // Patterns are stored raw (without delimiters/anchors) so the existing
+    // OpenApiResponseValidator::compileSkipPatterns() pipeline can anchor them.
+    /** @var string[] */
+    private array $skipNextResponseCodes = [];
 
     public static function resetValidatorCache(): void
     {
@@ -121,6 +131,39 @@ trait ValidatesOpenApiSchema
     }
 
     /**
+     * Adds one or more response status codes to skip for the next auto-assert
+     * HTTP call only. Merged with the config-level `skip_response_codes` set,
+     * then consumed (reset) after one call — matching the per-request
+     * consumption model of withoutValidation().
+     *
+     * - int: exact match (the existing skip-pattern compiler anchors it to
+     *   `^(?:500)$`, so `500` only matches `"500"`).
+     * - string: regex pattern (anchored by the compiler).
+     * - array: expanded one level; each element is treated as int or string
+     *   per the above.
+     *
+     * Scoped to auto-assert only, matching withoutValidation()'s convention.
+     * Explicit assertResponseMatchesOpenApiSchema() calls are the user's
+     * direct intent and ignore this flag.
+     *
+     * @param array<int|string>|int|string ...$codes
+     */
+    public function skipResponseCode(array|int|string ...$codes): static
+    {
+        foreach ($codes as $code) {
+            if (is_array($code)) {
+                foreach ($code as $inner) {
+                    $this->skipNextResponseCodes[] = self::normalizeSkipCode($inner);
+                }
+            } else {
+                $this->skipNextResponseCodes[] = self::normalizeSkipCode($code);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
      * Overrides Laravel's MakesHttpRequests::createTestResponse hook so every
      * HTTP test call runs schema validation when auto_assert is enabled.
      * When the library is used outside Laravel, this method is never called.
@@ -154,8 +197,10 @@ trait ValidatesOpenApiSchema
         // a flag set before an auto_assert=false call would silently leak
         // into the next call after auto_assert flips on.
         $skipResponse = $this->skipNextResponseValidation;
+        $extraSkipCodes = $this->skipNextResponseCodes;
         $this->skipNextRequestValidation = false;
         $this->skipNextResponseValidation = false;
+        $this->skipNextResponseCodes = [];
 
         if (!$this->isAutoAssertEnabled()) {
             return;
@@ -172,7 +217,7 @@ trait ValidatesOpenApiSchema
             return;
         }
 
-        $this->assertResponseMatchesOpenApiSchema($response, $method, $path);
+        $this->assertResponseMatchesOpenApiSchema($response, $method, $path, $extraSkipCodes);
     }
 
     protected function openApiSpec(): string
@@ -191,10 +236,19 @@ trait ValidatesOpenApiSchema
         return $this->openApiSpec();
     }
 
+    /**
+     * @param string[] $extraSkipResponseCodes Additional skip patterns merged
+     *                                         into the validator's skip set for this call only. Populated by
+     *                                         maybeAutoAssertOpenApiSchema() from the per-request
+     *                                         skipResponseCode() flag. Empty for explicit user calls — the flag
+     *                                         is scoped to auto-assert only, matching withoutValidation()'s
+     *                                         convention.
+     */
     protected function assertResponseMatchesOpenApiSchema(
         TestResponse $response,
         ?HttpMethod $method = null,
         ?string $path = null,
+        array $extraSkipResponseCodes = [],
     ): void {
         $skipAttribute = $this->findSkipOpenApiAttribute();
         if ($skipAttribute !== null) {
@@ -232,7 +286,12 @@ trait ValidatesOpenApiSchema
 
         $contentType = $response->headers->get('Content-Type', '');
 
-        $validator = $this->getOrCreateValidator();
+        // One-off validator when per-request skip codes are present — bypasses
+        // the static cache so test-local codes don't pollute it (and so
+        // cache-entry churn can't grow unbounded across tests).
+        $validator = $extraSkipResponseCodes !== []
+            ? $this->buildOneOffValidator($extraSkipResponseCodes)
+            : $this->getOrCreateValidator();
         $result = $validator->validate(
             $specName,
             $resolvedMethod,
@@ -276,11 +335,17 @@ trait ValidatesOpenApiSchema
         self::$validatedResponses[$response] = $signatures;
     }
 
+    private static function normalizeSkipCode(int|string $code): string
+    {
+        // Int codes are returned as a bare string so the existing
+        // OpenApiResponseValidator::compileSkipPatterns() pipeline wraps them
+        // in ^(?:...)$ for exact-match semantics. Strings are already regex.
+        return is_int($code) ? (string) $code : $code;
+    }
+
     private function getOrCreateValidator(): OpenApiResponseValidator
     {
-        $maxErrors = config('openapi-contract-testing.max_errors', 20);
-        $resolvedMaxErrors = is_numeric($maxErrors) ? (int) $maxErrors : 20;
-
+        $resolvedMaxErrors = $this->resolveMaxErrors();
         $resolvedSkipCodes = $this->resolveSkipResponseCodes();
 
         if (
@@ -297,6 +362,27 @@ trait ValidatesOpenApiSchema
         }
 
         return self::$cachedValidator;
+    }
+
+    /**
+     * @param string[] $extraSkipResponseCodes
+     */
+    private function buildOneOffValidator(array $extraSkipResponseCodes): OpenApiResponseValidator
+    {
+        return new OpenApiResponseValidator(
+            maxErrors: $this->resolveMaxErrors(),
+            skipResponseCodes: array_merge(
+                $this->resolveSkipResponseCodes(),
+                $extraSkipResponseCodes,
+            ),
+        );
+    }
+
+    private function resolveMaxErrors(): int
+    {
+        $maxErrors = config('openapi-contract-testing.max_errors', 20);
+
+        return is_numeric($maxErrors) ? (int) $maxErrors : 20;
     }
 
     /** @return string[] */

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -279,7 +279,11 @@ final class OpenApiResponseValidator
     {
         foreach ($this->skipPatterns as $raw => $anchored) {
             if (preg_match($anchored, $statusCode) === 1) {
-                return $raw;
+                // PHP coerces numeric-string array keys to int (e.g. the
+                // pattern "500" lands under key 500). Cast back to string so
+                // the documented ?string return type is honoured even for
+                // status-code-shaped patterns.
+                return (string) $raw;
             }
         }
 

--- a/tests/Integration/Laravel/AutoAssertIntegrationTest.php
+++ b/tests/Integration/Laravel/AutoAssertIntegrationTest.php
@@ -252,6 +252,43 @@ class AutoAssertIntegrationTest extends TestCase
         $this->withoutRequestValidation()->get('/v1/pets?bad=1');
     }
 
+    #[Test]
+    public function skip_response_code_suppresses_undocumented_status_end_to_end(): void
+    {
+        // End-to-end smoke test: fluent chain survives Laravel's HTTP
+        // dispatcher → createTestResponse hook. /v1/health defines only 200
+        // in the spec, so a 503 there would fail "Status code not defined"
+        // once config-level 5xx skipping is disabled. skipResponseCode(503)
+        // must suppress that. Unit tests exercise maybeAutoAssertOpenApiSchema
+        // directly — only this test proves the flag reaches the trait from
+        // the framework boundary.
+        config()->set('openapi-contract-testing.auto_assert', true);
+        config()->set('openapi-contract-testing.skip_response_codes', []);
+
+        $response = $this->skipResponseCode(503)->get('/v1/health');
+        $response->assertStatus(503);
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayHasKey('GET /v1/health', $covered['petstore-3.0'] ?? []);
+    }
+
+    #[Test]
+    public function skip_response_code_flag_resets_end_to_end(): void
+    {
+        // Per-request semantics through the real framework path: first call
+        // consumes the flag, second identical call must fail because no
+        // config-level skip is in effect.
+        config()->set('openapi-contract-testing.auto_assert', true);
+        config()->set('openapi-contract-testing.skip_response_codes', []);
+
+        $this->skipResponseCode(503)->get('/v1/health')->assertStatus(503);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Status code 503 not defined');
+
+        $this->get('/v1/health');
+    }
+
     /** @return array<int, class-string> */
     protected function getPackageProviders($app): array
     {
@@ -273,6 +310,14 @@ class AutoAssertIntegrationTest extends TestCase
         Route::post('/v1/pets', static fn() => response()->json(
             ['data' => ['id' => 42, 'name' => 'Buddy', 'tag' => null]],
             201,
+        ));
+
+        // 503 on a path whose spec only defines 200 — exercises the
+        // "Status code not defined" suppression path through the real
+        // framework boundary for skipResponseCode() integration tests.
+        Route::get('/v1/health', static fn() => response()->json(
+            ['error' => 'service unavailable'],
+            503,
         ));
     }
 }

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -413,6 +413,28 @@ class OpenApiResponseValidatorTest extends TestCase
     }
 
     #[Test]
+    public function numeric_string_pattern_key_survives_array_coercion(): void
+    {
+        // Regression guard: PHP coerces canonical-integer string array keys
+        // (e.g. "503") to int keys. The internal skipPatterns map is keyed by
+        // the raw user-supplied pattern, so a numeric pattern like "503"
+        // lands under int key 503. Without a string cast at retrieval time,
+        // skipReason() would return an int and violate its ?string contract.
+        //
+        // The Laravel adapter's skipResponseCode(int) path stringifies ints
+        // to bare "503" before passing them in, which exposes exactly this
+        // shape to compileSkipPatterns(). Pin the round-trip so a future
+        // refactor that drops the (string) cast fails here, not at the
+        // caller site where the root cause is less obvious.
+        $validator = new OpenApiResponseValidator(skipResponseCodes: ['503']);
+
+        $result = $validator->validate('petstore-3.0', 'GET', '/v1/pets', 503, null);
+
+        $this->assertTrue($result->isSkipped());
+        $this->assertSame('status 503 matched skip pattern 503', $result->skipReason());
+    }
+
+    #[Test]
     public function invalid_skip_pattern_throws(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Unit/ValidatesOpenApiSchemaSkipResponseCodeTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaSkipResponseCodeTest.php
@@ -6,6 +6,7 @@ namespace Studio\OpenApiContractTesting\Tests\Unit;
 
 use const JSON_THROW_ON_ERROR;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -13,6 +14,7 @@ use Studio\OpenApiContractTesting\HttpMethod;
 use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
 use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\SkipOpenApi;
 use Studio\OpenApiContractTesting\Tests\Helpers\CreatesTestResponse;
 
 use function json_encode;
@@ -21,17 +23,21 @@ use function json_encode;
 require_once __DIR__ . '/../Helpers/LaravelConfigMock.php';
 
 /**
- * Covers the per-request skipResponseCode() fluent API from issue #48.
+ * Covers the per-request skipResponseCode() fluent API.
  *
- * The flag rides on the #41 per-request consumption model: set before an HTTP
- * call, consumed (and reset) on the next auto-assert attempt. Here the "HTTP
- * call" is simulated by a direct call to maybeAutoAssertOpenApiSchema, which
- * is what createTestResponse delegates to under auto-assert.
+ * The flag shares the withoutValidation() per-request consumption model:
+ * set before an HTTP call, consumed (and reset) on the next auto-assert
+ * attempt. Here the "HTTP call" is simulated by a direct call to
+ * maybeAutoAssertOpenApiSchema, which is what createTestResponse delegates
+ * to under auto-assert.
  */
 class ValidatesOpenApiSchemaSkipResponseCodeTest extends TestCase
 {
     use CreatesTestResponse;
     use ValidatesOpenApiSchema;
+
+    /** @var string[] */
+    private array $capturedWarnings = [];
 
     protected function setUp(): void
     {
@@ -46,10 +52,18 @@ class ValidatesOpenApiSchemaSkipResponseCodeTest extends TestCase
             // without interference from the config-level skip set.
             'openapi-contract-testing.skip_response_codes' => [],
         ];
+        // Capture warnings so the explicit-assert warning path does not
+        // escalate E_USER_DEPRECATED during tests. Each test that asserts on
+        // warnings reads from $this->capturedWarnings.
+        $this->capturedWarnings = [];
+        self::$skipWarningHandler = function (string $message): void {
+            $this->capturedWarnings[] = $message;
+        };
     }
 
     protected function tearDown(): void
     {
+        self::$skipWarningHandler = null;
         self::resetValidatorCache();
         unset($GLOBALS['__openapi_testing_config']);
         OpenApiSpecLoader::reset();
@@ -249,6 +263,137 @@ class ValidatesOpenApiSchemaSkipResponseCodeTest extends TestCase
 
         $this->expectException(AssertionFailedError::class);
         $this->assertResponseMatchesOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+    }
+
+    #[Test]
+    public function explicit_assert_with_pending_flag_emits_warning_and_consumes(): void
+    {
+        // When the user sets skipResponseCode() then calls explicit assert,
+        // the flag is discarded by design. A silent discard is a UX trap —
+        // assert the discard is loud (warning) and the flag is consumed so
+        // a later HTTP call doesn't silently skip the wrong response.
+        $invalidBody = (string) json_encode(['wrong_key' => 'x'], JSON_THROW_ON_ERROR);
+        $okResponse = $this->makeTestResponse(
+            (string) json_encode(
+                ['data' => [['id' => 1, 'name' => 'Fido', 'tag' => null]]],
+                JSON_THROW_ON_ERROR,
+            ),
+            200,
+        );
+
+        $this->skipResponseCode(503);
+        // Explicit call on a spec-compliant 200 succeeds, but the pending flag
+        // should trigger a warning and be consumed on the way out.
+        $this->assertResponseMatchesOpenApiSchema($okResponse, HttpMethod::GET, '/v1/pets');
+
+        $this->assertCount(1, $this->capturedWarnings);
+        $this->assertStringContainsString('skipResponseCode()', $this->capturedWarnings[0]);
+
+        // Flag was consumed; next auto-assert on an invalid 200 body fails.
+        $this->expectException(AssertionFailedError::class);
+        $this->maybeAutoAssertOpenApiSchema(
+            $this->makeTestResponse($invalidBody, 200),
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+    }
+
+    #[Test]
+    public function skip_response_code_rejects_empty_variadic(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('skipResponseCode() requires at least one code');
+
+        $this->skipResponseCode();
+    }
+
+    #[Test]
+    public function skip_response_code_rejects_empty_array(): void
+    {
+        // skipResponseCode([]) is a silent no-op in the naive implementation —
+        // the inner foreach iterates zero times and no codes are appended.
+        // Reject it so a typo or unintended empty list surfaces loudly.
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('all supplied arrays were empty');
+
+        $this->skipResponseCode([]);
+    }
+
+    #[Test]
+    public function skip_response_code_rejects_nested_array(): void
+    {
+        // Nested arrays would otherwise produce a raw TypeError from
+        // normalizeSkipCode() with no mention of skipResponseCode — unhelpful
+        // in a stack trace. Reject them explicitly with a friendly message.
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Nested arrays are not supported');
+
+        // @phpstan-ignore-next-line argument.type — intentionally malformed
+        $this->skipResponseCode([[404, 503]]);
+    }
+
+    #[Test]
+    public function skip_response_code_invalid_regex_fails_at_http_call(): void
+    {
+        // Invalid regex is validated lazily (at validator construction, not
+        // at skipResponseCode() call time). Pin the failure mode so callers
+        // know where to look when a pattern is malformed.
+        $this->skipResponseCode('(unclosed');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('not a valid regex pattern');
+
+        $this->maybeAutoAssertOpenApiSchema(
+            $this->makeTestResponse('{}', 503),
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+    }
+
+    #[Test]
+    #[SkipOpenApi]
+    public function skip_response_code_with_skip_open_api_attribute_still_early_returns(): void
+    {
+        // #[SkipOpenApi] opts the whole test out of auto-assert. Adding
+        // skipResponseCode() on top must not turn auto-assert back on — the
+        // attribute takes precedence. No validation, no coverage, regardless
+        // of the flag.
+        $this->skipResponseCode(503);
+        $this->maybeAutoAssertOpenApiSchema(
+            $this->makeTestResponse('{}', 503),
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+
+        $this->assertArrayNotHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
+    }
+
+    #[Test]
+    public function without_validation_composes_with_skip_response_code(): void
+    {
+        // Both set per-request state, both auto-reset. Pin the ordering:
+        // withoutValidation() takes precedence (nothing validates), and
+        // skipResponseCode()'s flag is harmlessly consumed alongside it.
+        // Without this test, a refactor could accidentally validate despite
+        // the withoutValidation() intent.
+        $this->withoutValidation()->skipResponseCode(503);
+        $this->maybeAutoAssertOpenApiSchema(
+            $this->makeTestResponse((string) json_encode(['wrong_key' => 'x'], JSON_THROW_ON_ERROR), 200),
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+
+        // withoutValidation() wins: no coverage recorded, no failure despite
+        // invalid 200 body.
+        $this->assertArrayNotHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
+
+        // Both flags must be consumed; next invalid call fails.
+        $this->expectException(AssertionFailedError::class);
+        $this->maybeAutoAssertOpenApiSchema(
+            $this->makeTestResponse((string) json_encode(['wrong_key' => 'x'], JSON_THROW_ON_ERROR), 200),
+            HttpMethod::GET,
+            '/v1/pets',
+        );
     }
 
     #[Test]

--- a/tests/Unit/ValidatesOpenApiSchemaSkipResponseCodeTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaSkipResponseCodeTest.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use const JSON_THROW_ON_ERROR;
+
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\HttpMethod;
+use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
+use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\Tests\Helpers\CreatesTestResponse;
+
+use function json_encode;
+
+// Load namespace-level config() mock before the trait resolves the function call.
+require_once __DIR__ . '/../Helpers/LaravelConfigMock.php';
+
+/**
+ * Covers the per-request skipResponseCode() fluent API from issue #48.
+ *
+ * The flag rides on the #41 per-request consumption model: set before an HTTP
+ * call, consumed (and reset) on the next auto-assert attempt. Here the "HTTP
+ * call" is simulated by a direct call to maybeAutoAssertOpenApiSchema, which
+ * is what createTestResponse delegates to under auto-assert.
+ */
+class ValidatesOpenApiSchemaSkipResponseCodeTest extends TestCase
+{
+    use CreatesTestResponse;
+    use ValidatesOpenApiSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs');
+        OpenApiCoverageTracker::reset();
+        $GLOBALS['__openapi_testing_config'] = [
+            'openapi-contract-testing.default_spec' => 'petstore-3.0',
+            'openapi-contract-testing.auto_assert' => true,
+            // Disable the default 5xx skip so per-request behavior is observable
+            // without interference from the config-level skip set.
+            'openapi-contract-testing.skip_response_codes' => [],
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        self::resetValidatorCache();
+        unset($GLOBALS['__openapi_testing_config']);
+        OpenApiSpecLoader::reset();
+        OpenApiCoverageTracker::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function skip_response_code_int_exact_match_skips_auto_assert(): void
+    {
+        // 503 is not defined in the spec — without the skip, auto-assert would
+        // raise "Status code 503 not defined". skipResponseCode(503) must
+        // suppress that failure AND still record coverage (endpoint exercised).
+        $body = (string) json_encode(['error' => 'service unavailable'], JSON_THROW_ON_ERROR);
+        $response = $this->makeTestResponse($body, 503);
+
+        $this->skipResponseCode(503);
+        $this->maybeAutoAssertOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayHasKey('petstore-3.0', $covered);
+        $this->assertArrayHasKey('GET /v1/pets', $covered['petstore-3.0']);
+    }
+
+    #[Test]
+    public function skip_response_code_int_does_not_match_sibling_codes(): void
+    {
+        // Regression guard: int 50 must be anchored to match only "50", not any
+        // code starting with 50. A 503 response must still fail loudly when the
+        // skip pattern is just "50".
+        $response = $this->makeTestResponse('{}', 503);
+
+        $this->skipResponseCode(50);
+
+        try {
+            $this->maybeAutoAssertOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+            $this->fail('Expected AssertionFailedError was not thrown — skip_response_code(50) must not match 503.');
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString('Status code 503 not defined', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function skip_response_code_regex_string_matches_pattern(): void
+    {
+        // String codes are treated as regex. 404 is not in the spec, so without
+        // a skip this would fail; '4\d\d' must match and suppress the failure.
+        $response = $this->makeTestResponse('{}', 404);
+
+        $this->skipResponseCode('4\d\d');
+        $this->maybeAutoAssertOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayHasKey('petstore-3.0', $covered);
+    }
+
+    #[Test]
+    public function skip_response_code_array_expansion(): void
+    {
+        // Array argument must be expanded one level: mixed int + string regex
+        // entries are accepted and each individually matches on separate calls.
+        $this->skipResponseCode([404, '5\d\d']);
+        $this->maybeAutoAssertOpenApiSchema(
+            $this->makeTestResponse('{}', 404),
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+
+        // Second call with fresh expansion — the array must have carried '5\d\d'
+        // as a regex, not literalised it.
+        $this->skipResponseCode([404, '5\d\d']);
+        $this->maybeAutoAssertOpenApiSchema(
+            $this->makeTestResponse('{}', 503),
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayHasKey('GET /v1/pets', $covered['petstore-3.0']);
+    }
+
+    #[Test]
+    public function skip_response_code_variadic_args(): void
+    {
+        // Multiple positional arguments (without array wrapping) must all be
+        // registered. Proven by exercising each separately.
+        $this->skipResponseCode(404, 503);
+        $this->maybeAutoAssertOpenApiSchema(
+            $this->makeTestResponse('{}', 404),
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+
+        $this->skipResponseCode(404, 503);
+        $this->maybeAutoAssertOpenApiSchema(
+            $this->makeTestResponse('{}', 503),
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+
+        $this->assertArrayHasKey(
+            'GET /v1/pets',
+            OpenApiCoverageTracker::getCovered()['petstore-3.0'],
+        );
+    }
+
+    #[Test]
+    public function skip_response_code_merges_with_config_default(): void
+    {
+        // Per-request codes must be ADDED to the config default, not replace it.
+        // Config default covers 5xx; per-request adds 4xx. A 404 call should
+        // skip via per-request; a subsequent 503 call (no per-request) should
+        // still skip via the config default.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.skip_response_codes'] = ['5\d\d'];
+
+        $this->skipResponseCode('4\d\d');
+        $this->maybeAutoAssertOpenApiSchema(
+            $this->makeTestResponse('{}', 404),
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+
+        // No per-request flag this time — config default alone must cover 503.
+        $this->maybeAutoAssertOpenApiSchema(
+            $this->makeTestResponse('{}', 503),
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+
+        $this->assertArrayHasKey(
+            'GET /v1/pets',
+            OpenApiCoverageTracker::getCovered()['petstore-3.0'],
+        );
+    }
+
+    #[Test]
+    public function skip_response_code_resets_after_one_call(): void
+    {
+        // Core per-request guarantee: flag covers exactly the next HTTP call,
+        // then resets. Config skip is off, so the second call with no fresh
+        // skipResponseCode() must fail.
+        $this->skipResponseCode(503);
+        $this->maybeAutoAssertOpenApiSchema(
+            $this->makeTestResponse('{}', 503),
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->maybeAutoAssertOpenApiSchema(
+            $this->makeTestResponse('{}', 503),
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+    }
+
+    #[Test]
+    public function skip_response_code_returns_self_for_fluent_chain(): void
+    {
+        // The primary ergonomic reason for the method: lets tests write
+        // $this->skipResponseCode(503)->get('/v1/pets').
+        $this->assertSame($this, $this->skipResponseCode(503));
+        $this->assertSame($this, $this->skipResponseCode('5\d\d'));
+        $this->assertSame($this, $this->skipResponseCode([404, 503]));
+        $this->assertSame($this, $this->skipResponseCode(404, 503));
+    }
+
+    #[Test]
+    public function skip_response_code_chained_calls_accumulate(): void
+    {
+        // Chained calls must accumulate, not replace. Proving 503 was added by
+        // the second call after 404 was added by the first implies both calls'
+        // codes survived into the consumed flag.
+        $this->skipResponseCode(404)->skipResponseCode(503);
+        $this->maybeAutoAssertOpenApiSchema(
+            $this->makeTestResponse('{}', 503),
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+
+        $this->assertArrayHasKey(
+            'GET /v1/pets',
+            OpenApiCoverageTracker::getCovered()['petstore-3.0'],
+        );
+    }
+
+    #[Test]
+    public function skip_response_code_does_not_affect_explicit_assert(): void
+    {
+        // Scope is auto-assert only — matches withoutValidation()'s existing
+        // convention. An explicit assertResponseMatchesOpenApiSchema() call
+        // must ignore the per-request skip flag, because explicit calls are
+        // the user's direct intent.
+        $response = $this->makeTestResponse('{}', 503);
+
+        $this->skipResponseCode(503);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->assertResponseMatchesOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+    }
+
+    #[Test]
+    public function skip_response_code_consumes_flag_even_when_auto_assert_disabled(): void
+    {
+        // If the flag leaked past an auto_assert=false HTTP call, toggling
+        // auto_assert on mid-test would silently skip the wrong request.
+        // Consumption must happen at the boundary regardless of config state,
+        // mirroring how withoutValidation() behaves.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_assert'] = false;
+
+        $this->skipResponseCode(503);
+        $this->maybeAutoAssertOpenApiSchema(
+            $this->makeTestResponse('{}', 503),
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+
+        // Now enable auto-assert and send a 503 — must throw, proving the
+        // flag was already consumed by the previous call.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_assert'] = true;
+
+        $this->expectException(AssertionFailedError::class);
+        $this->maybeAutoAssertOpenApiSchema(
+            $this->makeTestResponse('{}', 503),
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+    }
+}


### PR DESCRIPTION
# 概要

テスト単位で特定の status code の response body 検証だけを個別にスキップできる fluent API `skipResponseCode()` を `ValidatesOpenApiSchema` trait に追加する。kirschbaum の同名 API 相当で、#41 の `withoutValidation()` と同じ per-request 消費モデルに相乗りする（Issue #48）。

config-level (#47) の `skip_response_codes` は「このプロジェクト全体で 5xx は常にスキップ」というグローバル運用設定だったが、個別テストごとに「このテストだけ 404 を許容したい」といった局所指定ができなかった。`skipResponseCode()` は config 設定の上乗せで、次の 1 HTTP 呼び出しだけ有効→自動リセット。

## 変更内容

- `ValidatesOpenApiSchema` trait
  - `skipResponseCode(int|array|string ...\$codes): static` を追加。int は exact match、string は regex、array は 1 段展開。variadic もサポート
  - `\$skipNextResponseCodes` instance フラグを追加。`maybeAutoAssertOpenApiSchema()` 先頭で他の per-request フラグと一緒にキャプチャ＆リセット
  - `assertResponseMatchesOpenApiSchema()` の署名に `array \$extraSkipResponseCodes = []` を追加（optional なので既存呼び出しに影響なし）
  - 新規 private helper `buildOneOffValidator()` — per-request skip codes がある時だけ cache バイパスで一時 validator を構築（キャッシュ汚染・無限増殖を回避）
  - 新規 private helper `resolveMaxErrors()` — `getOrCreateValidator()` と `buildOneOffValidator()` で共用
  - 新規 `normalizeSkipCode()` — int を bare string 化（anchor は既存 `compileSkipPatterns()` に任せる）
- `OpenApiResponseValidator::matchingSkipPattern()`
  - PHP の配列キー自動 int 化により、`\"500\"` のような数値文字列パターンが int キー化され `?string` 返却型を違反する潜在バグを修正（int skip 追加で顕在化）。`return (string) \$raw` で強制キャスト
- `tests/Unit/ValidatesOpenApiSchemaSkipResponseCodeTest.php` 新規: 11 テスト
  - int 完全一致 / anchor 回帰 / regex / array / variadic / config default との合成 / 1 呼び出しリセット / fluent 戻り値 / chain 累積 / 明示 assert に作用しない / auto_assert=false でのフラグ消費
- `README.md`
  - Features 行に fluent API 触れる
  - 「Per-request status-code skip with skipResponseCode()」セクション新規追加

## 設計メモ

- **Auto-assert only スコープ**: `withoutValidation()` と同じ規約。明示 assert はユーザーの直接意図なのでフラグを無視する。ユーザーと事前合意済み
- **Cache バイパス方式**: per-request codes 付きの時だけ one-off validator を new する。キャッシュキーに per-request codes を含める代替案は、テスト数 × 組み合わせでキャッシュエントリが無限増殖する懸念がある
- **Array 展開は 1 段のみ**: ネスト array は YAGNI。深い再帰展開はユースケースが想像できない
- **int の anchoring**: `skipResponseCode(500)` は bare \"500\" 文字列として保存され、既存 `compileSkipPatterns()` が `/^(?:500)\$/` で anchor。これで \"5000\" や \"50\" に事故的にヒットしない
- **数値キー自動 int 化バグ**: 既存 `compileSkipPatterns()` は raw pattern を array key にしているが、PHP は \"500\" のような数値文字列キーを int に自動変換する。int pattern 追加で初めて顕在化。`matchingSkipPattern()` の return に `(string)` キャストを追加する最小修正

## 品質ゲート

- PHPUnit: 424/424 PASS（うち新規 11 テスト）
- PHPStan level 6: No errors
- php-cs-fixer: クリーン

## 関連情報

- Closes #48
- Blocked by #47 (merged as PR #71)
- Rides on #41 per-request flag consumption model