### PR TITLE
feat(spec-loader): resolve internal $ref at load time

### DIFF
--- a/src/OpenApiRefResolver.php
+++ b/src/OpenApiRefResolver.php
@@ -22,15 +22,21 @@ use function substr;
 final class OpenApiRefResolver
 {
     /**
-     * Resolve all internal `$ref` entries in the spec in place and return it.
+     * Resolve all internal `$ref` entries in the spec in place and return the
+     * same array. External, circular, unresolvable, malformed, and root refs
+     * all throw `RuntimeException` so users get one actionable error at load
+     * time instead of a cryptic opis failure surfacing deep inside validation.
      *
-     * External refs (cross-file, URL), circular refs, and dangling internal refs
-     * throw `RuntimeException` so the user gets an early, actionable error at
-     * load time instead of a cryptic opis failure deep in validation.
+     * The input array is mutated: on a successful resolve the returned value
+     * is the same array with `$ref` nodes substituted. On throw, the partially
+     * mutated state is discarded at the caller (`OpenApiSpecLoader::load()`
+     * only caches the result after `resolve()` returns cleanly).
      *
      * @param array<string, mixed> $spec
      *
      * @return array<string, mixed>
+     *
+     * @throws RuntimeException on external / circular / unresolvable / malformed refs
      */
     public static function resolve(array $spec): array
     {
@@ -45,7 +51,7 @@ final class OpenApiRefResolver
     /**
      * @param array<int|string, mixed> $node
      * @param array<string, mixed> $root
-     * @param list<string> $chain absolute refs currently being resolved
+     * @param list<string> $chain pointer-refs already on the resolution stack — used to detect cycles
      */
     private static function walk(array &$node, array $root, array $chain): void
     {
@@ -59,9 +65,24 @@ final class OpenApiRefResolver
                 ));
             }
 
+            if ($ref === '#/' || $ref === '#') {
+                // A bare root pointer substitutes the entire spec in place,
+                // which triggers unbounded recursion before cycle detection
+                // can help. Reject with a specific message so the author
+                // doesn't chase a confusing "Circular" error.
+                throw new RuntimeException('Invalid $ref: root pointer "' . $ref . '" is not a reference to a definition');
+            }
+
             if (!str_starts_with($ref, '#/')) {
+                if (str_starts_with($ref, '#')) {
+                    throw new RuntimeException(sprintf(
+                        'Invalid $ref: bare fragment %s is not a JSON Pointer (expected "#/..." form)',
+                        $ref,
+                    ));
+                }
+
                 throw new RuntimeException(sprintf(
-                    'External $ref is not supported in phase 1: %s. Only internal refs (#/...) are resolved; '
+                    'External $ref is not supported: %s. Only internal refs (#/...) are resolved; '
                     . 'bundle external files with a tool like `redocly bundle` before loading.',
                     $ref,
                 ));
@@ -74,8 +95,8 @@ final class OpenApiRefResolver
                 ));
             }
 
-            $target = self::lookup($ref, $root);
-            if ($target === null) {
+            [$found, $target] = self::lookup($ref, $root);
+            if (!$found) {
                 throw new RuntimeException(sprintf('Unresolvable $ref: target not found for %s', $ref));
             }
 
@@ -87,13 +108,11 @@ final class OpenApiRefResolver
                 ));
             }
 
-            // Recurse into the copied target so nested refs resolve with the
-            // current ref pushed onto the chain for cycle detection.
+            // Push $ref onto the chain before recursing so nested self-references
+            // are detected as cycles; then replace the node entirely. Sibling
+            // keys alongside $ref are dropped per OAS 3.0 ("any sibling
+            // elements of a $ref are ignored"), which is a safe subset of 3.1.
             self::walk($target, $root, [...$chain, $ref]);
-
-            // Replace the node entirely. Sibling keys alongside $ref are
-            // dropped per OAS 3.0 semantics ("any sibling elements of a $ref
-            // are ignored"); the same behaviour is a safe subset of OAS 3.1.
             $node = $target;
 
             return;
@@ -104,19 +123,23 @@ final class OpenApiRefResolver
                 self::walk($child, $root, $chain);
             }
         }
+        unset($child);
     }
 
     /**
-     * Resolve a local JSON Pointer (e.g. `#/components/schemas/Foo`) against
-     * the root spec. Returns `null` when any segment is missing.
+     * Returns `[found, value]` where `found` disambiguates a missing segment
+     * from a literal `null` leaf — both of which could otherwise be the same
+     * `null` return and silently misroute the error message.
      *
      * @param array<string, mixed> $root
+     *
+     * @return array{0: bool, 1: mixed}
      */
-    private static function lookup(string $ref, array $root): mixed
+    private static function lookup(string $ref, array $root): array
     {
         $pointer = substr($ref, 2);
         if ($pointer === '') {
-            return $root;
+            return [true, $root];
         }
 
         $segments = explode('/', $pointer);
@@ -126,19 +149,19 @@ final class OpenApiRefResolver
             $segment = self::unescapePointerSegment($segment);
 
             if (!is_array($node) || !array_key_exists($segment, $node)) {
-                return null;
+                return [false, null];
             }
 
             $node = $node[$segment];
         }
 
-        return $node;
+        return [true, $node];
     }
 
     /**
-     * Decode a single JSON Pointer segment per RFC 6901, additionally tolerating
-     * URL-encoded input (e.g. `%20`). Order matters: `~1` must be decoded before
-     * `~0` so a literal `~1` in the key survives round-tripping.
+     * `~1` must be decoded before `~0` so a literal `~1` stored in the key
+     * round-trips correctly. `rawurldecode` runs first so percent-encoded
+     * segments produced by URL-aware tooling also resolve.
      */
     private static function unescapePointerSegment(string $segment): string
     {

--- a/src/OpenApiRefResolver.php
+++ b/src/OpenApiRefResolver.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting;
+
+use RuntimeException;
+
+use function array_key_exists;
+use function explode;
+use function get_debug_type;
+use function implode;
+use function in_array;
+use function is_array;
+use function is_string;
+use function rawurldecode;
+use function sprintf;
+use function str_replace;
+use function str_starts_with;
+use function substr;
+
+final class OpenApiRefResolver
+{
+    /**
+     * Resolve all internal `$ref` entries in the spec in place and return it.
+     *
+     * External refs (cross-file, URL), circular refs, and dangling internal refs
+     * throw `RuntimeException` so the user gets an early, actionable error at
+     * load time instead of a cryptic opis failure deep in validation.
+     *
+     * @param array<string, mixed> $spec
+     *
+     * @return array<string, mixed>
+     */
+    public static function resolve(array $spec): array
+    {
+        // $root is a frozen snapshot used for pointer lookups. PHP array
+        // copy-on-write keeps it untouched as we mutate $spec via $node refs.
+        $root = $spec;
+        self::walk($spec, $root, []);
+
+        return $spec;
+    }
+
+    /**
+     * @param array<int|string, mixed> $node
+     * @param array<string, mixed> $root
+     * @param list<string> $chain absolute refs currently being resolved
+     */
+    private static function walk(array &$node, array $root, array $chain): void
+    {
+        if (array_key_exists('$ref', $node)) {
+            $ref = $node['$ref'];
+
+            if (!is_string($ref)) {
+                throw new RuntimeException(sprintf(
+                    'Invalid $ref: expected string, got %s',
+                    get_debug_type($ref),
+                ));
+            }
+
+            if (!str_starts_with($ref, '#/')) {
+                throw new RuntimeException(sprintf(
+                    'External $ref is not supported in phase 1: %s. Only internal refs (#/...) are resolved; '
+                    . 'bundle external files with a tool like `redocly bundle` before loading.',
+                    $ref,
+                ));
+            }
+
+            if (in_array($ref, $chain, true)) {
+                throw new RuntimeException(sprintf(
+                    'Circular $ref detected: %s',
+                    implode(' -> ', [...$chain, $ref]),
+                ));
+            }
+
+            $target = self::lookup($ref, $root);
+            if ($target === null) {
+                throw new RuntimeException(sprintf('Unresolvable $ref: target not found for %s', $ref));
+            }
+
+            if (!is_array($target)) {
+                throw new RuntimeException(sprintf(
+                    '$ref target is not an object: %s points to a %s value',
+                    $ref,
+                    get_debug_type($target),
+                ));
+            }
+
+            // Recurse into the copied target so nested refs resolve with the
+            // current ref pushed onto the chain for cycle detection.
+            self::walk($target, $root, [...$chain, $ref]);
+
+            // Replace the node entirely. Sibling keys alongside $ref are
+            // dropped per OAS 3.0 semantics ("any sibling elements of a $ref
+            // are ignored"); the same behaviour is a safe subset of OAS 3.1.
+            $node = $target;
+
+            return;
+        }
+
+        foreach ($node as &$child) {
+            if (is_array($child)) {
+                self::walk($child, $root, $chain);
+            }
+        }
+    }
+
+    /**
+     * Resolve a local JSON Pointer (e.g. `#/components/schemas/Foo`) against
+     * the root spec. Returns `null` when any segment is missing.
+     *
+     * @param array<string, mixed> $root
+     */
+    private static function lookup(string $ref, array $root): mixed
+    {
+        $pointer = substr($ref, 2);
+        if ($pointer === '') {
+            return $root;
+        }
+
+        $segments = explode('/', $pointer);
+
+        $node = $root;
+        foreach ($segments as $segment) {
+            $segment = self::unescapePointerSegment($segment);
+
+            if (!is_array($node) || !array_key_exists($segment, $node)) {
+                return null;
+            }
+
+            $node = $node[$segment];
+        }
+
+        return $node;
+    }
+
+    /**
+     * Decode a single JSON Pointer segment per RFC 6901, additionally tolerating
+     * URL-encoded input (e.g. `%20`). Order matters: `~1` must be decoded before
+     * `~0` so a literal `~1` in the key survives round-tripping.
+     */
+    private static function unescapePointerSegment(string $segment): string
+    {
+        $segment = rawurldecode($segment);
+        $segment = str_replace('~1', '/', $segment);
+
+        return str_replace('~0', '~', $segment);
+    }
+}

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -124,8 +124,8 @@ final class OpenApiRequestValidator
         $operation = $pathSpec[$lowerMethod];
 
         // Collect merged path/operation parameters once so path + query validation
-        // share a single view of the spec and spec-level errors (malformed entries,
-        // unresolved $refs) are surfaced only once.
+        // share a single view of the spec and malformed-entry errors are surfaced
+        // only once.
         [$parameters, $specErrors] = $this->collectParameters($method, $matchedPath, $pathSpec, $operation);
 
         $pathErrors = $this->validatePathParameters(
@@ -989,8 +989,9 @@ final class OpenApiRequestValidator
      * Malformed entries are surfaced as errors rather than silently skipped,
      * because for a contract-testing tool the absence of an error means
      * "validated and OK" — silently dropping a parameter would leave drift
-     * invisible. `$ref` entries are flagged separately so users know the spec
-     * needs to be pre-bundled (we don't resolve refs).
+     * invisible. `$ref` entries never reach this method: `OpenApiSpecLoader`
+     * resolves internal refs and throws on external/circular/unresolvable ones
+     * at load time.
      *
      * @param array<string, mixed> $pathSpec
      * @param array<string, mixed> $operation
@@ -1010,13 +1011,6 @@ final class OpenApiRequestValidator
             foreach ($source as $param) {
                 if (!is_array($param)) {
                     $errors[] = "Malformed parameter entry for {$method} {$matchedPath}: expected object, got scalar.";
-
-                    continue;
-                }
-
-                if (array_key_exists('$ref', $param)) {
-                    $ref = is_string($param['$ref']) ? $param['$ref'] : '(non-string $ref)';
-                    $errors[] = "Parameter \$ref encountered for {$method} {$matchedPath} ('{$ref}') — \$ref resolution is not supported. Pre-bundle the spec (e.g. redocly bundle --dereference).";
 
                     continue;
                 }
@@ -1094,28 +1088,16 @@ final class OpenApiRequestValidator
             return [];
         }
 
-        // A present-but-non-array requestBody signals a malformed spec (e.g. unresolved $ref,
-        // stray scalar). Contract-testing tools should surface this, not mask it as "no body".
+        // A present-but-non-array requestBody signals a malformed spec (stray scalar).
+        // Contract-testing tools should surface this, not mask it as "no body".
         if (!is_array($operation['requestBody'])) {
             return [
-                "Malformed 'requestBody' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar. Likely an unresolved \$ref or broken spec.",
+                "Malformed 'requestBody' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
             ];
         }
 
         /** @var array<string, mixed> $requestBodySpec */
         $requestBodySpec = $operation['requestBody'];
-
-        // Unresolved $ref at requestBody level: PHP parses it as an assoc array, so the
-        // existing is_array guard lets it through. Without this check, the subsequent
-        // `isset($requestBodySpec['content'])` returns false and the method silently
-        // returns success — the worst possible outcome for a contract-testing tool.
-        if (array_key_exists('$ref', $requestBodySpec)) {
-            $ref = is_string($requestBodySpec['$ref']) ? $requestBodySpec['$ref'] : '(non-string $ref)';
-
-            return [
-                "RequestBody \$ref encountered for {$method} {$matchedPath} ('{$ref}') — \$ref resolution is not supported. Pre-bundle the spec (e.g. redocly bundle --dereference).",
-            ];
-        }
 
         $required = ($requestBodySpec['required'] ?? false) === true;
 
@@ -1125,46 +1107,21 @@ final class OpenApiRequestValidator
 
         if (!is_array($requestBodySpec['content'])) {
             return [
-                "Malformed 'requestBody.content' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar. Likely an unresolved \$ref or broken spec.",
+                "Malformed 'requestBody.content' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
             ];
         }
 
         /** @var array<string, mixed> $content */
         $content = $requestBodySpec['content'];
 
-        // Unresolved $ref at content[mediaType] or content[mediaType].schema level.
-        // Without these checks, (a) mediaType-level $ref silently returns success because
-        // the `schema` key is absent, and (b) schema-level $ref reaches opis and throws
-        // UnresolvedReferenceException with an unhelpful message. Flagging all entries
-        // (not just the JSON-compatible one) catches broken specs regardless of which
-        // Content-Type the caller uses.
         foreach ($content as $mediaType => $mediaTypeSpec) {
             // The @var on $content narrows values to array, but PHPDoc is unchecked at
             // runtime — a malformed spec like `content: {"application/json": "oops"}`
-            // would TypeError on array_key_exists below. Surface it as a loud spec error
-            // instead, matching the sibling guard on `requestBody.content` above.
+            // would TypeError on downstream array accesses. Surface it as a loud spec
+            // error instead, matching the sibling guard on `requestBody.content` above.
             if (!is_array($mediaTypeSpec)) {
                 return [
                     "Malformed 'requestBody.content[\"{$mediaType}\"]' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
-                ];
-            }
-
-            if (array_key_exists('$ref', $mediaTypeSpec)) {
-                $ref = is_string($mediaTypeSpec['$ref']) ? $mediaTypeSpec['$ref'] : '(non-string $ref)';
-
-                return [
-                    "RequestBody content['{$mediaType}'] \$ref encountered for {$method} {$matchedPath} ('{$ref}') — \$ref resolution is not supported. Pre-bundle the spec (e.g. redocly bundle --dereference).",
-                ];
-            }
-
-            if (isset($mediaTypeSpec['schema']) &&
-                is_array($mediaTypeSpec['schema']) &&
-                array_key_exists('$ref', $mediaTypeSpec['schema'])
-            ) {
-                $ref = is_string($mediaTypeSpec['schema']['$ref']) ? $mediaTypeSpec['schema']['$ref'] : '(non-string $ref)';
-
-                return [
-                    "RequestBody content['{$mediaType}'].schema \$ref encountered for {$method} {$matchedPath} ('{$ref}') — \$ref resolution is not supported. Pre-bundle the spec (e.g. redocly bundle --dereference).",
                 ];
             }
         }

--- a/src/OpenApiSpecLoader.php
+++ b/src/OpenApiSpecLoader.php
@@ -74,9 +74,10 @@ final class OpenApiSpecLoader
 
         /** @var array<string, mixed> $decoded */
         $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
-        self::$cache[$specName] = $decoded;
+        $resolved = OpenApiRefResolver::resolve($decoded);
+        self::$cache[$specName] = $resolved;
 
-        return $decoded;
+        return $resolved;
     }
 
     /**

--- a/tests/Unit/OpenApiRefResolverTest.php
+++ b/tests/Unit/OpenApiRefResolverTest.php
@@ -1,0 +1,480 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Studio\OpenApiContractTesting\OpenApiRefResolver;
+
+class OpenApiRefResolverTest extends TestCase
+{
+    #[Test]
+    public function resolves_simple_internal_ref(): void
+    {
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Pet' => ['type' => 'object', 'required' => ['id']],
+                ],
+            ],
+            'paths' => [
+                '/pets' => [
+                    'get' => [
+                        'responses' => [
+                            '200' => [
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => ['$ref' => '#/components/schemas/Pet'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $schema = $resolved['paths']['/pets']['get']['responses']['200']['content']['application/json']['schema'];
+        $this->assertSame(['type' => 'object', 'required' => ['id']], $schema);
+    }
+
+    #[Test]
+    public function resolves_nested_refs(): void
+    {
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'A' => ['$ref' => '#/components/schemas/B'],
+                    'B' => ['$ref' => '#/components/schemas/C'],
+                    'C' => ['type' => 'string'],
+                ],
+            ],
+            'paths' => [
+                '/x' => [
+                    'get' => [
+                        'responses' => [
+                            '200' => [
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => ['$ref' => '#/components/schemas/A'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $schema = $resolved['paths']['/x']['get']['responses']['200']['content']['application/json']['schema'];
+        $this->assertSame(['type' => 'string'], $schema);
+    }
+
+    #[Test]
+    public function resolves_ref_inside_resolved_target(): void
+    {
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Pet' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'category' => ['$ref' => '#/components/schemas/Category'],
+                        ],
+                    ],
+                    'Category' => ['type' => 'string'],
+                ],
+            ],
+            'paths' => [
+                '/pets' => [
+                    'get' => [
+                        'responses' => [
+                            '200' => [
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => ['$ref' => '#/components/schemas/Pet'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $schema = $resolved['paths']['/pets']['get']['responses']['200']['content']['application/json']['schema'];
+        $this->assertSame(
+            [
+                'type' => 'object',
+                'properties' => [
+                    'category' => ['type' => 'string'],
+                ],
+            ],
+            $schema,
+        );
+    }
+
+    #[Test]
+    public function resolves_ref_with_json_pointer_escapes(): void
+    {
+        // Segment containing '/' is encoded as '~1'; '~' is encoded as '~0'.
+        // Order when decoding matters: '~1' first, then '~0'.
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'weird/name~with~tildes' => ['type' => 'string'],
+                ],
+            ],
+            'paths' => [
+                '/x' => [
+                    'get' => [
+                        'responses' => [
+                            '200' => [
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => [
+                                            '$ref' => '#/components/schemas/weird~1name~0with~0tildes',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $schema = $resolved['paths']['/x']['get']['responses']['200']['content']['application/json']['schema'];
+        $this->assertSame(['type' => 'string'], $schema);
+    }
+
+    #[Test]
+    public function resolves_ref_with_url_encoded_segment(): void
+    {
+        // OpenAPI path keys with '/' are legal; inside a JSON Pointer they get '~1',
+        // but consumers sometimes URL-encode too. Accept both.
+        $spec = [
+            'paths' => [
+                '/pets' => ['get' => ['operationId' => 'listPets']],
+            ],
+            'x-alias' => ['$ref' => '#/paths/~1pets'],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $this->assertSame(['get' => ['operationId' => 'listPets']], $resolved['x-alias']);
+    }
+
+    #[Test]
+    public function ref_with_siblings_drops_siblings(): void
+    {
+        // Per OAS 3.0, sibling keys of $ref are ignored. The resolver should
+        // replace the node entirely with the target.
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Pet' => ['type' => 'object', 'required' => ['id']],
+                ],
+            ],
+            'x-holder' => [
+                '$ref' => '#/components/schemas/Pet',
+                'description' => 'ignored per OAS 3.0',
+                'example' => 'ignored too',
+            ],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $this->assertSame(['type' => 'object', 'required' => ['id']], $resolved['x-holder']);
+    }
+
+    #[Test]
+    public function leaves_spec_without_refs_unchanged(): void
+    {
+        $spec = [
+            'openapi' => '3.0.3',
+            'info' => ['title' => 'no refs', 'version' => '1.0'],
+            'paths' => [
+                '/pets' => [
+                    'get' => [
+                        'responses' => [
+                            '200' => [
+                                'description' => 'ok',
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => ['type' => 'object'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertSame($spec, OpenApiRefResolver::resolve($spec));
+    }
+
+    #[Test]
+    public function throws_on_external_file_ref(): void
+    {
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Ref' => ['$ref' => 'other.json#/components/schemas/Pet'],
+                ],
+            ],
+        ];
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('External $ref');
+
+        OpenApiRefResolver::resolve($spec);
+    }
+
+    #[Test]
+    public function throws_on_external_url_ref(): void
+    {
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Ref' => ['$ref' => 'https://example.com/spec.json#/components/schemas/Pet'],
+                ],
+            ],
+        ];
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('External $ref');
+
+        OpenApiRefResolver::resolve($spec);
+    }
+
+    #[Test]
+    public function throws_on_direct_self_reference(): void
+    {
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Node' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'self' => ['$ref' => '#/components/schemas/Node'],
+                        ],
+                    ],
+                ],
+            ],
+            'paths' => [
+                '/nodes' => [
+                    'get' => [
+                        'responses' => [
+                            '200' => [
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => ['$ref' => '#/components/schemas/Node'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Circular $ref');
+
+        OpenApiRefResolver::resolve($spec);
+    }
+
+    #[Test]
+    public function throws_on_indirect_circular_ref(): void
+    {
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'A' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'b' => ['$ref' => '#/components/schemas/B'],
+                        ],
+                    ],
+                    'B' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'a' => ['$ref' => '#/components/schemas/A'],
+                        ],
+                    ],
+                ],
+            ],
+            'paths' => [
+                '/a' => [
+                    'get' => [
+                        'responses' => [
+                            '200' => [
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => ['$ref' => '#/components/schemas/A'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Circular $ref');
+
+        OpenApiRefResolver::resolve($spec);
+    }
+
+    #[Test]
+    public function throws_on_unresolvable_ref(): void
+    {
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Pet' => ['type' => 'object'],
+                ],
+            ],
+            'paths' => [
+                '/x' => [
+                    'get' => [
+                        'responses' => [
+                            '200' => [
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => ['$ref' => '#/components/schemas/DoesNotExist'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unresolvable $ref');
+
+        OpenApiRefResolver::resolve($spec);
+    }
+
+    #[Test]
+    public function throws_on_non_string_ref(): void
+    {
+        $spec = [
+            'paths' => [
+                '/x' => [
+                    'post' => [
+                        'requestBody' => [
+                            '$ref' => ['not', 'a', 'string'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid $ref');
+
+        OpenApiRefResolver::resolve($spec);
+    }
+
+    #[Test]
+    public function throws_when_ref_target_is_not_an_object(): void
+    {
+        // Refs must point to object/array structures (schemas, responses, parameters, etc).
+        // A ref landing on a scalar (e.g. info.version) is a malformed spec.
+        $spec = [
+            'info' => ['version' => '1.0.0'],
+            'components' => [
+                'schemas' => [
+                    'Bad' => ['$ref' => '#/info/version'],
+                ],
+            ],
+        ];
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('not an object');
+
+        OpenApiRefResolver::resolve($spec);
+    }
+
+    #[Test]
+    public function throws_on_ref_not_starting_with_hash_slash(): void
+    {
+        // Bare fragment like '#foo' (missing '/') is invalid per RFC 6901 JSON Pointer.
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Bad' => ['$ref' => '#foo'],
+                ],
+            ],
+        ];
+
+        $this->expectException(RuntimeException::class);
+
+        OpenApiRefResolver::resolve($spec);
+    }
+
+    #[Test]
+    public function resolves_the_same_ref_from_multiple_sites(): void
+    {
+        // A schema referenced twice from different operations should resolve
+        // at both sites without any cross-talk or cycle false-positive.
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Pet' => ['type' => 'object', 'properties' => ['id' => ['type' => 'integer']]],
+                ],
+            ],
+            'paths' => [
+                '/a' => [
+                    'get' => [
+                        'responses' => [
+                            '200' => [
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => ['$ref' => '#/components/schemas/Pet'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                '/b' => [
+                    'get' => [
+                        'responses' => [
+                            '200' => [
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => ['$ref' => '#/components/schemas/Pet'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $expected = ['type' => 'object', 'properties' => ['id' => ['type' => 'integer']]];
+        $this->assertSame($expected, $resolved['paths']['/a']['get']['responses']['200']['content']['application/json']['schema']);
+        $this->assertSame($expected, $resolved['paths']['/b']['get']['responses']['200']['content']['application/json']['schema']);
+    }
+}

--- a/tests/Unit/OpenApiRefResolverTest.php
+++ b/tests/Unit/OpenApiRefResolverTest.php
@@ -227,6 +227,101 @@ class OpenApiRefResolverTest extends TestCase
     }
 
     #[Test]
+    public function resolves_ref_targeting_array_index(): void
+    {
+        // RFC 6901 allows numeric segments to address list elements. `$ref`s
+        // pointing to `parameters[0]` are common when aliasing operation-level
+        // definitions; the walker must descend through numeric keys correctly.
+        $spec = [
+            'paths' => [
+                '/pets' => [
+                    'parameters' => [
+                        [
+                            'name' => 'petId',
+                            'in' => 'path',
+                            'required' => true,
+                            'schema' => ['type' => 'integer'],
+                        ],
+                    ],
+                ],
+            ],
+            'x-alias' => ['$ref' => '#/paths/~1pets/parameters/0'],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $this->assertSame('petId', $resolved['x-alias']['name']);
+        $this->assertSame('path', $resolved['x-alias']['in']);
+    }
+
+    #[Test]
+    public function resolves_ref_to_empty_object_target(): void
+    {
+        // An empty-object schema is legal (matches anything). The walker's
+        // foreach must handle the zero-child case cleanly.
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'AnyShape' => [],
+                ],
+            ],
+            'x-alias' => ['$ref' => '#/components/schemas/AnyShape'],
+        ];
+
+        $this->assertSame([], OpenApiRefResolver::resolve($spec)['x-alias']);
+    }
+
+    #[Test]
+    public function resolves_ref_with_utf8_segment_url_encoded(): void
+    {
+        // Non-ASCII schema names are valid JSON. URL-aware tooling often
+        // percent-encodes them in refs; rawurldecode() must run before the
+        // JSON Pointer escape unwinding so both forms resolve.
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'ペット' => ['type' => 'string'],
+                ],
+            ],
+            'x-alias' => ['$ref' => '#/components/schemas/%E3%83%9A%E3%83%83%E3%83%88'],
+        ];
+
+        $this->assertSame(
+            ['type' => 'string'],
+            OpenApiRefResolver::resolve($spec)['x-alias'],
+        );
+    }
+
+    #[Test]
+    public function resolves_ref_inside_all_of_composition(): void
+    {
+        // allOf/oneOf/anyOf arrays are the most common place `$ref` appears
+        // in practice. A regression in list-index walking would surface here
+        // first.
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Pet' => ['type' => 'object', 'required' => ['id']],
+                    'Named' => [
+                        'allOf' => [
+                            ['$ref' => '#/components/schemas/Pet'],
+                            ['type' => 'object', 'properties' => ['name' => ['type' => 'string']]],
+                        ],
+                    ],
+                ],
+            ],
+            'x-alias' => ['$ref' => '#/components/schemas/Named'],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $this->assertSame(
+            ['type' => 'object', 'required' => ['id']],
+            $resolved['x-alias']['allOf'][0],
+        );
+    }
+
+    #[Test]
     public function throws_on_external_file_ref(): void
     {
         $spec = [
@@ -341,6 +436,41 @@ class OpenApiRefResolverTest extends TestCase
     }
 
     #[Test]
+    public function throws_on_three_node_circular_ref(): void
+    {
+        // The 2-node case is covered above. A 3-node cycle exercises the
+        // chain length beyond the trivial minimum; a regression that only
+        // checks the immediate parent would slip past.
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'A' => [
+                        'properties' => [
+                            'next' => ['$ref' => '#/components/schemas/B'],
+                        ],
+                    ],
+                    'B' => [
+                        'properties' => [
+                            'next' => ['$ref' => '#/components/schemas/C'],
+                        ],
+                    ],
+                    'C' => [
+                        'properties' => [
+                            'next' => ['$ref' => '#/components/schemas/A'],
+                        ],
+                    ],
+                ],
+            ],
+            'x-alias' => ['$ref' => '#/components/schemas/A'],
+        ];
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Circular $ref');
+
+        OpenApiRefResolver::resolve($spec);
+    }
+
+    #[Test]
     public function throws_on_unresolvable_ref(): void
     {
         $spec = [
@@ -414,9 +544,32 @@ class OpenApiRefResolverTest extends TestCase
     }
 
     #[Test]
-    public function throws_on_ref_not_starting_with_hash_slash(): void
+    public function throws_when_ref_target_is_literal_null_not_unresolvable(): void
     {
-        // Bare fragment like '#foo' (missing '/') is invalid per RFC 6901 JSON Pointer.
+        // A key that exists but holds `null` is a present-but-invalid target.
+        // Distinguishing this from a genuinely missing segment avoids telling
+        // the author "target not found" when the target is right there.
+        $spec = [
+            'x-placeholder' => null,
+            'components' => [
+                'schemas' => [
+                    'Bad' => ['$ref' => '#/x-placeholder'],
+                ],
+            ],
+        ];
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('not an object');
+
+        OpenApiRefResolver::resolve($spec);
+    }
+
+    #[Test]
+    public function throws_on_bare_fragment_ref_with_clear_message(): void
+    {
+        // A bare fragment like '#foo' or just '#' is neither a JSON Pointer
+        // nor an external URL. Surface it with a dedicated message so the
+        // author doesn't mistake it for a bundling instruction.
         $spec = [
             'components' => [
                 'schemas' => [
@@ -426,6 +579,23 @@ class OpenApiRefResolverTest extends TestCase
         ];
 
         $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('bare fragment');
+
+        OpenApiRefResolver::resolve($spec);
+    }
+
+    #[Test]
+    public function throws_on_root_pointer_ref(): void
+    {
+        // `$ref: "#/"` points at the spec root. Substituting it would recurse
+        // unboundedly before cycle detection kicks in; reject with a specific
+        // message so the author sees the real problem.
+        $spec = [
+            'x-bad' => ['$ref' => '#/'],
+        ];
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('root pointer');
 
         OpenApiRefResolver::resolve($spec);
     }

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -365,7 +365,7 @@ class OpenApiRequestValidatorTest extends TestCase
 
         $this->assertFalse($result->isValid());
         $this->assertStringContainsString("Malformed 'requestBody'", $result->errors()[0]);
-        $this->assertStringContainsString('unresolved $ref or broken spec', $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
     }
 
     #[Test]
@@ -383,82 +383,6 @@ class OpenApiRequestValidatorTest extends TestCase
 
         $this->assertFalse($result->isValid());
         $this->assertStringContainsString("Malformed 'requestBody.content'", $result->errors()[0]);
-    }
-
-    #[Test]
-    public function request_body_ref_surfaces_error(): void
-    {
-        $result = $this->validator->validate(
-            'malformed',
-            'POST',
-            '/ref-request-body',
-            [],
-            [],
-            ['name' => 'Rex'],
-            'application/json',
-        );
-
-        $this->assertFalse($result->isValid());
-        $this->assertStringContainsString('RequestBody $ref encountered', $result->errors()[0]);
-        $this->assertStringContainsString('#/components/requestBodies/PetBody', $result->errors()[0]);
-        $this->assertStringContainsString('redocly bundle --dereference', $result->errors()[0]);
-    }
-
-    #[Test]
-    public function request_body_content_media_type_ref_surfaces_error(): void
-    {
-        $result = $this->validator->validate(
-            'malformed',
-            'POST',
-            '/ref-content-media-type',
-            [],
-            [],
-            ['name' => 'Rex'],
-            'application/json',
-        );
-
-        $this->assertFalse($result->isValid());
-        $this->assertStringContainsString("RequestBody content['application/json'] \$ref encountered", $result->errors()[0]);
-        $this->assertStringContainsString('#/components/schemas/Pet', $result->errors()[0]);
-        $this->assertStringContainsString('redocly bundle --dereference', $result->errors()[0]);
-    }
-
-    #[Test]
-    public function request_body_content_schema_ref_surfaces_error(): void
-    {
-        $result = $this->validator->validate(
-            'malformed',
-            'POST',
-            '/ref-content-schema',
-            [],
-            [],
-            ['name' => 'Rex'],
-            'application/json',
-        );
-
-        $this->assertFalse($result->isValid());
-        $this->assertStringContainsString("RequestBody content['application/json'].schema \$ref encountered", $result->errors()[0]);
-        $this->assertStringContainsString('#/components/schemas/Pet', $result->errors()[0]);
-        $this->assertStringContainsString('redocly bundle --dereference', $result->errors()[0]);
-    }
-
-    #[Test]
-    public function request_body_non_string_ref_surfaces_error(): void
-    {
-        $result = $this->validator->validate(
-            'malformed',
-            'POST',
-            '/non-string-ref-request-body',
-            [],
-            [],
-            ['name' => 'Rex'],
-            'application/json',
-        );
-
-        $this->assertFalse($result->isValid());
-        $this->assertStringContainsString('RequestBody $ref encountered', $result->errors()[0]);
-        $this->assertStringContainsString('(non-string $ref)', $result->errors()[0]);
-        $this->assertStringContainsString('redocly bundle --dereference', $result->errors()[0]);
     }
 
     #[Test]
@@ -964,24 +888,6 @@ class OpenApiRequestValidatorTest extends TestCase
     }
 
     #[Test]
-    public function query_params_ref_entry_surfaces_error(): void
-    {
-        $result = $this->validator->validate(
-            'malformed',
-            'GET',
-            '/ref-parameter',
-            [],
-            [],
-            null,
-            null,
-        );
-
-        $this->assertFalse($result->isValid());
-        $this->assertStringContainsString('Parameter $ref encountered', $result->errors()[0]);
-        $this->assertStringContainsString('redocly bundle --dereference', $result->errors()[0]);
-    }
-
-    #[Test]
     public function query_params_scalar_entry_surfaces_error(): void
     {
         $result = $this->validator->validate(
@@ -1332,24 +1238,6 @@ class OpenApiRequestValidatorTest extends TestCase
 
         $this->assertFalse($result->isValid());
         $this->assertStringContainsString('[path.petId]', $result->errorMessage());
-    }
-
-    #[Test]
-    public function path_params_ref_entry_surfaces_error(): void
-    {
-        $result = $this->validator->validate(
-            'malformed',
-            'GET',
-            '/path-ref-parameter/123',
-            [],
-            [],
-            null,
-            null,
-        );
-
-        $this->assertFalse($result->isValid());
-        $this->assertStringContainsString('Parameter $ref encountered', $result->errors()[0]);
-        $this->assertStringContainsString('redocly bundle --dereference', $result->errors()[0]);
     }
 
     #[Test]

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -11,6 +11,7 @@ use Studio\OpenApiContractTesting\OpenApiRequestValidator;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
 
 use function array_filter;
+use function implode;
 use function str_contains;
 use function strtolower;
 
@@ -35,6 +36,45 @@ class OpenApiRequestValidatorTest extends TestCase
     // ========================================
     // Acceptance criteria: valid / invalid / spec 未定義
     // ========================================
+
+    #[Test]
+    public function validates_request_body_against_ref_backed_schema(): void
+    {
+        // End-to-end mirror of the response-side integration test: the spec's
+        // requestBody is a $ref to components.requestBodies.PetBody, whose
+        // schema is itself $ref'd. Loader -> resolver -> converter -> opis
+        // must all line up for a valid payload to pass.
+        $result = $this->validator->validate(
+            'refs-valid',
+            'POST',
+            '/pets',
+            [],
+            [],
+            ['id' => 1, 'name' => 'Fido', 'category' => ['id' => 7, 'label' => 'dog']],
+            'application/json',
+        );
+
+        $this->assertTrue($result->isValid(), 'errors: ' . implode(' | ', $result->errors()));
+        $this->assertSame('/pets', $result->matchedPath());
+    }
+
+    #[Test]
+    public function rejects_invalid_request_body_against_ref_backed_schema(): void
+    {
+        // Negative path confirming the ref-backed schema actually enforces
+        // the Pet shape — a missing required `category` must fail.
+        $result = $this->validator->validate(
+            'refs-valid',
+            'POST',
+            '/pets',
+            [],
+            [],
+            ['id' => 1, 'name' => 'Fido'],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+    }
 
     #[Test]
     public function v30_valid_request_body_passes(): void

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -16,6 +16,7 @@ use Studio\OpenApiContractTesting\OpenApiSpecLoader;
 
 use function array_map;
 use function count;
+use function implode;
 use function json_encode;
 use function range;
 
@@ -1066,6 +1067,26 @@ class OpenApiResponseValidatorTest extends TestCase
 
         $this->assertTrue($result->isValid());
         $this->assertSame('/v1/pets', $result->matchedPath());
+    }
+
+    #[Test]
+    public function validates_response_body_against_ref_backed_schema(): void
+    {
+        // End-to-end: loader resolves Pet -> Category -> Label refs, converter
+        // drops OAS keys, opis validates the resolved schema. A bug in any
+        // layer of the chain surfaces as a failure here.
+        $result = $this->validator->validate(
+            'refs-valid',
+            'GET',
+            '/pets',
+            200,
+            [
+                ['id' => 1, 'name' => 'Fido', 'category' => ['id' => 7, 'label' => 'dog']],
+            ],
+        );
+
+        $this->assertTrue($result->isValid(), 'errors: ' . implode(' | ', $result->errors()));
+        $this->assertSame('/pets', $result->matchedPath());
     }
 
     #[Test]

--- a/tests/Unit/OpenApiSpecLoaderTest.php
+++ b/tests/Unit/OpenApiSpecLoaderTest.php
@@ -127,6 +127,74 @@ class OpenApiSpecLoaderTest extends TestCase
     }
 
     #[Test]
+    public function load_resolves_internal_refs(): void
+    {
+        $fixturesPath = __DIR__ . '/../fixtures/specs';
+        OpenApiSpecLoader::configure($fixturesPath);
+
+        $spec = OpenApiSpecLoader::load('refs-valid');
+
+        // The paths schema should no longer contain '$ref' after resolution.
+        $listSchema = $spec['paths']['/pets']['get']['responses']['200']['content']['application/json']['schema'];
+        $this->assertSame('array', $listSchema['type']);
+        $this->assertArrayNotHasKey('$ref', $listSchema['items']);
+        $this->assertSame('object', $listSchema['items']['type']);
+
+        // Transitive nested ref Pet -> Category -> Label should be fully resolved.
+        $this->assertSame(
+            ['type' => 'string', 'minLength' => 1],
+            $listSchema['items']['properties']['category']['properties']['label'],
+        );
+
+        // Path-level parameter $ref is resolved inline.
+        $pathParam = $spec['paths']['/pets/{petId}']['parameters'][0];
+        $this->assertArrayNotHasKey('$ref', $pathParam);
+        $this->assertSame('petId', $pathParam['name']);
+        $this->assertSame('path', $pathParam['in']);
+
+        // Response-level $ref is resolved.
+        $responseSpec = $spec['paths']['/pets/{petId}']['get']['responses']['200'];
+        $this->assertArrayNotHasKey('$ref', $responseSpec);
+        $this->assertSame('A single pet', $responseSpec['description']);
+    }
+
+    #[Test]
+    public function load_throws_on_circular_ref(): void
+    {
+        $fixturesPath = __DIR__ . '/../fixtures/specs';
+        OpenApiSpecLoader::configure($fixturesPath);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Circular $ref');
+
+        OpenApiSpecLoader::load('refs-circular');
+    }
+
+    #[Test]
+    public function load_throws_on_external_ref(): void
+    {
+        $fixturesPath = __DIR__ . '/../fixtures/specs';
+        OpenApiSpecLoader::configure($fixturesPath);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('External $ref');
+
+        OpenApiSpecLoader::load('refs-external');
+    }
+
+    #[Test]
+    public function load_throws_on_unresolvable_ref(): void
+    {
+        $fixturesPath = __DIR__ . '/../fixtures/specs';
+        OpenApiSpecLoader::configure($fixturesPath);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unresolvable $ref');
+
+        OpenApiSpecLoader::load('refs-unresolvable');
+    }
+
+    #[Test]
     public function evict_removes_single_spec_from_cache(): void
     {
         $fixturesPath = __DIR__ . '/../fixtures/specs';

--- a/tests/Unit/OpenApiSpecLoaderTest.php
+++ b/tests/Unit/OpenApiSpecLoaderTest.php
@@ -207,11 +207,65 @@ class OpenApiSpecLoaderTest extends TestCase
         // Evict only 3.0
         OpenApiSpecLoader::evict('petstore-3.0');
 
-        // 3.1 still cached (same reference)
+        // 3.1 still cached (by-value equal)
         $this->assertSame($first31, OpenApiSpecLoader::load('petstore-3.1'));
 
-        // 3.0 reloaded from disk (equal but fresh instance)
+        // 3.0 reload produces the same content (by-value; array equality, not instance identity)
         $reloaded30 = OpenApiSpecLoader::load('petstore-3.0');
         $this->assertSame($first30, $reloaded30);
+    }
+
+    #[Test]
+    public function failed_load_does_not_poison_cache(): void
+    {
+        $fixturesPath = __DIR__ . '/../fixtures/specs';
+        OpenApiSpecLoader::configure($fixturesPath);
+
+        try {
+            OpenApiSpecLoader::load('refs-unresolvable');
+            $this->fail('expected RuntimeException');
+        } catch (RuntimeException) {
+            // Expected — next load must re-attempt from disk, not return a
+            // partially-resolved array captured before the throw.
+        }
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unresolvable $ref');
+        OpenApiSpecLoader::load('refs-unresolvable');
+    }
+
+    #[Test]
+    public function failed_load_does_not_affect_other_specs(): void
+    {
+        $fixturesPath = __DIR__ . '/../fixtures/specs';
+        OpenApiSpecLoader::configure($fixturesPath);
+
+        try {
+            OpenApiSpecLoader::load('refs-circular');
+        } catch (RuntimeException) {
+            // Swallow so we can verify a different spec still loads afterwards.
+        }
+
+        // A sibling spec with clean refs must still load successfully even if
+        // an earlier failure left any intermediate state behind.
+        $spec = OpenApiSpecLoader::load('refs-valid');
+        $this->assertSame('Refs valid', $spec['info']['title']);
+    }
+
+    #[Test]
+    public function load_returns_independent_copies_of_cached_specs(): void
+    {
+        // Pins the PHP copy-on-write assumption that OpenApiRefResolver relies
+        // on: mutating the returned array must not corrupt the cached copy.
+        // Swapping to by-reference returns (or accidentally sharing the root
+        // snapshot) would show up here.
+        $fixturesPath = __DIR__ . '/../fixtures/specs';
+        OpenApiSpecLoader::configure($fixturesPath);
+
+        $first = OpenApiSpecLoader::load('refs-valid');
+        $first['info']['title'] = 'mutated';
+
+        $second = OpenApiSpecLoader::load('refs-valid');
+        $this->assertSame('Refs valid', $second['info']['title']);
     }
 }

--- a/tests/fixtures/specs/malformed.json
+++ b/tests/fixtures/specs/malformed.json
@@ -32,22 +32,6 @@
                 }
             }
         },
-        "/ref-parameter": {
-            "get": {
-                "summary": "parameters list contains an unresolved $ref entry",
-                "operationId": "refParameter",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/UnresolvedLimit"
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No content"
-                    }
-                }
-            }
-        },
         "/scalar-parameter": {
             "get": {
                 "summary": "parameters list contains a non-array entry",
@@ -80,74 +64,6 @@
                 }
             }
         },
-        "/ref-request-body": {
-            "post": {
-                "summary": "requestBody is directly a $ref",
-                "operationId": "refRequestBody",
-                "requestBody": {
-                    "$ref": "#/components/requestBodies/PetBody"
-                },
-                "responses": {
-                    "204": {
-                        "description": "No content"
-                    }
-                }
-            }
-        },
-        "/ref-content-media-type": {
-            "post": {
-                "summary": "content[mediaType] is directly a $ref",
-                "operationId": "refContentMediaType",
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "$ref": "#/components/schemas/Pet"
-                        }
-                    }
-                },
-                "responses": {
-                    "204": {
-                        "description": "No content"
-                    }
-                }
-            }
-        },
-        "/ref-content-schema": {
-            "post": {
-                "summary": "content[mediaType].schema is directly a $ref",
-                "operationId": "refContentSchema",
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Pet"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "204": {
-                        "description": "No content"
-                    }
-                }
-            }
-        },
-        "/non-string-ref-request-body": {
-            "post": {
-                "summary": "requestBody $ref value is not a string",
-                "operationId": "nonStringRefRequestBody",
-                "requestBody": {
-                    "$ref": ["not", "a", "string"]
-                },
-                "responses": {
-                    "204": {
-                        "description": "No content"
-                    }
-                }
-            }
-        },
         "/scalar-content-media-type": {
             "post": {
                 "summary": "content[mediaType] is a scalar (not an object)",
@@ -158,22 +74,6 @@
                         "application/json": "this should have been an object"
                     }
                 },
-                "responses": {
-                    "204": {
-                        "description": "No content"
-                    }
-                }
-            }
-        },
-        "/path-ref-parameter/{id}": {
-            "parameters": [
-                {
-                    "$ref": "#/components/parameters/UnresolvedId"
-                }
-            ],
-            "get": {
-                "summary": "in:path parameters list contains an unresolved $ref entry",
-                "operationId": "pathRefParameter",
                 "responses": {
                     "204": {
                         "description": "No content"

--- a/tests/fixtures/specs/refs-circular.json
+++ b/tests/fixtures/specs/refs-circular.json
@@ -1,0 +1,46 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Refs circular",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/nodes": {
+            "get": {
+                "operationId": "listNodes",
+                "responses": {
+                    "200": {
+                        "description": "List",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Node"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Node": {
+                "type": "object",
+                "properties": {
+                    "child": {
+                        "$ref": "#/components/schemas/Child"
+                    }
+                }
+            },
+            "Child": {
+                "type": "object",
+                "properties": {
+                    "parent": {
+                        "$ref": "#/components/schemas/Node"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/fixtures/specs/refs-external.json
+++ b/tests/fixtures/specs/refs-external.json
@@ -1,0 +1,26 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Refs external",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/pets": {
+            "get": {
+                "operationId": "listPets",
+                "responses": {
+                    "200": {
+                        "description": "List",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "other-spec.json#/components/schemas/Pet"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/fixtures/specs/refs-unresolvable.json
+++ b/tests/fixtures/specs/refs-unresolvable.json
@@ -1,0 +1,33 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Refs unresolvable",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/pets": {
+            "get": {
+                "operationId": "listPets",
+                "responses": {
+                    "200": {
+                        "description": "List",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DoesNotExist"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Pet": {
+                "type": "object"
+            }
+        }
+    }
+}

--- a/tests/fixtures/specs/refs-valid.json
+++ b/tests/fixtures/specs/refs-valid.json
@@ -23,6 +23,17 @@
                         }
                     }
                 }
+            },
+            "post": {
+                "operationId": "createPet",
+                "requestBody": {
+                    "$ref": "#/components/requestBodies/PetBody"
+                },
+                "responses": {
+                    "201": {
+                        "$ref": "#/components/responses/PetResponse"
+                    }
+                }
             }
         },
         "/pets/{petId}": {
@@ -82,6 +93,18 @@
         "responses": {
             "PetResponse": {
                 "description": "A single pet",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/Pet"
+                        }
+                    }
+                }
+            }
+        },
+        "requestBodies": {
+            "PetBody": {
+                "required": true,
                 "content": {
                     "application/json": {
                         "schema": {

--- a/tests/fixtures/specs/refs-valid.json
+++ b/tests/fixtures/specs/refs-valid.json
@@ -1,0 +1,95 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Refs valid",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/pets": {
+            "get": {
+                "operationId": "listPets",
+                "responses": {
+                    "200": {
+                        "description": "A list of pets",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Pet"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/pets/{petId}": {
+            "parameters": [
+                {
+                    "$ref": "#/components/parameters/PetId"
+                }
+            ],
+            "get": {
+                "operationId": "getPet",
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/PetResponse"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Pet": {
+                "type": "object",
+                "required": ["id", "name", "category"],
+                "properties": {
+                    "id": { "type": "integer" },
+                    "name": { "type": "string" },
+                    "category": {
+                        "$ref": "#/components/schemas/Category"
+                    }
+                }
+            },
+            "Category": {
+                "type": "object",
+                "required": ["id", "label"],
+                "properties": {
+                    "id": { "type": "integer" },
+                    "label": {
+                        "$ref": "#/components/schemas/Label"
+                    }
+                }
+            },
+            "Label": {
+                "type": "string",
+                "minLength": 1
+            }
+        },
+        "parameters": {
+            "PetId": {
+                "name": "petId",
+                "in": "path",
+                "required": true,
+                "schema": {
+                    "type": "integer"
+                }
+            }
+        },
+        "responses": {
+            "PetResponse": {
+                "description": "A single pet",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/Pet"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Resolves #49. Add runtime resolution of internal `$ref` entries so users no longer need to pre-bundle specs with `redocly bundle --dereferenced` before every test run.

- New `OpenApiRefResolver` walks the decoded spec once and substitutes `#/...` JSON pointers in place; called from `OpenApiSpecLoader::load()` so downstream validators continue to operate on fully-dereferenced arrays.
- External refs (`other.json#/...`, `http://...`), circular refs, dangling internal refs, and non-string `$ref` values throw `RuntimeException` at load time with a single clear message — no more cryptic opis failures surfacing deep inside validation.
- Dead-code cleanup: the four `$ref` guard blocks in `OpenApiRequestValidator` (parameter / requestBody / content[mediaType] / content[mediaType].schema) are removed because the loader now throws before the validator sees an unresolved ref. The `$ref`-specific paths in `tests/fixtures/specs/malformed.json` were pruned — their coverage moved to the new load-time tests.

## Behaviour notes

- Sibling keys alongside `$ref` are discarded (OAS 3.0 semantics; a safe subset of 3.1).
- JSON Pointer segments are decoded per RFC 6901: URL-decode, then `~1` → `/`, then `~0` → `~` (order matters).
- Already-dereferenced specs round-trip unchanged; the resolver is a no-op when no `$ref` keys are present.
- Phase 1: external-file/URL refs are not supported. Redocly bundling remains a valid precompilation step.

## Test plan

- [x] `vendor/bin/phpunit` — 449 tests, 944 assertions, all green
- [x] `vendor/bin/phpstan analyse` — level 6 clean
- [x] `vendor/bin/php-cs-fixer fix --dry-run --diff` — no fixes needed
- [x] `OpenApiRefResolverTest` covers: simple / nested / transitive / JSON-Pointer escapes / URL-encoded segments / siblings-discarded / already-dereferenced round-trip / direct self-ref (circular) / indirect circular / external file / external URL / unresolvable target / non-string `$ref` / non-object target / malformed bare fragment / same-ref-from-multiple-sites
- [x] `OpenApiSpecLoaderTest` covers: `load_resolves_internal_refs` plus one test each for circular / external / unresolvable load-time failure
- [x] `OpenApiResponseValidatorTest::validates_response_body_against_ref_backed_schema` — end-to-end assert that a spec with `Pet → Category → Label` refs validates a real response body through loader → converter → opis