### PR TITLE
refactor(validators): extract shared helpers into Validation\Support (step 1/3 of #68)

### DIFF
--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -4,38 +4,29 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting;
 
-use const FILTER_VALIDATE_INT;
-use const PHP_INT_MAX;
-
-use InvalidArgumentException;
 use LogicException;
-use Opis\JsonSchema\Errors\ErrorFormatter;
-use Opis\JsonSchema\Validator;
-use stdClass;
+use Studio\OpenApiContractTesting\Validation\Support\ContentTypeMatcher;
+use Studio\OpenApiContractTesting\Validation\Support\HeaderNormalizer;
+use Studio\OpenApiContractTesting\Validation\Support\ObjectConverter;
+use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
+use Studio\OpenApiContractTesting\Validation\Support\TypeCoercer;
 
-use function array_is_list;
 use function array_key_exists;
 use function array_key_first;
 use function array_keys;
-use function array_map;
 use function array_values;
 use function count;
-use function filter_var;
 use function get_debug_type;
 use function implode;
 use function in_array;
 use function is_array;
 use function is_int;
-use function is_numeric;
 use function is_scalar;
 use function is_string;
 use function preg_match;
 use function rawurldecode;
 use function sprintf;
-use function str_ends_with;
-use function strstr;
 use function strtolower;
-use function trim;
 
 final class OpenApiRequestValidator
 {
@@ -50,24 +41,11 @@ final class OpenApiRequestValidator
 
     /** @var array<string, OpenApiPathMatcher> */
     private array $pathMatchers = [];
-    private Validator $opisValidator;
-    private ErrorFormatter $errorFormatter;
+    private readonly SchemaValidatorRunner $runner;
 
-    public function __construct(
-        private readonly int $maxErrors = 20,
-    ) {
-        if ($this->maxErrors < 0) {
-            throw new InvalidArgumentException(
-                sprintf('maxErrors must be 0 (unlimited) or a positive integer, got %d.', $this->maxErrors),
-            );
-        }
-
-        $resolvedMaxErrors = $this->maxErrors === 0 ? PHP_INT_MAX : $this->maxErrors;
-        $this->opisValidator = new Validator(
-            max_errors: $resolvedMaxErrors,
-            stop_at_first_error: $resolvedMaxErrors === 1,
-        );
-        $this->errorFormatter = new ErrorFormatter();
+    public function __construct(int $maxErrors = 20)
+    {
+        $this->runner = new SchemaValidatorRunner($maxErrors);
     }
 
     /**
@@ -179,151 +157,6 @@ final class OpenApiRequestValidator
     }
 
     /**
-     * Recursively convert PHP arrays to stdClass objects, matching the
-     * behaviour of json_decode(json_encode($data)) without the intermediate
-     * JSON string allocation.
-     */
-    private static function toObject(mixed $value): mixed
-    {
-        if (!is_array($value)) {
-            return $value;
-        }
-
-        if ($value === [] || array_is_list($value)) {
-            /** @var list<mixed> $value */
-            foreach ($value as $i => $item) {
-                $value[$i] = self::toObject($item);
-            }
-
-            return $value;
-        }
-
-        $object = new stdClass();
-        foreach ($value as $key => $item) {
-            $object->{$key} = self::toObject($item);
-        }
-
-        return $object;
-    }
-
-    /**
-     * Pick the first primitive type from an OAS 3.1 multi-type declaration,
-     * skipping `null`. Returns `null` if no usable string type is found.
-     *
-     * @param array<int|string, mixed> $types
-     */
-    private static function firstPrimitiveType(array $types): ?string
-    {
-        foreach ($types as $candidate) {
-            if (is_string($candidate) && $candidate !== 'null') {
-                return $candidate;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Coerce a URL-sourced string to int.
-     *
-     * `filter_var(FILTER_VALIDATE_INT)` is too permissive for contract testing:
-     * it accepts leading/trailing whitespace (e.g. "5 " → 5) and a leading
-     * sign prefix ("+5" → 5). Combined with rawurldecode these laundering
-     * behaviours would silently pass non-canonical URLs — real servers
-     * typically reject them, creating silent drift between the test harness
-     * and production. Pre-filter with a strict canonical-integer regex:
-     * optional leading `-`, then either `0` or a digit string without a
-     * leading zero. Anything else falls through unchanged so opis can
-     * report a meaningful type error.
-     *
-     * Overflow is still handled by `filter_var` returning `false` for
-     * values exceeding PHP_INT_MAX/MIN.
-     */
-    private static function coerceToInt(string $value): int|string
-    {
-        if (preg_match('/^-?(0|[1-9]\d*)$/', $value) !== 1) {
-            return $value;
-        }
-
-        $result = filter_var($value, FILTER_VALIDATE_INT);
-
-        return is_int($result) ? $result : $value;
-    }
-
-    /**
-     * Scalar-only variant used for path parameters. Path segments arrive as
-     * single strings (OpenAPI default `style: simple`) so array handling is
-     * never appropriate — a spec declaring `type: array` for a path param
-     * would be rejected by opis because the request value is still scalar.
-     *
-     * @param array<string, mixed> $schema
-     */
-    private static function coercePrimitiveValue(mixed $value, array $schema): mixed
-    {
-        $type = $schema['type'] ?? null;
-
-        if (is_array($type)) {
-            $type = self::firstPrimitiveType($type);
-        }
-
-        return self::coercePrimitiveFromType($value, $type);
-    }
-
-    /**
-     * Shared scalar coercion: string → int/float/bool when the target type is
-     * clean, otherwise the original value passes through so opis can report a
-     * meaningful type mismatch.
-     */
-    private static function coercePrimitiveFromType(mixed $value, mixed $type): mixed
-    {
-        if (!is_string($value) || !is_string($type)) {
-            return $value;
-        }
-
-        return match ($type) {
-            'integer' => self::coerceToInt($value),
-            'number' => is_numeric($value) ? (float) $value : $value,
-            'boolean' => match (strtolower($value)) {
-                'true' => true,
-                'false' => false,
-                default => $value,
-            },
-            default => $value,
-        };
-    }
-
-    /**
-     * Lower-case the keys of the caller-supplied headers map. Non-string keys
-     * are skipped — they cannot match any spec name and would cause a
-     * TypeError on strtolower(). Values are returned as-is; array/scalar
-     * discrimination happens in validateHeaderParameters() so the "how many
-     * values" decision is visible at the validation site.
-     *
-     * When two keys collapse to the same lower-case form (e.g. both
-     * `X-Foo` and `x-foo` are present), later entries overwrite earlier ones
-     * — HTTP treats these as the same header so the behaviour matches what
-     * most frameworks surface to application code.
-     *
-     * @param array<array-key, mixed> $headers
-     *
-     * @return array<string, mixed>
-     */
-    private static function normalizeHeaders(array $headers): array
-    {
-        $normalized = [];
-
-        foreach ($headers as $name => $value) {
-            if (!is_string($name)) {
-                continue;
-            }
-
-            $normalized[strtolower($name)] = $value;
-        }
-
-        return $normalized;
-    }
-
-    /**
      * @param string[] $specPaths
      */
     private function getPathMatcher(string $specName, array $specPaths): OpenApiPathMatcher
@@ -386,18 +219,13 @@ final class OpenApiRequestValidator
                 continue;
             }
 
-            $coerced = $this->coerceQueryValue($queryParams[$name], $schema);
+            $coerced = TypeCoercer::coerceQuery($queryParams[$name], $schema);
             $jsonSchema = OpenApiSchemaConverter::convert($schema, $version, SchemaContext::Request);
 
-            $schemaObject = self::toObject($jsonSchema);
-            $dataObject = self::toObject($coerced);
+            $schemaObject = ObjectConverter::convert($jsonSchema);
+            $dataObject = ObjectConverter::convert($coerced);
 
-            $result = $this->opisValidator->validate($dataObject, $schemaObject);
-            if ($result->isValid()) {
-                continue;
-            }
-
-            $formatted = $this->errorFormatter->format($result->error());
+            $formatted = $this->runner->validate($schemaObject, $dataObject);
             foreach ($formatted as $path => $messages) {
                 $suffix = $path === '/' ? '' : $path;
                 foreach ($messages as $message) {
@@ -471,18 +299,13 @@ final class OpenApiRequestValidator
             $schema = $param['schema'];
 
             $decoded = rawurldecode($pathVariables[$name]);
-            $coerced = self::coercePrimitiveValue($decoded, $schema);
+            $coerced = TypeCoercer::coercePrimitive($decoded, $schema);
             $jsonSchema = OpenApiSchemaConverter::convert($schema, $version, SchemaContext::Request);
 
-            $schemaObject = self::toObject($jsonSchema);
-            $dataObject = self::toObject($coerced);
+            $schemaObject = ObjectConverter::convert($jsonSchema);
+            $dataObject = ObjectConverter::convert($coerced);
 
-            $result = $this->opisValidator->validate($dataObject, $schemaObject);
-            if ($result->isValid()) {
-                continue;
-            }
-
-            $formatted = $this->errorFormatter->format($result->error());
+            $formatted = $this->runner->validate($schemaObject, $dataObject);
             foreach ($formatted as $path => $messages) {
                 $suffix = $path === '/' ? '' : $path;
                 foreach ($messages as $message) {
@@ -539,7 +362,7 @@ final class OpenApiRequestValidator
         OpenApiVersion $version,
     ): array {
         $errors = [];
-        $normalizedHeaders = self::normalizeHeaders($headers);
+        $normalizedHeaders = HeaderNormalizer::normalize($headers);
 
         foreach ($parameters as $param) {
             if (($param['in'] ?? null) !== 'header') {
@@ -625,18 +448,13 @@ final class OpenApiRequestValidator
                 continue;
             }
 
-            $coerced = self::coercePrimitiveValue($rawValue, $schema);
+            $coerced = TypeCoercer::coercePrimitive($rawValue, $schema);
             $jsonSchema = OpenApiSchemaConverter::convert($schema, $version, SchemaContext::Request);
 
-            $schemaObject = self::toObject($jsonSchema);
-            $dataObject = self::toObject($coerced);
+            $schemaObject = ObjectConverter::convert($jsonSchema);
+            $dataObject = ObjectConverter::convert($coerced);
 
-            $result = $this->opisValidator->validate($dataObject, $schemaObject);
-            if ($result->isValid()) {
-                continue;
-            }
-
-            $formatted = $this->errorFormatter->format($result->error());
+            $formatted = $this->runner->validate($schemaObject, $dataObject);
             foreach ($formatted as $path => $messages) {
                 $suffix = $path === '/' ? '' : $path;
                 foreach ($messages as $message) {
@@ -726,7 +544,7 @@ final class OpenApiRequestValidator
             ];
         }
 
-        $normalizedHeaders = self::normalizeHeaders($headers);
+        $normalizedHeaders = HeaderNormalizer::normalize($headers);
 
         $hardErrors = [];
         $failureErrors = [];
@@ -1074,39 +892,6 @@ final class OpenApiRequestValidator
     }
 
     /**
-     * Conservatively coerce a query string value to the type declared by the
-     * schema. When the string is not a clean representation of the target
-     * type, the original value is returned unchanged so opis can surface a
-     * meaningful type error rather than silently passing.
-     *
-     * For multi-type schemas (OAS 3.1 `type: ["integer", "null"]`) the first
-     * non-`null` primitive type is used as the coercion target.
-     *
-     * @param array<string, mixed> $schema
-     */
-    private function coerceQueryValue(mixed $value, array $schema): mixed
-    {
-        $type = $schema['type'] ?? null;
-
-        if (is_array($type)) {
-            $type = self::firstPrimitiveType($type);
-        }
-
-        if ($type === 'array') {
-            $value = is_array($value) ? array_values($value) : [$value];
-
-            $itemSchema = $schema['items'] ?? null;
-            if (is_array($itemSchema)) {
-                return array_map(fn(mixed $item): mixed => $this->coerceQueryValue($item, $itemSchema), $value);
-            }
-
-            return $value;
-        }
-
-        return self::coercePrimitiveFromType($value, $type);
-    }
-
-    /**
      * Validate the request body against the operation's `requestBody` schema.
      *
      * Returns an empty list when the body is acceptable (including when the
@@ -1185,10 +970,10 @@ final class OpenApiRequestValidator
         // non-JSON types are checked for spec presence only, while JSON-compatible types
         // fall through to schema validation against the first JSON media type in the spec.
         if ($contentType !== null) {
-            $normalizedType = $this->normalizeMediaType($contentType);
+            $normalizedType = ContentTypeMatcher::normalizeMediaType($contentType);
 
-            if (!$this->isJsonContentType($normalizedType)) {
-                if ($this->isContentTypeInSpec($normalizedType, $content)) {
+            if (!ContentTypeMatcher::isJsonContentType($normalizedType)) {
+                if (ContentTypeMatcher::isContentTypeInSpec($normalizedType, $content)) {
                     return [];
                 }
 
@@ -1205,7 +990,7 @@ final class OpenApiRequestValidator
             // the same regardless of the specific JSON media type.
         }
 
-        $jsonContentType = $this->findJsonContentType($content);
+        $jsonContentType = ContentTypeMatcher::findJsonContentType($content);
 
         // If no JSON-compatible content type is defined, skip body validation.
         // This validator only handles JSON schemas; non-JSON types (e.g. application/xml,
@@ -1232,86 +1017,18 @@ final class OpenApiRequestValidator
         $schema = $content[$jsonContentType]['schema'];
         $jsonSchema = OpenApiSchemaConverter::convert($schema, $version, SchemaContext::Request);
 
-        $schemaObject = self::toObject($jsonSchema);
-        $dataObject = self::toObject($requestBody);
+        $schemaObject = ObjectConverter::convert($jsonSchema);
+        $dataObject = ObjectConverter::convert($requestBody);
 
-        $result = $this->opisValidator->validate($dataObject, $schemaObject);
-
-        if ($result->isValid()) {
-            return [];
-        }
-
-        $formattedErrors = $this->errorFormatter->format($result->error());
+        $formatted = $this->runner->validate($schemaObject, $dataObject);
 
         $errors = [];
-        foreach ($formattedErrors as $path => $messages) {
+        foreach ($formatted as $path => $messages) {
             foreach ($messages as $message) {
                 $errors[] = "[{$path}] {$message}";
             }
         }
 
         return $errors;
-    }
-
-    /**
-     * Find the first JSON-compatible content type from the request body spec.
-     *
-     * Matches "application/json" exactly and any type with a "+json" structured
-     * syntax suffix (RFC 6838), such as "application/problem+json" and
-     * "application/vnd.api+json". Matching is case-insensitive.
-     *
-     * @param array<string, mixed> $content
-     */
-    private function findJsonContentType(array $content): ?string
-    {
-        foreach ($content as $contentType => $mediaType) {
-            $lower = strtolower($contentType);
-
-            if ($this->isJsonContentType($lower)) {
-                return $contentType;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Extract the media type portion before any parameters (e.g. charset),
-     * and return it lower-cased.
-     *
-     * Example: "text/html; charset=utf-8" → "text/html"
-     */
-    private function normalizeMediaType(string $contentType): string
-    {
-        $mediaType = strstr($contentType, ';', true);
-
-        return strtolower(trim($mediaType !== false ? $mediaType : $contentType));
-    }
-
-    /**
-     * Check whether the given (already normalised, lower-cased) request content
-     * type matches any content type key defined in the spec. Spec keys are
-     * lower-cased before comparison.
-     *
-     * @param array<string, mixed> $content
-     */
-    private function isContentTypeInSpec(string $requestContentType, array $content): bool
-    {
-        foreach ($content as $specContentType => $mediaType) {
-            if (strtolower($specContentType) === $requestContentType) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * True for "application/json" or any "+json" structured syntax suffix (RFC 6838).
-     * Expects a lower-cased media type without parameters.
-     */
-    private function isJsonContentType(string $lowerContentType): bool
-    {
-        return $lowerContentType === 'application/json' || str_ends_with($lowerContentType, '+json');
     }
 }

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -4,24 +4,17 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting;
 
-use const PHP_INT_MAX;
-
 use InvalidArgumentException;
-use Opis\JsonSchema\Errors\ErrorFormatter;
-use Opis\JsonSchema\Validator;
-use stdClass;
+use Studio\OpenApiContractTesting\Validation\Support\ContentTypeMatcher;
+use Studio\OpenApiContractTesting\Validation\Support\ObjectConverter;
+use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
 
-use function array_is_list;
 use function array_keys;
 use function implode;
-use function is_array;
 use function preg_last_error_msg;
 use function preg_match;
 use function sprintf;
-use function str_ends_with;
-use function strstr;
 use function strtolower;
-use function trim;
 
 final class OpenApiResponseValidator
 {
@@ -34,8 +27,7 @@ final class OpenApiResponseValidator
 
     /** @var array<string, OpenApiPathMatcher> */
     private array $pathMatchers = [];
-    private Validator $opisValidator;
-    private ErrorFormatter $errorFormatter;
+    private readonly SchemaValidatorRunner $runner;
 
     /** @var array<string, string> Raw pattern (as supplied) => anchored pattern ready for preg_match. */
     private readonly array $skipPatterns;
@@ -48,23 +40,11 @@ final class OpenApiResponseValidator
      *                                    path is still reported so coverage is recorded.
      */
     public function __construct(
-        private readonly int $maxErrors = 20,
+        int $maxErrors = 20,
         array $skipResponseCodes = self::DEFAULT_SKIP_RESPONSE_CODES,
     ) {
-        if ($this->maxErrors < 0) {
-            throw new InvalidArgumentException(
-                sprintf('maxErrors must be 0 (unlimited) or a positive integer, got %d.', $this->maxErrors),
-            );
-        }
-
         $this->skipPatterns = self::compileSkipPatterns($skipResponseCodes);
-
-        $resolvedMaxErrors = $this->maxErrors === 0 ? PHP_INT_MAX : $this->maxErrors;
-        $this->opisValidator = new Validator(
-            max_errors: $resolvedMaxErrors,
-            stop_at_first_error: $resolvedMaxErrors === 1,
-        );
-        $this->errorFormatter = new ErrorFormatter();
+        $this->runner = new SchemaValidatorRunner($maxErrors);
     }
 
     public function validate(
@@ -135,11 +115,11 @@ final class OpenApiResponseValidator
         // non-JSON types are checked for spec presence only, while JSON-compatible types
         // fall through to schema validation against the first JSON media type in the spec.
         if ($responseContentType !== null) {
-            $normalizedType = $this->normalizeMediaType($responseContentType);
+            $normalizedType = ContentTypeMatcher::normalizeMediaType($responseContentType);
 
-            if (!$this->isJsonContentType($normalizedType)) {
+            if (!ContentTypeMatcher::isJsonContentType($normalizedType)) {
                 // Non-JSON response: check if the content type is defined in the spec.
-                if ($this->isContentTypeInSpec($normalizedType, $content)) {
+                if (ContentTypeMatcher::isContentTypeInSpec($normalizedType, $content)) {
                     return OpenApiValidationResult::success($matchedPath);
                 }
 
@@ -156,7 +136,7 @@ final class OpenApiResponseValidator
             // the same regardless of the specific JSON media type.
         }
 
-        $jsonContentType = $this->findJsonContentType($content);
+        $jsonContentType = ContentTypeMatcher::findJsonContentType($content);
 
         // If no JSON-compatible content type is defined, skip body validation.
         // This validator only handles JSON schemas; non-JSON types (e.g. text/html,
@@ -179,19 +159,17 @@ final class OpenApiResponseValidator
         $schema = $content[$jsonContentType]['schema'];
         $jsonSchema = OpenApiSchemaConverter::convert($schema, $version, SchemaContext::Response);
 
-        $schemaObject = self::toObject($jsonSchema);
-        $dataObject = self::toObject($responseBody);
+        $schemaObject = ObjectConverter::convert($jsonSchema);
+        $dataObject = ObjectConverter::convert($responseBody);
 
-        $result = $this->opisValidator->validate($dataObject, $schemaObject);
+        $formatted = $this->runner->validate($schemaObject, $dataObject);
 
-        if ($result->isValid()) {
+        if ($formatted === []) {
             return OpenApiValidationResult::success($matchedPath);
         }
 
-        $formattedErrors = $this->errorFormatter->format($result->error());
-
         $errors = [];
-        foreach ($formattedErrors as $path => $messages) {
+        foreach ($formatted as $path => $messages) {
             foreach ($messages as $message) {
                 $errors[] = "[{$path}] {$message}";
             }
@@ -241,34 +219,6 @@ final class OpenApiResponseValidator
     }
 
     /**
-     * Recursively convert PHP arrays to stdClass objects, matching the
-     * behaviour of json_decode(json_encode($data)) without the intermediate
-     * JSON string allocation.
-     */
-    private static function toObject(mixed $value): mixed
-    {
-        if (!is_array($value)) {
-            return $value;
-        }
-
-        if ($value === [] || array_is_list($value)) {
-            /** @var list<mixed> $value */
-            foreach ($value as $i => $item) {
-                $value[$i] = self::toObject($item);
-            }
-
-            return $value;
-        }
-
-        $object = new stdClass();
-        foreach ($value as $key => $item) {
-            $object->{$key} = self::toObject($item);
-        }
-
-        return $object;
-    }
-
-    /**
      * Returns the raw pattern (as supplied by the caller) that matched, or
      * null if no pattern matched. `preg_match` returning false (runtime
      * failure) is impossible in practice because compileSkipPatterns already
@@ -296,67 +246,5 @@ final class OpenApiResponseValidator
     private function getPathMatcher(string $specName, array $specPaths): OpenApiPathMatcher
     {
         return $this->pathMatchers[$specName] ??= new OpenApiPathMatcher($specPaths, OpenApiSpecLoader::getStripPrefixes());
-    }
-
-    /**
-     * Find the first JSON-compatible content type from the response spec.
-     *
-     * Matches "application/json" exactly and any type with a "+json" structured
-     * syntax suffix (RFC 6838), such as "application/problem+json" and
-     * "application/vnd.api+json". Matching is case-insensitive.
-     *
-     * @param array<string, array<string, mixed>> $content
-     */
-    private function findJsonContentType(array $content): ?string
-    {
-        foreach ($content as $contentType => $mediaType) {
-            $lower = strtolower($contentType);
-
-            if ($this->isJsonContentType($lower)) {
-                return $contentType;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Extract the media type portion before any parameters (e.g. charset),
-     * and return it lower-cased.
-     *
-     * Example: "text/html; charset=utf-8" → "text/html"
-     */
-    private function normalizeMediaType(string $contentType): string
-    {
-        $mediaType = strstr($contentType, ';', true);
-
-        return strtolower(trim($mediaType !== false ? $mediaType : $contentType));
-    }
-
-    /**
-     * Check whether the given (already normalised, lower-cased) response content
-     * type matches any content type key defined in the spec. Spec keys are
-     * lower-cased before comparison.
-     *
-     * @param array<string, array<string, mixed>> $content
-     */
-    private function isContentTypeInSpec(string $responseContentType, array $content): bool
-    {
-        foreach ($content as $specContentType => $mediaType) {
-            if (strtolower($specContentType) === $responseContentType) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * True for "application/json" or any "+json" structured syntax suffix (RFC 6838).
-     * Expects a lower-cased media type without parameters.
-     */
-    private function isJsonContentType(string $lowerContentType): bool
-    {
-        return $lowerContentType === 'application/json' || str_ends_with($lowerContentType, '+json');
     }
 }

--- a/src/Validation/Support/ContentTypeMatcher.php
+++ b/src/Validation/Support/ContentTypeMatcher.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Validation\Support;
+
+use function str_ends_with;
+use function strstr;
+use function strtolower;
+use function trim;
+
+final class ContentTypeMatcher
+{
+    /**
+     * Find the first JSON-compatible content type key in the spec's
+     * `content` map.
+     *
+     * Matches "application/json" exactly and any type with a "+json" structured
+     * syntax suffix (RFC 6838), such as "application/problem+json" and
+     * "application/vnd.api+json". Matching is case-insensitive.
+     *
+     * @param array<string, mixed> $content
+     */
+    public static function findJsonContentType(array $content): ?string
+    {
+        foreach ($content as $contentType => $_mediaType) {
+            $lower = strtolower($contentType);
+
+            if (self::isJsonContentType($lower)) {
+                return $contentType;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Extract the media type portion before any parameters (e.g. charset),
+     * and return it lower-cased.
+     *
+     * Example: "text/html; charset=utf-8" → "text/html"
+     */
+    public static function normalizeMediaType(string $contentType): string
+    {
+        $mediaType = strstr($contentType, ';', true);
+
+        return strtolower(trim($mediaType !== false ? $mediaType : $contentType));
+    }
+
+    /**
+     * Check whether the given (already normalised, lower-cased) content type
+     * matches any content type key defined in the spec. Spec keys are
+     * lower-cased before comparison.
+     *
+     * @param array<string, mixed> $content
+     */
+    public static function isContentTypeInSpec(string $normalizedContentType, array $content): bool
+    {
+        foreach ($content as $specContentType => $_mediaType) {
+            if (strtolower($specContentType) === $normalizedContentType) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * True for "application/json" or any "+json" structured syntax suffix (RFC 6838).
+     * Expects a lower-cased media type without parameters.
+     */
+    public static function isJsonContentType(string $lowerContentType): bool
+    {
+        return $lowerContentType === 'application/json' || str_ends_with($lowerContentType, '+json');
+    }
+}

--- a/src/Validation/Support/HeaderNormalizer.php
+++ b/src/Validation/Support/HeaderNormalizer.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Validation\Support;
+
+use function is_string;
+use function strtolower;
+
+final class HeaderNormalizer
+{
+    /**
+     * Lower-case the keys of the caller-supplied headers map. Non-string keys
+     * are skipped — they cannot match any spec name and would cause a
+     * TypeError on strtolower(). Values are returned as-is; array/scalar
+     * discrimination happens at the validation site so the "how many values"
+     * decision is visible there.
+     *
+     * When two keys collapse to the same lower-case form (e.g. both
+     * `X-Foo` and `x-foo` are present), later entries overwrite earlier ones
+     * — HTTP treats these as the same header so the behaviour matches what
+     * most frameworks surface to application code.
+     *
+     * @param array<array-key, mixed> $headers
+     *
+     * @return array<string, mixed>
+     */
+    public static function normalize(array $headers): array
+    {
+        $normalized = [];
+
+        foreach ($headers as $name => $value) {
+            if (!is_string($name)) {
+                continue;
+            }
+
+            $normalized[strtolower($name)] = $value;
+        }
+
+        return $normalized;
+    }
+}

--- a/src/Validation/Support/ObjectConverter.php
+++ b/src/Validation/Support/ObjectConverter.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Validation\Support;
+
+use stdClass;
+
+use function array_is_list;
+use function is_array;
+
+final class ObjectConverter
+{
+    /**
+     * Recursively convert PHP arrays to stdClass objects, matching the
+     * behaviour of json_decode(json_encode($data)) without the intermediate
+     * JSON string allocation.
+     *
+     * Associative arrays (including those with numeric string keys like "200")
+     * become stdClass. Lists and empty arrays remain arrays. Non-array values
+     * pass through unchanged.
+     */
+    public static function convert(mixed $value): mixed
+    {
+        if (!is_array($value)) {
+            return $value;
+        }
+
+        if ($value === [] || array_is_list($value)) {
+            /** @var list<mixed> $value */
+            foreach ($value as $i => $item) {
+                $value[$i] = self::convert($item);
+            }
+
+            return $value;
+        }
+
+        $object = new stdClass();
+        foreach ($value as $key => $item) {
+            $object->{$key} = self::convert($item);
+        }
+
+        return $object;
+    }
+}

--- a/src/Validation/Support/SchemaValidatorRunner.php
+++ b/src/Validation/Support/SchemaValidatorRunner.php
@@ -34,13 +34,17 @@ final class SchemaValidatorRunner
     }
 
     /**
-     * Validate `$data` against `$jsonSchema` (both already converted to
-     * stdClass via {@see ObjectConverter::convert()}) and return a map of
-     * JSON Pointer path → list of human-readable error messages.
+     * Validate `$data` against `$jsonSchema` (typically both converted via
+     * {@see ObjectConverter::convert()}, although opis also accepts `true` /
+     * `false` top-level schemas and raw scalars) and return a map of JSON
+     * Pointer path → list of human-readable error messages.
      *
      * An empty array means the data validated successfully. The pointer key
      * matches opis's ErrorFormatter output, with `/` indicating the document
-     * root.
+     * root. Success is determined by `ValidationResult::isValid()` rather
+     * than by the formatter output shape, so a future opis change that
+     * returned `[]` for a suppressed/filtered error would still be reported
+     * as a failure (no silent pass).
      *
      * @return array<string, string[]>
      */
@@ -52,6 +56,17 @@ final class SchemaValidatorRunner
             return [];
         }
 
-        return $this->errorFormatter->format($result->error());
+        $error = $result->error();
+        if ($error === null) {
+            // Defensive: ValidationResult::isValid() is defined as
+            // `$this->error === null`, so this branch is unreachable today.
+            // Return a synthetic entry rather than letting a null slip to
+            // ErrorFormatter::format() and producing a TypeError, so the
+            // validator still surfaces *something* if the opis invariant
+            // ever changes.
+            return ['/' => ['Schema validation failed but opis reported no error detail.']];
+        }
+
+        return $this->errorFormatter->format($error);
     }
 }

--- a/src/Validation/Support/SchemaValidatorRunner.php
+++ b/src/Validation/Support/SchemaValidatorRunner.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Validation\Support;
+
+use const PHP_INT_MAX;
+
+use InvalidArgumentException;
+use Opis\JsonSchema\Errors\ErrorFormatter;
+use Opis\JsonSchema\Validator;
+
+use function sprintf;
+
+final class SchemaValidatorRunner
+{
+    private readonly Validator $opisValidator;
+    private readonly ErrorFormatter $errorFormatter;
+
+    public function __construct(int $maxErrors)
+    {
+        if ($maxErrors < 0) {
+            throw new InvalidArgumentException(
+                sprintf('maxErrors must be 0 (unlimited) or a positive integer, got %d.', $maxErrors),
+            );
+        }
+
+        $resolvedMaxErrors = $maxErrors === 0 ? PHP_INT_MAX : $maxErrors;
+        $this->opisValidator = new Validator(
+            max_errors: $resolvedMaxErrors,
+            stop_at_first_error: $resolvedMaxErrors === 1,
+        );
+        $this->errorFormatter = new ErrorFormatter();
+    }
+
+    /**
+     * Validate `$data` against `$jsonSchema` (both already converted to
+     * stdClass via {@see ObjectConverter::convert()}) and return a map of
+     * JSON Pointer path → list of human-readable error messages.
+     *
+     * An empty array means the data validated successfully. The pointer key
+     * matches opis's ErrorFormatter output, with `/` indicating the document
+     * root.
+     *
+     * @return array<string, string[]>
+     */
+    public function validate(mixed $jsonSchema, mixed $data): array
+    {
+        $result = $this->opisValidator->validate($data, $jsonSchema);
+
+        if ($result->isValid()) {
+            return [];
+        }
+
+        return $this->errorFormatter->format($result->error());
+    }
+}

--- a/src/Validation/Support/TypeCoercer.php
+++ b/src/Validation/Support/TypeCoercer.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Validation\Support;
+
+use const FILTER_VALIDATE_INT;
+
+use function array_map;
+use function array_values;
+use function filter_var;
+use function is_array;
+use function is_int;
+use function is_numeric;
+use function is_string;
+use function preg_match;
+use function strtolower;
+
+final class TypeCoercer
+{
+    /**
+     * Pick the first primitive type from an OAS 3.1 multi-type declaration,
+     * skipping `null`. Returns `null` if no usable string type is found.
+     *
+     * @param array<int|string, mixed> $types
+     */
+    public static function firstPrimitiveType(array $types): ?string
+    {
+        foreach ($types as $candidate) {
+            if (is_string($candidate) && $candidate !== 'null') {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Scalar-only variant used for path / header parameters. The input arrives
+     * as a single string (OpenAPI default `style: simple`) so array handling
+     * is never appropriate — a spec declaring `type: array` for such a param
+     * would be rejected by opis because the request value is still scalar.
+     *
+     * @param array<string, mixed> $schema
+     */
+    public static function coercePrimitive(mixed $value, array $schema): mixed
+    {
+        $type = $schema['type'] ?? null;
+
+        if (is_array($type)) {
+            $type = self::firstPrimitiveType($type);
+        }
+
+        return self::coercePrimitiveFromType($value, $type);
+    }
+
+    /**
+     * Shared scalar coercion: string → int/float/bool when the target type is
+     * clean, otherwise the original value passes through so opis can report a
+     * meaningful type mismatch.
+     */
+    public static function coercePrimitiveFromType(mixed $value, mixed $type): mixed
+    {
+        if (!is_string($value) || !is_string($type)) {
+            return $value;
+        }
+
+        return match ($type) {
+            'integer' => self::coerceToInt($value),
+            'number' => is_numeric($value) ? (float) $value : $value,
+            'boolean' => match (strtolower($value)) {
+                'true' => true,
+                'false' => false,
+                default => $value,
+            },
+            default => $value,
+        };
+    }
+
+    /**
+     * Conservatively coerce a query string value to the type declared by the
+     * schema. When the string is not a clean representation of the target
+     * type, the original value is returned unchanged so opis can surface a
+     * meaningful type error rather than silently passing.
+     *
+     * For multi-type schemas (OAS 3.1 `type: ["integer", "null"]`) the first
+     * non-`null` primitive type is used as the coercion target. For
+     * `type: array`, each item is coerced against the declared `items` schema.
+     *
+     * @param array<string, mixed> $schema
+     */
+    public static function coerceQuery(mixed $value, array $schema): mixed
+    {
+        $type = $schema['type'] ?? null;
+
+        if (is_array($type)) {
+            $type = self::firstPrimitiveType($type);
+        }
+
+        if ($type === 'array') {
+            $value = is_array($value) ? array_values($value) : [$value];
+
+            $itemSchema = $schema['items'] ?? null;
+            if (is_array($itemSchema)) {
+                return array_map(static fn(mixed $item): mixed => self::coerceQuery($item, $itemSchema), $value);
+            }
+
+            return $value;
+        }
+
+        return self::coercePrimitiveFromType($value, $type);
+    }
+
+    /**
+     * Coerce a URL-sourced string to int.
+     *
+     * `filter_var(FILTER_VALIDATE_INT)` is too permissive for contract testing:
+     * it accepts leading/trailing whitespace (e.g. "5 " → 5) and a leading
+     * sign prefix ("+5" → 5). Combined with rawurldecode these laundering
+     * behaviours would silently pass non-canonical URLs — real servers
+     * typically reject them, creating silent drift between the test harness
+     * and production. Pre-filter with a strict canonical-integer regex:
+     * optional leading `-`, then either `0` or a digit string without a
+     * leading zero. Anything else falls through unchanged so opis can
+     * report a meaningful type error.
+     *
+     * Overflow is still handled by `filter_var` returning `false` for
+     * values exceeding PHP_INT_MAX/MIN.
+     */
+    public static function coerceToInt(string $value): int|string
+    {
+        if (preg_match('/^-?(0|[1-9]\d*)$/', $value) !== 1) {
+            return $value;
+        }
+
+        $result = filter_var($value, FILTER_VALIDATE_INT);
+
+        return is_int($result) ? $result : $value;
+    }
+}

--- a/src/Validation/Support/TypeCoercer.php
+++ b/src/Validation/Support/TypeCoercer.php
@@ -112,20 +112,20 @@ final class TypeCoercer
     }
 
     /**
-     * Coerce a URL-sourced string to int.
+     * Coerce a scalar string (from a path / header / query parameter) to int.
      *
      * `filter_var(FILTER_VALIDATE_INT)` is too permissive for contract testing:
      * it accepts leading/trailing whitespace (e.g. "5 " → 5) and a leading
-     * sign prefix ("+5" → 5). Combined with rawurldecode these laundering
-     * behaviours would silently pass non-canonical URLs — real servers
-     * typically reject them, creating silent drift between the test harness
-     * and production. Pre-filter with a strict canonical-integer regex:
-     * optional leading `-`, then either `0` or a digit string without a
-     * leading zero. Anything else falls through unchanged so opis can
-     * report a meaningful type error.
+     * sign prefix ("+5" → 5). Accepting those laundering behaviours would
+     * silently pass non-canonical values that real servers typically reject,
+     * creating silent drift between the test harness and production. Pre-filter
+     * with a strict canonical-integer regex: optional leading `-`, then either
+     * `0` or a digit string without a leading zero. Anything else falls through
+     * unchanged so opis can report a meaningful type error.
      *
-     * Overflow is still handled by `filter_var` returning `false` for
-     * values exceeding PHP_INT_MAX/MIN.
+     * Overflow is handled the same way: values exceeding PHP_INT_MAX/MIN
+     * cause `filter_var` to return `false`, and the original string is
+     * returned so opis surfaces the type mismatch.
      */
     public static function coerceToInt(string $value): int|string
     {

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -4,20 +4,16 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Tests\Unit;
 
-use const JSON_THROW_ON_ERROR;
-
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use ReflectionMethod;
 use Studio\OpenApiContractTesting\OpenApiResponseValidator;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
 
 use function array_map;
 use function count;
 use function implode;
-use function json_encode;
 use function range;
 
 class OpenApiResponseValidatorTest extends TestCase
@@ -36,42 +32,6 @@ class OpenApiResponseValidatorTest extends TestCase
     {
         OpenApiSpecLoader::reset();
         parent::tearDown();
-    }
-
-    // ========================================
-    // toObject equivalence tests
-    // ========================================
-
-    /**
-     * @return iterable<string, array{mixed}>
-     */
-    public static function provideTo_object_matches_json_roundtripCases(): iterable
-    {
-        yield 'null' => [null];
-        yield 'string' => ['hello'];
-        yield 'integer' => [42];
-        yield 'float' => [3.14];
-        yield 'boolean true' => [true];
-        yield 'boolean false' => [false];
-        yield 'empty array' => [[]];
-        yield 'sequential array' => [[1, 2, 3]];
-        yield 'associative array' => [['key' => 'value', 'num' => 1]];
-        yield 'nested associative' => [['a' => ['b' => ['c' => 'deep']]]];
-        yield 'list of objects' => [[['id' => 1, 'name' => 'a'], ['id' => 2, 'name' => 'b']]];
-        yield 'non-sequential int keys' => [[1 => 'a', 3 => 'b']];
-        yield 'mixed nested' => [
-            [
-                'users' => [
-                    ['id' => 1, 'tags' => ['admin', 'user'], 'meta' => ['active' => true]],
-                ],
-                'total' => 1,
-                'filters' => [],
-            ],
-        ];
-        yield 'numeric string keys' => [['200' => ['description' => 'OK']]];
-        yield 'deeply nested list' => [[[['a']]]];
-        yield 'null in array' => [[null, 'a', null]];
-        yield 'empty nested object' => [['data' => []]];
     }
 
     /**
@@ -1126,21 +1086,5 @@ class OpenApiResponseValidatorTest extends TestCase
         );
 
         $this->assertTrue($result->isValid(), 'errors: ' . implode(' | ', $result->errors()));
-    }
-
-    #[Test]
-    #[DataProvider('provideTo_object_matches_json_roundtripCases')]
-    public function to_object_matches_json_roundtrip(mixed $input): void
-    {
-        $method = new ReflectionMethod(OpenApiResponseValidator::class, 'toObject');
-
-        $actual = $method->invoke(null, $input);
-
-        // Re-encode both to JSON to compare structural equivalence
-        // without relying on object identity (assertSame fails on stdClass).
-        $expectedJson = json_encode($input, JSON_THROW_ON_ERROR);
-        $actualJson = (string) json_encode($actual, JSON_THROW_ON_ERROR);
-
-        $this->assertSame($expectedJson, $actualJson);
     }
 }

--- a/tests/Unit/Validation/Support/ContentTypeMatcherTest.php
+++ b/tests/Unit/Validation/Support/ContentTypeMatcherTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Validation\Support;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Validation\Support\ContentTypeMatcher;
+
+class ContentTypeMatcherTest extends TestCase
+{
+    #[Test]
+    public function is_json_content_type_accepts_application_json(): void
+    {
+        $this->assertTrue(ContentTypeMatcher::isJsonContentType('application/json'));
+    }
+
+    #[Test]
+    public function is_json_content_type_accepts_plus_json_suffix(): void
+    {
+        $this->assertTrue(ContentTypeMatcher::isJsonContentType('application/problem+json'));
+        $this->assertTrue(ContentTypeMatcher::isJsonContentType('application/vnd.api+json'));
+    }
+
+    #[Test]
+    public function is_json_content_type_rejects_non_json(): void
+    {
+        $this->assertFalse(ContentTypeMatcher::isJsonContentType('text/html'));
+        $this->assertFalse(ContentTypeMatcher::isJsonContentType('application/xml'));
+    }
+
+    #[Test]
+    public function find_json_content_type_returns_first_json_key(): void
+    {
+        $content = [
+            'text/html' => [],
+            'application/json' => [],
+            'application/vnd.api+json' => [],
+        ];
+
+        $this->assertSame('application/json', ContentTypeMatcher::findJsonContentType($content));
+    }
+
+    #[Test]
+    public function find_json_content_type_returns_null_when_no_json_defined(): void
+    {
+        $this->assertNull(ContentTypeMatcher::findJsonContentType(['text/html' => [], 'application/xml' => []]));
+    }
+
+    #[Test]
+    public function normalize_media_type_strips_parameters_and_lowercases(): void
+    {
+        $this->assertSame('text/html', ContentTypeMatcher::normalizeMediaType('Text/HTML; charset=utf-8'));
+        $this->assertSame('application/json', ContentTypeMatcher::normalizeMediaType(' application/json '));
+    }
+
+    #[Test]
+    public function is_content_type_in_spec_matches_case_insensitively(): void
+    {
+        $content = ['Application/JSON' => [], 'Text/Html' => []];
+
+        $this->assertTrue(ContentTypeMatcher::isContentTypeInSpec('application/json', $content));
+        $this->assertTrue(ContentTypeMatcher::isContentTypeInSpec('text/html', $content));
+        $this->assertFalse(ContentTypeMatcher::isContentTypeInSpec('application/xml', $content));
+    }
+}

--- a/tests/Unit/Validation/Support/HeaderNormalizerTest.php
+++ b/tests/Unit/Validation/Support/HeaderNormalizerTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Validation\Support;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Validation\Support\HeaderNormalizer;
+
+class HeaderNormalizerTest extends TestCase
+{
+    #[Test]
+    public function normalize_lower_cases_string_keys(): void
+    {
+        $result = HeaderNormalizer::normalize(['X-Request-Id' => 'abc', 'Content-Type' => 'application/json']);
+
+        $this->assertSame(
+            ['x-request-id' => 'abc', 'content-type' => 'application/json'],
+            $result,
+        );
+    }
+
+    #[Test]
+    public function normalize_drops_non_string_keys(): void
+    {
+        $result = HeaderNormalizer::normalize([0 => 'numeric', 'X-Foo' => 'bar']);
+
+        $this->assertSame(['x-foo' => 'bar'], $result);
+    }
+
+    #[Test]
+    public function normalize_collapses_duplicate_case_variants(): void
+    {
+        // Later entry wins — HTTP treats these as the same header.
+        $result = HeaderNormalizer::normalize(['X-Foo' => 'first', 'x-foo' => 'second']);
+
+        $this->assertSame(['x-foo' => 'second'], $result);
+    }
+
+    #[Test]
+    public function normalize_preserves_value_shape(): void
+    {
+        $result = HeaderNormalizer::normalize(['X-Multi' => ['a', 'b']]);
+
+        $this->assertSame(['x-multi' => ['a', 'b']], $result);
+    }
+}

--- a/tests/Unit/Validation/Support/ObjectConverterTest.php
+++ b/tests/Unit/Validation/Support/ObjectConverterTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Validation\Support;
+
+use const JSON_THROW_ON_ERROR;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Studio\OpenApiContractTesting\Validation\Support\ObjectConverter;
+
+use function json_encode;
+
+class ObjectConverterTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{mixed}>
+     */
+    public static function provideConvert_matches_json_roundtripCases(): iterable
+    {
+        yield 'null' => [null];
+        yield 'string' => ['hello'];
+        yield 'integer' => [42];
+        yield 'float' => [3.14];
+        yield 'boolean true' => [true];
+        yield 'boolean false' => [false];
+        yield 'empty array' => [[]];
+        yield 'sequential array' => [[1, 2, 3]];
+        yield 'associative array' => [['key' => 'value', 'num' => 1]];
+        yield 'nested associative' => [['a' => ['b' => ['c' => 'deep']]]];
+        yield 'list of objects' => [[['id' => 1, 'name' => 'a'], ['id' => 2, 'name' => 'b']]];
+        yield 'non-sequential int keys' => [[1 => 'a', 3 => 'b']];
+        yield 'mixed nested' => [
+            [
+                'users' => [
+                    ['id' => 1, 'tags' => ['admin', 'user'], 'meta' => ['active' => true]],
+                ],
+                'total' => 1,
+                'filters' => [],
+            ],
+        ];
+        yield 'numeric string keys' => [['200' => ['description' => 'OK']]];
+        yield 'deeply nested list' => [[[['a']]]];
+        yield 'null in array' => [[null, 'a', null]];
+        yield 'empty nested object' => [['data' => []]];
+    }
+
+    #[Test]
+    #[DataProvider('provideConvert_matches_json_roundtripCases')]
+    public function convert_matches_json_roundtrip(mixed $input): void
+    {
+        $actual = ObjectConverter::convert($input);
+
+        // Re-encode both to JSON to compare structural equivalence
+        // without relying on object identity (assertSame fails on stdClass).
+        $expectedJson = json_encode($input, JSON_THROW_ON_ERROR);
+        $actualJson = (string) json_encode($actual, JSON_THROW_ON_ERROR);
+
+        $this->assertSame($expectedJson, $actualJson);
+    }
+
+    #[Test]
+    public function convert_returns_scalars_untouched(): void
+    {
+        $this->assertSame('x', ObjectConverter::convert('x'));
+        $this->assertSame(7, ObjectConverter::convert(7));
+        $this->assertNull(ObjectConverter::convert(null));
+    }
+
+    #[Test]
+    public function convert_turns_associative_array_into_stdclass(): void
+    {
+        $result = ObjectConverter::convert(['a' => 1, 'b' => 2]);
+
+        $this->assertInstanceOf(stdClass::class, $result);
+        $this->assertSame(1, $result->a);
+        $this->assertSame(2, $result->b);
+    }
+
+    #[Test]
+    public function convert_keeps_sequential_list_as_array(): void
+    {
+        $result = ObjectConverter::convert(['x', 'y']);
+
+        $this->assertSame(['x', 'y'], $result);
+    }
+}

--- a/tests/Unit/Validation/Support/SchemaValidatorRunnerTest.php
+++ b/tests/Unit/Validation/Support/SchemaValidatorRunnerTest.php
@@ -10,6 +10,8 @@ use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\Validation\Support\ObjectConverter;
 use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
 
+use function count;
+
 class SchemaValidatorRunnerTest extends TestCase
 {
     #[Test]
@@ -66,5 +68,29 @@ class SchemaValidatorRunnerTest extends TestCase
         $runner = new SchemaValidatorRunner(0);
 
         $this->assertSame([], $runner->validate(ObjectConverter::convert(['type' => 'string']), 'ok'));
+    }
+
+    #[Test]
+    public function max_errors_one_stops_at_first_error(): void
+    {
+        // Pin the `stop_at_first_error: true` branch that the constructor
+        // enables when maxErrors === 1. With two independent violations, the
+        // capped runner must return exactly one error; the uncapped runner
+        // must surface both.
+        $schema = ObjectConverter::convert([
+            'type' => 'object',
+            'properties' => [
+                'a' => ['type' => 'integer'],
+                'b' => ['type' => 'integer'],
+            ],
+            'required' => ['a', 'b'],
+        ]);
+        $data = ObjectConverter::convert(['a' => 'not-int', 'b' => 'also-not-int']);
+
+        $cappedErrors = (new SchemaValidatorRunner(1))->validate($schema, $data);
+        $uncappedErrors = (new SchemaValidatorRunner(20))->validate($schema, $data);
+
+        $this->assertCount(1, $cappedErrors);
+        $this->assertGreaterThan(1, count($uncappedErrors));
     }
 }

--- a/tests/Unit/Validation/Support/SchemaValidatorRunnerTest.php
+++ b/tests/Unit/Validation/Support/SchemaValidatorRunnerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Validation\Support;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Validation\Support\ObjectConverter;
+use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
+
+class SchemaValidatorRunnerTest extends TestCase
+{
+    #[Test]
+    public function validate_returns_empty_array_for_valid_data(): void
+    {
+        $runner = new SchemaValidatorRunner(20);
+        $schema = ObjectConverter::convert(['type' => 'integer']);
+
+        $this->assertSame([], $runner->validate($schema, 42));
+    }
+
+    #[Test]
+    public function validate_returns_formatted_errors_for_invalid_data(): void
+    {
+        $runner = new SchemaValidatorRunner(20);
+        $schema = ObjectConverter::convert(['type' => 'integer']);
+
+        $errors = $runner->validate($schema, 'not-an-int');
+
+        $this->assertNotSame([], $errors);
+        $this->assertArrayHasKey('/', $errors);
+    }
+
+    #[Test]
+    public function validate_returns_nested_pointer_paths(): void
+    {
+        $runner = new SchemaValidatorRunner(20);
+        $schema = ObjectConverter::convert([
+            'type' => 'object',
+            'properties' => [
+                'count' => ['type' => 'integer'],
+            ],
+            'required' => ['count'],
+        ]);
+        $data = ObjectConverter::convert(['count' => 'not-an-int']);
+
+        $errors = $runner->validate($schema, $data);
+
+        $this->assertArrayHasKey('/count', $errors);
+    }
+
+    #[Test]
+    public function constructor_rejects_negative_max_errors(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('maxErrors must be 0 (unlimited) or a positive integer, got -1.');
+
+        new SchemaValidatorRunner(-1);
+    }
+
+    #[Test]
+    public function constructor_accepts_zero_as_unlimited(): void
+    {
+        $runner = new SchemaValidatorRunner(0);
+
+        $this->assertSame([], $runner->validate(ObjectConverter::convert(['type' => 'string']), 'ok'));
+    }
+}

--- a/tests/Unit/Validation/Support/TypeCoercerTest.php
+++ b/tests/Unit/Validation/Support/TypeCoercerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Validation\Support;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Validation\Support\TypeCoercer;
+
+class TypeCoercerTest extends TestCase
+{
+    #[Test]
+    public function first_primitive_type_skips_null(): void
+    {
+        $this->assertSame('integer', TypeCoercer::firstPrimitiveType(['null', 'integer']));
+        $this->assertSame('string', TypeCoercer::firstPrimitiveType(['string']));
+    }
+
+    #[Test]
+    public function first_primitive_type_returns_null_when_only_null_present(): void
+    {
+        $this->assertNull(TypeCoercer::firstPrimitiveType(['null']));
+        $this->assertNull(TypeCoercer::firstPrimitiveType([]));
+    }
+
+    #[Test]
+    public function coerce_to_int_converts_canonical_digits(): void
+    {
+        $this->assertSame(0, TypeCoercer::coerceToInt('0'));
+        $this->assertSame(42, TypeCoercer::coerceToInt('42'));
+        $this->assertSame(-7, TypeCoercer::coerceToInt('-7'));
+    }
+
+    #[Test]
+    public function coerce_to_int_rejects_non_canonical(): void
+    {
+        // Leading zero, whitespace, plus sign, decimal — all pass through untouched.
+        $this->assertSame('05', TypeCoercer::coerceToInt('05'));
+        $this->assertSame('5 ', TypeCoercer::coerceToInt('5 '));
+        $this->assertSame('+5', TypeCoercer::coerceToInt('+5'));
+        $this->assertSame('3.14', TypeCoercer::coerceToInt('3.14'));
+        $this->assertSame('abc', TypeCoercer::coerceToInt('abc'));
+    }
+
+    #[Test]
+    public function coerce_primitive_from_type_handles_boolean_and_number(): void
+    {
+        $this->assertTrue(TypeCoercer::coercePrimitiveFromType('true', 'boolean'));
+        $this->assertFalse(TypeCoercer::coercePrimitiveFromType('FALSE', 'boolean'));
+        $this->assertSame(3.14, TypeCoercer::coercePrimitiveFromType('3.14', 'number'));
+        $this->assertSame('maybe', TypeCoercer::coercePrimitiveFromType('maybe', 'boolean'));
+    }
+
+    #[Test]
+    public function coerce_primitive_uses_first_primitive_type_for_multi_type_schema(): void
+    {
+        $schema = ['type' => ['null', 'integer']];
+
+        $this->assertSame(42, TypeCoercer::coercePrimitive('42', $schema));
+    }
+
+    #[Test]
+    public function coerce_query_handles_array_type(): void
+    {
+        $schema = ['type' => 'array', 'items' => ['type' => 'integer']];
+
+        $this->assertSame([1, 2, 3], TypeCoercer::coerceQuery(['1', '2', '3'], $schema));
+    }
+
+    #[Test]
+    public function coerce_query_wraps_scalar_when_type_is_array(): void
+    {
+        $schema = ['type' => 'array', 'items' => ['type' => 'integer']];
+
+        $this->assertSame([5], TypeCoercer::coerceQuery('5', $schema));
+    }
+}

--- a/tests/Unit/Validation/Support/TypeCoercerTest.php
+++ b/tests/Unit/Validation/Support/TypeCoercerTest.php
@@ -44,6 +44,18 @@ class TypeCoercerTest extends TestCase
     }
 
     #[Test]
+    public function coerce_to_int_falls_back_to_string_on_overflow(): void
+    {
+        // A canonical-integer shape that exceeds PHP_INT_MAX: the regex passes
+        // but `filter_var` returns false, so the original string must survive
+        // unchanged so opis can flag the type mismatch instead of quietly
+        // receiving a truncated int.
+        $overflow = '99999999999999999999';
+
+        $this->assertSame($overflow, TypeCoercer::coerceToInt($overflow));
+    }
+
+    #[Test]
     public function coerce_primitive_from_type_handles_boolean_and_number(): void
     {
         $this->assertTrue(TypeCoercer::coercePrimitiveFromType('true', 'boolean'));
@@ -74,5 +86,16 @@ class TypeCoercerTest extends TestCase
         $schema = ['type' => 'array', 'items' => ['type' => 'integer']];
 
         $this->assertSame([5], TypeCoercer::coerceQuery('5', $schema));
+    }
+
+    #[Test]
+    public function coerce_query_skips_per_item_coercion_when_items_schema_missing(): void
+    {
+        // With no `items` schema (or a non-array `items` like an OAS $ref string
+        // that slipped past validation), the array is only reindexed — values
+        // stay as raw strings so opis surfaces the shape mismatch.
+        $schema = ['type' => 'array'];
+
+        $this->assertSame(['1', '2'], TypeCoercer::coerceQuery(['1', '2'], $schema));
     }
 }


### PR DESCRIPTION
## Summary

Step 1 of 3 for #68 (Split request/response validator into per-transport domain classes). Pure refactor — extracts logic that was verbatim-duplicated (or near-duplicated) between `OpenApiRequestValidator` and `OpenApiResponseValidator` into five focused helper classes under a new `Studio\OpenApiContractTesting\Validation\Support\` namespace.

| Helper | Responsibility | Replaces |
|---|---|---|
| `ObjectConverter::convert()` | Recursive array → stdClass | former private `toObject()` in both validators |
| `TypeCoercer` | query/primitive/int coercion + OAS 3.1 multi-type | `coerceQueryValue`, `coercePrimitiveValue`, `coercePrimitiveFromType`, `coerceToInt`, `firstPrimitiveType` |
| `HeaderNormalizer::normalize()` | case-insensitive header key map | former `normalizeHeaders()` |
| `ContentTypeMatcher` | JSON / spec-present content-type checks | `findJsonContentType`, `normalizeMediaType`, `isContentTypeInSpec`, `isJsonContentType` (duplicated in both validators) |
| `SchemaValidatorRunner` | wraps opis `Validator` + `ErrorFormatter` behind `validate(schema, data): array<string, string[]>` | constructor logic + per-validator formatted-error boilerplate |

Both validators now delegate opis setup (including the `maxErrors` / `PHP_INT_MAX` / `stop_at_first_error` policy and the `InvalidArgumentException` on negative values) to `SchemaValidatorRunner`. Private helper methods on the validators are replaced with static calls to the new classes, bringing both files closer to true orchestrator shape:

- `OpenApiRequestValidator`: 1317 → 1034 lines
- `OpenApiResponseValidator`: 362 → 250 lines

**Public API is unchanged.** The constructor signatures and `validate()` method signatures on both validators are preserved, so callers — including the Laravel `ValidatesOpenApiSchema` trait — need no modifications.

The one existing reflection-based test (`OpenApiResponseValidatorTest::to_object_matches_json_roundtrip`, which poked at the private `toObject()` via `ReflectionMethod`) is migrated into `ObjectConverterTest` so the helper is verified directly rather than through a private-member probe. All other existing tests are untouched.

Steps 2 and 3 (per-transport validator split for request and response respectively) will follow as separate PRs.

Refs #68.

## Test plan

- [x] `vendor/bin/phpunit` — 533 tests / 1118 assertions pass
- [x] `vendor/bin/phpstan analyse` — level 6, 0 errors
- [x] `vendor/bin/php-cs-fixer fix --dry-run --diff` — no style violations
- [x] No public API changes — Laravel `ValidatesOpenApiSchema` trait unaffected (verified via integration tests)