### PR TITLE
Bugfix: $ref プロパティ名を持つ spec のロード失敗を修正

### DIFF
--- a/src/OpenApiRefResolver.php
+++ b/src/OpenApiRefResolver.php
@@ -124,6 +124,9 @@ final class OpenApiRefResolver
 
         foreach ($node as $key => &$child) {
             if (is_array($child)) {
+                // additionalProperties is intentionally excluded: its value is a single
+                // schema (not a dict of schemas), so a direct $ref under it is a
+                // legitimate Reference Object that must resolve.
                 $childInsidePropertiesMap = $key === 'properties' || $key === 'patternProperties';
                 self::walk($child, $root, $chain, $childInsidePropertiesMap);
             }

--- a/src/OpenApiRefResolver.php
+++ b/src/OpenApiRefResolver.php
@@ -52,10 +52,14 @@ final class OpenApiRefResolver
      * @param array<int|string, mixed> $node
      * @param array<string, mixed> $root
      * @param list<string> $chain pointer-refs already on the resolution stack — used to detect cycles
+     * @param bool $insidePropertiesMap true when `$node` is the direct children dict of
+     *                                  a `properties` / `patternProperties` map, where keys are property names
+     *                                  rather than schema keywords. The flag resets one level deeper, because
+     *                                  each named entry is itself a schema.
      */
-    private static function walk(array &$node, array $root, array $chain): void
+    private static function walk(array &$node, array $root, array $chain, bool $insidePropertiesMap = false): void
     {
-        if (array_key_exists('$ref', $node)) {
+        if (!$insidePropertiesMap && array_key_exists('$ref', $node)) {
             $ref = $node['$ref'];
 
             if (!is_string($ref)) {
@@ -118,9 +122,10 @@ final class OpenApiRefResolver
             return;
         }
 
-        foreach ($node as &$child) {
+        foreach ($node as $key => &$child) {
             if (is_array($child)) {
-                self::walk($child, $root, $chain);
+                $childInsidePropertiesMap = $key === 'properties' || $key === 'patternProperties';
+                self::walk($child, $root, $chain, $childInsidePropertiesMap);
             }
         }
         unset($child);

--- a/tests/Unit/OpenApiRefResolverTest.php
+++ b/tests/Unit/OpenApiRefResolverTest.php
@@ -758,4 +758,121 @@ class OpenApiRefResolverTest extends TestCase
         $schema = $resolved['paths']['/pets']['get']['responses']['200']['content']['application/xml']['schema'];
         $this->assertSame(['type' => 'object', 'required' => ['id']], $schema);
     }
+
+    #[Test]
+    public function resolves_schema_with_ref_as_property_name(): void
+    {
+        // Specs for JSON Patch / JSON-LD / JSON Schema payloads legally describe
+        // an object with a property literally named `$ref`. The walker must
+        // treat keys inside a `properties` map as property names, not as
+        // Reference Object markers — otherwise load throws on a valid spec.
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'JsonPatch' => [
+                        'type' => 'object',
+                        'properties' => [
+                            '$ref' => ['type' => 'string'],
+                            'value' => ['type' => 'string'],
+                        ],
+                    ],
+                ],
+            ],
+            'paths' => [
+                '/patches' => [
+                    'get' => [
+                        'responses' => [
+                            '200' => [
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => ['$ref' => '#/components/schemas/JsonPatch'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $schema = $resolved['paths']['/patches']['get']['responses']['200']['content']['application/json']['schema'];
+        $this->assertSame(
+            [
+                'type' => 'object',
+                'properties' => [
+                    '$ref' => ['type' => 'string'],
+                    'value' => ['type' => 'string'],
+                ],
+            ],
+            $schema,
+        );
+    }
+
+    #[Test]
+    public function resolves_ref_inside_schema_with_ref_property_name(): void
+    {
+        // Pins that the property-name guard is one level deep only: the entry
+        // `properties.$ref` is a schema, and if that schema itself is a
+        // Reference Object it must still resolve at the next level.
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Label' => ['type' => 'string'],
+                    'Holder' => [
+                        'type' => 'object',
+                        'properties' => [
+                            '$ref' => ['$ref' => '#/components/schemas/Label'],
+                        ],
+                    ],
+                ],
+            ],
+            'x-alias' => ['$ref' => '#/components/schemas/Holder'],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $this->assertSame(
+            [
+                'type' => 'object',
+                'properties' => [
+                    '$ref' => ['type' => 'string'],
+                ],
+            ],
+            $resolved['x-alias'],
+        );
+    }
+
+    #[Test]
+    public function resolves_schema_with_ref_as_pattern_property_name(): void
+    {
+        // `patternProperties` has the same shape as `properties` (dict of
+        // schemas keyed by arbitrary strings). The same context guard applies.
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'PatternHolder' => [
+                        'type' => 'object',
+                        'patternProperties' => [
+                            '$ref' => ['type' => 'string'],
+                        ],
+                    ],
+                ],
+            ],
+            'x-alias' => ['$ref' => '#/components/schemas/PatternHolder'],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $this->assertSame(
+            [
+                'type' => 'object',
+                'patternProperties' => [
+                    '$ref' => ['type' => 'string'],
+                ],
+            ],
+            $resolved['x-alias'],
+        );
+    }
 }

--- a/tests/Unit/OpenApiRefResolverTest.php
+++ b/tests/Unit/OpenApiRefResolverTest.php
@@ -875,4 +875,99 @@ class OpenApiRefResolverTest extends TestCase
             $resolved['x-alias'],
         );
     }
+
+    #[Test]
+    public function resolves_ref_as_additional_properties_schema(): void
+    {
+        // `additionalProperties` holds a single schema, not a dict of schemas,
+        // so a $ref directly under it is a legitimate Reference Object and
+        // must still resolve. Pins that `additionalProperties` is deliberately
+        // excluded from the property-name guard.
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Pet' => ['type' => 'object', 'required' => ['id']],
+                ],
+            ],
+            'x-alias' => [
+                'type' => 'object',
+                'additionalProperties' => ['$ref' => '#/components/schemas/Pet'],
+            ],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $this->assertSame(
+            ['type' => 'object', 'required' => ['id']],
+            $resolved['x-alias']['additionalProperties'],
+        );
+    }
+
+    #[Test]
+    public function resolves_nested_ref_as_property_name_inside_all_of(): void
+    {
+        // Pins that the property-name guard applies exactly at the children
+        // of properties/patternProperties, not at every descendant. A sibling
+        // $ref at a deeper schema level (inside allOf, here) must still
+        // resolve as a Reference Object.
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Label' => ['type' => 'string'],
+                    'Holder' => [
+                        'allOf' => [
+                            [
+                                'type' => 'object',
+                                'properties' => [
+                                    '$ref' => ['type' => 'string'],
+                                    'label' => ['$ref' => '#/components/schemas/Label'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'x-alias' => ['$ref' => '#/components/schemas/Holder'],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $this->assertSame(
+            [
+                'allOf' => [
+                    [
+                        'type' => 'object',
+                        'properties' => [
+                            '$ref' => ['type' => 'string'],
+                            'label' => ['type' => 'string'],
+                        ],
+                    ],
+                ],
+            ],
+            $resolved['x-alias'],
+        );
+    }
+
+    #[Test]
+    public function throws_on_malformed_ref_as_value_of_ref_property(): void
+    {
+        // The property-name guard resets exactly one level deep. When a
+        // `properties.$ref` entry's VALUE is itself a malformed Reference
+        // Object (non-string $ref), the resolver must still throw — otherwise
+        // the one-level reset would widen into a broader silent-pass hole.
+        $spec = [
+            'x-holder' => [
+                'properties' => [
+                    '$ref' => [
+                        '$ref' => ['not', 'a', 'string'],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid $ref');
+
+        OpenApiRefResolver::resolve($spec);
+    }
 }

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -1043,6 +1043,29 @@ class OpenApiResponseValidatorTest extends TestCase
         $this->assertSame('/pets', $result->matchedPath());
     }
 
+    #[Test]
+    public function validates_response_body_with_ref_as_property_name(): void
+    {
+        // End-to-end: a spec that models a JSON Patch payload legally names a
+        // property `$ref`. The resolver must not misread it as a Reference
+        // Object, and the downstream converter + opis must accept a response
+        // body that carries a `$ref` field.
+        $result = $this->validator->validate(
+            'refs-property-name',
+            'GET',
+            '/patches',
+            200,
+            [
+                'op' => 'replace',
+                'path' => '/a/b',
+                '$ref' => '#/definitions/Foo',
+            ],
+        );
+
+        $this->assertTrue($result->isValid(), 'errors: ' . implode(' | ', $result->errors()));
+        $this->assertSame('/patches', $result->matchedPath());
+    }
+
     // ========================================
     // readOnly / writeOnly enforcement
     // ========================================

--- a/tests/fixtures/specs/refs-property-name.json
+++ b/tests/fixtures/specs/refs-property-name.json
@@ -1,0 +1,40 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Refs property name",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/patches": {
+            "get": {
+                "operationId": "listPatches",
+                "responses": {
+                    "200": {
+                        "description": "A JSON Patch document",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonPatchOp"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "JsonPatchOp": {
+                "type": "object",
+                "required": ["op", "path"],
+                "properties": {
+                    "op": { "type": "string" },
+                    "path": { "type": "string" },
+                    "value": { "type": "string" },
+                    "$ref": { "type": "string" }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 概要

`OpenApiRefResolver` が `properties` / `patternProperties` 配下のキー `$ref` を誤って Reference Object として解釈し、合法な OAS spec のロードに失敗していた問題を修正します。

## 変更内容

walker にコンテキストフラグ `$insidePropertiesMap` を追加し、`properties` / `patternProperties` dict 直下では `$ref` キーをプロパティ名として扱う（Reference Object として解決しない）ようにしました。フラグは1階層で自然にリセットされるため、プロパティ値そのものが Reference Object（`{"$ref": "#/..."}`）であれば次の階層で従来どおり解決されます。

- `src/OpenApiRefResolver.php`: `walk()` に `bool $insidePropertiesMap` パラメータを追加。`properties` / `patternProperties` 直下では `$ref` の Reference Object 判定をスキップ
- `tests/Unit/OpenApiRefResolverTest.php`: 3 件追加
  - `resolves_schema_with_ref_as_property_name` — `properties.$ref = {type: string}` がロードでき、内容が保持されること
  - `resolves_ref_inside_schema_with_ref_property_name` — フラグが1階層で解除され、`properties.$ref` の値が Reference Object の場合は次の階層で解決されること
  - `resolves_schema_with_ref_as_pattern_property_name` — `patternProperties` 側も同様に扱うこと
- `tests/fixtures/specs/refs-property-name.json`: 新規 fixture（OAS 3.0 / JsonPatchOp の `properties` に `$ref` キーを含む）
- `tests/Unit/OpenApiResponseValidatorTest.php`: e2e 1 件追加（loader → resolver → converter → opis 全段で `$ref` プロパティ名を含む response body を検証）

## スコープ

- `additionalProperties` はあえて対象外。`additionalProperties` 自体が schema であり、そこに直接現れる `$ref` は正当な Reference Object のため、従来どおり解決する必要があります。
- 既存の `throws_on_non_string_ref`（`requestBody.$ref = [...]`）は `properties` map の外なので挙動は不変。malformed ref の regression guard が維持されます。

## 検証結果

- `vendor/bin/phpunit` — **653 tests, 1367 assertions, all green**（新規 4 件を含む）
- `vendor/bin/phpstan analyse` — **No errors**（level 6）
- `vendor/bin/php-cs-fixer fix --dry-run` — clean

## 関連情報

- Closes #78
- 原因となった PR: #77（internal `$ref` の load-time 解決を導入）