### PR TITLE
Refactoring: skip-precedence regression tests の petstore-3.0 5xx 依存を解消

### DIFF
--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -292,18 +292,15 @@ class OpenApiResponseValidatorTest extends TestCase
     #[Test]
     public function skip_pattern_is_anchored(): void
     {
-        // Anchoring matters: "50" must not match "500". Without anchors, a
-        // pattern like "50" would accidentally skip any code starting with 50.
-        // Also assert that validation still proceeds normally — petstore-3.0
-        // defines 500 with an empty application/json schema, so the result is
-        // a regular success, not a skip.
-        $validator = new OpenApiResponseValidator(skipResponseCodes: ['50']);
+        // Anchoring matters: "20" must not match "201". Without anchors, a
+        // pattern like "20" would accidentally skip any code starting with 20.
+        $validator = new OpenApiResponseValidator(skipResponseCodes: ['20']);
 
         $result = $validator->validate(
-            'petstore-3.0',
+            'content-without-schema',
             'GET',
-            '/v1/pets',
-            500,
+            '/widgets',
+            201,
             null,
         );
 
@@ -529,23 +526,20 @@ class OpenApiResponseValidatorTest extends TestCase
     #[Test]
     public function v30_json_content_type_without_schema_skips_validation(): void
     {
-        // Bypass the 5xx default skip so we exercise the "content entry with
-        // no schema" path specifically (petstore-3.0 defines 500 with an empty
-        // application/json object). With the default skip list, the 5xx check
-        // would short-circuit before reaching the schema-less branch.
-        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
-
-        $result = $validator->validate(
-            'petstore-3.0',
+        // The content-without-schema fixture declares application/json with no
+        // schema on 201, outside the default 5xx skip window — so the default
+        // validator reaches the schema-less branch directly.
+        $result = $this->validator->validate(
+            'content-without-schema',
             'GET',
-            '/v1/pets',
-            500,
+            '/widgets',
+            201,
             ['error' => 'something went wrong'],
         );
 
         $this->assertTrue($result->isValid());
         $this->assertFalse($result->isSkipped());
-        $this->assertSame('/v1/pets', $result->matchedPath());
+        $this->assertSame('/widgets', $result->matchedPath());
     }
 
     #[Test]

--- a/tests/fixtures/specs/content-without-schema.json
+++ b/tests/fixtures/specs/content-without-schema.json
@@ -1,0 +1,22 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Content without schema fixture",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/widgets": {
+            "get": {
+                "operationId": "listWidgets",
+                "responses": {
+                    "201": {
+                        "description": "Response declares application/json but omits schema",
+                        "content": {
+                            "application/json": {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 概要

`OpenApiResponseValidatorTest` の 2 つのテストが `petstore-3.0.json` fixture の 500 エントリ (`application/json: {}`) という実装詳細に依存していた点を解消するため、専用の小さな fixture を導入してテストを書き換えた。

## 変更内容

fixture 依存を減らすための方針として、Issue で挙げられた 3 案のうち **案 A (専用 fixture 追加)** を採用。理由:
- 案 B (inline spec helper) は `OpenApiSpecLoader` の公開 API をテスト専用のために広げる必要がある
- 案 C (petstore-3.0 に非 5xx の content-without-schema ケースを追加) は Issue でも指摘されている「fixture の肥大化」を招く

- `tests/fixtures/specs/content-without-schema.json` を新規追加 — `GET /widgets` の `201` が `application/json: {}`（schema 無し）。fixture 名から意図が読み取れる。
- `v30_json_content_type_without_schema_skips_validation` を書き換え — 新 fixture を使うことで `skipResponseCodes: []` の回避策が不要になり、default validator で schema-less branch を直接踏める。
- `skip_pattern_is_anchored` を書き換え — 新 fixture に切り替え、パターンを `['50']`→`['20']`、ステータスを 500→201 に変更。同じアンカリング検証の意図を保ちつつ、schema-less branch への偶然の依存を断った。

### 検証

- 対象 2 テスト + データプロバイダ: pass (3 tests, 7 assertions)
- フルスイート: 649 tests, 1362 assertions すべて pass
- PHPStan (level 6): 0 errors
- PHP-CS-Fixer: 0 fixable files
- スモークテスト: fixture に schema を追加すると `v30_json_content_type_without_schema_skips_validation` が失敗することを確認（= schema-less branch を実際に踏んでいる証拠）。revert 済み。

## 関連情報

- Closes #75
- 元の指摘: PR #71 のレビュー