### PR TITLE
refactor(response-validator): split into orchestrator + ResponseBodyValidator (step 3/3 of #68)

### DIFF
--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 namespace Studio\OpenApiContractTesting;
 
 use InvalidArgumentException;
-use Studio\OpenApiContractTesting\Validation\Support\ContentTypeMatcher;
-use Studio\OpenApiContractTesting\Validation\Support\ObjectConverter;
+use Studio\OpenApiContractTesting\Validation\Response\ResponseBodyValidator;
 use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
 
 use function array_keys;
-use function implode;
 use function preg_last_error_msg;
 use function preg_match;
 use function sprintf;
@@ -27,7 +25,7 @@ final class OpenApiResponseValidator
 
     /** @var array<string, OpenApiPathMatcher> */
     private array $pathMatchers = [];
-    private readonly SchemaValidatorRunner $runner;
+    private readonly ResponseBodyValidator $bodyValidator;
 
     /** @var array<string, string> Raw pattern (as supplied) => anchored pattern ready for preg_match. */
     private readonly array $skipPatterns;
@@ -44,7 +42,7 @@ final class OpenApiResponseValidator
         array $skipResponseCodes = self::DEFAULT_SKIP_RESPONSE_CODES,
     ) {
         $this->skipPatterns = self::compileSkipPatterns($skipResponseCodes);
-        $this->runner = new SchemaValidatorRunner($maxErrors);
+        $this->bodyValidator = new ResponseBodyValidator(new SchemaValidatorRunner($maxErrors));
     }
 
     public function validate(
@@ -111,68 +109,19 @@ final class OpenApiResponseValidator
         /** @var array<string, array<string, mixed>> $content */
         $content = $responseSpec['content'];
 
-        // When the actual response Content-Type is provided, handle content negotiation:
-        // non-JSON types are checked for spec presence only, while JSON-compatible types
-        // fall through to schema validation against the first JSON media type in the spec.
-        if ($responseContentType !== null) {
-            $normalizedType = ContentTypeMatcher::normalizeMediaType($responseContentType);
+        $errors = $this->bodyValidator->validate(
+            $specName,
+            $method,
+            $matchedPath,
+            $statusCode,
+            $content,
+            $responseBody,
+            $responseContentType,
+            $version,
+        );
 
-            if (!ContentTypeMatcher::isJsonContentType($normalizedType)) {
-                // Non-JSON response: check if the content type is defined in the spec.
-                if (ContentTypeMatcher::isContentTypeInSpec($normalizedType, $content)) {
-                    return OpenApiValidationResult::success($matchedPath);
-                }
-
-                $defined = implode(', ', array_keys($content));
-
-                return OpenApiValidationResult::failure([
-                    "Response Content-Type '{$normalizedType}' is not defined for {$method} {$matchedPath} (status {$statusCode}) in '{$specName}' spec. Defined content types: {$defined}",
-                ], $matchedPath);
-            }
-
-            // JSON-compatible response: fall through to existing JSON schema validation.
-            // JSON types are treated as interchangeable (e.g. application/vnd.api+json
-            // validates against an application/json spec entry) because the schema is
-            // the same regardless of the specific JSON media type.
-        }
-
-        $jsonContentType = ContentTypeMatcher::findJsonContentType($content);
-
-        // If no JSON-compatible content type is defined, skip body validation.
-        // This validator only handles JSON schemas; non-JSON types (e.g. text/html,
-        // application/xml) are outside its scope.
-        if ($jsonContentType === null) {
+        if ($errors === []) {
             return OpenApiValidationResult::success($matchedPath);
-        }
-
-        if (!isset($content[$jsonContentType]['schema'])) {
-            return OpenApiValidationResult::success($matchedPath);
-        }
-
-        if ($responseBody === null) {
-            return OpenApiValidationResult::failure([
-                "Response body is empty but {$method} {$matchedPath} (status {$statusCode}) defines a JSON-compatible response schema in '{$specName}' spec.",
-            ], $matchedPath);
-        }
-
-        /** @var array<string, mixed> $schema */
-        $schema = $content[$jsonContentType]['schema'];
-        $jsonSchema = OpenApiSchemaConverter::convert($schema, $version, SchemaContext::Response);
-
-        $schemaObject = ObjectConverter::convert($jsonSchema);
-        $dataObject = ObjectConverter::convert($responseBody);
-
-        $formatted = $this->runner->validate($schemaObject, $dataObject);
-
-        if ($formatted === []) {
-            return OpenApiValidationResult::success($matchedPath);
-        }
-
-        $errors = [];
-        foreach ($formatted as $path => $messages) {
-            foreach ($messages as $message) {
-                $errors[] = "[{$path}] {$message}";
-            }
         }
 
         return OpenApiValidationResult::failure($errors, $matchedPath);

--- a/src/Validation/Response/ResponseBodyValidator.php
+++ b/src/Validation/Response/ResponseBodyValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Validation\Response;
 
+use Studio\OpenApiContractTesting\OpenApiResponseValidator;
 use Studio\OpenApiContractTesting\OpenApiSchemaConverter;
 use Studio\OpenApiContractTesting\OpenApiValidationResult;
 use Studio\OpenApiContractTesting\OpenApiVersion;
@@ -23,12 +24,16 @@ final class ResponseBodyValidator
 
     /**
      * Validate the response body against the matched operation's response
-     * entry. Returns an empty list when the body is acceptable (including
-     * no-content responses, non-JSON content types without explicit schema,
-     * and schema-less entries). Hard failures (content-type not defined,
-     * empty body against JSON schema, schema mismatch) are returned as
-     * error strings so the orchestrator can assemble the final
-     * {@see OpenApiValidationResult}.
+     * entry. Returns an empty list when the body is acceptable (non-JSON
+     * content types that are present in the spec, JSON media types with no
+     * `schema` key, and JSON bodies that pass schema validation). Hard
+     * failures (content-type not defined, empty body against a JSON schema,
+     * schema mismatch) are returned as error strings so the orchestrator can
+     * assemble the final {@see OpenApiValidationResult}.
+     *
+     * The 204-style "no content" case is handled upstream in
+     * {@see OpenApiResponseValidator::validate()} — when the response spec
+     * has no `content` key, this validator is never invoked.
      *
      * @param array<string, array<string, mixed>> $content the `responses[$status].content` map
      *
@@ -63,7 +68,7 @@ final class ResponseBodyValidator
                 ];
             }
 
-            // JSON-compatible response: fall through to existing JSON schema validation.
+            // JSON-compatible response: continue to JSON schema validation below.
             // JSON types are treated as interchangeable (e.g. application/vnd.api+json
             // validates against an application/json spec entry) because the schema is
             // the same regardless of the specific JSON media type.

--- a/src/Validation/Response/ResponseBodyValidator.php
+++ b/src/Validation/Response/ResponseBodyValidator.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Validation\Response;
+
+use Studio\OpenApiContractTesting\OpenApiSchemaConverter;
+use Studio\OpenApiContractTesting\OpenApiValidationResult;
+use Studio\OpenApiContractTesting\OpenApiVersion;
+use Studio\OpenApiContractTesting\SchemaContext;
+use Studio\OpenApiContractTesting\Validation\Support\ContentTypeMatcher;
+use Studio\OpenApiContractTesting\Validation\Support\ObjectConverter;
+use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
+
+use function array_keys;
+use function implode;
+
+final class ResponseBodyValidator
+{
+    public function __construct(
+        private readonly SchemaValidatorRunner $runner,
+    ) {}
+
+    /**
+     * Validate the response body against the matched operation's response
+     * entry. Returns an empty list when the body is acceptable (including
+     * no-content responses, non-JSON content types without explicit schema,
+     * and schema-less entries). Hard failures (content-type not defined,
+     * empty body against JSON schema, schema mismatch) are returned as
+     * error strings so the orchestrator can assemble the final
+     * {@see OpenApiValidationResult}.
+     *
+     * @param array<string, array<string, mixed>> $content the `responses[$status].content` map
+     *
+     * @return string[]
+     */
+    public function validate(
+        string $specName,
+        string $method,
+        string $matchedPath,
+        int $statusCode,
+        array $content,
+        mixed $responseBody,
+        ?string $responseContentType,
+        OpenApiVersion $version,
+    ): array {
+        // When the actual response Content-Type is provided, handle content negotiation:
+        // non-JSON types are checked for spec presence only, while JSON-compatible types
+        // fall through to schema validation against the first JSON media type in the spec.
+        if ($responseContentType !== null) {
+            $normalizedType = ContentTypeMatcher::normalizeMediaType($responseContentType);
+
+            if (!ContentTypeMatcher::isJsonContentType($normalizedType)) {
+                // Non-JSON response: check if the content type is defined in the spec.
+                if (ContentTypeMatcher::isContentTypeInSpec($normalizedType, $content)) {
+                    return [];
+                }
+
+                $defined = implode(', ', array_keys($content));
+
+                return [
+                    "Response Content-Type '{$normalizedType}' is not defined for {$method} {$matchedPath} (status {$statusCode}) in '{$specName}' spec. Defined content types: {$defined}",
+                ];
+            }
+
+            // JSON-compatible response: fall through to existing JSON schema validation.
+            // JSON types are treated as interchangeable (e.g. application/vnd.api+json
+            // validates against an application/json spec entry) because the schema is
+            // the same regardless of the specific JSON media type.
+        }
+
+        $jsonContentType = ContentTypeMatcher::findJsonContentType($content);
+
+        // If no JSON-compatible content type is defined, skip body validation.
+        // This validator only handles JSON schemas; non-JSON types (e.g. text/html,
+        // application/xml) are outside its scope.
+        if ($jsonContentType === null) {
+            return [];
+        }
+
+        if (!isset($content[$jsonContentType]['schema'])) {
+            return [];
+        }
+
+        if ($responseBody === null) {
+            return [
+                "Response body is empty but {$method} {$matchedPath} (status {$statusCode}) defines a JSON-compatible response schema in '{$specName}' spec.",
+            ];
+        }
+
+        /** @var array<string, mixed> $schema */
+        $schema = $content[$jsonContentType]['schema'];
+        $jsonSchema = OpenApiSchemaConverter::convert($schema, $version, SchemaContext::Response);
+
+        $schemaObject = ObjectConverter::convert($jsonSchema);
+        $dataObject = ObjectConverter::convert($responseBody);
+
+        $formatted = $this->runner->validate($schemaObject, $dataObject);
+
+        $errors = [];
+        foreach ($formatted as $path => $messages) {
+            foreach ($messages as $message) {
+                $errors[] = "[{$path}] {$message}";
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
+++ b/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Validation\Response;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\OpenApiVersion;
+use Studio\OpenApiContractTesting\Validation\Response\ResponseBodyValidator;
+use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
+
+class ResponseBodyValidatorTest extends TestCase
+{
+    private ResponseBodyValidator $validator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->validator = new ResponseBodyValidator(new SchemaValidatorRunner(20));
+    }
+
+    #[Test]
+    public function validate_passes_valid_json_body_against_schema(): void
+    {
+        $content = [
+            'application/json' => [
+                'schema' => [
+                    'type' => 'object',
+                    'properties' => ['id' => ['type' => 'integer']],
+                    'required' => ['id'],
+                ],
+            ],
+        ];
+
+        $errors = $this->validator->validate(
+            'spec',
+            'GET',
+            '/pets/{id}',
+            200,
+            $content,
+            ['id' => 1],
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function validate_flags_empty_body_against_json_schema(): void
+    {
+        $content = [
+            'application/json' => ['schema' => ['type' => 'object']],
+        ];
+
+        $errors = $this->validator->validate(
+            'spec',
+            'GET',
+            '/pets',
+            200,
+            $content,
+            null,
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('Response body is empty', $errors[0]);
+    }
+
+    #[Test]
+    public function validate_accepts_non_json_content_type_when_defined_in_spec(): void
+    {
+        $content = [
+            'text/plain' => ['schema' => ['type' => 'string']],
+        ];
+
+        $errors = $this->validator->validate(
+            'spec',
+            'GET',
+            '/robots.txt',
+            200,
+            $content,
+            'User-agent: *',
+            'text/plain; charset=utf-8',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function validate_flags_non_json_content_type_not_in_spec(): void
+    {
+        $content = [
+            'application/json' => ['schema' => ['type' => 'object']],
+        ];
+
+        $errors = $this->validator->validate(
+            'spec',
+            'GET',
+            '/pets',
+            200,
+            $content,
+            'blob',
+            'application/xml',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString("Content-Type 'application/xml' is not defined", $errors[0]);
+    }
+
+    #[Test]
+    public function validate_returns_empty_when_no_json_content_defined(): void
+    {
+        // Non-JSON spec entries with no Content-Type header → out-of-scope, pass.
+        $content = ['application/xml' => ['schema' => ['type' => 'string']]];
+
+        $errors = $this->validator->validate(
+            'spec',
+            'GET',
+            '/pets',
+            200,
+            $content,
+            '<pets/>',
+            null,
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function validate_flags_schema_mismatch(): void
+    {
+        $content = [
+            'application/json' => [
+                'schema' => [
+                    'type' => 'object',
+                    'properties' => ['id' => ['type' => 'integer']],
+                    'required' => ['id'],
+                ],
+            ],
+        ];
+
+        $errors = $this->validator->validate(
+            'spec',
+            'GET',
+            '/pets/{id}',
+            200,
+            $content,
+            ['id' => 'not-an-int'],
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertNotEmpty($errors);
+        $this->assertStringContainsString('/id', $errors[0]);
+    }
+}


### PR DESCRIPTION
## Summary

Final step (3/3) of the #68 per-transport split. Request-side split landed in PR #91; this PR does the smaller-scope response-side equivalent.

**New class:** `Studio\OpenApiContractTesting\Validation\Response\ResponseBodyValidator` takes `SchemaValidatorRunner` via constructor and owns the content-negotiation branches, JSON-schema delegation, and the "no JSON content type / no schema / non-null but unsupported media" pass-through policy.

**What stays in the orchestrator:** Status-code skip logic (`DEFAULT_SKIP_RESPONSE_CODES`, `compileSkipPatterns()`, `matchingSkipPattern()`, `skipPatterns` property). That lives at the orchestrator because it resolves to `OpenApiValidationResult::skipped()` — a result-level concern the body validator has no reason to know about.

**Line counts:**
- \`OpenApiResponseValidator\`: 250 → **199 lines** (orchestration only)
- \`ResponseBodyValidator\`: 109 lines (new, focused)

**Orchestration shape:**

1. Load spec → detect version → match path
2. Check method existence
3. Skip-by-status-code
4. Check status in spec \`responses\` map
5. Early-return for missing \`content\` (e.g. 204 No Content)
6. Delegate to \`ResponseBodyValidator::validate()\`
7. Wrap resulting \`string[]\` into \`OpenApiValidationResult\`

**Public API unchanged** — \`new OpenApiResponseValidator(int \$maxErrors = 20, array \$skipResponseCodes = ...)\` and \`validate(...)\` signatures are preserved. The Laravel \`ValidatesOpenApiSchema\` trait (the only external consumer) needs no changes.

## Tests

- existing \`OpenApiResponseValidatorTest\` (60 tests / 125 assertions) untouched, still passes
- new \`ResponseBodyValidatorTest\` (6 tests) covers critical branches: valid JSON, empty body against JSON schema, non-JSON in spec pass-through, non-JSON not-in-spec failure, no JSON type defined pass, schema mismatch
- **Full suite: 571 tests / 1185 assertions pass**

## Closes #68

This completes the per-transport domain class split. The repo now has a clean orchestrator/sub-validator separation for both request and response paths under \`src/Validation/\`:

\`\`\`
src/Validation/
├── Request/       ParameterCollector, PathParameterValidator, QueryParameterValidator,
│                  HeaderParameterValidator, RequestBodyValidator, SecurityValidator,
│                  CollectionResult, SchemeKind, SchemeClassification
├── Response/      ResponseBodyValidator
└── Support/       ObjectConverter, TypeCoercer, HeaderNormalizer,
                   ContentTypeMatcher, SchemaValidatorRunner
\`\`\`

An observability follow-up (per-sub-validator error boundary around body validator throwables) was extracted to #92 so it can be tracked independently.

## Test plan

- [x] \`vendor/bin/phpunit\` — 571 tests / 1185 assertions pass
- [x] \`vendor/bin/phpstan analyse\` — level 6, 0 errors
- [x] \`vendor/bin/php-cs-fixer fix --dry-run --diff\` — clean
- [x] Existing \`OpenApiResponseValidatorTest\` (60 tests) passes unmodified
- [x] No changes to \`src/Laravel/ValidatesOpenApiSchema.php\` — public API preserved