### PR TITLE
refactor(validation-result): reject failure([]) (#73)

### DIFF
--- a/src/OpenApiValidationResult.php
+++ b/src/OpenApiValidationResult.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting;
 
+use InvalidArgumentException;
+
 use function implode;
 
 final class OpenApiValidationResult
@@ -28,9 +30,23 @@ final class OpenApiValidationResult
         return new self(OpenApiValidationOutcome::Success, [], $matchedPath);
     }
 
-    /** @param string[] $errors */
+    /**
+     * Reject `failure([])` so a Failure always carries at least one error
+     * message. Without this guard, `errorMessage()` would return an empty
+     * string and the Failure would surface as a silent assertion failure.
+     *
+     * @param string[] $errors
+     *
+     * @throws InvalidArgumentException when $errors is empty
+     */
     public static function failure(array $errors, ?string $matchedPath = null): self
     {
+        if ($errors === []) {
+            throw new InvalidArgumentException(
+                'OpenApiValidationResult::failure() requires at least one error message.',
+            );
+        }
+
         return new self(OpenApiValidationOutcome::Failure, $errors, $matchedPath);
     }
 

--- a/tests/Unit/OpenApiValidationResultTest.php
+++ b/tests/Unit/OpenApiValidationResultTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Tests\Unit;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\OpenApiValidationOutcome;
@@ -46,6 +47,15 @@ class OpenApiValidationResultTest extends TestCase
         $this->assertFalse($result->isSkipped());
         $this->assertSame($errors, $result->errors());
         $this->assertNull($result->matchedPath());
+    }
+
+    #[Test]
+    public function failure_with_empty_errors_throws(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('failure() requires at least one error message');
+
+        OpenApiValidationResult::failure([]);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- `OpenApiValidationResult::failure([])` throws `InvalidArgumentException` instead of constructing a Failure with no error messages
- Updates the docblock to document the new contract (`@throws`, plus a short Why explaining the silent-failure motivation)
- Adds a unit test covering the empty-array rejection

## Why

Previously `failure([])` produced an `OpenApiValidationResult` whose `errorMessage()` returned `''`. When such a result reached an assertion like `$this->assertTrue($result->isValid(), $result->errorMessage())`, the test failed with no diagnostic context — a silent failure of the kind this repo has been actively eliminating (b018758, 6327833, 1edb6f8 …). Failing at construction time forces the bug to the call site instead of the assertion site.

## Call-site safety

All existing `::failure(...)` call sites were verified to never pass empty arrays:

- `src/OpenApiRequestValidator.php:72,85` — pass literal non-empty error strings
- `src/OpenApiRequestValidator.php:111` — passes accumulated `$errors`, guarded by `if ($errors === []) return success(...)` on the line above
- `src/OpenApiResponseValidator.php:66,75,97` — pass literal non-empty error strings
- `src/OpenApiResponseValidator.php:127` — passes accumulated `$errors`, guarded by `if ($errors === []) return success(...)` on the line above

So no production code path triggers the new exception.

## Out of scope

Per the issue, narrowing `errors()` to a `non-empty-array<string>` PHPStan type is deferred to a separate discussion.

## Test plan

- [x] `vendor/bin/phpunit --filter failure_with_empty_errors_throws` — new test passes
- [x] `vendor/bin/phpunit tests/Unit/OpenApiValidationResultTest.php` — 9 tests, 36 assertions
- [x] `vendor/bin/phpunit` — full suite: 628 tests, 1306 assertions, all green
- [x] `vendor/bin/phpstan analyse` — no errors
- [x] `vendor/bin/php-cs-fixer fix --dry-run --diff` — no diffs

Closes #73