### PR TITLE
fix(request-validator): surface scalar content[mediaType].schema as hard error

### DIFF
--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -1124,6 +1124,17 @@ final class OpenApiRequestValidator
                     "Malformed 'requestBody.content[\"{$mediaType}\"]' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
                 ];
             }
+
+            // `schema: "oops"` (or any other non-array scalar) would slip past the
+            // downstream `isset(...['schema'])` presence check and reach
+            // OpenApiSchemaConverter::convert() as a scalar, producing a confusing
+            // TypeError instead of a spec-level error. array_key_exists rather than
+            // isset so an explicit `schema: null` is also flagged.
+            if (array_key_exists('schema', $mediaTypeSpec) && !is_array($mediaTypeSpec['schema'])) {
+                return [
+                    "Malformed 'requestBody.content[\"{$mediaType}\"].schema' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+                ];
+            }
         }
 
         // When the actual request Content-Type is provided, handle content negotiation:

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -464,6 +464,32 @@ class OpenApiRequestValidatorTest extends TestCase
         $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
     }
 
+    /**
+     * Locks in the `array_key_exists` vs `isset` choice in the guard. If a
+     * future refactor swaps to `isset`, `schema: null` would silently fall
+     * through the downstream presence check and accept any request body —
+     * the exact silent failure this guard exists to prevent.
+     */
+    #[Test]
+    public function null_content_media_type_schema_returns_failure(): void
+    {
+        $result = $this->validator->validate(
+            'malformed',
+            'POST',
+            '/null-content-schema',
+            [],
+            [],
+            ['foo' => 'bar'],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "Malformed 'requestBody.content[\"application/json\"].schema'",
+            $result->errors()[0],
+        );
+    }
+
     // ========================================
     // Constructor validation (mirrors response validator)
     // ========================================

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -443,6 +443,27 @@ class OpenApiRequestValidatorTest extends TestCase
         $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
     }
 
+    #[Test]
+    public function scalar_content_media_type_schema_returns_failure(): void
+    {
+        $result = $this->validator->validate(
+            'malformed',
+            'POST',
+            '/scalar-content-schema',
+            [],
+            [],
+            ['foo' => 'bar'],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "Malformed 'requestBody.content[\"application/json\"].schema'",
+            $result->errors()[0],
+        );
+        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+    }
+
     // ========================================
     // Constructor validation (mirrors response validator)
     // ========================================

--- a/tests/fixtures/specs/malformed.json
+++ b/tests/fixtures/specs/malformed.json
@@ -81,6 +81,25 @@
                 }
             }
         },
+        "/scalar-content-schema": {
+            "post": {
+                "summary": "content[mediaType].schema is a scalar (not an object)",
+                "operationId": "scalarContentSchema",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": "this should have been an object"
+                        }
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
         "/path-scalar-parameter/{id}": {
             "parameters": [
                 "this should have been an object"

--- a/tests/fixtures/specs/malformed.json
+++ b/tests/fixtures/specs/malformed.json
@@ -100,6 +100,25 @@
                 }
             }
         },
+        "/null-content-schema": {
+            "post": {
+                "summary": "content[mediaType].schema is null (explicitly absent value)",
+                "operationId": "nullContentSchema",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": null
+                        }
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
         "/path-scalar-parameter/{id}": {
             "parameters": [
                 "this should have been an object"


### PR DESCRIPTION
## Summary

Closes #62. Follow-up to PR #61: the same silent-failure pattern (malformed spec → opaque downstream error) remained one layer deeper than the guards PR #61 added.

### The leftover silent failure

When `content[mediaType].schema` holds a non-array scalar (e.g. the typo `schema: "oops"`), the current code:

1. Passes the `is_array($mediaTypeSpec)` guard (the enclosing `application/json` entry is a valid object).
2. Passes the downstream `isset($content[$jsonContentType]['schema'])` presence check (the scalar *is* set).
3. Reaches `OpenApiSchemaConverter::convert()` with a string → `TypeError: Argument #1 ($schema) must be of type array, string given`.

The user sees a PHP stack trace, not a pointer at the broken spec.

### Fix

Extend the existing `foreach ($content as $mediaType => $mediaTypeSpec)` loop in `validateRequestBody()` with a sibling guard that mirrors the `requestBody` / `content` / `content[mediaType]` guards:

```
Malformed 'requestBody.content["application/json"].schema' for POST /x in 'spec' spec: expected object, got scalar.
```

- Error string format matches the acceptance-criteria example verbatim.
- Uses `array_key_exists` (not `isset`) so an explicit `schema: null` is also flagged — otherwise it would slip past the guard, hit the downstream "no schema → success" path, and silently pass every request.
- Placed inside the pre-existing sanity-check loop so it fires regardless of which media type the actual request used, matching the behaviour of its sibling `!is_array($mediaTypeSpec)` guard.

### Scope

- Only `OpenApiRequestValidator`. Response-side same-shape silent failure is intentionally out of scope per the issue.
- `headers` / `cookies` parameter `$ref` is tracked under #45.

## Test plan

- [x] New TDD test `scalar_content_media_type_schema_returns_failure` in `OpenApiRequestValidatorTest` — verified red (TypeError at the converter) before adding the guard, green after.
- [x] New fixture `/scalar-content-schema` in `tests/fixtures/specs/malformed.json` following the `/scalar-content-media-type` pattern.
- [x] `vendor/bin/phpunit` — 493 tests, 1019 assertions, all green.
- [x] `vendor/bin/phpstan analyse` — no errors.
- [x] `vendor/bin/php-cs-fixer fix --dry-run --diff` — no diffs.