### PR TITLE
Refactoring: OpenApiValidationResult の状態表現を bool ペアから enum に置換 (#72)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ This is a PHP library (`studio-design/openapi-contract-testing`) that validates 
 
 - **`OpenApiVersion`** (`V3_0` | `V3_1`) — Auto-detected from spec's `openapi` field.
 - **`HttpMethod`** — GET, POST, PUT, PATCH, DELETE.
+- **`OpenApiValidationOutcome`** (`Success` | `Failure` | `Skipped`) — Tri-state outcome of a validation run, exposed via `OpenApiValidationResult::outcome()`. `isValid()` / `isSkipped()` remain as bool wrappers for back-compat.
 
 ## Code Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ This is a PHP library (`studio-design/openapi-contract-testing`) that validates 
 
 - **`OpenApiVersion`** (`V3_0` | `V3_1`) — Auto-detected from spec's `openapi` field.
 - **`HttpMethod`** — GET, POST, PUT, PATCH, DELETE.
-- **`OpenApiValidationOutcome`** (`Success` | `Failure` | `Skipped`) — Tri-state outcome of a validation run, exposed via `OpenApiValidationResult::outcome()`. `isValid()` / `isSkipped()` remain as bool wrappers for back-compat.
+- **`OpenApiValidationOutcome`** (`Success` | `Failure` | `Skipped`) — Tri-state outcome of a validation run, exposed via `OpenApiValidationResult::outcome()`. `isValid()` / `isSkipped()` are bool wrappers over this enum.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Notes:
 - Patterns are regex strings **without** `/` delimiters or `^$` anchors; they are anchored automatically, so `5\d\d` matches exactly `500`–`599` (not `5000`).
 - The skip check sits **between** the "path / method not in spec" checks and the "status code not defined" / schema-validation checks. A skipped code therefore suppresses both status-code failure modes (undocumented code AND body mismatch for a documented code), but typos in the request path or method still fail loudly.
 - Skipped endpoints count as covered — the endpoint was exercised, just not schema-validated. Coverage semantics here match how non-JSON content types and schema-less `204` responses are handled, but `OpenApiValidationResult::isSkipped()` returns `true` **only** for status-code skips; the other no-body-validation branches still return a plain `success()`.
-- `OpenApiValidationResult::isSkipped()` is exposed for callers who want to distinguish a skip from a genuine success. `skipReason()` identifies the matched pattern.
+- `OpenApiValidationResult::isSkipped()` is exposed for callers who want to distinguish a skip from a genuine success. `skipReason()` identifies the matched pattern. `outcome()` returns an `OpenApiValidationOutcome` enum (`Success` / `Failure` / `Skipped`) for callers who want exhaustive `match` handling instead of two bool predicates.
 - **Observability trade-off**: a real regression that causes an unrelated `500` will not fail this assertion. Keep your HTTP-level assertions (`$response->assertOk()`, status-code expectations in the test) alongside the contract check so a stray 5xx still surfaces — the contract assertion alone is not a substitute for status-code assertions on happy paths.
 
 #### Auto-assert every response
@@ -648,12 +648,23 @@ $result = $validator->validate(
     responseContentType: 'application/json',
 );
 
+$result->outcome();      // OpenApiValidationOutcome (Success | Failure | Skipped)
 $result->isValid();      // bool (true for both successes AND skipped results)
 $result->isSkipped();    // bool (true when the status code matched skip_response_codes)
 $result->errors();       // string[]
 $result->errorMessage(); // string (joined errors)
 $result->matchedPath();  // ?string (e.g., '/v1/pets/{petId}')
 $result->skipReason();   // ?string (non-null when skipped)
+```
+
+Prefer `outcome()` when you need to distinguish all three states explicitly — PHPStan enforces `match` exhaustiveness, so adding a future outcome cannot silently slip past a caller:
+
+```php
+match ($result->outcome()) {
+    OpenApiValidationOutcome::Success => /* schema matched */,
+    OpenApiValidationOutcome::Failure => throw new AssertionFailedError($result->errorMessage()),
+    OpenApiValidationOutcome::Skipped => logger()->info('skipped', ['reason' => $result->skipReason()]),
+};
 ```
 
 ### `OpenApiSpecLoader`

--- a/README.md
+++ b/README.md
@@ -660,8 +660,11 @@ $result->skipReason();   // ?string (non-null when skipped)
 Prefer `outcome()` when you need to distinguish all three states explicitly — PHPStan enforces `match` exhaustiveness, so adding a future outcome cannot silently slip past a caller:
 
 ```php
+use PHPUnit\Framework\AssertionFailedError;
+use Studio\OpenApiContractTesting\OpenApiValidationOutcome;
+
 match ($result->outcome()) {
-    OpenApiValidationOutcome::Success => /* schema matched */,
+    OpenApiValidationOutcome::Success => null, // schema matched
     OpenApiValidationOutcome::Failure => throw new AssertionFailedError($result->errorMessage()),
     OpenApiValidationOutcome::Skipped => logger()->info('skipped', ['reason' => $result->skipReason()]),
 };

--- a/src/OpenApiValidationOutcome.php
+++ b/src/OpenApiValidationOutcome.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 namespace Studio\OpenApiContractTesting;
 
 /**
- * Tri-state outcome of an OpenAPI validation run.
- *
- * Replaces the prior (valid:bool, skipped:bool) pair on {@see OpenApiValidationResult}
- * so the legal state space is expressed as 3 cases rather than 3-of-4 bool combinations.
- * Callers can `match ($result->outcome())` with PHPStan exhaustiveness checking instead
- * of relying on the implicit `isValid() === success OR skipped` convention.
+ * Tri-state outcome of an OpenAPI validation run, exposed via
+ * {@see OpenApiValidationResult::outcome()}. Callers can `match` over
+ * this enum and rely on PHPStan exhaustiveness to ensure every case is
+ * handled, rather than deriving intent from `isValid()` / `isSkipped()`.
  */
 enum OpenApiValidationOutcome: string
 {

--- a/src/OpenApiValidationOutcome.php
+++ b/src/OpenApiValidationOutcome.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting;
+
+/**
+ * Tri-state outcome of an OpenAPI validation run.
+ *
+ * Replaces the prior (valid:bool, skipped:bool) pair on {@see OpenApiValidationResult}
+ * so the legal state space is expressed as 3 cases rather than 3-of-4 bool combinations.
+ * Callers can `match ($result->outcome())` with PHPStan exhaustiveness checking instead
+ * of relying on the implicit `isValid() === success OR skipped` convention.
+ */
+enum OpenApiValidationOutcome: string
+{
+    case Success = 'success';
+    case Failure = 'failure';
+    case Skipped = 'skipped';
+}

--- a/src/OpenApiValidationResult.php
+++ b/src/OpenApiValidationResult.php
@@ -10,51 +10,58 @@ final class OpenApiValidationResult
 {
     /**
      * Private so the three factories (success / failure / skipped) are the
-     * only way to construct a result. This prevents illegal combinations such
-     * as `valid=false, skipped=true` or `valid=true, errors=['x']` — the
-     * factories enforce every invariant the type depends on.
+     * only way to construct a result. The outcome enum narrows the legal
+     * state space to exactly those three cases — errors are only attached
+     * to Failure, and skipReason is only attached to Skipped.
      *
      * @param string[] $errors
      */
     private function __construct(
-        private readonly bool $valid,
+        private readonly OpenApiValidationOutcome $outcome,
         private readonly array $errors = [],
         private readonly ?string $matchedPath = null,
-        private readonly bool $skipped = false,
         private readonly ?string $skipReason = null,
     ) {}
 
     public static function success(?string $matchedPath = null): self
     {
-        return new self(true, [], $matchedPath);
+        return new self(OpenApiValidationOutcome::Success, [], $matchedPath);
     }
 
     /** @param string[] $errors */
     public static function failure(array $errors, ?string $matchedPath = null): self
     {
-        return new self(false, $errors, $matchedPath);
+        return new self(OpenApiValidationOutcome::Failure, $errors, $matchedPath);
     }
 
     /**
      * Represents a response whose body was intentionally not validated (e.g. a
      * 5xx production error that the spec does not document). isValid() stays
      * true so callers that gate on it (e.g. PHPUnit assertions) treat the
-     * result as non-failing; isSkipped() distinguishes it from a genuine
-     * successful schema match.
+     * result as non-failing; isSkipped() / outcome() distinguish it from a
+     * genuine successful schema match.
      */
     public static function skipped(?string $matchedPath = null, ?string $reason = null): self
     {
-        return new self(true, [], $matchedPath, true, $reason);
+        return new self(OpenApiValidationOutcome::Skipped, [], $matchedPath, $reason);
+    }
+
+    public function outcome(): OpenApiValidationOutcome
+    {
+        return $this->outcome;
     }
 
     public function isValid(): bool
     {
-        return $this->valid;
+        return match ($this->outcome) {
+            OpenApiValidationOutcome::Success, OpenApiValidationOutcome::Skipped => true,
+            OpenApiValidationOutcome::Failure => false,
+        };
     }
 
     public function isSkipped(): bool
     {
-        return $this->skipped;
+        return $this->outcome === OpenApiValidationOutcome::Skipped;
     }
 
     /** @return string[] */

--- a/tests/Unit/OpenApiValidationResultTest.php
+++ b/tests/Unit/OpenApiValidationResultTest.php
@@ -6,6 +6,7 @@ namespace Studio\OpenApiContractTesting\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\OpenApiValidationOutcome;
 use Studio\OpenApiContractTesting\OpenApiValidationResult;
 
 class OpenApiValidationResultTest extends TestCase
@@ -15,6 +16,7 @@ class OpenApiValidationResultTest extends TestCase
     {
         $result = OpenApiValidationResult::success('/v1/pets');
 
+        $this->assertSame(OpenApiValidationOutcome::Success, $result->outcome());
         $this->assertTrue($result->isValid());
         $this->assertFalse($result->isSkipped());
         $this->assertSame([], $result->errors());
@@ -27,6 +29,7 @@ class OpenApiValidationResultTest extends TestCase
     {
         $result = OpenApiValidationResult::success();
 
+        $this->assertSame(OpenApiValidationOutcome::Success, $result->outcome());
         $this->assertTrue($result->isValid());
         $this->assertFalse($result->isSkipped());
         $this->assertNull($result->matchedPath());
@@ -38,6 +41,7 @@ class OpenApiValidationResultTest extends TestCase
         $errors = ['Error 1', 'Error 2'];
         $result = OpenApiValidationResult::failure($errors);
 
+        $this->assertSame(OpenApiValidationOutcome::Failure, $result->outcome());
         $this->assertFalse($result->isValid());
         $this->assertFalse($result->isSkipped());
         $this->assertSame($errors, $result->errors());
@@ -59,6 +63,7 @@ class OpenApiValidationResultTest extends TestCase
 
         // isValid() remains true so the assertion surface does not fail the test,
         // but isSkipped() distinguishes the case from a genuine success.
+        $this->assertSame(OpenApiValidationOutcome::Skipped, $result->outcome());
         $this->assertTrue($result->isValid());
         $this->assertTrue($result->isSkipped());
         $this->assertSame([], $result->errors());
@@ -72,6 +77,7 @@ class OpenApiValidationResultTest extends TestCase
     {
         $result = OpenApiValidationResult::skipped('/v1/pets');
 
+        $this->assertSame(OpenApiValidationOutcome::Skipped, $result->outcome());
         $this->assertTrue($result->isValid());
         $this->assertTrue($result->isSkipped());
         $this->assertSame('/v1/pets', $result->matchedPath());
@@ -83,9 +89,31 @@ class OpenApiValidationResultTest extends TestCase
     {
         $result = OpenApiValidationResult::skipped();
 
+        $this->assertSame(OpenApiValidationOutcome::Skipped, $result->outcome());
         $this->assertTrue($result->isValid());
         $this->assertTrue($result->isSkipped());
         $this->assertNull($result->matchedPath());
         $this->assertNull($result->skipReason());
+    }
+
+    #[Test]
+    public function outcome_match_covers_all_three_cases_exhaustively(): void
+    {
+        $results = [
+            OpenApiValidationResult::success(),
+            OpenApiValidationResult::failure(['err']),
+            OpenApiValidationResult::skipped(reason: 'reason'),
+        ];
+
+        $labels = [];
+        foreach ($results as $result) {
+            $labels[] = match ($result->outcome()) {
+                OpenApiValidationOutcome::Success => 'success',
+                OpenApiValidationOutcome::Failure => 'failure',
+                OpenApiValidationOutcome::Skipped => 'skipped',
+            };
+        }
+
+        $this->assertSame(['success', 'failure', 'skipped'], $labels);
     }
 }


### PR DESCRIPTION
# 概要

`OpenApiValidationResult` の内部状態を 2 つの bool (`$valid`, `$skipped`) から 1 つの `OpenApiValidationOutcome` enum に置換し、tri-state (Success / Failure / Skipped) を型で明示する。

## 変更内容

PR #71 で Skipped 状態が追加されたことで bool×bool (3 of 4 legal) という暗黙の state space が生まれ、type-design レビューで Invariant expression 2/5 / Enforcement 2/5 と指摘されていた。これを既存 `OpenApiVersion` / `HttpMethod` と同じ backed enum パターンに揃え、`match($result->outcome())` で PHPStan level 6 の網羅性検査が効くようにする。

- `src/OpenApiValidationOutcome.php` を新規追加（`Success` / `Failure` / `Skipped` の string-backed enum）
- `OpenApiValidationResult` のプロパティを 2 bool → 1 enum に置換
- `isValid()` / `isSkipped()` は `match` ベースの thin wrapper として維持（**完全後方互換**）
- 公開 getter `outcome(): OpenApiValidationOutcome` を追加
- 既存 `OpenApiValidationResultTest` に `outcome()` assertion を追加、`match` 網羅性テストを 1 ケース追加
- README の API Reference に `outcome()` と `match` 使用例を追記
- CLAUDE.md の Key Enums 節に新 enum を追加

呼び出し側 (`ValidatesOpenApiSchema` / `OpenApiResponseValidator`) の `outcome()`-based 書き換えは issue 本体で明示的にスコープ外（別 PR）。本 PR は型リファクタのみで、既存テスト (627 件) は無変更で全て通過し後方互換を担保している。

### 検証

- `vendor/bin/phpunit` → 627 tests, 1304 assertions, all green
- `vendor/bin/phpstan analyse` → No errors (level 6)
- `vendor/bin/php-cs-fixer fix --dry-run --diff` → 0 files to fix

## 関連情報

- Closes #72
- Refs PR #71 (Tier 1 対応で private constructor を導入した先行 PR)