### PR TITLE
feat(request-validation): wire OpenApiRequestValidator + auto-inject bearer (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ Three scopes are available:
 
 - `withoutValidation()` — skip both request and response validation
 - `withoutResponseValidation()` — skip response validation only
-- `withoutRequestValidation()` — skip request validation only (forward-looking hook; request validation itself is not yet implemented)
+- `withoutRequestValidation()` — skip request validation only (active when `auto_validate_request` is on)
 
 Notes:
 
@@ -441,7 +441,54 @@ Notes:
 - **One HTTP call**: same consumption model as `withoutValidation()`. The codes are consumed on the next auto-assert attempt and reset, so the next call falls back to the config-level set.
 - **Auto-assert only**. Explicit `assertResponseMatchesOpenApiSchema()` calls ignore per-request codes — explicit calls are the user's direct intent.
 - **Chainable**: returns `$this`. Multiple chained calls accumulate (`$this->skipResponseCode(404)->skipResponseCode(503)` registers both).
-- `withoutRequestValidation()` currently has no observable effect because request validation has not landed yet — the method exists so tests can adopt the intended API surface today without a later rewrite.
+
+### Auto-validate every request
+
+Request-side contract drift (missing query params, body-shape divergence, absent security headers) goes undetected unless the test explicitly checks for it. Enable `auto_validate_request` to run `OpenApiRequestValidator` against every request Laravel's HTTP helpers dispatch:
+
+```php
+// config/openapi-contract-testing.php
+return [
+    'default_spec'               => 'front',
+    'auto_validate_request'      => true,
+    'auto_inject_dummy_bearer'   => true, // optional — see below
+];
+```
+
+Validation covers path / query / header parameters, request body (JSON Schema), and security schemes. Failures raise a PHPUnit assertion error from inside the HTTP call, exactly like `auto_assert`.
+
+Notes:
+
+- Independent of `auto_assert` — either side can be enabled on its own. Both default to `false` for backward compatibility.
+- `withoutRequestValidation()` and `#[SkipOpenApi]` both opt a single call (or a whole test) out of request validation, with the same per-request semantics already documented for response-side auto-assert.
+- `auto_validate_request` accepts boolean-compatible values (`"true"`, `"1"`, etc.) like `auto_assert`. Unrecognized values fail the test loudly.
+- Coverage is recorded for every matched request path, so enabling auto-validate-request without auto-assert still lights up your coverage report.
+
+#### Auto-inject dummy bearer
+
+When `auto_validate_request=true`, endpoints whose spec declares `bearerAuth` fail the security check unless the test supplies an `Authorization: Bearer …` header. For test suites that authenticate via `actingAs()` or middleware bypass — and therefore never set the header — set `auto_inject_dummy_bearer=true` to auto-inject `Authorization: Bearer test-token` into the validator's view of the request:
+
+```php
+class SecureEndpointTest extends TestCase
+{
+    use ValidatesOpenApiSchema;
+
+    public function test_secure_endpoint(): void
+    {
+        $this->actingAs(User::factory()->create());
+
+        // No header set, but auto-inject lets request validation pass.
+        $this->get('/v1/secure/bearer')->assertOk();
+    }
+}
+```
+
+Notes:
+
+- **View-only rewrite**: the Symfony `Request` itself is not modified; Laravel has already dispatched by the time the trait runs. The inject exists purely to prevent the security check from false-failing.
+- **Bearer only**: `apiKey` and `oauth2` endpoints are not affected (the header name for `apiKey` is arbitrary per spec; `oauth2` is classified as unsupported in phase 1 anyway).
+- **Never overrides user values**: if the test already set an `Authorization` header (in any case), the user's value wins.
+- **Requires `auto_validate_request=true`** — the inject is a sub-feature of request validation. Setting the inject flag alone has no effect.
 
 ## Coverage Report
 

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -13,6 +13,7 @@ use const STDERR;
 use Illuminate\Testing\TestResponse;
 use InvalidArgumentException;
 use JsonException;
+use RuntimeException;
 use Studio\OpenApiContractTesting\HttpMethod;
 use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\OpenApiPathMatcher;
@@ -26,7 +27,6 @@ use Studio\OpenApiContractTesting\Validation\Request\SecuritySchemeIntrospector;
 use Studio\OpenApiContractTesting\Validation\Support\HeaderNormalizer;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Throwable;
 use WeakMap;
 
 use function array_merge;
@@ -52,8 +52,9 @@ trait ValidatesOpenApiSchema
 
     // Fixed dummy token injected when auto_inject_dummy_bearer is enabled and
     // the endpoint spec requires bearerAuth but the test did not set one.
-    // Issue #69 scoped the value to a fixed string; making it configurable is
-    // a deliberate separate discussion.
+    // A fixed string is sufficient because the value is never evaluated by
+    // anything downstream — the inject only silences the spec's security
+    // check. Making it configurable is a deliberate separate discussion.
     private const DUMMY_BEARER_TOKEN = 'test-token';
     private static ?OpenApiResponseValidator $cachedValidator = null;
     private static ?int $cachedMaxErrors = null;
@@ -531,10 +532,16 @@ trait ValidatesOpenApiSchema
 
     /**
      * Decide whether to rewrite the validator's view of the request with a
-     * dummy Authorization header. True only when: (1) the feature is enabled
-     * AND auto-validate-request is on, (2) no Authorization is already present,
-     * and (3) the matched operation's spec security accepts a bearer
-     * credential (see {@see SecuritySchemeIntrospector}).
+     * dummy Authorization header. True only when: (1) the inject feature is
+     * enabled, (2) no Authorization is already present (any case), and (3)
+     * the matched operation's spec security accepts a bearer credential (see
+     * {@see SecuritySchemeIntrospector}).
+     *
+     * Callers are expected to have already confirmed auto-validate-request
+     * is on — this method is reached only from {@see self::maybeAutoValidateOpenApiRequest()},
+     * which gates on that flag. Calling it from a new code path without the
+     * same gate would silently load the spec even when request validation is
+     * disabled.
      *
      * Errors walking the spec (unreadable file, no matching path, missing
      * operation) fall through as "do not inject" — the validator will surface
@@ -560,7 +567,13 @@ trait ValidatesOpenApiSchema
 
         try {
             $spec = OpenApiSpecLoader::load($specName);
-        } catch (Throwable) {
+        } catch (RuntimeException) {
+            // OpenApiSpecLoader throws RuntimeException on unreadable files,
+            // malformed JSON/YAML, unsupported extensions, etc. Swallow those
+            // and decline to inject — the validator re-loads the same spec
+            // immediately after and will surface the real error. Broader
+            // Throwable (TypeError, AssertionError, ...) keeps bubbling so
+            // programmer bugs are not silently downgraded to "missing auth".
             return false;
         }
 

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -7,6 +7,7 @@ namespace Studio\OpenApiContractTesting\Laravel;
 use const E_USER_DEPRECATED;
 use const FILTER_NULL_ON_FAILURE;
 use const FILTER_VALIDATE_BOOLEAN;
+use const JSON_THROW_ON_ERROR;
 use const STDERR;
 
 use Illuminate\Testing\TestResponse;
@@ -14,12 +15,18 @@ use InvalidArgumentException;
 use JsonException;
 use Studio\OpenApiContractTesting\HttpMethod;
 use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\OpenApiPathMatcher;
+use Studio\OpenApiContractTesting\OpenApiRequestValidator;
 use Studio\OpenApiContractTesting\OpenApiResponseValidator;
+use Studio\OpenApiContractTesting\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\OpenApiSpecResolver;
 use Studio\OpenApiContractTesting\SkipOpenApi;
 use Studio\OpenApiContractTesting\SkipOpenApiResolver;
+use Studio\OpenApiContractTesting\Validation\Request\SecuritySchemeIntrospector;
+use Studio\OpenApiContractTesting\Validation\Support\HeaderNormalizer;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 use WeakMap;
 
 use function array_merge;
@@ -30,6 +37,7 @@ use function is_array;
 use function is_int;
 use function is_numeric;
 use function is_string;
+use function json_decode;
 use function sprintf;
 use function str_contains;
 use function strtolower;
@@ -41,8 +49,17 @@ trait ValidatesOpenApiSchema
 {
     use OpenApiSpecResolver;
     use SkipOpenApiResolver;
+
+    // Fixed dummy token injected when auto_inject_dummy_bearer is enabled and
+    // the endpoint spec requires bearerAuth but the test did not set one.
+    // Issue #69 scoped the value to a fixed string; making it configurable is
+    // a deliberate separate discussion.
+    private const DUMMY_BEARER_TOKEN = 'test-token';
     private static ?OpenApiResponseValidator $cachedValidator = null;
     private static ?int $cachedMaxErrors = null;
+    private static ?OpenApiRequestValidator $cachedRequestValidator = null;
+    private static ?int $cachedRequestMaxErrors = null;
+    private static ?SecuritySchemeIntrospector $cachedSecuritySchemeIntrospector = null;
 
     /** @var null|string[] */
     private static ?array $cachedSkipResponseCodes = null;
@@ -84,6 +101,9 @@ trait ValidatesOpenApiSchema
         self::$cachedValidator = null;
         self::$cachedMaxErrors = null;
         self::$cachedSkipResponseCodes = null;
+        self::$cachedRequestValidator = null;
+        self::$cachedRequestMaxErrors = null;
+        self::$cachedSecuritySchemeIntrospector = null;
         self::$validatedResponses = null;
     }
 
@@ -105,10 +125,10 @@ trait ValidatesOpenApiSchema
     }
 
     /**
-     * Skips request validation for the next HTTP call only. Currently a
-     * forward-looking hook: request validation itself lands in #43, and this
-     * method wires up the flag ahead of time so callers can already write the
-     * intended API surface.
+     * Skips request validation for the next HTTP call only. The flag
+     * self-resets after one auto-validate-request attempt. Scoped to
+     * auto-validate only — the request validator is otherwise only exercised
+     * from user code (no explicit-assertion counterpart on the request side).
      */
     public function withoutRequestValidation(): static
     {
@@ -213,9 +233,118 @@ trait ValidatesOpenApiSchema
         $method = $request !== null ? HttpMethod::tryFrom(strtoupper($request->getMethod())) : null;
         $path = $request?->getPathInfo();
 
+        // Request-side runs first so that the skipNextRequestValidation flag is
+        // consumed at the HTTP boundary before the response hook gets a chance
+        // to (defensively) clear it.
+        $this->maybeAutoValidateOpenApiRequest($request, $method, $path);
         $this->maybeAutoAssertOpenApiSchema($testResponse, $method, $path);
 
         return $testResponse;
+    }
+
+    /**
+     * Request-side counterpart to {@see self::maybeAutoAssertOpenApiSchema()}.
+     * Invokes {@see OpenApiRequestValidator} against the Laravel-dispatched
+     * Request when `auto_validate_request` is enabled, mirroring the
+     * per-request opt-out (withoutRequestValidation / #[SkipOpenApi]) and
+     * coverage-recording behavior already in place for responses.
+     *
+     * Auto-inject-dummy-bearer is a view-only rewrite: the Authorization
+     * header is injected into the headers array we hand to the validator, not
+     * into the Symfony Request itself. Laravel has already dispatched by the
+     * time this method runs, so mutating the Request would be pointless — the
+     * rewrite exists purely to keep the security check from false-failing on
+     * tests that authenticate via actingAs() or middleware bypass.
+     */
+    protected function maybeAutoValidateOpenApiRequest(
+        ?Request $request,
+        ?HttpMethod $method = null,
+        ?string $path = null,
+    ): void {
+        // Consume the per-request skip flag unconditionally at the HTTP call
+        // boundary — see the analogous comment in maybeAutoAssertOpenApiSchema().
+        $skipRequest = $this->skipNextRequestValidation;
+        $this->skipNextRequestValidation = false;
+
+        if (!$this->isAutoValidateRequestEnabled()) {
+            return;
+        }
+
+        if ($skipRequest) {
+            return;
+        }
+
+        // No request object or unrecognizable HTTP verb → nothing meaningful
+        // to validate. Stay silent rather than fabricating an error; Laravel
+        // only passes null/unknown in edge cases (direct TestResponse
+        // construction outside MakesHttpRequests).
+        if ($request === null || $method === null) {
+            return;
+        }
+
+        if ($this->findSkipOpenApiAttribute() !== null) {
+            return;
+        }
+
+        $specName = $this->resolveOpenApiSpec();
+        if ($specName === '') {
+            $this->fail(
+                'openApiSpec() must return a non-empty spec name, but an empty string was returned. '
+                . 'Either add #[OpenApiSpec(\'your-spec\')] to your test class or method, '
+                . 'override openApiSpec() in your test class, or set the "default_spec" key '
+                . 'in config/openapi-contract-testing.php.',
+            );
+        }
+
+        $resolvedMethod = $method->value;
+        $resolvedPath = $path ?? $request->getPathInfo();
+
+        /** @var array<string, mixed> $queryParams */
+        $queryParams = $request->query->all();
+        /** @var array<string, array<int, null|string>> $headers */
+        $headers = $request->headers->all();
+        /** @var array<string, mixed> $cookies */
+        $cookies = $request->cookies->all();
+        $rawContentType = $request->headers->get('Content-Type');
+        $contentType = is_string($rawContentType) ? $rawContentType : '';
+
+        $body = $this->extractRequestBody($request, $contentType);
+
+        if ($this->shouldAutoInjectDummyBearer($specName, $resolvedMethod, $resolvedPath, $headers)) {
+            // Inject under the canonical framework key (Symfony lowercases) so
+            // both any existing "Authorization" and the validator's
+            // case-insensitive lookup see the same value.
+            $headers['authorization'] = ['Bearer ' . self::DUMMY_BEARER_TOKEN];
+        }
+
+        $validator = $this->getOrCreateRequestValidator();
+        $result = $validator->validate(
+            $specName,
+            $resolvedMethod,
+            $resolvedPath,
+            $queryParams,
+            $headers,
+            $body,
+            $contentType !== '' ? $contentType : null,
+            $cookies,
+        );
+
+        // Record coverage when the request matched a spec path, same
+        // tracking semantics as the response-side hook. The tracker is a set,
+        // so this does not double-count when response auto-assert also fires.
+        if ($result->matchedPath() !== null) {
+            OpenApiCoverageTracker::record(
+                $specName,
+                $resolvedMethod,
+                $result->matchedPath(),
+            );
+        }
+
+        $this->assertTrue(
+            $result->isValid(),
+            "OpenAPI request validation failed for {$resolvedMethod} {$resolvedPath} (spec: {$specName}):\n"
+            . $result->errorMessage(),
+        );
     }
 
     protected function maybeAutoAssertOpenApiSchema(
@@ -380,6 +509,113 @@ trait ValidatesOpenApiSchema
         return is_int($code) ? (string) $code : $code;
     }
 
+    private function getOrCreateRequestValidator(): OpenApiRequestValidator
+    {
+        $resolvedMaxErrors = $this->resolveMaxErrors();
+
+        if (
+            self::$cachedRequestValidator === null ||
+            self::$cachedRequestMaxErrors !== $resolvedMaxErrors
+        ) {
+            self::$cachedRequestValidator = new OpenApiRequestValidator($resolvedMaxErrors);
+            self::$cachedRequestMaxErrors = $resolvedMaxErrors;
+        }
+
+        return self::$cachedRequestValidator;
+    }
+
+    private function getSecuritySchemeIntrospector(): SecuritySchemeIntrospector
+    {
+        return self::$cachedSecuritySchemeIntrospector ??= new SecuritySchemeIntrospector();
+    }
+
+    /**
+     * Decide whether to rewrite the validator's view of the request with a
+     * dummy Authorization header. True only when: (1) the feature is enabled
+     * AND auto-validate-request is on, (2) no Authorization is already present,
+     * and (3) the matched operation's spec security accepts a bearer
+     * credential (see {@see SecuritySchemeIntrospector}).
+     *
+     * Errors walking the spec (unreadable file, no matching path, missing
+     * operation) fall through as "do not inject" — the validator will surface
+     * the real error. We stay silent here so a broken spec produces exactly
+     * one failure, not a confusing cascade.
+     *
+     * @param array<string, mixed> $headers
+     */
+    private function shouldAutoInjectDummyBearer(
+        string $specName,
+        string $method,
+        string $path,
+        array $headers,
+    ): bool {
+        if (!$this->isAutoInjectDummyBearerEnabled()) {
+            return false;
+        }
+
+        $normalized = HeaderNormalizer::normalize($headers);
+        if (isset($normalized['authorization']) && $normalized['authorization'] !== '' && $normalized['authorization'] !== []) {
+            return false;
+        }
+
+        try {
+            $spec = OpenApiSpecLoader::load($specName);
+        } catch (Throwable) {
+            return false;
+        }
+
+        $paths = $spec['paths'] ?? null;
+        if (!is_array($paths)) {
+            return false;
+        }
+
+        $matchedOperation = $this->findOperationForRequest($paths, $method, $path);
+        if ($matchedOperation === null) {
+            return false;
+        }
+
+        return $this->getSecuritySchemeIntrospector()->endpointAcceptsBearer($spec, $matchedOperation);
+    }
+
+    /**
+     * Locate the spec operation for (method, path) without re-running
+     * OpenApiPathMatcher — the validator will match again internally when it
+     * runs, and one extra literal lookup here avoids exposing its cache.
+     * Only spec-declared paths are consulted; prefix stripping matches the
+     * validator's behavior via OpenApiSpecLoader.
+     *
+     * @param array<string, mixed> $paths
+     *
+     * @return null|array<string, mixed>
+     */
+    private function findOperationForRequest(array $paths, string $method, string $path): ?array
+    {
+        $specPaths = [];
+        foreach ($paths as $specPath => $_definition) {
+            if (is_string($specPath)) {
+                $specPaths[] = $specPath;
+            }
+        }
+
+        $matcher = new OpenApiPathMatcher(
+            $specPaths,
+            OpenApiSpecLoader::getStripPrefixes(),
+        );
+        $matched = $matcher->match($path);
+        if ($matched === null) {
+            return null;
+        }
+
+        $pathSpec = $paths[$matched] ?? null;
+        if (!is_array($pathSpec)) {
+            return null;
+        }
+
+        $operation = $pathSpec[strtolower($method)] ?? null;
+
+        return is_array($operation) ? $operation : null;
+    }
+
     private function getOrCreateValidator(): OpenApiResponseValidator
     {
         $resolvedMaxErrors = $this->resolveMaxErrors();
@@ -504,7 +740,29 @@ trait ValidatesOpenApiSchema
 
     private function isAutoAssertEnabled(): bool
     {
-        $raw = config('openapi-contract-testing.auto_assert', false);
+        return $this->resolveBoolConfig('auto_assert');
+    }
+
+    private function isAutoValidateRequestEnabled(): bool
+    {
+        return $this->resolveBoolConfig('auto_validate_request');
+    }
+
+    private function isAutoInjectDummyBearerEnabled(): bool
+    {
+        return $this->resolveBoolConfig('auto_inject_dummy_bearer');
+    }
+
+    /**
+     * Three-way coercion for a config flag: real bool passes through, null
+     * coerces to false, string passes through FILTER_VALIDATE_BOOLEAN so
+     * `'auto_X' => env('X')` (strings like "true" / "1") works without an
+     * explicit cast. Anything else raises a loud PHPUnit failure so a typo
+     * is not silently read as "off".
+     */
+    private function resolveBoolConfig(string $key): bool
+    {
+        $raw = config('openapi-contract-testing.' . $key, false);
 
         if ($raw === true) {
             return true;
@@ -516,14 +774,45 @@ trait ValidatesOpenApiSchema
         $parsed = filter_var($raw, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
         if ($parsed === null) {
             $this->fail(sprintf(
-                'openapi-contract-testing.auto_assert must be a boolean (or a boolean-compatible value '
+                'openapi-contract-testing.%s must be a boolean (or a boolean-compatible value '
                 . 'like "true"/"false"/"1"/"0"), got %s: %s.',
+                $key,
                 get_debug_type($raw),
                 var_export($raw, true),
             ));
         }
 
         return $parsed;
+    }
+
+    /**
+     * Extract the request body in the shape OpenApiRequestValidator expects.
+     * Mirrors {@see self::extractJsonBody()} for the request side: parse JSON
+     * only when the Content-Type claims it, stay `null` on empty or non-JSON
+     * bodies so the validator decides whether the spec required one.
+     */
+    private function extractRequestBody(Request $request, string $contentType): mixed
+    {
+        $content = $request->getContent();
+        if ($content === '') {
+            return null;
+        }
+
+        if ($contentType !== '' && !str_contains(strtolower($contentType), 'json')) {
+            return null;
+        }
+
+        try {
+            /** @var mixed $decoded */
+            $decoded = json_decode($content, true, flags: JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            $this->fail(
+                'Request body could not be parsed as JSON: ' . $e->getMessage()
+                . ($contentType === '' ? ' (no Content-Type header was present on the request)' : ''),
+            );
+        }
+
+        return $decoded;
     }
 
     /** @return null|array<string, mixed> */

--- a/src/Laravel/config.php
+++ b/src/Laravel/config.php
@@ -17,6 +17,23 @@ return [
     // call in each test. Defaults to false for backward compatibility.
     'auto_assert' => false,
 
+    // When true, every Request dispatched by Laravel HTTP test helpers is
+    // validated against the OpenAPI spec (path / query / headers / body /
+    // security) alongside the response. Independent of `auto_assert` — either
+    // side can be enabled on its own. Defaults to false for backward
+    // compatibility.
+    'auto_validate_request' => false,
+
+    // When true (and `auto_validate_request` is on), endpoints whose spec
+    // security requires `bearerAuth` automatically receive a fixed dummy
+    // `Authorization: Bearer test-token` header in the validator's view when
+    // the test did not set one. The Symfony Request itself is not modified —
+    // this only prevents the security check from false-failing on tests that
+    // authenticate via actingAs() or auth middleware bypass. apiKey-only and
+    // oauth2-only endpoints are not affected. Defaults to false for backward
+    // compatibility.
+    'auto_inject_dummy_bearer' => false,
+
     // Regex patterns (without delimiters or anchors) matched against the
     // response status code. Matching codes short-circuit body validation and
     // return a "skipped" result — the test is not failed, and the endpoint is

--- a/src/Validation/Request/SecuritySchemeIntrospector.php
+++ b/src/Validation/Request/SecuritySchemeIntrospector.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Validation\Request;
+
+use function array_key_exists;
+use function is_array;
+use function is_string;
+use function strtolower;
+
+/**
+ * Decides whether an endpoint's spec-declared security permits a bearer
+ * credential. Used by the Laravel trait that drives auto-injection of a
+ * dummy `Authorization: Bearer <token>` header into the request validator's
+ * view — the only reason this lookup exists.
+ *
+ * The classification rules mirror {@see SecurityValidator::classifyScheme()}
+ * exactly; keeping them in sync is a hard requirement because a mismatch
+ * would cause the trait to inject on endpoints the validator then considers
+ * unauthenticated (or vice versa). This class deliberately returns `false`
+ * on malformed or unsupported spec entries rather than mirroring
+ * SecurityValidator's hard-error surface: the validator is still the
+ * source of truth for "is this spec broken" and we do not want two layers
+ * producing redundant errors.
+ */
+final class SecuritySchemeIntrospector
+{
+    /**
+     * Return true if any spec-declared security requirement for the operation
+     * names a scheme that is `http` + `bearer`.
+     *
+     * Returns true even when bearer appears alongside other schemes in an
+     * AND-entry (e.g. `bearer + apiKey`). Injecting bearer alone won't satisfy
+     * that entry, but it does silence the "Authorization header is missing"
+     * noise and leaves only the actionable apiKey error for the user.
+     *
+     * @param array<string, mixed> $spec full spec root (for
+     *                                   `components.securitySchemes` +
+     *                                   root-level `security` inheritance)
+     * @param array<string, mixed> $operation operation spec (for
+     *                                        operation-level `security` override)
+     */
+    public function endpointAcceptsBearer(array $spec, array $operation): bool
+    {
+        $security = array_key_exists('security', $operation)
+            ? $operation['security']
+            : ($spec['security'] ?? null);
+
+        if (!is_array($security) || $security === []) {
+            return false;
+        }
+
+        $schemes = $spec['components']['securitySchemes'] ?? [];
+        if (!is_array($schemes)) {
+            return false;
+        }
+
+        foreach ($security as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+
+            foreach ($entry as $schemeName => $_scopes) {
+                if (!is_string($schemeName)) {
+                    continue;
+                }
+
+                $definition = $schemes[$schemeName] ?? null;
+                if (!is_array($definition)) {
+                    continue;
+                }
+
+                if ($this->definitionIsBearer($definition)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $definition
+     */
+    private function definitionIsBearer(array $definition): bool
+    {
+        $type = $definition['type'] ?? null;
+        if ($type !== 'http') {
+            return false;
+        }
+
+        $scheme = $definition['scheme'] ?? null;
+        if (!is_string($scheme)) {
+            return false;
+        }
+
+        return strtolower($scheme) === 'bearer';
+    }
+}

--- a/tests/Integration/Laravel/AutoValidateRequestIntegrationTest.php
+++ b/tests/Integration/Laravel/AutoValidateRequestIntegrationTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Integration\Laravel;
+
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\Test;
+use Studio\OpenApiContractTesting\Laravel\OpenApiContractTestingServiceProvider;
+use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
+use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+
+use function dirname;
+
+/**
+ * Complements the ValidatesOpenApiSchemaAutoValidateRequestTest unit test by
+ * exercising the full `$this->postJson()` → Laravel kernel →
+ * `MakesHttpRequests::createTestResponse` → trait override pipeline under a
+ * real Testbench app. Unit tests drive the hook directly; this file proves
+ * the hook actually fires when a Laravel HTTP helper dispatches a request.
+ */
+class AutoValidateRequestIntegrationTest extends TestCase
+{
+    use ValidatesOpenApiSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(dirname(__DIR__, 2) . '/fixtures/specs');
+        OpenApiCoverageTracker::reset();
+        config()->set('openapi-contract-testing.default_spec', 'petstore-3.0');
+    }
+
+    protected function tearDown(): void
+    {
+        self::resetValidatorCache();
+        OpenApiSpecLoader::reset();
+        OpenApiCoverageTracker::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function auto_validate_request_true_accepts_valid_post_body(): void
+    {
+        config()->set('openapi-contract-testing.auto_validate_request', true);
+
+        $response = $this->postJson('/v1/pets', ['name' => 'Buddy']);
+        $response->assertCreated();
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayHasKey('POST /v1/pets', $covered['petstore-3.0'] ?? []);
+    }
+
+    #[Test]
+    public function auto_validate_request_true_raises_on_invalid_post_body(): void
+    {
+        // Missing required `name` field — the canonical request-side drift.
+        // Proves the hook survives the Laravel HTTP helper chain.
+        config()->set('openapi-contract-testing.auto_validate_request', true);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('OpenAPI request validation failed');
+
+        $this->postJson('/v1/pets', ['not_name' => 'x']);
+    }
+
+    #[Test]
+    public function auto_validate_request_false_does_not_validate_invalid_body(): void
+    {
+        config()->set('openapi-contract-testing.auto_validate_request', false);
+
+        $response = $this->postJson('/v1/pets', ['not_name' => 'x']);
+        $response->assertCreated();
+
+        $this->assertArrayNotHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
+    }
+
+    #[Test]
+    public function without_request_validation_skips_next_call_end_to_end(): void
+    {
+        // Fluent chain survives Laravel's dispatcher → createTestResponse
+        // hook. Mirrors `without_validation_skips_next_http_call_only` for
+        // the request side.
+        config()->set('openapi-contract-testing.auto_validate_request', true);
+
+        $response = $this->withoutRequestValidation()->postJson('/v1/pets', ['not_name' => 'x']);
+        $response->assertCreated();
+
+        $this->assertArrayNotHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
+    }
+
+    #[Test]
+    public function without_request_validation_flag_resets_after_one_call_end_to_end(): void
+    {
+        config()->set('openapi-contract-testing.auto_validate_request', true);
+
+        $this->withoutRequestValidation()
+            ->postJson('/v1/pets', ['not_name' => 'x'])
+            ->assertCreated();
+
+        // Second identical call must re-validate — flag is per-call.
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('OpenAPI request validation failed');
+
+        $this->postJson('/v1/pets', ['not_name' => 'x']);
+    }
+
+    #[Test]
+    public function auto_inject_dummy_bearer_passes_bearer_endpoint_without_real_header(): void
+    {
+        // End-to-end for #69's second half: the test sets no Authorization,
+        // but `auto_inject_dummy_bearer=true` fills it in for the validator
+        // so security validation does not false-fail.
+        config()->set('openapi-contract-testing.auto_validate_request', true);
+        config()->set('openapi-contract-testing.auto_inject_dummy_bearer', true);
+
+        $response = $this->get('/v1/secure/bearer');
+        $response->assertOk();
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayHasKey('GET /v1/secure/bearer', $covered['petstore-3.0'] ?? []);
+    }
+
+    #[Test]
+    public function auto_inject_off_still_fails_bearer_endpoint_without_header(): void
+    {
+        // Default off: the test-author must set a real Authorization header
+        // or opt into auto-inject. Confirms the feature is gated.
+        config()->set('openapi-contract-testing.auto_validate_request', true);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Authorization header is missing');
+
+        $this->get('/v1/secure/bearer');
+    }
+
+    /** @return array<int, class-string> */
+    protected function getPackageProviders($app): array
+    {
+        return [OpenApiContractTestingServiceProvider::class];
+    }
+
+    protected function defineRoutes($router): void
+    {
+        Route::post('/v1/pets', static fn() => response()->json(
+            ['data' => ['id' => 42, 'name' => 'Buddy', 'tag' => null]],
+            201,
+        ));
+
+        // Bearer-protected endpoint in the spec. Route implementation is
+        // auth-free in the test app — the library validates against the
+        // *spec*'s security declaration, not Laravel's actual middleware.
+        Route::get('/v1/secure/bearer', static fn() => response()->json(null));
+    }
+}

--- a/tests/Integration/Laravel/AutoValidateRequestIntegrationTest.php
+++ b/tests/Integration/Laravel/AutoValidateRequestIntegrationTest.php
@@ -138,6 +138,43 @@ class AutoValidateRequestIntegrationTest extends TestCase
         $this->get('/v1/secure/bearer');
     }
 
+    #[Test]
+    public function both_hooks_enabled_runs_request_before_response_and_records_coverage_once(): void
+    {
+        // With both auto_assert and auto_validate_request on, the trait must
+        // (1) run request validation first so the skipNextRequestValidation
+        // flag is consumed at the right boundary, (2) record coverage only
+        // once per (spec,method,path) despite both hooks calling the tracker,
+        // and (3) both validations must see a consistent request/response.
+        config()->set('openapi-contract-testing.auto_assert', true);
+        config()->set('openapi-contract-testing.auto_validate_request', true);
+
+        $response = $this->postJson('/v1/pets', ['name' => 'Buddy']);
+        $response->assertCreated();
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayHasKey('petstore-3.0', $covered);
+        $this->assertArrayHasKey('POST /v1/pets', $covered['petstore-3.0']);
+        // Tracker de-dupes by (spec,method,path) — exactly one entry, not two.
+        $this->assertCount(1, $covered['petstore-3.0']);
+    }
+
+    #[Test]
+    public function both_hooks_enabled_request_failure_takes_precedence(): void
+    {
+        // If both hooks are on and the request is invalid, the request-side
+        // assertion fires first (before the response hook runs), so the
+        // surfaced error is the request one. Response drift on the same call
+        // does not override this.
+        config()->set('openapi-contract-testing.auto_assert', true);
+        config()->set('openapi-contract-testing.auto_validate_request', true);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('OpenAPI request validation failed');
+
+        $this->postJson('/v1/pets', ['not_name' => 'x']);
+    }
+
     /** @return array<int, class-string> */
     protected function getPackageProviders($app): array
     {

--- a/tests/Unit/ValidatesOpenApiSchemaAutoInjectBearerTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaAutoInjectBearerTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\HttpMethod;
+use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
+use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+use Symfony\Component\HttpFoundation\Request;
+
+// Load namespace-level config() mock before the trait resolves the function call.
+require_once __DIR__ . '/../Helpers/LaravelConfigMock.php';
+
+/**
+ * Covers the `auto_inject_dummy_bearer` branch of request validation. The
+ * inject path is a spec-driven convenience for tests that authenticate via
+ * actingAs() or middleware bypass and therefore never set a real
+ * Authorization header — without the inject, every bearer-protected endpoint
+ * would false-fail the security check.
+ */
+class ValidatesOpenApiSchemaAutoInjectBearerTest extends TestCase
+{
+    use ValidatesOpenApiSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs');
+        OpenApiCoverageTracker::reset();
+        $GLOBALS['__openapi_testing_config'] = [
+            'openapi-contract-testing.default_spec' => 'petstore-3.0',
+            'openapi-contract-testing.auto_validate_request' => true,
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        self::resetValidatorCache();
+        unset($GLOBALS['__openapi_testing_config']);
+        OpenApiSpecLoader::reset();
+        OpenApiCoverageTracker::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function config_file_defaults_auto_inject_dummy_bearer_to_false(): void
+    {
+        $config = require __DIR__ . '/../../src/Laravel/config.php';
+
+        $this->assertArrayHasKey('auto_inject_dummy_bearer', $config);
+        $this->assertFalse($config['auto_inject_dummy_bearer']);
+    }
+
+    #[Test]
+    public function inject_true_satisfies_bearer_endpoint_without_real_header(): void
+    {
+        // /v1/secure/bearer requires `bearerAuth`. With the inject flag on,
+        // the validator's view of the request gets a dummy Bearer token even
+        // though the Symfony Request has none — security check passes.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_bearer'] = true;
+
+        $request = Request::create('/v1/secure/bearer', 'GET');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/bearer');
+
+        $this->assertArrayHasKey(
+            'GET /v1/secure/bearer',
+            OpenApiCoverageTracker::getCovered()['petstore-3.0'] ?? [],
+        );
+    }
+
+    #[Test]
+    public function inject_false_still_fails_bearer_endpoint_without_header(): void
+    {
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_bearer'] = false;
+
+        $request = Request::create('/v1/secure/bearer', 'GET');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Authorization header is missing');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/bearer');
+    }
+
+    #[Test]
+    public function inject_does_not_override_user_supplied_authorization(): void
+    {
+        // If the test has already set Authorization (e.g. a malformed value
+        // to deliberately exercise a failure path), the inject must leave it
+        // alone so the test's intent wins. Here we set an invalid value and
+        // assert the validator sees it.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_bearer'] = true;
+
+        $request = Request::create(
+            '/v1/secure/bearer',
+            'GET',
+            [],
+            [],
+            [],
+            ['HTTP_AUTHORIZATION' => 'Malformed'],
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("Authorization header does not contain a 'Bearer <token>' credential");
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/bearer');
+    }
+
+    #[Test]
+    public function inject_is_noop_on_apikey_only_endpoint(): void
+    {
+        // Inject is bearer-only by design. An apiKey endpoint still fails
+        // with the apiKey-specific message so the user is directed to the
+        // right fix (set the api key), not a misleading "bearer missing".
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_bearer'] = true;
+
+        $request = Request::create('/v1/secure/apikey-header', 'GET');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("api key 'X-API-Key' is missing from the header");
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/apikey-header');
+    }
+
+    #[Test]
+    public function inject_is_noop_on_oauth2_only_endpoint(): void
+    {
+        // oauth2-only endpoints are classified as Unsupported by the
+        // validator (phase 1), so the requirement entry is skipped; injecting
+        // bearer would be a lie. Validation must pass on its own (skipped).
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_bearer'] = true;
+
+        $request = Request::create('/v1/secure/oauth2-only', 'GET');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/oauth2-only');
+
+        $this->assertArrayHasKey(
+            'GET /v1/secure/oauth2-only',
+            OpenApiCoverageTracker::getCovered()['petstore-3.0'] ?? [],
+        );
+    }
+
+    #[Test]
+    public function inject_in_and_requirement_still_surfaces_apikey_error(): void
+    {
+        // /v1/secure/and requires bearer AND apiKey in a single entry.
+        // Injecting bearer alone cannot satisfy the entry, but the surfaced
+        // error narrows to the apiKey (the actionable one) rather than both.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_bearer'] = true;
+
+        $request = Request::create('/v1/secure/and', 'GET');
+
+        try {
+            $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/and');
+            $this->fail('Expected AssertionFailedError');
+        } catch (AssertionFailedError $e) {
+            $message = $e->getMessage();
+            $this->assertStringContainsString("api key 'X-API-Key' is missing", $message);
+            $this->assertStringNotContainsString('Authorization header is missing', $message);
+        }
+    }
+
+    #[Test]
+    public function inject_flag_alone_without_auto_validate_request_does_nothing(): void
+    {
+        // Inject is a sub-feature of request validation — with validation
+        // off, the inject flag must not run the validator as a side effect.
+        // Proves the feature flags compose independently.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = false;
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_bearer'] = true;
+
+        $request = Request::create('/v1/secure/bearer', 'GET');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/bearer');
+
+        $this->assertArrayNotHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
+    }
+
+    #[Test]
+    public function inject_respects_existing_lowercase_authorization_header(): void
+    {
+        // Symfony's HeaderBag normalizes to lowercase. The inject must see
+        // either case and not overwrite — regression guard for the
+        // case-insensitive lookup used in shouldAutoInjectDummyBearer().
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_bearer'] = true;
+
+        $request = Request::create(
+            '/v1/secure/bearer',
+            'GET',
+            [],
+            [],
+            [],
+            ['HTTP_AUTHORIZATION' => 'Bearer real-token.from-test'],
+        );
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/bearer');
+
+        // Valid bearer → covered. The dummy was not substituted.
+        $this->assertArrayHasKey(
+            'GET /v1/secure/bearer',
+            OpenApiCoverageTracker::getCovered()['petstore-3.0'] ?? [],
+        );
+    }
+}

--- a/tests/Unit/ValidatesOpenApiSchemaAutoInjectBearerTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaAutoInjectBearerTest.php
@@ -7,6 +7,7 @@ namespace Studio\OpenApiContractTesting\Tests\Unit;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use Studio\OpenApiContractTesting\HttpMethod;
 use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
 use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
@@ -180,6 +181,42 @@ class ValidatesOpenApiSchemaAutoInjectBearerTest extends TestCase
         $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/bearer');
 
         $this->assertArrayNotHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
+    }
+
+    #[Test]
+    public function inject_flag_with_non_bool_value_fails_loudly(): void
+    {
+        // Same three-way coercion that auto_assert / auto_validate_request
+        // use — wiring regression guard for the shared resolveBoolConfig()
+        // helper. A typo'd env value must not silently disable the feature.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_bearer'] = 'yolo';
+
+        $request = Request::create('/v1/secure/bearer', 'GET');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('auto_inject_dummy_bearer must be a boolean');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/bearer');
+    }
+
+    #[Test]
+    public function inject_swallows_runtime_exception_from_spec_load_and_lets_validator_surface_it(): void
+    {
+        // RuntimeException from OpenApiSpecLoader::load() (unreadable file,
+        // malformed JSON, unsupported extension, etc.) is caught inside
+        // shouldAutoInjectDummyBearer() so the inject path returns false.
+        // The validator loads the same spec immediately after and re-raises
+        // the error — confirming "one failure, not a cascade" doctrine.
+        // Uses a spec name with no corresponding file to trigger the real
+        // RuntimeException path.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.default_spec'] = 'nonexistent-spec-name';
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_bearer'] = true;
+
+        $request = Request::create('/v1/secure/bearer', 'GET');
+
+        $this->expectException(RuntimeException::class);
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/bearer');
     }
 
     #[Test]

--- a/tests/Unit/ValidatesOpenApiSchemaAutoValidateRequestTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaAutoValidateRequestTest.php
@@ -1,0 +1,296 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use const JSON_THROW_ON_ERROR;
+
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\HttpMethod;
+use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
+use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\SkipOpenApi;
+use Symfony\Component\HttpFoundation\Request;
+
+use function json_encode;
+
+// Load namespace-level config() mock before the trait resolves the function call.
+require_once __DIR__ . '/../Helpers/LaravelConfigMock.php';
+
+/**
+ * Covers the request-side auto-validation hook introduced by issue #69. The
+ * hook mirrors {@see ValidatesOpenApiSchema::maybeAutoAssertOpenApiSchema()}
+ * for requests: same per-request flag consumption, same #[SkipOpenApi]
+ * opt-out, same config-driven on/off.
+ *
+ * End-to-end integration through Laravel's HTTP helpers lives in
+ * AutoValidateRequestIntegrationTest. These unit tests drive the hook
+ * directly so failure modes can be pinned without a full Testbench app.
+ */
+class ValidatesOpenApiSchemaAutoValidateRequestTest extends TestCase
+{
+    use ValidatesOpenApiSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs');
+        OpenApiCoverageTracker::reset();
+        $GLOBALS['__openapi_testing_config'] = [
+            'openapi-contract-testing.default_spec' => 'petstore-3.0',
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        self::resetValidatorCache();
+        unset($GLOBALS['__openapi_testing_config']);
+        OpenApiSpecLoader::reset();
+        OpenApiCoverageTracker::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function config_file_defaults_auto_validate_request_to_false(): void
+    {
+        $config = require __DIR__ . '/../../src/Laravel/config.php';
+
+        $this->assertArrayHasKey('auto_validate_request', $config);
+        $this->assertFalse($config['auto_validate_request']);
+    }
+
+    #[Test]
+    public function auto_validate_request_true_passes_valid_post_body(): void
+    {
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = true;
+
+        $request = $this->makeJsonRequest('POST', '/v1/pets', ['name' => 'Fido']);
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/v1/pets');
+
+        // Valid request records coverage under the matched path.
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayHasKey('petstore-3.0', $covered);
+        $this->assertArrayHasKey('POST /v1/pets', $covered['petstore-3.0']);
+    }
+
+    #[Test]
+    public function auto_validate_request_true_raises_on_invalid_body(): void
+    {
+        // /v1/pets POST requires `name` per the spec. Sending a body without
+        // it is the canonical request-side contract drift.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = true;
+
+        $request = $this->makeJsonRequest('POST', '/v1/pets', ['not_name' => 'x']);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('OpenAPI request validation failed');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/v1/pets');
+    }
+
+    #[Test]
+    public function auto_validate_request_true_raises_on_missing_bearer(): void
+    {
+        // Without auto-inject, a bearer-protected endpoint called without any
+        // Authorization header must fail request validation — proves that the
+        // security-side of the validator is wired through.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = true;
+
+        $request = Request::create('/v1/secure/bearer', 'GET');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Authorization header is missing');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/bearer');
+    }
+
+    #[Test]
+    public function auto_validate_request_false_does_not_validate(): void
+    {
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = false;
+
+        $request = $this->makeJsonRequest('POST', '/v1/pets', ['not_name' => 'x']);
+
+        // No exception even though the body is invalid.
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/v1/pets');
+
+        $this->assertArrayNotHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
+    }
+
+    #[Test]
+    public function auto_validate_request_not_set_defaults_to_skip(): void
+    {
+        $request = $this->makeJsonRequest('POST', '/v1/pets', ['not_name' => 'x']);
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/v1/pets');
+
+        $this->assertArrayNotHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
+    }
+
+    #[Test]
+    public function without_request_validation_skips_next_call(): void
+    {
+        // Flag must actually suppress validation now that the hook is live —
+        // previously this was forward-looking and had no observable effect.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = true;
+
+        $request = $this->makeJsonRequest('POST', '/v1/pets', ['not_name' => 'x']);
+
+        $this->withoutRequestValidation();
+        // Does not throw despite invalid body.
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/v1/pets');
+
+        $this->assertArrayNotHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
+    }
+
+    #[Test]
+    public function without_request_validation_flag_resets_after_one_call(): void
+    {
+        // Core guarantee from #41 — same semantics apply to the request side.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = true;
+
+        $invalidRequest = $this->makeJsonRequest('POST', '/v1/pets', ['not_name' => 'x']);
+
+        $this->withoutRequestValidation();
+        $this->maybeAutoValidateOpenApiRequest($invalidRequest, HttpMethod::POST, '/v1/pets');
+
+        // Second identical call must re-validate.
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('OpenAPI request validation failed');
+
+        $this->maybeAutoValidateOpenApiRequest($invalidRequest, HttpMethod::POST, '/v1/pets');
+    }
+
+    #[Test]
+    public function skip_flag_consumed_even_when_auto_validate_request_disabled(): void
+    {
+        // Flag tracks the HTTP call boundary; consumption must happen whether
+        // or not validation ran. Otherwise, flipping auto_validate_request
+        // from off → on mid-test would silently apply the stale flag.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = false;
+
+        $this->withoutRequestValidation();
+        $this->maybeAutoValidateOpenApiRequest(
+            $this->makeJsonRequest('POST', '/v1/pets', ['name' => 'ok']),
+            HttpMethod::POST,
+            '/v1/pets',
+        );
+
+        // Re-enable and send an invalid body — must throw, proving the flag
+        // did not carry over from the previous (config-disabled) call.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = true;
+
+        $this->expectException(AssertionFailedError::class);
+        $this->maybeAutoValidateOpenApiRequest(
+            $this->makeJsonRequest('POST', '/v1/pets', ['not_name' => 'x']),
+            HttpMethod::POST,
+            '/v1/pets',
+        );
+    }
+
+    #[Test]
+    #[SkipOpenApi(reason: 'intentional contract violation')]
+    public function skip_open_api_attribute_opts_method_out_of_request_validation(): void
+    {
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = true;
+
+        $request = $this->makeJsonRequest('POST', '/v1/pets', ['not_name' => 'x']);
+
+        // Does not throw, does not record coverage — parallels attribute
+        // behavior on the response side.
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/v1/pets');
+
+        $this->assertArrayNotHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
+    }
+
+    #[Test]
+    public function null_request_is_noop(): void
+    {
+        // Defensive: createTestResponse receives a nullable $request from
+        // Laravel. If null is ever passed through, the hook must not crash.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = true;
+
+        $this->maybeAutoValidateOpenApiRequest(null, null, null);
+
+        $this->assertArrayNotHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
+    }
+
+    #[Test]
+    public function null_method_is_noop(): void
+    {
+        // HttpMethod::tryFrom() returns null for unrecognized verbs (e.g. a
+        // hypothetical LINK / UNLINK). The hook must not try to validate.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = true;
+
+        $request = $this->makeJsonRequest('POST', '/v1/pets', ['name' => 'ok']);
+
+        $this->maybeAutoValidateOpenApiRequest($request, null, '/v1/pets');
+
+        $this->assertArrayNotHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
+    }
+
+    #[Test]
+    public function auto_validate_request_accepts_truthy_string(): void
+    {
+        // `'auto_validate_request' => env('X')` is the idiomatic Laravel path
+        // and yields "true" (string) — must be coerced just like auto_assert.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = 'true';
+
+        $request = $this->makeJsonRequest('POST', '/v1/pets', ['name' => 'ok']);
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/v1/pets');
+
+        $this->assertArrayHasKey('POST /v1/pets', OpenApiCoverageTracker::getCovered()['petstore-3.0'] ?? []);
+    }
+
+    #[Test]
+    public function auto_validate_request_with_non_bool_value_fails_loudly(): void
+    {
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = 'yolo';
+
+        $request = $this->makeJsonRequest('POST', '/v1/pets', ['name' => 'ok']);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('auto_validate_request must be a boolean');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/v1/pets');
+    }
+
+    #[Test]
+    public function unmatched_path_fails_validation(): void
+    {
+        // OpenApiRequestValidator itself produces the "No matching path" error;
+        // this test pins that the trait surfaces it as an assertion failure
+        // rather than swallowing it.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = true;
+
+        $request = $this->makeJsonRequest('POST', '/does/not/exist', ['name' => 'ok']);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('No matching path');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/does/not/exist');
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     */
+    private function makeJsonRequest(string $method, string $path, array $body): Request
+    {
+        return Request::create(
+            $path,
+            $method,
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            (string) json_encode($body, JSON_THROW_ON_ERROR),
+        );
+    }
+}

--- a/tests/Unit/ValidatesOpenApiSchemaAutoValidateRequestTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaAutoValidateRequestTest.php
@@ -278,6 +278,94 @@ class ValidatesOpenApiSchemaAutoValidateRequestTest extends TestCase
         $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/does/not/exist');
     }
 
+    #[Test]
+    public function empty_spec_name_fails_loudly_on_request_side(): void
+    {
+        // Mirrors the response-side guard: returning `''` from openApiSpec()
+        // is the misconfigured-defaults case. The trait must shout with an
+        // actionable hint rather than silently skipping validation.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = true;
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.default_spec'] = '';
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('openApiSpec() must return a non-empty spec name');
+
+        $this->maybeAutoValidateOpenApiRequest(
+            $this->makeJsonRequest('POST', '/v1/pets', ['name' => 'ok']),
+            HttpMethod::POST,
+            '/v1/pets',
+        );
+    }
+
+    #[Test]
+    public function malformed_json_body_with_content_type_fails_with_clear_message(): void
+    {
+        // json_decode with JSON_THROW_ON_ERROR raises JsonException on broken
+        // bodies; the trait converts it to a PHPUnit failure so the test
+        // author sees what happened instead of a mid-stack exception.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = true;
+
+        $request = Request::create(
+            '/v1/pets',
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            '{not valid json',
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Request body could not be parsed as JSON');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/v1/pets');
+    }
+
+    #[Test]
+    public function malformed_json_body_without_content_type_adds_hint(): void
+    {
+        // Missing Content-Type on a non-empty body falls through to the JSON
+        // decode path (documented lenient behavior). If it fails, the error
+        // message appends a hint that the header was absent so the user
+        // knows to set it. Symfony's Request::create auto-sets Content-Type
+        // to x-www-form-urlencoded when a body is provided, so we explicitly
+        // clear it to reach the "empty Content-Type" branch of extractRequestBody().
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = true;
+
+        $request = Request::create('/v1/pets', 'POST', [], [], [], [], '{not valid json');
+        $request->headers->remove('Content-Type');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('no Content-Type header was present on the request');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/v1/pets');
+    }
+
+    #[Test]
+    public function non_json_content_type_body_is_treated_as_null(): void
+    {
+        // Regression guard: a form-urlencoded body must not be handed to the
+        // validator as raw content — it returns `null` so the validator's
+        // body-schema check runs against "no JSON body" and surfaces the
+        // right error rather than a coercion one.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = true;
+
+        $request = Request::create(
+            '/v1/pets',
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/x-www-form-urlencoded'],
+            'name=fido',
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('OpenAPI request validation failed');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/v1/pets');
+    }
+
     /**
      * @param array<string, mixed> $body
      */

--- a/tests/Unit/Validation/Request/SecuritySchemeIntrospectorTest.php
+++ b/tests/Unit/Validation/Request/SecuritySchemeIntrospectorTest.php
@@ -1,0 +1,308 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Validation\Request;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Validation\Request\SecuritySchemeIntrospector;
+use Studio\OpenApiContractTesting\Validation\Request\SecurityValidator;
+
+/**
+ * Covers the spec-side "does this endpoint accept a bearer credential?" probe
+ * used by the auto-inject-dummy-bearer path in the Laravel
+ * `ValidatesOpenApiSchema` trait. The rules mirror
+ * {@see SecurityValidator::classifyScheme()} exactly — any discrepancy would
+ * cause the trait to inject a token that the validator then considers out of
+ * spec.
+ */
+class SecuritySchemeIntrospectorTest extends TestCase
+{
+    private SecuritySchemeIntrospector $introspector;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->introspector = new SecuritySchemeIntrospector();
+    }
+
+    #[Test]
+    public function detects_bearer_on_operation_with_bearer_auth_requirement(): void
+    {
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'bearerAuth' => ['type' => 'http', 'scheme' => 'bearer'],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['bearerAuth' => []]]];
+
+        $this->assertTrue($this->introspector->endpointAcceptsBearer($spec, $operation));
+    }
+
+    #[Test]
+    public function accepts_uppercase_bearer_scheme_value(): void
+    {
+        // RFC 7235 makes the HTTP auth scheme name case-insensitive. The
+        // introspector must mirror SecurityValidator's `strtolower()` handling
+        // so a spec author writing "Bearer" (capitalized) does not quietly
+        // disable the auto-inject path for their bearer endpoints.
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'bearerAuth' => ['type' => 'http', 'scheme' => 'Bearer'],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['bearerAuth' => []]]];
+
+        $this->assertTrue($this->introspector->endpointAcceptsBearer($spec, $operation));
+    }
+
+    #[Test]
+    public function returns_false_for_apikey_only_endpoint(): void
+    {
+        // apiKey schemes are intentionally NOT auto-injectable — the header
+        // name (e.g. "X-API-Key") is arbitrary per spec and we will not guess
+        // a reasonable dummy value for it.
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'apiKeyHeader' => [
+                        'type' => 'apiKey',
+                        'in' => 'header',
+                        'name' => 'X-API-Key',
+                    ],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['apiKeyHeader' => []]]];
+
+        $this->assertFalse($this->introspector->endpointAcceptsBearer($spec, $operation));
+    }
+
+    #[Test]
+    public function returns_false_for_oauth2_only_endpoint(): void
+    {
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'oauth2Flow' => [
+                        'type' => 'oauth2',
+                        'flows' => ['implicit' => ['authorizationUrl' => 'https://example.com/oauth', 'scopes' => []]],
+                    ],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['oauth2Flow' => ['read']]]];
+
+        $this->assertFalse($this->introspector->endpointAcceptsBearer($spec, $operation));
+    }
+
+    #[Test]
+    public function returns_false_when_security_is_empty_array_opt_out(): void
+    {
+        // Explicit `security: []` opts the operation out of authentication.
+        // No injection needed even if a root-level bearer requirement exists.
+        $spec = [
+            'security' => [['bearerAuth' => []]],
+            'components' => [
+                'securitySchemes' => [
+                    'bearerAuth' => ['type' => 'http', 'scheme' => 'bearer'],
+                ],
+            ],
+        ];
+        $operation = ['security' => []];
+
+        $this->assertFalse($this->introspector->endpointAcceptsBearer($spec, $operation));
+    }
+
+    #[Test]
+    public function returns_false_when_neither_operation_nor_root_security_defined(): void
+    {
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'bearerAuth' => ['type' => 'http', 'scheme' => 'bearer'],
+                ],
+            ],
+        ];
+        $operation = [];
+
+        $this->assertFalse($this->introspector->endpointAcceptsBearer($spec, $operation));
+    }
+
+    #[Test]
+    public function inherits_root_level_security_when_operation_silent(): void
+    {
+        // OpenAPI 3.x: operations without a `security` key inherit the root
+        // array. The trait relies on this to auto-inject on endpoints whose
+        // spec authors only declared bearer once at the top.
+        $spec = [
+            'security' => [['bearerAuth' => []]],
+            'components' => [
+                'securitySchemes' => [
+                    'bearerAuth' => ['type' => 'http', 'scheme' => 'bearer'],
+                ],
+            ],
+        ];
+        $operation = [];
+
+        $this->assertTrue($this->introspector->endpointAcceptsBearer($spec, $operation));
+    }
+
+    #[Test]
+    public function operation_level_security_overrides_root(): void
+    {
+        // Root says bearer, operation says apiKey. OpenAPI override semantics
+        // mean the operation wins — no bearer involved, no inject.
+        $spec = [
+            'security' => [['bearerAuth' => []]],
+            'components' => [
+                'securitySchemes' => [
+                    'bearerAuth' => ['type' => 'http', 'scheme' => 'bearer'],
+                    'apiKeyHeader' => ['type' => 'apiKey', 'in' => 'header', 'name' => 'X-API-Key'],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['apiKeyHeader' => []]]];
+
+        $this->assertFalse($this->introspector->endpointAcceptsBearer($spec, $operation));
+    }
+
+    #[Test]
+    public function detects_bearer_in_or_requirement_with_unsupported_peer(): void
+    {
+        // Mirrors petstore-3.0 fixture /v1/secure/bearer-or-oauth2. Bearer is
+        // one OR-alternative alongside oauth2. Injecting bearer lets the
+        // bearer branch succeed; the oauth2 branch stays unsupported.
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'bearerAuth' => ['type' => 'http', 'scheme' => 'bearer'],
+                    'oauth2Flow' => ['type' => 'oauth2', 'flows' => ['implicit' => []]],
+                ],
+            ],
+        ];
+        $operation = [
+            'security' => [
+                ['bearerAuth' => []],
+                ['oauth2Flow' => ['read']],
+            ],
+        ];
+
+        $this->assertTrue($this->introspector->endpointAcceptsBearer($spec, $operation));
+    }
+
+    #[Test]
+    public function detects_bearer_in_and_requirement_mixed_with_apikey(): void
+    {
+        // AND-entry: bearer + apiKey. Injecting bearer alone won't satisfy
+        // validation but it WILL remove the "Authorization header is missing"
+        // noise so the user sees only the apiKey error — the actionable one.
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'bearerAuth' => ['type' => 'http', 'scheme' => 'bearer'],
+                    'apiKeyHeader' => ['type' => 'apiKey', 'in' => 'header', 'name' => 'X-API-Key'],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['bearerAuth' => [], 'apiKeyHeader' => []]]];
+
+        $this->assertTrue($this->introspector->endpointAcceptsBearer($spec, $operation));
+    }
+
+    #[Test]
+    public function returns_false_when_http_scheme_is_basic_not_bearer(): void
+    {
+        // http+basic / http+digest are the other validatable http schemes.
+        // Phase 1 treats them as Unsupported in SecurityValidator and we
+        // likewise refuse to auto-inject anything for them.
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'basicAuth' => ['type' => 'http', 'scheme' => 'basic'],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['basicAuth' => []]]];
+
+        $this->assertFalse($this->introspector->endpointAcceptsBearer($spec, $operation));
+    }
+
+    #[Test]
+    public function returns_false_when_scheme_reference_is_undefined(): void
+    {
+        // Broken spec (dangling reference). The introspector must not crash;
+        // SecurityValidator will surface the hard error during validation.
+        $spec = ['components' => ['securitySchemes' => []]];
+        $operation = ['security' => [['bearerAuth' => []]]];
+
+        $this->assertFalse($this->introspector->endpointAcceptsBearer($spec, $operation));
+    }
+
+    #[Test]
+    public function returns_false_when_components_security_schemes_is_non_array(): void
+    {
+        // Spec is malformed (scalar securitySchemes). We refuse to inject
+        // rather than risk masking a real spec bug — the validator will
+        // surface this as a hard error on its own.
+        $spec = ['components' => ['securitySchemes' => 'not-an-array']];
+        $operation = ['security' => [['bearerAuth' => []]]];
+
+        $this->assertFalse($this->introspector->endpointAcceptsBearer($spec, $operation));
+    }
+
+    #[Test]
+    public function returns_false_when_security_is_non_array_malformed(): void
+    {
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'bearerAuth' => ['type' => 'http', 'scheme' => 'bearer'],
+                ],
+            ],
+        ];
+        $operation = ['security' => 'not-an-array'];
+
+        $this->assertFalse($this->introspector->endpointAcceptsBearer($spec, $operation));
+    }
+
+    #[Test]
+    public function ignores_non_string_scheme_name_keys(): void
+    {
+        // Scheme names must be strings; a numeric/boolean-ish key would be
+        // malformed spec. Skip and continue — do not match bearer off it.
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'bearerAuth' => ['type' => 'http', 'scheme' => 'bearer'],
+                ],
+            ],
+        ];
+        $operation = ['security' => [[0 => []]]];
+
+        $this->assertFalse($this->introspector->endpointAcceptsBearer($spec, $operation));
+    }
+
+    #[Test]
+    public function returns_false_when_http_scheme_field_is_missing(): void
+    {
+        // Malformed http scheme entry (no `scheme` field). SecurityValidator
+        // would classify this as Malformed and raise a hard error — the
+        // introspector stays quiet and lets the validator handle it.
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'bearerAuth' => ['type' => 'http'],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['bearerAuth' => []]]];
+
+        $this->assertFalse($this->introspector->endpointAcceptsBearer($spec, $operation));
+    }
+}


### PR DESCRIPTION
## Summary

- Wires `OpenApiRequestValidator` into the Laravel `ValidatesOpenApiSchema` trait via a new `maybeAutoValidateOpenApiRequest()` hook called from `createTestResponse()`, gated on a new `auto_validate_request` config key.
- Adds `auto_inject_dummy_bearer`: when enabled and the spec security for the matched endpoint declares `bearerAuth`, the validator's view of the request is rewritten with `Authorization: Bearer test-token` so tests that authenticate via `actingAs()` / middleware bypass stop false-failing the security check.
- `withoutRequestValidation()` and `#[SkipOpenApi]` now actually opt a request out, with the same per-request consumption semantics already used on the response side.

Closes #69.

### What changed

- New `SecuritySchemeIntrospector` encapsulates the spec-side "does this endpoint accept a bearer?" probe. Classification rules mirror `SecurityValidator::classifyScheme()` exactly (shared invariant enforced by tests) so inject and validation cannot disagree.
- New `maybeAutoValidateOpenApiRequest(?Request, ?HttpMethod, ?string)` in the trait. Consumes `skipNextRequestValidation` unconditionally at the HTTP-call boundary, then early-returns on: config disabled, flag set, null request / null method, `#[SkipOpenApi]`. Otherwise runs `OpenApiRequestValidator::validate()`, records coverage, and asserts.
- The response-side bool-coercion logic was extracted into a shared `resolveBoolConfig()` helper so the three config flags (`auto_assert`, `auto_validate_request`, `auto_inject_dummy_bearer`) all accept `env("X")` string values with consistent error messages.
- Auto-inject is a **view-only rewrite** (per issue hint): the Symfony Request is never mutated — Laravel has already dispatched by the time `createTestResponse` runs, so mutation would be pointless. The inject rewrites the headers array handed to the validator. `apiKey` / `oauth2` endpoints are not touched.
- README section added covering both new flags.

### Files

- `src/Laravel/ValidatesOpenApiSchema.php` — new hook, static cache for `OpenApiRequestValidator`, `DUMMY_BEARER_TOKEN`, helpers.
- `src/Laravel/config.php` — two new keys (`auto_validate_request`, `auto_inject_dummy_bearer`, both default `false`).
- `src/Validation/Request/SecuritySchemeIntrospector.php` — new helper.
- `tests/Unit/Validation/Request/SecuritySchemeIntrospectorTest.php` — 16 unit tests.
- `tests/Unit/ValidatesOpenApiSchemaAutoValidateRequestTest.php` — 15 unit tests.
- `tests/Unit/ValidatesOpenApiSchemaAutoInjectBearerTest.php` — 9 unit tests.
- `tests/Integration/Laravel/AutoValidateRequestIntegrationTest.php` — 7 end-to-end Testbench tests.

### Backward compatibility

Both flags default to `false`, so existing suites are unaffected. `withoutRequestValidation()`'s previously forward-looking behavior now has observable effect — its README note was updated accordingly.

## Test plan

- [x] `vendor/bin/phpunit` — 618 tests / 1272 assertions pass (was 580 before).
- [x] `vendor/bin/phpstan analyse` — 0 errors (level 6).
- [x] `vendor/bin/php-cs-fixer fix --dry-run --diff` — 0 fixable issues.
- [x] `auto_validate_request=true` + invalid POST body → `AssertionFailedError` with `"OpenAPI request validation failed"` via the full Laravel HTTP pipeline.
- [x] `auto_inject_dummy_bearer=true` + bearer endpoint + no `Authorization` header → request validation passes (coverage recorded); same setup with inject off → fails with `"Authorization header is missing"`.
- [x] `withoutRequestValidation()` suppresses exactly one call end-to-end; the next call re-validates.