### PR TITLE
fix(request-validator): surface reserved header declarations as spec errors

### DIFF
--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -549,10 +549,6 @@ final class OpenApiRequestValidator
             $name = $param['name'];
             $lowerName = strtolower($name);
 
-            if (in_array($lowerName, self::RESERVED_HEADER_NAMES, true)) {
-                continue;
-            }
-
             $required = ($param['required'] ?? false) === true;
 
             // Same reasoning as query/path: a required parameter without a schema would
@@ -1017,6 +1013,23 @@ final class OpenApiRequestValidator
 
                 if (!isset($param['in'], $param['name']) || !is_string($param['in']) || !is_string($param['name'])) {
                     $errors[] = "Malformed parameter entry for {$method} {$matchedPath}: 'name' and 'in' must be strings.";
+
+                    continue;
+                }
+
+                // OAS 3.x §4.7.12.1 says `Accept`/`Content-Type`/`Authorization`
+                // in:header parameter definitions SHALL be ignored — content
+                // negotiation and security schemes own them. Silently skipping
+                // would let a spec author's `required: true` pass every request;
+                // surface as a hard spec error and drop the entry so downstream
+                // per-request validation stays OAS-compliant (no runtime effect).
+                if ($param['in'] === 'header' && in_array(strtolower($param['name']), self::RESERVED_HEADER_NAMES, true)) {
+                    $errors[] = sprintf(
+                        '[header.%s] reserved header declared for %s %s; per OpenAPI 3.x §4.7.12.1, `Accept`/`Content-Type`/`Authorization` parameter definitions SHALL be ignored. Remove the declaration or use `content` / security schemes instead.',
+                        $param['name'],
+                        $method,
+                        $matchedPath,
+                    );
 
                     continue;
                 }

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -1023,12 +1023,15 @@ final class OpenApiRequestValidator
                 // would let a spec author's `required: true` pass every request;
                 // surface as a hard spec error and drop the entry so downstream
                 // per-request validation stays OAS-compliant (no runtime effect).
+                // The `in === 'header'` guard keeps a non-header parameter that
+                // coincidentally shares a reserved name (e.g. `in: query, name: accept`)
+                // out of scope — only in:header entries are governed by §4.7.12.1.
                 if ($param['in'] === 'header' && in_array(strtolower($param['name']), self::RESERVED_HEADER_NAMES, true)) {
                     $errors[] = sprintf(
-                        '[header.%s] reserved header declared for %s %s; per OpenAPI 3.x §4.7.12.1, `Accept`/`Content-Type`/`Authorization` parameter definitions SHALL be ignored. Remove the declaration or use `content` / security schemes instead.',
-                        $param['name'],
+                        'Reserved in:header parameter declared for %s %s: [header.%s] — per OpenAPI 3.x §4.7.12.1, `Accept`/`Content-Type`/`Authorization` parameter definitions SHALL be ignored. Remove the declaration or use `content` / security schemes instead.',
                         $method,
                         $matchedPath,
+                        $param['name'],
                     );
 
                     continue;

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -1665,8 +1665,7 @@ class OpenApiRequestValidatorTest extends TestCase
         // the caller are handled by content negotiation / security schemes, not
         // parameter validation. When the spec declares none of them (the normal
         // case), runtime values at any casing must pass through untouched — this
-        // pins that the per-request side stays OAS-compliant. The spec-side
-        // detection is covered by reserved_header_declaration_case_insensitive_in_spec.
+        // pins that the per-request side stays OAS-compliant.
         $result = $this->validator->validate(
             'petstore-3.0',
             'GET',
@@ -1775,8 +1774,8 @@ class OpenApiRequestValidatorTest extends TestCase
     #[Test]
     public function reserved_header_declaration_content_type_optional_surfaces_spec_error(): void
     {
-        // `required` is absent (implicit false). The detection is name-based, not
-        // required-based — any reserved declaration is a spec defect regardless.
+        // Detection is name-based, not required-based — `required` is absent
+        // (implicit false) yet the declaration is still a spec defect.
         $result = $this->validator->validate(
             'malformed',
             'GET',
@@ -1791,13 +1790,12 @@ class OpenApiRequestValidatorTest extends TestCase
         $message = $result->errorMessage();
         $this->assertStringContainsString('[header.Content-Type]', $message);
         $this->assertStringContainsString('SHALL be ignored', $message);
+        $this->assertStringContainsString('§4.7.12.1', $message);
     }
 
     #[Test]
     public function reserved_header_declaration_authorization_required_surfaces_spec_error(): void
     {
-        // Reserved-name detection applies to Authorization too — security schemes
-        // are the intended mechanism, so an in:header declaration is a spec defect.
         $result = $this->validator->validate(
             'malformed',
             'GET',
@@ -1812,15 +1810,14 @@ class OpenApiRequestValidatorTest extends TestCase
         $message = $result->errorMessage();
         $this->assertStringContainsString('[header.Authorization]', $message);
         $this->assertStringContainsString('SHALL be ignored', $message);
+        $this->assertStringContainsString('§4.7.12.1', $message);
     }
 
     #[Test]
     public function reserved_header_declaration_case_insensitive_in_spec(): void
     {
-        // Spec author may write `ACCEPT` / `accept` / any other casing. HTTP header
-        // names are case-insensitive so detection must be too — and the error
-        // message preserves the author's original casing so the offending entry
-        // is easy to grep in their spec file.
+        // The error message preserves the author's original casing so the
+        // offending entry is easy to grep in their spec file.
         $result = $this->validator->validate(
             'malformed',
             'GET',
@@ -1835,14 +1832,12 @@ class OpenApiRequestValidatorTest extends TestCase
         $message = $result->errorMessage();
         $this->assertStringContainsString('[header.ACCEPT]', $message);
         $this->assertStringContainsString('SHALL be ignored', $message);
+        $this->assertStringContainsString('§4.7.12.1', $message);
     }
 
     #[Test]
     public function reserved_header_declaration_multiple_entries_surface_multiple_errors(): void
     {
-        // Two reserved entries in the same operation should each surface their own
-        // error — pinning that the spec-error loop does not short-circuit after
-        // the first detection.
         $result = $this->validator->validate(
             'malformed',
             'GET',
@@ -1855,10 +1850,36 @@ class OpenApiRequestValidatorTest extends TestCase
 
         $this->assertFalse($result->isValid());
         $errors = $result->errors();
+        // Pin the total so a future bug producing a duplicate or extra error is caught.
+        $this->assertCount(2, $errors, 'expected exactly 2 errors, got: ' . implode(' | ', $errors));
         $accept = array_filter($errors, static fn(string $e): bool => str_contains($e, '[header.Accept]'));
         $contentType = array_filter($errors, static fn(string $e): bool => str_contains($e, '[header.Content-Type]'));
         $this->assertCount(1, $accept, 'expected one [header.Accept] error, got: ' . implode(' | ', $errors));
         $this->assertCount(1, $contentType, 'expected one [header.Content-Type] error, got: ' . implode(' | ', $errors));
+    }
+
+    #[Test]
+    public function reserved_header_declaration_path_level_surfaces_spec_error(): void
+    {
+        // Path-level `parameters` are a separate source from operation-level
+        // `parameters` in collectParameters. Pin that reserved-header detection
+        // applies to both — a future refactor that dedupes sources before
+        // detection must not silently drop the path-level case.
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/header-reserved-path-level',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $message = $result->errorMessage();
+        $this->assertStringContainsString('[header.Authorization]', $message);
+        $this->assertStringContainsString('SHALL be ignored', $message);
+        $this->assertStringContainsString('§4.7.12.1', $message);
     }
 
     #[Test]

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -1547,26 +1547,6 @@ class OpenApiRequestValidatorTest extends TestCase
     }
 
     #[Test]
-    public function header_params_reserved_accept_ignored(): void
-    {
-        // Per OAS 3.x: "If in is header and the name field is Accept, Content-Type
-        // or Authorization, the parameter definition SHALL be ignored." The fixture
-        // declares Accept with a deliberately unmatchable enum — if our code still
-        // validated it, the request would always fail. It does not, so pass.
-        $result = $this->validator->validate(
-            'petstore-3.0',
-            'GET',
-            '/v1/reports',
-            [],
-            ['X-Request-ID' => 'f47ac10b-58cc-4372-a567-0e02b2c3d479'],
-            null,
-            null,
-        );
-
-        $this->assertTrue($result->isValid(), $result->errorMessage());
-    }
-
-    #[Test]
     public function header_params_single_element_array_is_unwrapped(): void
     {
         $result = $this->validator->validate(
@@ -1679,31 +1659,14 @@ class OpenApiRequestValidatorTest extends TestCase
     }
 
     #[Test]
-    public function header_params_reserved_content_type_ignored(): void
+    public function header_runtime_reserved_names_silently_ignored_when_not_declared(): void
     {
-        // The /v1/reports fixture declares Content-Type with an unmatchable enum.
-        // If the reserved-skip list ever regresses, the call would fail required /
-        // enum checks simultaneously. It does not, so pass.
-        $result = $this->validator->validate(
-            'petstore-3.0',
-            'GET',
-            '/v1/reports',
-            [],
-            ['X-Request-ID' => 'f47ac10b-58cc-4372-a567-0e02b2c3d479'],
-            null,
-            null,
-        );
-
-        $this->assertTrue($result->isValid(), $result->errorMessage());
-    }
-
-    #[Test]
-    public function header_params_reserved_names_case_insensitive_ignored(): void
-    {
-        // Reserved-list comparison is lower-cased. Spec-declared `Accept` /
-        // `Content-Type` / `Authorization` are ignored regardless of casing,
-        // AND caller-supplied values at any casing are also ignored — nothing
-        // about them flows into validation.
+        // Per OAS 3.x §4.7.12.1: `Accept`/`Content-Type`/`Authorization` sent by
+        // the caller are handled by content negotiation / security schemes, not
+        // parameter validation. When the spec declares none of them (the normal
+        // case), runtime values at any casing must pass through untouched — this
+        // pins that the per-request side stays OAS-compliant. The spec-side
+        // detection is covered by reserved_header_declaration_case_insensitive_in_spec.
         $result = $this->validator->validate(
             'petstore-3.0',
             'GET',
@@ -1782,6 +1745,120 @@ class OpenApiRequestValidatorTest extends TestCase
 
         $this->assertFalse($result->isValid());
         $this->assertStringContainsString('[header.X-Api-Key]', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function reserved_header_declaration_accept_required_surfaces_spec_error(): void
+    {
+        // Per OAS 3.x §4.7.12.1, `Accept`/`Content-Type`/`Authorization` parameter
+        // definitions SHALL be ignored. Silently skipping would let a spec author's
+        // `required: true` declaration pass every request, masking the footgun —
+        // so we surface the declaration as a hard spec error instead.
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/header-reserved-accept-required',
+            [],
+            ['Accept' => 'application/json'],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $message = $result->errorMessage();
+        $this->assertStringContainsString('[header.Accept]', $message);
+        $this->assertStringContainsString('GET /header-reserved-accept-required', $message);
+        $this->assertStringContainsString('SHALL be ignored', $message);
+        $this->assertStringContainsString('§4.7.12.1', $message);
+    }
+
+    #[Test]
+    public function reserved_header_declaration_content_type_optional_surfaces_spec_error(): void
+    {
+        // `required` is absent (implicit false). The detection is name-based, not
+        // required-based — any reserved declaration is a spec defect regardless.
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/header-reserved-content-type-optional',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $message = $result->errorMessage();
+        $this->assertStringContainsString('[header.Content-Type]', $message);
+        $this->assertStringContainsString('SHALL be ignored', $message);
+    }
+
+    #[Test]
+    public function reserved_header_declaration_authorization_required_surfaces_spec_error(): void
+    {
+        // Reserved-name detection applies to Authorization too — security schemes
+        // are the intended mechanism, so an in:header declaration is a spec defect.
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/header-reserved-authorization-required',
+            [],
+            ['Authorization' => 'Bearer token'],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $message = $result->errorMessage();
+        $this->assertStringContainsString('[header.Authorization]', $message);
+        $this->assertStringContainsString('SHALL be ignored', $message);
+    }
+
+    #[Test]
+    public function reserved_header_declaration_case_insensitive_in_spec(): void
+    {
+        // Spec author may write `ACCEPT` / `accept` / any other casing. HTTP header
+        // names are case-insensitive so detection must be too — and the error
+        // message preserves the author's original casing so the offending entry
+        // is easy to grep in their spec file.
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/header-reserved-accept-upper',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $message = $result->errorMessage();
+        $this->assertStringContainsString('[header.ACCEPT]', $message);
+        $this->assertStringContainsString('SHALL be ignored', $message);
+    }
+
+    #[Test]
+    public function reserved_header_declaration_multiple_entries_surface_multiple_errors(): void
+    {
+        // Two reserved entries in the same operation should each surface their own
+        // error — pinning that the spec-error loop does not short-circuit after
+        // the first detection.
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/header-reserved-multiple',
+            [],
+            [],
+            null,
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $errors = $result->errors();
+        $accept = array_filter($errors, static fn(string $e): bool => str_contains($e, '[header.Accept]'));
+        $contentType = array_filter($errors, static fn(string $e): bool => str_contains($e, '[header.Content-Type]'));
+        $this->assertCount(1, $accept, 'expected one [header.Accept] error, got: ' . implode(' | ', $errors));
+        $this->assertCount(1, $contentType, 'expected one [header.Content-Type] error, got: ' . implode(' | ', $errors));
     }
 
     #[Test]

--- a/tests/fixtures/specs/malformed.json
+++ b/tests/fixtures/specs/malformed.json
@@ -295,6 +295,27 @@
                 }
             }
         },
+        "/header-reserved-path-level": {
+            "parameters": [
+                {
+                    "name": "Authorization",
+                    "in": "header",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "get": {
+                "summary": "reserved in:header declared at path-level parameters (not operation-level)",
+                "operationId": "headerReservedPathLevel",
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
         "/security-undefined-scheme": {
             "get": {
                 "summary": "security references a scheme not defined in components.securitySchemes",

--- a/tests/fixtures/specs/malformed.json
+++ b/tests/fixtures/specs/malformed.json
@@ -183,6 +183,118 @@
                 }
             }
         },
+        "/header-reserved-accept-required": {
+            "get": {
+                "summary": "in:header Accept declared with required:true — OAS 3.x §4.7.12.1 says SHALL be ignored",
+                "operationId": "headerReservedAcceptRequired",
+                "parameters": [
+                    {
+                        "name": "Accept",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": ["application/json"]
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
+        "/header-reserved-content-type-optional": {
+            "get": {
+                "summary": "in:header Content-Type declared without required (implicit false)",
+                "operationId": "headerReservedContentTypeOptional",
+                "parameters": [
+                    {
+                        "name": "Content-Type",
+                        "in": "header",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
+        "/header-reserved-authorization-required": {
+            "get": {
+                "summary": "in:header Authorization declared instead of using a security scheme",
+                "operationId": "headerReservedAuthorizationRequired",
+                "parameters": [
+                    {
+                        "name": "Authorization",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^Bearer "
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
+        "/header-reserved-accept-upper": {
+            "get": {
+                "summary": "in:header ACCEPT (upper-case) — detection must be case-insensitive",
+                "operationId": "headerReservedAcceptUpper",
+                "parameters": [
+                    {
+                        "name": "ACCEPT",
+                        "in": "header",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
+        "/header-reserved-multiple": {
+            "get": {
+                "summary": "two reserved in:header entries in one operation — both must surface",
+                "operationId": "headerReservedMultiple",
+                "parameters": [
+                    {
+                        "name": "Accept",
+                        "in": "header",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "Content-Type",
+                        "in": "header",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    }
+                }
+            }
+        },
         "/security-undefined-scheme": {
             "get": {
                 "summary": "security references a scheme not defined in components.securitySchemes",

--- a/tests/fixtures/specs/petstore-3.0.json
+++ b/tests/fixtures/specs/petstore-3.0.json
@@ -584,33 +584,6 @@
                         }
                     },
                     {
-                        "name": "Accept",
-                        "in": "header",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "enum": ["never-match"]
-                        }
-                    },
-                    {
-                        "name": "Content-Type",
-                        "in": "header",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "enum": ["never-match"]
-                        }
-                    },
-                    {
-                        "name": "Authorization",
-                        "in": "header",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "enum": ["never-match"]
-                        }
-                    },
-                    {
                         "name": "X-Category",
                         "in": "header",
                         "schema": {

--- a/tests/fixtures/specs/petstore-3.1.json
+++ b/tests/fixtures/specs/petstore-3.1.json
@@ -455,15 +455,6 @@
                             "minimum": 1,
                             "maximum": 100
                         }
-                    },
-                    {
-                        "name": "Accept",
-                        "in": "header",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "enum": ["never-match"]
-                        }
                     }
                 ],
                 "responses": {


### PR DESCRIPTION
# 概要

`in: header` パラメータ名が `Accept` / `Content-Type` / `Authorization` の宣言を **hard spec error** として surface します。Issue #66 への対応。

PR #65 (Issue #45) で header 検証を追加した際、OAS 3.x §4.7.12.1 に従いこれら予約ヘッダーの宣言は silently skip していました。しかし spec author が誤って `required: true` と書くと、リクエストから該当ヘッダーが欠落していても **silently pass** してしまう footgun が残存していました。本 PR で宣言自体を spec error として検出し、`content` / security schemes への誘導を含む修正案内を提示します。per-request validation 側の挙動（caller が送信した `Accept` / `Content-Type` / `Authorization` を silently drop する OAS 準拠挙動）はそのまま維持しています。

## 変更内容

- `OpenApiRequestValidator::collectParameters()` に予約ヘッダー検出を追加（`$param['in'] === 'header'` かつ name が `RESERVED_HEADER_NAMES` に一致する entry を検出）
- 検出時、`$merged` には含めず（per-request validator には流さず）、以下の形式で spec error を push:
  ```
  [header.{OriginalName}] reserved header declared for {METHOD} {matchedPath}; per OpenAPI 3.x §4.7.12.1, `Accept`/`Content-Type`/`Authorization` parameter definitions SHALL be ignored. Remove the declaration or use `content` / security schemes instead.
  ```
- 名前比較は `strtolower()` による case-insensitive 比較、エラー文言は spec の元ケースを保持（grep しやすくするため）
- `validateHeaderParameters()` 内の予約ヘッダー skip (`continue`) を削除（upstream で filter 済みの dead code）
- `RESERVED_HEADER_NAMES` 定数の所在は維持（参照元が `collectParameters` に移動）
- fixture 追加 (`malformed.json`): `/header-reserved-accept-required` / `/header-reserved-content-type-optional` / `/header-reserved-authorization-required` / `/header-reserved-accept-upper` / `/header-reserved-multiple`（計 5 path）
- fixture クリーンアップ: `petstore-3.0.json` / `petstore-3.1.json` の `/v1/reports` から `Accept` / `Content-Type` / `Authorization` 宣言を削除（happy-path fixture の clean-up）
- テスト変更:
  - 旧 `header_params_reserved_accept_ignored` / `header_params_reserved_content_type_ignored` は削除（silent-skip 前提の assertion が失効）
  - 旧 `header_params_reserved_names_case_insensitive_ignored` は runtime-side のみを検証する `header_runtime_reserved_names_silently_ignored_when_not_declared` に書き換え（spec-side 検証は下記の新規テストに委譲）
  - 新規 5 件: `reserved_header_declaration_{accept_required,content_type_optional,authorization_required,case_insensitive_in_spec,multiple_entries_surface_multiple_errors}_surfaces_spec_error`
  - 受け入れ条件の `required=true` と `required=false` をそれぞれ別 fixture/test で pin

## スコープ外

- per-request validation 側の skip 挙動（caller 送信ヘッダーの silently drop）は現状維持（OAS 準拠）
- `Authorization` の実検証 → #46 (security scheme) 側で対応

## 品質ゲート

- `vendor/bin/phpunit`: 500 tests / 1041 assertions, all passing
- `vendor/bin/phpstan analyse`: level 6, no errors
- `vendor/bin/php-cs-fixer fix --dry-run --diff`: clean

## 関連情報

- Closes #66
- Preceded by: #65 (header validation introduction)