### PR TITLE
Document: #[OpenApiSpec] の解決優先度をテストと docs で担保する

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Resolution priority (highest to lowest) — the first match wins:
 | 3 | `openApiSpec()` method override          | Class-specific spec without the attribute (e.g. dynamically chosen at runtime) |
 | 4 | `config('openapi-contract-testing.default_spec')` | Project-wide default set once in `config/openapi-contract-testing.php` |
 
-Concrete example where all four layers are populated:
+Concrete example where all four layers are populated (class name differs from the earlier `MixedApiTest` example so both snippets can coexist in one project):
 
 ```php
 use Studio\OpenApiContractTesting\OpenApiSpec;
@@ -171,7 +171,7 @@ use Studio\OpenApiContractTesting\OpenApiSpec;
 // config/openapi-contract-testing.php → ['default_spec' => 'front']   (layer 4)
 
 #[OpenApiSpec('admin')]                                             // layer 2
-class MixedApiTest extends TestCase
+class AllLayersPriorityTest extends TestCase
 {
     use ValidatesOpenApiSchema;
 

--- a/README.md
+++ b/README.md
@@ -154,14 +154,55 @@ class MixedApiTest extends TestCase
 }
 ```
 
-Resolution priority (highest to lowest):
+Resolution priority (highest to lowest) — the first match wins:
 
-1. Method-level `#[OpenApiSpec]` attribute
-2. Class-level `#[OpenApiSpec]` attribute
-3. `openApiSpec()` method override
-4. `config('openapi-contract-testing.default_spec')`
+| # | Layer | Typical use |
+|---|---|---|
+| 1 | Method-level `#[OpenApiSpec]` attribute | Per-test override inside a class whose other tests target a different spec |
+| 2 | Class-level `#[OpenApiSpec]` attribute  | Default spec for a class whose tests all hit the same API surface |
+| 3 | `openApiSpec()` method override          | Class-specific spec without the attribute (e.g. dynamically chosen at runtime) |
+| 4 | `config('openapi-contract-testing.default_spec')` | Project-wide default set once in `config/openapi-contract-testing.php` |
 
-> **Note:** You can still override `openApiSpec()` as before — it remains fully backward-compatible.
+Concrete example where all four layers are populated:
+
+```php
+use Studio\OpenApiContractTesting\OpenApiSpec;
+
+// config/openapi-contract-testing.php → ['default_spec' => 'front']   (layer 4)
+
+#[OpenApiSpec('admin')]                                             // layer 2
+class MixedApiTest extends TestCase
+{
+    use ValidatesOpenApiSchema;
+
+    protected function openApiSpec(): string                        // layer 3
+    {
+        return 'internal';
+    }
+
+    public function test_uses_class_attr(): void
+    {
+        // Resolves to 'admin' — layer 2 wins over layer 3 and layer 4.
+    }
+
+    #[OpenApiSpec('experimental')]                                  // layer 1
+    public function test_uses_method_attr(): void
+    {
+        // Resolves to 'experimental' — layer 1 wins over all lower layers.
+    }
+}
+```
+
+If every layer is absent (no attributes, `openApiSpec()` not overridden, and `default_spec` empty), the assertion fails with a message that points at each opt-in location:
+
+```
+openApiSpec() must return a non-empty spec name, but an empty string was returned.
+Either add #[OpenApiSpec('your-spec')] to your test class or method,
+override openApiSpec() in your test class, or set the "default_spec" key
+in config/openapi-contract-testing.php.
+```
+
+> **Note:** `openApiSpec()` remains the original extension hook and is fully backward-compatible — overriding it works exactly as before.
 
 #### Framework-agnostic
 

--- a/src/OpenApiSpecResolver.php
+++ b/src/OpenApiSpecResolver.php
@@ -10,16 +10,23 @@ use ReflectionMethod;
 /**
  * Resolves which OpenAPI spec name a test case should validate against.
  *
- * The resolver itself has three layers; framework adapters (e.g. the Laravel
- * `ValidatesOpenApiSchema` trait) typically split the last one into two by
- * overriding `openApiSpecFallback()`. Together they form the four-layer
- * priority documented in README (highest first; first match wins):
+ * The resolver itself evaluates three layers. When a framework adapter (e.g.
+ * the Laravel `ValidatesOpenApiSchema` trait) overrides `openApiSpecFallback()`
+ * to delegate to its own user-overridable hook, the last layer splits into
+ * two — producing the four-layer priority documented in README (highest first;
+ * first match wins):
  *
  *   1. Method-level `#[OpenApiSpec]` attribute on the running test method.
  *   2. Class-level `#[OpenApiSpec]` attribute on the test class.
- *   3. `openApiSpec()` override (host test class overrides the adapter hook).
- *   4. Adapter default — e.g. `config('openapi-contract-testing.default_spec')`
- *      via the Laravel trait's `openApiSpec()` implementation.
+ *   3. Adapter's user-overridable hook. For the Laravel adapter this is
+ *      `openApiSpec()`; a host test class may override it to inject a
+ *      class-specific spec without using the attribute.
+ *   4. Adapter's ultimate default. For the Laravel adapter this is
+ *      `config('openapi-contract-testing.default_spec')`, returned by the
+ *      trait's own `openApiSpec()` implementation when not overridden.
+ *
+ * Adapters that don't override `openApiSpecFallback()` collapse layers 3 and 4
+ * into a single fallback and remain three-layer.
  *
  * Attribute layers return the attribute's raw `name` as-is. `#[OpenApiSpec('')]`
  * is still "set" and short-circuits resolution to the empty string — the

--- a/src/OpenApiSpecResolver.php
+++ b/src/OpenApiSpecResolver.php
@@ -7,6 +7,25 @@ namespace Studio\OpenApiContractTesting;
 use ReflectionClass;
 use ReflectionMethod;
 
+/**
+ * Resolves which OpenAPI spec name a test case should validate against.
+ *
+ * The resolver itself has three layers; framework adapters (e.g. the Laravel
+ * `ValidatesOpenApiSchema` trait) typically split the last one into two by
+ * overriding `openApiSpecFallback()`. Together they form the four-layer
+ * priority documented in README (highest first; first match wins):
+ *
+ *   1. Method-level `#[OpenApiSpec]` attribute on the running test method.
+ *   2. Class-level `#[OpenApiSpec]` attribute on the test class.
+ *   3. `openApiSpec()` override (host test class overrides the adapter hook).
+ *   4. Adapter default — e.g. `config('openapi-contract-testing.default_spec')`
+ *      via the Laravel trait's `openApiSpec()` implementation.
+ *
+ * Attribute layers return the attribute's raw `name` as-is. `#[OpenApiSpec('')]`
+ * is still "set" and short-circuits resolution to the empty string — the
+ * consumer treats that as an error with a helpful message (see
+ * `ValidatesOpenApiSchema::assertResponseMatchesOpenApiSchema`).
+ */
 trait OpenApiSpecResolver
 {
     protected function openApiSpecFallback(): string

--- a/tests/Unit/SpecPriorityClassAttrTest.php
+++ b/tests/Unit/SpecPriorityClassAttrTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
+use Studio\OpenApiContractTesting\OpenApiSpec;
+
+require_once __DIR__ . '/../Helpers/LaravelConfigMock.php';
+
+/**
+ * Priority row 2 of 4: class-level #[OpenApiSpec] wins when no method-level
+ * attribute is present, even if openApiSpec() override and config are set.
+ */
+#[OpenApiSpec('from-class-attr')]
+class SpecPriorityClassAttrTest extends TestCase
+{
+    use ValidatesOpenApiSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $GLOBALS['__openapi_testing_config'] = [
+            'openapi-contract-testing.default_spec' => 'from-config',
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        self::resetValidatorCache();
+        unset($GLOBALS['__openapi_testing_config']);
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function class_attr_wins_over_override_and_config(): void
+    {
+        $this->assertSame('from-class-attr', $this->resolveOpenApiSpec());
+    }
+
+    protected function openApiSpec(): string
+    {
+        return 'from-override';
+    }
+}

--- a/tests/Unit/SpecPriorityConfigTest.php
+++ b/tests/Unit/SpecPriorityConfigTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
+
+require_once __DIR__ . '/../Helpers/LaravelConfigMock.php';
+
+/**
+ * Priority row 4 of 4: config default_spec is used when no #[OpenApiSpec]
+ * attribute is present and openApiSpec() is not overridden (so it falls
+ * through to the trait's default implementation that reads from config).
+ */
+class SpecPriorityConfigTest extends TestCase
+{
+    use ValidatesOpenApiSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $GLOBALS['__openapi_testing_config'] = [
+            'openapi-contract-testing.default_spec' => 'from-config',
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        self::resetValidatorCache();
+        unset($GLOBALS['__openapi_testing_config']);
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function config_is_used_when_all_higher_layers_absent(): void
+    {
+        $this->assertSame('from-config', $this->resolveOpenApiSpec());
+    }
+}

--- a/tests/Unit/SpecPriorityMethodAttrTest.php
+++ b/tests/Unit/SpecPriorityMethodAttrTest.php
@@ -16,9 +16,9 @@ require_once __DIR__ . '/../Helpers/LaravelConfigMock.php';
  * Priority row 1 of 4: method-level #[OpenApiSpec] wins over every lower layer.
  *
  * All four priority layers are populated with distinct `from-<layer>` markers;
- * the assertion proves the method attribute is chosen. Pairs with
- * SpecPriorityClassAttrTest, SpecPriorityOverrideTest, and SpecPriorityConfigTest
- * — together they cover the table in issue #51.
+ * the assertion proves the method attribute is chosen. Together with the other
+ * `SpecPriority*Test` cases, this covers each row of the resolution priority
+ * table (see the Resolution priority section in README).
  */
 #[OpenApiSpec('from-class-attr')]
 class SpecPriorityMethodAttrTest extends TestCase

--- a/tests/Unit/SpecPriorityMethodAttrTest.php
+++ b/tests/Unit/SpecPriorityMethodAttrTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
+use Studio\OpenApiContractTesting\OpenApiSpec;
+
+// Load namespace-level config() mock before the trait resolves the function call.
+require_once __DIR__ . '/../Helpers/LaravelConfigMock.php';
+
+/**
+ * Priority row 1 of 4: method-level #[OpenApiSpec] wins over every lower layer.
+ *
+ * All four priority layers are populated with distinct `from-<layer>` markers;
+ * the assertion proves the method attribute is chosen. Pairs with
+ * SpecPriorityClassAttrTest, SpecPriorityOverrideTest, and SpecPriorityConfigTest
+ * — together they cover the table in issue #51.
+ */
+#[OpenApiSpec('from-class-attr')]
+class SpecPriorityMethodAttrTest extends TestCase
+{
+    use ValidatesOpenApiSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $GLOBALS['__openapi_testing_config'] = [
+            'openapi-contract-testing.default_spec' => 'from-config',
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        self::resetValidatorCache();
+        unset($GLOBALS['__openapi_testing_config']);
+        parent::tearDown();
+    }
+
+    #[Test]
+    #[OpenApiSpec('from-method-attr')]
+    public function method_attr_wins_over_class_attr_override_and_config(): void
+    {
+        $this->assertSame('from-method-attr', $this->resolveOpenApiSpec());
+    }
+
+    // Layer 3 override: returning a distinct marker proves the method attribute
+    // (layer 1) is still chosen over it. If the resolver regressed to pick this
+    // up, the assertion above would see 'from-override' instead.
+    protected function openApiSpec(): string
+    {
+        return 'from-override';
+    }
+}

--- a/tests/Unit/SpecPriorityOverrideTest.php
+++ b/tests/Unit/SpecPriorityOverrideTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
+
+require_once __DIR__ . '/../Helpers/LaravelConfigMock.php';
+
+/**
+ * Priority row 3 of 4: an openApiSpec() override wins over config when no
+ * #[OpenApiSpec] attribute is present at either class or method level.
+ */
+class SpecPriorityOverrideTest extends TestCase
+{
+    use ValidatesOpenApiSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $GLOBALS['__openapi_testing_config'] = [
+            'openapi-contract-testing.default_spec' => 'from-config',
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        self::resetValidatorCache();
+        unset($GLOBALS['__openapi_testing_config']);
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function override_wins_over_config(): void
+    {
+        $this->assertSame('from-override', $this->resolveOpenApiSpec());
+    }
+
+    protected function openApiSpec(): string
+    {
+        return 'from-override';
+    }
+}


### PR DESCRIPTION
# 概要

`#[OpenApiSpec]` の解決優先度（method attr > class attr > `openApiSpec()` override > config）は README に記載されていたが、全層を一枚で確認する回帰テストと、ソース側のドックコメントが無かった。issue #51 の受け入れ条件に沿って、表駆動テスト・trait docblock・README 拡充の 3 点を追加する。

## 変更内容

- **優先度表の regression テストを追加** — 表の 1 行 = 1 テストファイルで 4 本 (`tests/Unit/SpecPriority*Test.php`)。各層のマーカーを `from-method-attr` / `from-class-attr` / `from-override` / `from-config` とし、assertion を見ただけでどの層が勝ったか分かる命名に揃えた。
- **row 5（全層 empty → 親切なエラー）は意図的に重複追加せず** — 既存の `ValidatesOpenApiSchemaDefaultSpecTest::empty_config_default_spec_fails_with_clear_message` が同じエラーメッセージを assert しており、二重管理はメッセージ文言を直すたびに両方更新する負債を生むため。row 5 は priority 順序の話ではなく UX 契約の話なので扱いを分けた。
- **`OpenApiSpecResolver` trait に PHPDoc を追加** — 3 層の resolver と framework adapter によって 4 層に展開される構造、`openApiSpecFallback()` という拡張点、`#[OpenApiSpec('')]` の境界挙動を記述。
- **README の優先度セクションを拡充** — 箇条書きを表に変更し各層の典型ユースケースを併記。全 4 層を同時に指定した `MixedApiTest` の具体例と、全層 empty 時のエラーメッセージを実例として追加。

## 品質ゲート

- `vendor/bin/phpunit` — 475 tests / 988 assertions pass
- `vendor/bin/phpstan analyse` — No errors
- `vendor/bin/php-cs-fixer fix --dry-run --diff` — 0 of 55 files need fixing

## 関連情報

- Closes #51