### PR TITLE
fix(coverage-ext): hard-fail on broken OpenAPI $ref at bootstrap

### DIFF
--- a/src/InvalidOpenApiSpecException.php
+++ b/src/InvalidOpenApiSpecException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting;
+
+use RuntimeException;
+
+/**
+ * Thrown when an OpenAPI spec is syntactically parseable but semantically
+ * broken in a way that makes contract validation impossible — currently
+ * limited to `$ref` resolution failures (external / circular / unresolvable
+ * / malformed / bare-fragment / non-string).
+ *
+ * Separate from generic `RuntimeException` so the PHPUnit extension can
+ * hard-fail the run on broken specs while continuing to `warn` on lesser
+ * issues such as a missing spec file.
+ */
+final class InvalidOpenApiSpecException extends RuntimeException {}

--- a/src/InvalidOpenApiSpecException.php
+++ b/src/InvalidOpenApiSpecException.php
@@ -5,15 +5,44 @@ declare(strict_types=1);
 namespace Studio\OpenApiContractTesting;
 
 use RuntimeException;
+use Throwable;
 
 /**
- * Thrown when an OpenAPI spec is syntactically parseable but semantically
- * broken in a way that makes contract validation impossible — currently
- * limited to `$ref` resolution failures (external / circular / unresolvable
- * / malformed / bare-fragment / non-string).
+ * Thrown when an OpenAPI spec is syntactically parseable as a file but
+ * semantically broken in a way that makes contract validation impossible.
+ * The exhaustive list of failure categories lives on
+ * `InvalidOpenApiSpecReason`; consumers should branch on `$reason` rather
+ * than pattern-matching `$message`.
  *
- * Separate from generic `RuntimeException` so the PHPUnit extension can
- * hard-fail the run on broken specs while continuing to `warn` on lesser
- * issues such as a missing spec file.
+ * Separate from `SpecFileNotFoundException` so the PHPUnit coverage
+ * extension can hard-fail the run on broken specs while continuing to
+ * warn for a missing spec file.
  */
-final class InvalidOpenApiSpecException extends RuntimeException {}
+final class InvalidOpenApiSpecException extends RuntimeException
+{
+    public function __construct(
+        public readonly InvalidOpenApiSpecReason $reason,
+        string $message,
+        public readonly ?string $ref = null,
+        public readonly ?string $specName = null,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
+
+    /**
+     * Return a copy of this exception with `$specName` attached. Used by
+     * `OpenApiSpecLoader` to annotate resolver-originated throws (the
+     * resolver is stateless and does not know the spec name).
+     */
+    public function withSpecName(string $specName): self
+    {
+        return new self(
+            $this->reason,
+            $this->getMessage(),
+            $this->ref,
+            $specName,
+            $this,
+        );
+    }
+}

--- a/src/InvalidOpenApiSpecReason.php
+++ b/src/InvalidOpenApiSpecReason.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting;
+
+/**
+ * Categorical reasons an OpenAPI spec is considered broken. Carried on
+ * `InvalidOpenApiSpecException` so consumers can branch on the concrete
+ * failure kind instead of regex-ing the human-readable message.
+ */
+enum InvalidOpenApiSpecReason
+{
+    case ExternalRef;
+    case CircularRef;
+    case UnresolvableRef;
+    case NonStringRef;
+    case BareFragmentRef;
+    case RootPointerRef;
+    case NonObjectRefTarget;
+    case MalformedJson;
+    case MalformedYaml;
+    case NonMappingRoot;
+    case YamlLibraryMissing;
+    case UnsupportedExtension;
+    case BasePathNotConfigured;
+}

--- a/src/OpenApiRefResolver.php
+++ b/src/OpenApiRefResolver.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting;
 
-use RuntimeException;
-
 use function array_key_exists;
 use function explode;
 use function get_debug_type;
@@ -24,8 +22,9 @@ final class OpenApiRefResolver
     /**
      * Resolve all internal `$ref` entries in the spec in place and return the
      * same array. External, circular, unresolvable, malformed, and root refs
-     * all throw `RuntimeException` so users get one actionable error at load
-     * time instead of a cryptic opis failure surfacing deep inside validation.
+     * all throw `InvalidOpenApiSpecException` so users get one actionable
+     * error at load time instead of a cryptic opis failure surfacing deep
+     * inside validation.
      *
      * The input array is mutated: on a successful resolve the returned value
      * is the same array with `$ref` nodes substituted. On throw, the partially
@@ -36,7 +35,7 @@ final class OpenApiRefResolver
      *
      * @return array<string, mixed>
      *
-     * @throws RuntimeException on external / circular / unresolvable / malformed refs
+     * @throws InvalidOpenApiSpecException on external / circular / unresolvable / malformed refs
      */
     public static function resolve(array $spec): array
     {
@@ -63,7 +62,7 @@ final class OpenApiRefResolver
             $ref = $node['$ref'];
 
             if (!is_string($ref)) {
-                throw new RuntimeException(sprintf(
+                throw new InvalidOpenApiSpecException(sprintf(
                     'Invalid $ref: expected string, got %s',
                     get_debug_type($ref),
                 ));
@@ -74,18 +73,18 @@ final class OpenApiRefResolver
                 // which triggers unbounded recursion before cycle detection
                 // can help. Reject with a specific message so the author
                 // doesn't chase a confusing "Circular" error.
-                throw new RuntimeException('Invalid $ref: root pointer "' . $ref . '" is not a reference to a definition');
+                throw new InvalidOpenApiSpecException('Invalid $ref: root pointer "' . $ref . '" is not a reference to a definition');
             }
 
             if (!str_starts_with($ref, '#/')) {
                 if (str_starts_with($ref, '#')) {
-                    throw new RuntimeException(sprintf(
+                    throw new InvalidOpenApiSpecException(sprintf(
                         'Invalid $ref: bare fragment %s is not a JSON Pointer (expected "#/..." form)',
                         $ref,
                     ));
                 }
 
-                throw new RuntimeException(sprintf(
+                throw new InvalidOpenApiSpecException(sprintf(
                     'External $ref is not supported: %s. Only internal refs (#/...) are resolved; '
                     . 'bundle external files with a tool like `redocly bundle` before loading.',
                     $ref,
@@ -93,7 +92,7 @@ final class OpenApiRefResolver
             }
 
             if (in_array($ref, $chain, true)) {
-                throw new RuntimeException(sprintf(
+                throw new InvalidOpenApiSpecException(sprintf(
                     'Circular $ref detected: %s',
                     implode(' -> ', [...$chain, $ref]),
                 ));
@@ -101,11 +100,11 @@ final class OpenApiRefResolver
 
             [$found, $target] = self::lookup($ref, $root);
             if (!$found) {
-                throw new RuntimeException(sprintf('Unresolvable $ref: target not found for %s', $ref));
+                throw new InvalidOpenApiSpecException(sprintf('Unresolvable $ref: target not found for %s', $ref));
             }
 
             if (!is_array($target)) {
-                throw new RuntimeException(sprintf(
+                throw new InvalidOpenApiSpecException(sprintf(
                     '$ref target is not an object: %s points to a %s value',
                     $ref,
                     get_debug_type($target),

--- a/src/OpenApiRefResolver.php
+++ b/src/OpenApiRefResolver.php
@@ -21,10 +21,11 @@ final class OpenApiRefResolver
 {
     /**
      * Resolve all internal `$ref` entries in the spec in place and return the
-     * same array. External, circular, unresolvable, malformed, and root refs
-     * all throw `InvalidOpenApiSpecException` so users get one actionable
-     * error at load time instead of a cryptic opis failure surfacing deep
-     * inside validation.
+     * same array. Any structural problem with a `$ref` throws
+     * `InvalidOpenApiSpecException` so users get one actionable error at
+     * load time instead of a cryptic opis failure surfacing deep inside
+     * validation. See `InvalidOpenApiSpecReason` for the exhaustive list of
+     * failure categories produced here.
      *
      * The input array is mutated: on a successful resolve the returned value
      * is the same array with `$ref` nodes substituted. On throw, the partially
@@ -35,7 +36,7 @@ final class OpenApiRefResolver
      *
      * @return array<string, mixed>
      *
-     * @throws InvalidOpenApiSpecException on external / circular / unresolvable / malformed refs
+     * @throws InvalidOpenApiSpecException when a `$ref` cannot be resolved
      */
     public static function resolve(array $spec): array
     {
@@ -62,10 +63,10 @@ final class OpenApiRefResolver
             $ref = $node['$ref'];
 
             if (!is_string($ref)) {
-                throw new InvalidOpenApiSpecException(sprintf(
-                    'Invalid $ref: expected string, got %s',
-                    get_debug_type($ref),
-                ));
+                throw new InvalidOpenApiSpecException(
+                    InvalidOpenApiSpecReason::NonStringRef,
+                    sprintf('Invalid $ref: expected string, got %s', get_debug_type($ref)),
+                );
             }
 
             if ($ref === '#/' || $ref === '#') {
@@ -73,42 +74,56 @@ final class OpenApiRefResolver
                 // which triggers unbounded recursion before cycle detection
                 // can help. Reject with a specific message so the author
                 // doesn't chase a confusing "Circular" error.
-                throw new InvalidOpenApiSpecException('Invalid $ref: root pointer "' . $ref . '" is not a reference to a definition');
+                throw new InvalidOpenApiSpecException(
+                    InvalidOpenApiSpecReason::RootPointerRef,
+                    'Invalid $ref: root pointer "' . $ref . '" is not a reference to a definition',
+                    ref: $ref,
+                );
             }
 
             if (!str_starts_with($ref, '#/')) {
                 if (str_starts_with($ref, '#')) {
-                    throw new InvalidOpenApiSpecException(sprintf(
-                        'Invalid $ref: bare fragment %s is not a JSON Pointer (expected "#/..." form)',
-                        $ref,
-                    ));
+                    throw new InvalidOpenApiSpecException(
+                        InvalidOpenApiSpecReason::BareFragmentRef,
+                        sprintf('Invalid $ref: bare fragment %s is not a JSON Pointer (expected "#/..." form)', $ref),
+                        ref: $ref,
+                    );
                 }
 
-                throw new InvalidOpenApiSpecException(sprintf(
-                    'External $ref is not supported: %s. Only internal refs (#/...) are resolved; '
-                    . 'bundle external files with a tool like `redocly bundle` before loading.',
-                    $ref,
-                ));
+                throw new InvalidOpenApiSpecException(
+                    InvalidOpenApiSpecReason::ExternalRef,
+                    sprintf(
+                        'External $ref is not supported: %s. Only internal refs (#/...) are resolved; '
+                        . 'bundle external files with a tool like `redocly bundle` before loading.',
+                        $ref,
+                    ),
+                    ref: $ref,
+                );
             }
 
             if (in_array($ref, $chain, true)) {
-                throw new InvalidOpenApiSpecException(sprintf(
-                    'Circular $ref detected: %s',
-                    implode(' -> ', [...$chain, $ref]),
-                ));
+                throw new InvalidOpenApiSpecException(
+                    InvalidOpenApiSpecReason::CircularRef,
+                    sprintf('Circular $ref detected: %s', implode(' -> ', [...$chain, $ref])),
+                    ref: $ref,
+                );
             }
 
             [$found, $target] = self::lookup($ref, $root);
             if (!$found) {
-                throw new InvalidOpenApiSpecException(sprintf('Unresolvable $ref: target not found for %s', $ref));
+                throw new InvalidOpenApiSpecException(
+                    InvalidOpenApiSpecReason::UnresolvableRef,
+                    sprintf('Unresolvable $ref: target not found for %s', $ref),
+                    ref: $ref,
+                );
             }
 
             if (!is_array($target)) {
-                throw new InvalidOpenApiSpecException(sprintf(
-                    '$ref target is not an object: %s points to a %s value',
-                    $ref,
-                    get_debug_type($target),
-                ));
+                throw new InvalidOpenApiSpecException(
+                    InvalidOpenApiSpecReason::NonObjectRefTarget,
+                    sprintf('$ref target is not an object: %s points to a %s value', $ref, get_debug_type($target)),
+                    ref: $ref,
+                );
             }
 
             // Push $ref onto the chain before recursing so nested self-references

--- a/src/OpenApiSpecLoader.php
+++ b/src/OpenApiSpecLoader.php
@@ -7,7 +7,6 @@ namespace Studio\OpenApiContractTesting;
 use const JSON_THROW_ON_ERROR;
 
 use JsonException;
-use RuntimeException;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
@@ -58,7 +57,8 @@ final class OpenApiSpecLoader
     public static function getBasePath(): string
     {
         if (self::$basePath === null) {
-            throw new RuntimeException(
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::BasePathNotConfigured,
                 'OpenApiSpecLoader base path not configured. '
                 . 'Call OpenApiSpecLoader::configure() or set spec_base_path in PHPUnit extension parameters.',
             );
@@ -83,12 +83,24 @@ final class OpenApiSpecLoader
         ['path' => $path, 'extension' => $extension] = self::resolveSpecFile($specName);
 
         $decoded = match ($extension) {
-            'json' => self::decodeJsonSpec($path),
-            'yaml', 'yml' => self::decodeYamlSpec($path),
-            default => throw new RuntimeException("Unsupported spec extension: .{$extension}"),
+            'json' => self::decodeJsonSpec($path, $specName),
+            'yaml', 'yml' => self::decodeYamlSpec($path, $specName),
+            default => throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::UnsupportedExtension,
+                "Unsupported spec extension: .{$extension}",
+                specName: $specName,
+            ),
         };
 
-        $resolved = OpenApiRefResolver::resolve($decoded);
+        try {
+            $resolved = OpenApiRefResolver::resolve($decoded);
+        } catch (InvalidOpenApiSpecException $e) {
+            // The resolver is stateless and therefore cannot know which spec
+            // produced the throw. Re-wrap once so consumers (e.g. the coverage
+            // extension) can surface the spec name in diagnostics without
+            // having to correlate against the call site.
+            throw $e->withSpecName($specName);
+        }
         self::$cache[$specName] = $resolved;
 
         return $resolved;
@@ -141,40 +153,52 @@ final class OpenApiSpecLoader
             }
         }
 
-        throw new RuntimeException(sprintf(
-            'OpenAPI bundled spec not found: %s/%s (tried extensions: %s). '
-            . "Run 'cd openapi && npm run bundle' to generate a JSON bundle, "
-            . 'or place a .yaml / .yml source file alongside.',
-            $basePath,
+        throw new SpecFileNotFoundException(
             $specName,
-            '.' . implode(', .', self::SEARCH_EXTENSIONS),
-        ));
+            $basePath,
+            sprintf(
+                'OpenAPI bundled spec not found: %s/%s (tried extensions: %s). '
+                . "Run 'cd openapi && npm run bundle' to generate a JSON bundle, "
+                . 'or place a .yaml / .yml source file alongside.',
+                $basePath,
+                $specName,
+                '.' . implode(', .', self::SEARCH_EXTENSIONS),
+            ),
+        );
     }
 
     /** @return array<string, mixed> */
-    private static function decodeJsonSpec(string $path): array
+    private static function decodeJsonSpec(string $path, string $specName): array
     {
         $content = file_get_contents($path);
         if ($content === false) {
-            throw new RuntimeException("Failed to read OpenAPI spec: {$path}");
+            // I/O failure after resolveSpecFile() already confirmed the file
+            // exists is practically always a permissions / concurrent-unlink
+            // issue — treat the file as effectively missing.
+            throw new SpecFileNotFoundException(
+                $specName,
+                self::getBasePath(),
+                "Failed to read OpenAPI spec: {$path}",
+            );
         }
 
         try {
             $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {
-            throw new RuntimeException(
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::MalformedJson,
                 "Failed to parse JSON OpenAPI spec: {$path}. {$e->getMessage()}",
-                0,
-                $e,
+                specName: $specName,
+                previous: $e,
             );
         }
 
         if (!is_array($decoded)) {
-            throw new RuntimeException(sprintf(
-                'JSON OpenAPI spec must decode to a mapping (got %s): %s',
-                get_debug_type($decoded),
-                $path,
-            ));
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::NonMappingRoot,
+                sprintf('JSON OpenAPI spec must decode to a mapping (got %s): %s', get_debug_type($decoded), $path),
+                specName: $specName,
+            );
         }
 
         /** @var array<string, mixed> $decoded */
@@ -182,12 +206,14 @@ final class OpenApiSpecLoader
     }
 
     /** @return array<string, mixed> */
-    private static function decodeYamlSpec(string $path): array
+    private static function decodeYamlSpec(string $path, string $specName): array
     {
         if (!self::isYamlLibraryAvailable()) {
-            throw new RuntimeException(
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::YamlLibraryMissing,
                 'Loading YAML OpenAPI specs requires symfony/yaml. '
                 . 'Install it via: composer require --dev symfony/yaml',
+                specName: $specName,
             );
         }
 
@@ -196,19 +222,20 @@ final class OpenApiSpecLoader
         try {
             $decoded = Yaml::parseFile($path);
         } catch (ParseException $e) {
-            throw new RuntimeException(
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::MalformedYaml,
                 "Failed to parse YAML OpenAPI spec: {$path}. {$e->getMessage()}",
-                0,
-                $e,
+                specName: $specName,
+                previous: $e,
             );
         }
 
         if (!is_array($decoded)) {
-            throw new RuntimeException(sprintf(
-                'YAML OpenAPI spec must decode to a mapping (got %s): %s',
-                get_debug_type($decoded),
-                $path,
-            ));
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::NonMappingRoot,
+                sprintf('YAML OpenAPI spec must decode to a mapping (got %s): %s', get_debug_type($decoded), $path),
+                specName: $specName,
+            );
         }
 
         /** @var array<string, mixed> $decoded */

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -14,13 +14,14 @@ use PHPUnit\Runner\Extension\Extension;
 use PHPUnit\Runner\Extension\Facade;
 use PHPUnit\Runner\Extension\ParameterCollection;
 use PHPUnit\TextUI\Configuration\Configuration;
-use RuntimeException;
 use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\SpecFileNotFoundException;
 
 use function array_map;
 use function explode;
+use function fflush;
 use function file_put_contents;
 use function fwrite;
 use function getcwd;
@@ -30,14 +31,14 @@ use function str_starts_with;
 final class OpenApiCoverageExtension implements Extension
 {
     /**
-     * Test-only override for STDERR writes. null means "use STDERR".
+     * Test-only override for STDERR writes.
      *
      * @var null|resource
      */
     private static $stderrOverride;
 
     /**
-     * Redirect STDERR writes to a test-supplied stream. Pass null to restore.
+     * Redirect STDERR writes to a test-supplied stream.
      *
      * @param null|resource $stream
      *
@@ -64,19 +65,25 @@ final class OpenApiCoverageExtension implements Extension
         } catch (InvalidOpenApiSpecException) {
             // setupExtension() has already written a FATAL line to stderr and
             // (if GITHUB_STEP_SUMMARY is set) appended a fatal block to it.
-            // PHPUnit's ExtensionBootstrapper::bootstrap() swallows Throwable
-            // and converts it to testRunnerTriggeredPhpunitWarning, which does
-            // not fail the run unless consumers also set failOnPhpunitWarning.
-            // Relying on that flag would re-open the exact silent-pass hole
-            // this extension exists to close, so force a non-zero exit here.
+            // PHPUnit's ExtensionBootstrapper::bootstrap() wraps this call in
+            // catch(Throwable) and demotes it to testRunnerTriggeredPhpunitWarning,
+            // which only fails the run when consumers opt in via
+            // failOnPhpunitWarning (or failOnAllIssues). Depending on that
+            // would re-open the silent-pass hole this extension exists to
+            // close, so force a non-zero exit here. fflush guards against
+            // output ordering surprises on exit().
+            if (self::$stderrOverride === null) {
+                fflush(STDERR);
+            }
+
             exit(1);
         }
     }
 
     /**
      * Exposed for testing: accepts the injectable parts of bootstrap without
-     * requiring a real PHPUnit Configuration (which is a final readonly class
-     * with a 150-arg constructor and cannot reasonably be stubbed).
+     * requiring a real PHPUnit `Configuration`, which is a `final readonly`
+     * class with over 150 ctor parameters and is not reasonable to stub.
      *
      * @internal
      */
@@ -101,21 +108,23 @@ final class OpenApiCoverageExtension implements Extension
             $specs = array_map('trim', explode(',', $parameters->get('specs')));
         }
 
-        // Eager-load every registered spec so $ref resolution failures surface
-        // at PHPUnit bootstrap (hard fail) rather than being silently swallowed
-        // when a test happens not to exercise the broken spec. File-not-found
-        // and other non-ref RuntimeExceptions keep the legacy warn-and-continue
-        // behavior so a stale entry in `specs=` doesn't block unrelated work.
+        // Eager-load every registered spec so structural problems surface at
+        // PHPUnit bootstrap (hard fail via bootstrap()) rather than being
+        // silently swallowed when a test happens not to exercise the broken
+        // spec. Only SpecFileNotFoundException keeps the legacy warn-and-
+        // continue behavior, so a stale entry in `specs=` does not block
+        // unrelated work; everything else — broken `$ref`, malformed
+        // JSON/YAML, non-mapping root, missing `symfony/yaml` — is fatal.
         foreach ($specs as $spec) {
             try {
                 OpenApiSpecLoader::load($spec);
+            } catch (SpecFileNotFoundException $e) {
+                self::writeStderr("[OpenAPI Coverage] WARNING: Skipping spec '{$spec}': {$e->getMessage()}\n");
             } catch (InvalidOpenApiSpecException $e) {
                 self::writeStderr("[OpenAPI Coverage] FATAL: Invalid OpenAPI spec '{$spec}': {$e->getMessage()}\n");
                 self::appendGithubStepSummaryFatalBlock($githubSummaryPath, $spec, $e->getMessage());
 
                 throw $e;
-            } catch (RuntimeException $e) {
-                self::writeStderr("[OpenAPI Coverage] WARNING: Skipping spec '{$spec}': {$e->getMessage()}\n");
             }
         }
 
@@ -193,17 +202,22 @@ final class OpenApiCoverageExtension implements Extension
                 foreach ($this->specs as $spec) {
                     try {
                         $results[$spec] = OpenApiCoverageTracker::computeCoverage($spec);
-                    } catch (InvalidOpenApiSpecException $e) {
-                        // Defensive: bootstrap eager-load should have already
-                        // aborted the run. Surface the error prominently if a
-                        // later cache eviction or spec edit somehow revived it.
-                        OpenApiCoverageExtension::writeStderr("[OpenAPI Coverage] FATAL: Invalid OpenAPI spec '{$spec}': {$e->getMessage()}\n");
-
-                        throw $e;
-                    } catch (RuntimeException $e) {
+                    } catch (SpecFileNotFoundException $e) {
+                        // Warn-and-continue for stale specs=, same semantics
+                        // as bootstrap. Unlike bootstrap, the subscriber runs
+                        // after tests finished, so continuing lets partial
+                        // coverage reports still render.
                         OpenApiCoverageExtension::writeStderr("[OpenAPI Coverage] WARNING: Skipping spec '{$spec}': {$e->getMessage()}\n");
 
                         continue;
+                    } catch (InvalidOpenApiSpecException $e) {
+                        // Defensive: only reachable if OpenApiSpecLoader::evict()
+                        // was called mid-run and the on-disk spec was edited
+                        // between bootstrap and ExecutionFinished. Preserves
+                        // the hard-fail contract in that edge case.
+                        OpenApiCoverageExtension::writeStderr("[OpenAPI Coverage] FATAL: Invalid OpenAPI spec '{$spec}': {$e->getMessage()}\n");
+
+                        throw $e;
                     }
                 }
 

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio\OpenApiContractTesting\PHPUnit;
 
 use const FILE_APPEND;
+use const PHP_EOL;
 use const STDERR;
 
 use PHPUnit\Event\TestRunner\ExecutionFinished;
@@ -14,6 +15,7 @@ use PHPUnit\Runner\Extension\Facade;
 use PHPUnit\Runner\Extension\ParameterCollection;
 use PHPUnit\TextUI\Configuration\Configuration;
 use RuntimeException;
+use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
 
@@ -27,8 +29,58 @@ use function str_starts_with;
 
 final class OpenApiCoverageExtension implements Extension
 {
+    /**
+     * Test-only override for STDERR writes. null means "use STDERR".
+     *
+     * @var null|resource
+     */
+    private static $stderrOverride;
+
+    /**
+     * Redirect STDERR writes to a test-supplied stream. Pass null to restore.
+     *
+     * @param null|resource $stream
+     *
+     * @internal
+     */
+    public static function overrideStderrForTesting($stream): void
+    {
+        self::$stderrOverride = $stream;
+    }
+
+    /**
+     * @internal exposed so the anonymous subscriber class can reuse the stream override.
+     */
+    public static function writeStderr(string $message): void
+    {
+        fwrite(self::$stderrOverride ?? STDERR, $message);
+    }
+
     /** @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter */
     public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
+    {
+        try {
+            $this->setupExtension($facade, $parameters, getenv('GITHUB_STEP_SUMMARY') ?: null);
+        } catch (InvalidOpenApiSpecException) {
+            // setupExtension() has already written a FATAL line to stderr and
+            // (if GITHUB_STEP_SUMMARY is set) appended a fatal block to it.
+            // PHPUnit's ExtensionBootstrapper::bootstrap() swallows Throwable
+            // and converts it to testRunnerTriggeredPhpunitWarning, which does
+            // not fail the run unless consumers also set failOnPhpunitWarning.
+            // Relying on that flag would re-open the exact silent-pass hole
+            // this extension exists to close, so force a non-zero exit here.
+            exit(1);
+        }
+    }
+
+    /**
+     * Exposed for testing: accepts the injectable parts of bootstrap without
+     * requiring a real PHPUnit Configuration (which is a final readonly class
+     * with a 150-arg constructor and cannot reasonably be stubbed).
+     *
+     * @internal
+     */
+    public function setupExtension(Facade $facade, ParameterCollection $parameters, ?string $githubSummaryPath): void
     {
         if ($parameters->has('spec_base_path')) {
             $basePath = $parameters->get('spec_base_path');
@@ -49,6 +101,24 @@ final class OpenApiCoverageExtension implements Extension
             $specs = array_map('trim', explode(',', $parameters->get('specs')));
         }
 
+        // Eager-load every registered spec so $ref resolution failures surface
+        // at PHPUnit bootstrap (hard fail) rather than being silently swallowed
+        // when a test happens not to exercise the broken spec. File-not-found
+        // and other non-ref RuntimeExceptions keep the legacy warn-and-continue
+        // behavior so a stale entry in `specs=` doesn't block unrelated work.
+        foreach ($specs as $spec) {
+            try {
+                OpenApiSpecLoader::load($spec);
+            } catch (InvalidOpenApiSpecException $e) {
+                self::writeStderr("[OpenAPI Coverage] FATAL: Invalid OpenAPI spec '{$spec}': {$e->getMessage()}\n");
+                self::appendGithubStepSummaryFatalBlock($githubSummaryPath, $spec, $e->getMessage());
+
+                throw $e;
+            } catch (RuntimeException $e) {
+                self::writeStderr("[OpenAPI Coverage] WARNING: Skipping spec '{$spec}': {$e->getMessage()}\n");
+            }
+        }
+
         $outputFile = null;
         if ($parameters->has('output_file')) {
             $outputFile = $parameters->get('output_file');
@@ -60,8 +130,6 @@ final class OpenApiCoverageExtension implements Extension
         $consoleOutput = ConsoleOutput::resolve(
             $parameters->has('console_output') ? $parameters->get('console_output') : null,
         );
-
-        $githubSummaryPath = getenv('GITHUB_STEP_SUMMARY') ?: null;
 
         $facade->registerSubscriber(new class ($specs, $outputFile, $consoleOutput, $githubSummaryPath) implements ExecutionFinishedSubscriber {
             /**
@@ -125,8 +193,15 @@ final class OpenApiCoverageExtension implements Extension
                 foreach ($this->specs as $spec) {
                     try {
                         $results[$spec] = OpenApiCoverageTracker::computeCoverage($spec);
+                    } catch (InvalidOpenApiSpecException $e) {
+                        // Defensive: bootstrap eager-load should have already
+                        // aborted the run. Surface the error prominently if a
+                        // later cache eviction or spec edit somehow revived it.
+                        OpenApiCoverageExtension::writeStderr("[OpenAPI Coverage] FATAL: Invalid OpenAPI spec '{$spec}': {$e->getMessage()}\n");
+
+                        throw $e;
                     } catch (RuntimeException $e) {
-                        fwrite(STDERR, "[OpenAPI Coverage] WARNING: Skipping spec '{$spec}': {$e->getMessage()}\n");
+                        OpenApiCoverageExtension::writeStderr("[OpenAPI Coverage] WARNING: Skipping spec '{$spec}': {$e->getMessage()}\n");
 
                         continue;
                     }
@@ -153,7 +228,7 @@ final class OpenApiCoverageExtension implements Extension
                     $written = file_put_contents($this->outputFile, $markdown);
 
                     if ($written === false) {
-                        fwrite(STDERR, "[OpenAPI Coverage] WARNING: Failed to write Markdown report to {$this->outputFile}\n");
+                        OpenApiCoverageExtension::writeStderr("[OpenAPI Coverage] WARNING: Failed to write Markdown report to {$this->outputFile}\n");
                     }
                 }
 
@@ -161,10 +236,31 @@ final class OpenApiCoverageExtension implements Extension
                     $written = file_put_contents($this->githubSummaryPath, $markdown . "\n", FILE_APPEND);
 
                     if ($written === false) {
-                        fwrite(STDERR, "[OpenAPI Coverage] WARNING: Failed to append Markdown report to GITHUB_STEP_SUMMARY ({$this->githubSummaryPath})\n");
+                        OpenApiCoverageExtension::writeStderr("[OpenAPI Coverage] WARNING: Failed to append Markdown report to GITHUB_STEP_SUMMARY ({$this->githubSummaryPath})\n");
                     }
                 }
             }
         });
+    }
+
+    private static function appendGithubStepSummaryFatalBlock(?string $path, string $spec, string $reason): void
+    {
+        if ($path === null) {
+            return;
+        }
+
+        $block = '## :rotating_light: FATAL OpenAPI spec error' . PHP_EOL
+            . PHP_EOL
+            . "Spec `{$spec}` could not be loaded and the test run was aborted." . PHP_EOL
+            . PHP_EOL
+            . '```' . PHP_EOL
+            . $reason . PHP_EOL
+            . '```' . PHP_EOL
+            . PHP_EOL;
+
+        $written = file_put_contents($path, $block, FILE_APPEND);
+        if ($written === false) {
+            self::writeStderr("[OpenAPI Coverage] WARNING: Failed to append FATAL block to GITHUB_STEP_SUMMARY ({$path})\n");
+        }
     }
 }

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -85,9 +85,14 @@ final class OpenApiCoverageExtension implements Extension
      * requiring a real PHPUnit `Configuration`, which is a `final readonly`
      * class with over 150 ctor parameters and is not reasonable to stub.
      *
+     * `$facade` is nullable so unit tests can exercise the eager-load path
+     * without supplying a real `Facade`. Its shape changed between PHPUnit
+     * 11/12 (class) and 13 (interface), so a portable stub is not possible;
+     * skipping subscriber registration in tests is the clean fix.
+     *
      * @internal
      */
-    public function setupExtension(Facade $facade, ParameterCollection $parameters, ?string $githubSummaryPath): void
+    public function setupExtension(?Facade $facade, ParameterCollection $parameters, ?string $githubSummaryPath): void
     {
         if ($parameters->has('spec_base_path')) {
             $basePath = $parameters->get('spec_base_path');
@@ -139,6 +144,10 @@ final class OpenApiCoverageExtension implements Extension
         $consoleOutput = ConsoleOutput::resolve(
             $parameters->has('console_output') ? $parameters->get('console_output') : null,
         );
+
+        if ($facade === null) {
+            return;
+        }
 
         $facade->registerSubscriber(new class ($specs, $outputFile, $consoleOutput, $githubSummaryPath) implements ExecutionFinishedSubscriber {
             /**

--- a/src/SpecFileNotFoundException.php
+++ b/src/SpecFileNotFoundException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting;
+
+use RuntimeException;
+use Throwable;
+
+/**
+ * Thrown when a registered spec name has no matching file on disk. Distinct
+ * from `InvalidOpenApiSpecException` so the coverage extension can continue
+ * past a stale `specs=` entry with a warning instead of aborting the run.
+ */
+final class SpecFileNotFoundException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $specName,
+        public readonly string $basePath,
+        string $message,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/tests/Integration/OpenApiCoverageExtensionBootstrapTest.php
+++ b/tests/Integration/OpenApiCoverageExtensionBootstrapTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Integration;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function escapeshellarg;
+use function fclose;
+use function file_put_contents;
+use function is_resource;
+use function proc_close;
+use function proc_open;
+use function realpath;
+use function sprintf;
+use function stream_get_contents;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+/**
+ * Exercises the real `bootstrap()` -> `exit(1)` path by spawning a child
+ * PHPUnit process. The unit tests cover `setupExtension()` directly, which
+ * bypasses the wrapper; this test pins the observable contract — broken
+ * spec → non-zero PHPUnit exit — that the PR exists to guarantee.
+ */
+class OpenApiCoverageExtensionBootstrapTest extends TestCase
+{
+    private string $repoRoot;
+    private ?string $configPath = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repoRoot = realpath(__DIR__ . '/../..') ?: __DIR__ . '/../..';
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->configPath !== null) {
+            @unlink($this->configPath);
+            $this->configPath = null;
+        }
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function phpunit_exits_non_zero_when_registered_spec_has_unresolvable_ref(): void
+    {
+        // Filter matches no real tests so we observe the bootstrap-only path:
+        // if the suite exited 0 here, the hard-fail contract is broken.
+        [$exit, $stderr] = $this->runPhpunit('refs-unresolvable', '--filter=DoesNotMatchAnyTest');
+
+        $this->assertNotSame(0, $exit, "Expected non-zero exit; stderr was:\n" . $stderr);
+        $this->assertStringContainsString('FATAL', $stderr);
+        $this->assertStringContainsString('refs-unresolvable', $stderr);
+    }
+
+    #[Test]
+    public function phpunit_exits_zero_when_registered_spec_file_is_missing(): void
+    {
+        // `OpenApiVersionTest` is a lightweight, always-present target so the
+        // suite has something to pass; the stale `specs=` entry must degrade
+        // to a warning without aborting.
+        [$exit, $stderr] = $this->runPhpunit('does-not-exist', '--filter=OpenApiVersionTest');
+
+        $this->assertSame(0, $exit, "Expected exit 0; stderr was:\n" . $stderr);
+        $this->assertStringContainsString('WARNING', $stderr);
+        $this->assertStringContainsString('does-not-exist', $stderr);
+    }
+
+    /**
+     * @return array{0: int, 1: string} [exit code, combined stderr]
+     */
+    private function runPhpunit(string $specsParam, string $filterArg): array
+    {
+        $xml = sprintf(
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            . '<phpunit bootstrap="%s/vendor/autoload.php" cacheDirectory="%s/.phpunit.cache" colors="false">'
+            . '<testsuites><testsuite name="Unit"><directory>%s/tests/Unit</directory></testsuite></testsuites>'
+            . '<extensions><bootstrap class="Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension">'
+            . '<parameter name="spec_base_path" value="%s/tests/fixtures/specs"/>'
+            . '<parameter name="specs" value="%s"/>'
+            . '</bootstrap></extensions>'
+            . '</phpunit>',
+            $this->repoRoot,
+            $this->repoRoot,
+            $this->repoRoot,
+            $this->repoRoot,
+            $specsParam,
+        );
+
+        $tmp = tempnam(sys_get_temp_dir(), 'openapi-ext-integration-') ?: null;
+        if ($tmp === null) {
+            $this->fail('Could not create temp phpunit config');
+        }
+        $this->configPath = $tmp;
+        file_put_contents($tmp, $xml);
+
+        $cmd = sprintf(
+            '%s/vendor/bin/phpunit -c %s %s',
+            escapeshellarg($this->repoRoot),
+            escapeshellarg($tmp),
+            escapeshellarg($filterArg),
+        );
+
+        $descriptors = [
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+        $process = proc_open($cmd, $descriptors, $pipes, $this->repoRoot);
+        if (!is_resource($process)) {
+            $this->fail('Could not spawn phpunit subprocess');
+        }
+
+        $stdout = (string) stream_get_contents($pipes[1]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        foreach ($pipes as $pipe) {
+            fclose($pipe);
+        }
+        $exit = proc_close($process);
+
+        // Both streams may carry the FATAL/WARNING line depending on where
+        // PHP flushes; the caller only cares about the combined text.
+        return [$exit, $stdout . $stderr];
+    }
+}

--- a/tests/Unit/OpenApiCoverageExtensionTest.php
+++ b/tests/Unit/OpenApiCoverageExtensionTest.php
@@ -4,11 +4,8 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Tests\Unit;
 
-use PHPUnit\Event\Subscriber;
-use PHPUnit\Event\Tracer\Tracer;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Runner\Extension\Facade;
 use PHPUnit\Runner\Extension\ParameterCollection;
 use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\InvalidOpenApiSpecReason;
@@ -70,7 +67,7 @@ class OpenApiCoverageExtensionTest extends TestCase
         $this->expectException(InvalidOpenApiSpecException::class);
         $this->expectExceptionMessage('Unresolvable $ref');
 
-        $extension->setupExtension($this->stubFacade(), $parameters, null);
+        $extension->setupExtension(null, $parameters, null);
     }
 
     #[Test]
@@ -82,7 +79,7 @@ class OpenApiCoverageExtensionTest extends TestCase
             'specs' => 'does-not-exist',
         ]);
 
-        $extension->setupExtension($this->stubFacade(), $parameters, null);
+        $extension->setupExtension(null, $parameters, null);
 
         $this->assertStringContainsString('WARNING', $this->readStderr());
         $this->assertStringContainsString('does-not-exist', $this->readStderr());
@@ -97,7 +94,7 @@ class OpenApiCoverageExtensionTest extends TestCase
             'specs' => 'refs-valid',
         ]);
 
-        $extension->setupExtension($this->stubFacade(), $parameters, null);
+        $extension->setupExtension(null, $parameters, null);
 
         $this->assertSame('', $this->readStderr());
     }
@@ -118,7 +115,7 @@ class OpenApiCoverageExtensionTest extends TestCase
         ]);
 
         try {
-            $extension->setupExtension($this->stubFacade(), $parameters, $tmp);
+            $extension->setupExtension(null, $parameters, $tmp);
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException) {
             // Expected — the FATAL block must still have been written before re-throw.
@@ -143,7 +140,7 @@ class OpenApiCoverageExtensionTest extends TestCase
         ]);
 
         try {
-            $extension->setupExtension($this->stubFacade(), $parameters, null);
+            $extension->setupExtension(null, $parameters, null);
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
             $this->assertSame(InvalidOpenApiSpecReason::MalformedJson, $e->reason);
@@ -164,7 +161,7 @@ class OpenApiCoverageExtensionTest extends TestCase
         ]);
 
         try {
-            $extension->setupExtension($this->stubFacade(), $parameters, null);
+            $extension->setupExtension(null, $parameters, null);
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
             $this->assertSame(InvalidOpenApiSpecReason::BasePathNotConfigured, $e->reason);
@@ -183,7 +180,7 @@ class OpenApiCoverageExtensionTest extends TestCase
             'specs' => 'does-not-exist,refs-valid',
         ]);
 
-        $extension->setupExtension($this->stubFacade(), $parameters, null);
+        $extension->setupExtension(null, $parameters, null);
 
         $this->assertStringContainsString("WARNING: Skipping spec 'does-not-exist'", $this->readStderr());
         // refs-valid must have loaded cleanly — its content is cached.
@@ -206,7 +203,7 @@ class OpenApiCoverageExtensionTest extends TestCase
         $this->expectException(InvalidOpenApiSpecException::class);
         $this->expectExceptionMessage('Unresolvable $ref');
 
-        $extension->setupExtension($this->stubFacade(), $parameters, null);
+        $extension->setupExtension(null, $parameters, null);
     }
 
     private function readStderr(): string
@@ -217,24 +214,5 @@ class OpenApiCoverageExtensionTest extends TestCase
         rewind($this->stderrBuffer);
 
         return (string) stream_get_contents($this->stderrBuffer);
-    }
-
-    private function stubFacade(): Facade
-    {
-        return new class implements Facade {
-            public function registerSubscribers(Subscriber ...$subscribers): void {}
-
-            public function registerSubscriber(Subscriber $subscriber): void {}
-
-            public function registerTracer(Tracer $tracer): void {}
-
-            public function replaceOutput(): void {}
-
-            public function replaceProgressOutput(): void {}
-
-            public function replaceResultOutput(): void {}
-
-            public function requireCodeCoverageCollection(): void {}
-        };
     }
 }

--- a/tests/Unit/OpenApiCoverageExtensionTest.php
+++ b/tests/Unit/OpenApiCoverageExtensionTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\Extension\Facade;
 use PHPUnit\Runner\Extension\ParameterCollection;
 use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
+use Studio\OpenApiContractTesting\InvalidOpenApiSpecReason;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension;
 
@@ -127,6 +128,85 @@ class OpenApiCoverageExtensionTest extends TestCase
         $this->assertStringContainsString('FATAL OpenAPI spec error', $contents);
         $this->assertStringContainsString('refs-unresolvable', $contents);
         $this->assertStringContainsString('Unresolvable $ref', $contents);
+    }
+
+    #[Test]
+    public function bootstrap_throws_for_malformed_json_spec(): void
+    {
+        // Pre-PR catch-all demoted malformed JSON to a stderr WARNING, which
+        // is functionally the same silent-pass hole as the $ref case issue
+        // #79 set out to close. Pin the fatal treatment so it cannot regress.
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => 'malformed-json',
+        ]);
+
+        try {
+            $extension->setupExtension($this->stubFacade(), $parameters, null);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::MalformedJson, $e->reason);
+        }
+
+        $this->assertStringContainsString('FATAL', $this->readStderr());
+    }
+
+    #[Test]
+    public function bootstrap_throws_when_base_path_not_configured(): void
+    {
+        // Omitting spec_base_path is a misconfiguration, not a missing file —
+        // previously bundled into the warn-and-continue bucket via the broad
+        // RuntimeException catch. Treat as fatal so users see their mistake.
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'specs' => 'refs-valid',
+        ]);
+
+        try {
+            $extension->setupExtension($this->stubFacade(), $parameters, null);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::BasePathNotConfigured, $e->reason);
+        }
+    }
+
+    #[Test]
+    public function bootstrap_continues_past_missing_spec_to_load_valid_ones(): void
+    {
+        // A stale entry in `specs=` should not block the rest of the list
+        // from being eager-loaded. Pins the warn-and-continue semantics that
+        // differentiate SpecFileNotFoundException from the fatal paths.
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => 'does-not-exist,refs-valid',
+        ]);
+
+        $extension->setupExtension($this->stubFacade(), $parameters, null);
+
+        $this->assertStringContainsString("WARNING: Skipping spec 'does-not-exist'", $this->readStderr());
+        // refs-valid must have loaded cleanly — its content is cached.
+        $spec = OpenApiSpecLoader::load('refs-valid');
+        $this->assertSame('Refs valid', $spec['info']['title']);
+    }
+
+    #[Test]
+    public function bootstrap_hard_fails_even_when_earlier_specs_are_valid(): void
+    {
+        // Order-independence: the loop must reach and trip on the broken spec
+        // even if a good spec ran first. A future early-return on "first
+        // successful load" refactor would be caught here.
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => 'refs-valid,refs-unresolvable',
+        ]);
+
+        $this->expectException(InvalidOpenApiSpecException::class);
+        $this->expectExceptionMessage('Unresolvable $ref');
+
+        $extension->setupExtension($this->stubFacade(), $parameters, null);
     }
 
     private function readStderr(): string

--- a/tests/Unit/OpenApiCoverageExtensionTest.php
+++ b/tests/Unit/OpenApiCoverageExtensionTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use PHPUnit\Event\Subscriber;
+use PHPUnit\Event\Tracer\Tracer;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Runner\Extension\Facade;
+use PHPUnit\Runner\Extension\ParameterCollection;
+use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
+use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension;
+
+use function fclose;
+use function file_get_contents;
+use function fopen;
+use function rewind;
+use function stream_get_contents;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+class OpenApiCoverageExtensionTest extends TestCase
+{
+    /** @var null|resource */
+    private $stderrBuffer;
+    private ?string $githubSummaryTmp = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiSpecLoader::reset();
+
+        $buffer = fopen('php://memory', 'w+');
+        if ($buffer === false) {
+            $this->fail('Could not open in-memory buffer for STDERR capture');
+        }
+        $this->stderrBuffer = $buffer;
+        OpenApiCoverageExtension::overrideStderrForTesting($buffer);
+    }
+
+    protected function tearDown(): void
+    {
+        OpenApiCoverageExtension::overrideStderrForTesting(null);
+        if ($this->stderrBuffer !== null) {
+            fclose($this->stderrBuffer);
+            $this->stderrBuffer = null;
+        }
+        if ($this->githubSummaryTmp !== null) {
+            @unlink($this->githubSummaryTmp);
+            $this->githubSummaryTmp = null;
+        }
+        OpenApiSpecLoader::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function bootstrap_throws_invalid_spec_exception_when_ref_unresolvable(): void
+    {
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => 'refs-unresolvable',
+        ]);
+
+        $this->expectException(InvalidOpenApiSpecException::class);
+        $this->expectExceptionMessage('Unresolvable $ref');
+
+        $extension->setupExtension($this->stubFacade(), $parameters, null);
+    }
+
+    #[Test]
+    public function bootstrap_writes_warning_but_continues_for_missing_spec_file(): void
+    {
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => 'does-not-exist',
+        ]);
+
+        $extension->setupExtension($this->stubFacade(), $parameters, null);
+
+        $this->assertStringContainsString('WARNING', $this->readStderr());
+        $this->assertStringContainsString('does-not-exist', $this->readStderr());
+    }
+
+    #[Test]
+    public function bootstrap_loads_cleanly_for_valid_spec(): void
+    {
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => 'refs-valid',
+        ]);
+
+        $extension->setupExtension($this->stubFacade(), $parameters, null);
+
+        $this->assertSame('', $this->readStderr());
+    }
+
+    #[Test]
+    public function bootstrap_appends_fatal_block_to_github_step_summary(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'openapi-summary-');
+        if ($tmp === false) {
+            $this->fail('Could not create temp file for GITHUB_STEP_SUMMARY');
+        }
+        $this->githubSummaryTmp = $tmp;
+
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => 'refs-unresolvable',
+        ]);
+
+        try {
+            $extension->setupExtension($this->stubFacade(), $parameters, $tmp);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException) {
+            // Expected — the FATAL block must still have been written before re-throw.
+        }
+
+        $contents = (string) file_get_contents($tmp);
+        $this->assertStringContainsString('FATAL OpenAPI spec error', $contents);
+        $this->assertStringContainsString('refs-unresolvable', $contents);
+        $this->assertStringContainsString('Unresolvable $ref', $contents);
+    }
+
+    private function readStderr(): string
+    {
+        if ($this->stderrBuffer === null) {
+            return '';
+        }
+        rewind($this->stderrBuffer);
+
+        return (string) stream_get_contents($this->stderrBuffer);
+    }
+
+    private function stubFacade(): Facade
+    {
+        return new class implements Facade {
+            public function registerSubscribers(Subscriber ...$subscribers): void {}
+
+            public function registerSubscriber(Subscriber $subscriber): void {}
+
+            public function registerTracer(Tracer $tracer): void {}
+
+            public function replaceOutput(): void {}
+
+            public function replaceProgressOutput(): void {}
+
+            public function replaceResultOutput(): void {}
+
+            public function requireCodeCoverageCollection(): void {}
+        };
+    }
+}

--- a/tests/Unit/OpenApiRefResolverTest.php
+++ b/tests/Unit/OpenApiRefResolverTest.php
@@ -6,7 +6,7 @@ namespace Studio\OpenApiContractTesting\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
+use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\OpenApiRefResolver;
 
 class OpenApiRefResolverTest extends TestCase
@@ -332,7 +332,7 @@ class OpenApiRefResolverTest extends TestCase
             ],
         ];
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidOpenApiSpecException::class);
         $this->expectExceptionMessage('External $ref');
 
         OpenApiRefResolver::resolve($spec);
@@ -349,7 +349,7 @@ class OpenApiRefResolverTest extends TestCase
             ],
         ];
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidOpenApiSpecException::class);
         $this->expectExceptionMessage('External $ref');
 
         OpenApiRefResolver::resolve($spec);
@@ -386,7 +386,7 @@ class OpenApiRefResolverTest extends TestCase
             ],
         ];
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidOpenApiSpecException::class);
         $this->expectExceptionMessage('Circular $ref');
 
         OpenApiRefResolver::resolve($spec);
@@ -429,7 +429,7 @@ class OpenApiRefResolverTest extends TestCase
             ],
         ];
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidOpenApiSpecException::class);
         $this->expectExceptionMessage('Circular $ref');
 
         OpenApiRefResolver::resolve($spec);
@@ -464,7 +464,7 @@ class OpenApiRefResolverTest extends TestCase
             'x-alias' => ['$ref' => '#/components/schemas/A'],
         ];
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidOpenApiSpecException::class);
         $this->expectExceptionMessage('Circular $ref');
 
         OpenApiRefResolver::resolve($spec);
@@ -496,7 +496,7 @@ class OpenApiRefResolverTest extends TestCase
             ],
         ];
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidOpenApiSpecException::class);
         $this->expectExceptionMessage('Unresolvable $ref');
 
         OpenApiRefResolver::resolve($spec);
@@ -530,7 +530,7 @@ class OpenApiRefResolverTest extends TestCase
             ],
         ];
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidOpenApiSpecException::class);
         $this->expectExceptionMessage('Unresolvable $ref');
 
         OpenApiRefResolver::resolve($spec);
@@ -551,7 +551,7 @@ class OpenApiRefResolverTest extends TestCase
             ],
         ];
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidOpenApiSpecException::class);
         $this->expectExceptionMessage('Invalid $ref');
 
         OpenApiRefResolver::resolve($spec);
@@ -571,7 +571,7 @@ class OpenApiRefResolverTest extends TestCase
             ],
         ];
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidOpenApiSpecException::class);
         $this->expectExceptionMessage('not an object');
 
         OpenApiRefResolver::resolve($spec);
@@ -592,7 +592,7 @@ class OpenApiRefResolverTest extends TestCase
             ],
         ];
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidOpenApiSpecException::class);
         $this->expectExceptionMessage('not an object');
 
         OpenApiRefResolver::resolve($spec);
@@ -612,7 +612,7 @@ class OpenApiRefResolverTest extends TestCase
             ],
         ];
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidOpenApiSpecException::class);
         $this->expectExceptionMessage('bare fragment');
 
         OpenApiRefResolver::resolve($spec);
@@ -628,7 +628,7 @@ class OpenApiRefResolverTest extends TestCase
             'x-bad' => ['$ref' => '#/'],
         ];
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidOpenApiSpecException::class);
         $this->expectExceptionMessage('root pointer');
 
         OpenApiRefResolver::resolve($spec);
@@ -965,7 +965,7 @@ class OpenApiRefResolverTest extends TestCase
             ],
         ];
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidOpenApiSpecException::class);
         $this->expectExceptionMessage('Invalid $ref');
 
         OpenApiRefResolver::resolve($spec);

--- a/tests/Unit/OpenApiSpecLoaderTest.php
+++ b/tests/Unit/OpenApiSpecLoaderTest.php
@@ -6,9 +6,10 @@ namespace Studio\OpenApiContractTesting\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
 use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
+use Studio\OpenApiContractTesting\InvalidOpenApiSpecReason;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\SpecFileNotFoundException;
 
 use function file_put_contents;
 use function mkdir;
@@ -59,10 +60,13 @@ class OpenApiSpecLoaderTest extends TestCase
     #[Test]
     public function get_base_path_throws_when_not_configured(): void
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('OpenApiSpecLoader base path not configured');
-
-        OpenApiSpecLoader::getBasePath();
+        try {
+            OpenApiSpecLoader::getBasePath();
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::BasePathNotConfigured, $e->reason);
+            $this->assertStringContainsString('OpenApiSpecLoader base path not configured', $e->getMessage());
+        }
     }
 
     #[Test]
@@ -95,10 +99,14 @@ class OpenApiSpecLoaderTest extends TestCase
     {
         OpenApiSpecLoader::configure('/nonexistent/path');
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('OpenAPI bundled spec not found');
-
-        OpenApiSpecLoader::load('nonexistent');
+        try {
+            OpenApiSpecLoader::load('nonexistent');
+            $this->fail('expected SpecFileNotFoundException');
+        } catch (SpecFileNotFoundException $e) {
+            $this->assertSame('nonexistent', $e->specName);
+            $this->assertSame('/nonexistent/path', $e->basePath);
+            $this->assertStringContainsString('OpenAPI bundled spec not found', $e->getMessage());
+        }
     }
 
     #[Test]
@@ -110,7 +118,7 @@ class OpenApiSpecLoaderTest extends TestCase
 
         $this->assertSame([], OpenApiSpecLoader::getStripPrefixes());
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidOpenApiSpecException::class);
         OpenApiSpecLoader::getBasePath();
     }
 
@@ -196,10 +204,17 @@ class OpenApiSpecLoaderTest extends TestCase
         $fixturesPath = __DIR__ . '/../fixtures/specs';
         OpenApiSpecLoader::configure($fixturesPath);
 
-        $this->expectException(InvalidOpenApiSpecException::class);
-        $this->expectExceptionMessage('Unresolvable $ref');
-
-        OpenApiSpecLoader::load('refs-unresolvable');
+        try {
+            OpenApiSpecLoader::load('refs-unresolvable');
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::UnresolvableRef, $e->reason);
+            // Loader re-wraps resolver throws with the spec name it knows;
+            // pins that wrap so consumers can surface the spec in diagnostics.
+            $this->assertSame('refs-unresolvable', $e->specName);
+            $this->assertSame('#/components/schemas/DoesNotExist', $e->ref);
+            $this->assertStringContainsString('Unresolvable $ref', $e->getMessage());
+        }
     }
 
     #[Test]
@@ -350,10 +365,14 @@ class OpenApiSpecLoaderTest extends TestCase
         $fixturesPath = __DIR__ . '/../fixtures/specs';
         OpenApiSpecLoader::configure($fixturesPath);
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Failed to parse YAML');
-
-        OpenApiSpecLoader::load('malformed-yaml');
+        try {
+            OpenApiSpecLoader::load('malformed-yaml');
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::MalformedYaml, $e->reason);
+            $this->assertSame('malformed-yaml', $e->specName);
+            $this->assertStringContainsString('Failed to parse YAML', $e->getMessage());
+        }
     }
 
     #[Test]
@@ -362,10 +381,14 @@ class OpenApiSpecLoaderTest extends TestCase
         $fixturesPath = __DIR__ . '/../fixtures/specs';
         OpenApiSpecLoader::configure($fixturesPath);
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('YAML OpenAPI spec must decode to a mapping');
-
-        OpenApiSpecLoader::load('non-array-root');
+        try {
+            OpenApiSpecLoader::load('non-array-root');
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::NonMappingRoot, $e->reason);
+            $this->assertSame('non-array-root', $e->specName);
+            $this->assertStringContainsString('YAML OpenAPI spec must decode to a mapping', $e->getMessage());
+        }
     }
 
     #[Test]
@@ -374,10 +397,14 @@ class OpenApiSpecLoaderTest extends TestCase
         $fixturesPath = __DIR__ . '/../fixtures/specs';
         OpenApiSpecLoader::configure($fixturesPath);
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('JSON OpenAPI spec must decode to a mapping');
-
-        OpenApiSpecLoader::load('non-array-json-root');
+        try {
+            OpenApiSpecLoader::load('non-array-json-root');
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::NonMappingRoot, $e->reason);
+            $this->assertSame('non-array-json-root', $e->specName);
+            $this->assertStringContainsString('JSON OpenAPI spec must decode to a mapping', $e->getMessage());
+        }
     }
 
     #[Test]
@@ -386,11 +413,14 @@ class OpenApiSpecLoaderTest extends TestCase
         $fixturesPath = __DIR__ . '/../fixtures/specs';
         OpenApiSpecLoader::configure($fixturesPath);
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Failed to parse JSON OpenAPI spec');
-        $this->expectExceptionMessage('malformed-json');
-
-        OpenApiSpecLoader::load('malformed-json');
+        try {
+            OpenApiSpecLoader::load('malformed-json');
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::MalformedJson, $e->reason);
+            $this->assertSame('malformed-json', $e->specName);
+            $this->assertStringContainsString('Failed to parse JSON OpenAPI spec', $e->getMessage());
+        }
     }
 
     #[Test]
@@ -400,11 +430,14 @@ class OpenApiSpecLoaderTest extends TestCase
         OpenApiSpecLoader::configure($fixturesPath);
         OpenApiSpecLoader::overrideYamlAvailabilityForTesting(false);
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('symfony/yaml');
-        $this->expectExceptionMessage('composer require');
-
-        OpenApiSpecLoader::load('petstore-yaml');
+        try {
+            OpenApiSpecLoader::load('petstore-yaml');
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::YamlLibraryMissing, $e->reason);
+            $this->assertStringContainsString('symfony/yaml', $e->getMessage());
+            $this->assertStringContainsString('composer require', $e->getMessage());
+        }
     }
 
     #[Test]
@@ -414,8 +447,8 @@ class OpenApiSpecLoaderTest extends TestCase
 
         try {
             OpenApiSpecLoader::load('nowhere');
-            $this->fail('expected RuntimeException');
-        } catch (RuntimeException $e) {
+            $this->fail('expected SpecFileNotFoundException');
+        } catch (SpecFileNotFoundException $e) {
             $message = $e->getMessage();
             $this->assertStringContainsString('.json', $message);
             $this->assertStringContainsString('.yaml', $message);

--- a/tests/Unit/OpenApiSpecLoaderTest.php
+++ b/tests/Unit/OpenApiSpecLoaderTest.php
@@ -7,6 +7,7 @@ namespace Studio\OpenApiContractTesting\Tests\Unit;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
 
 use function file_put_contents;
@@ -171,7 +172,7 @@ class OpenApiSpecLoaderTest extends TestCase
         $fixturesPath = __DIR__ . '/../fixtures/specs';
         OpenApiSpecLoader::configure($fixturesPath);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidOpenApiSpecException::class);
         $this->expectExceptionMessage('Circular $ref');
 
         OpenApiSpecLoader::load('refs-circular');
@@ -183,7 +184,7 @@ class OpenApiSpecLoaderTest extends TestCase
         $fixturesPath = __DIR__ . '/../fixtures/specs';
         OpenApiSpecLoader::configure($fixturesPath);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidOpenApiSpecException::class);
         $this->expectExceptionMessage('External $ref');
 
         OpenApiSpecLoader::load('refs-external');
@@ -195,7 +196,7 @@ class OpenApiSpecLoaderTest extends TestCase
         $fixturesPath = __DIR__ . '/../fixtures/specs';
         OpenApiSpecLoader::configure($fixturesPath);
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidOpenApiSpecException::class);
         $this->expectExceptionMessage('Unresolvable $ref');
 
         OpenApiSpecLoader::load('refs-unresolvable');
@@ -230,13 +231,13 @@ class OpenApiSpecLoaderTest extends TestCase
 
         try {
             OpenApiSpecLoader::load('refs-unresolvable');
-            $this->fail('expected RuntimeException');
-        } catch (RuntimeException) {
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException) {
             // Expected — next load must re-attempt from disk, not return a
             // partially-resolved array captured before the throw.
         }
 
-        $this->expectException(RuntimeException::class);
+        $this->expectException(InvalidOpenApiSpecException::class);
         $this->expectExceptionMessage('Unresolvable $ref');
         OpenApiSpecLoader::load('refs-unresolvable');
     }
@@ -249,7 +250,7 @@ class OpenApiSpecLoaderTest extends TestCase
 
         try {
             OpenApiSpecLoader::load('refs-circular');
-        } catch (RuntimeException) {
+        } catch (InvalidOpenApiSpecException) {
             // Swallow so we can verify a different spec still loads afterwards.
         }
 


### PR DESCRIPTION
## Summary

Closes #79.

- After PR #77 the loader started throwing `RuntimeException` on broken `$ref` entries (external / circular / unresolvable / malformed). `OpenApiCoverageExtension`'s legacy `catch (RuntimeException)` block — originally there to warn past a missing spec file — silently absorbed those too, letting a broken spec flow through as "phpunit green, coverage mysteriously empty" (the worst failure mode for a contract-testing tool).
- Introduces `InvalidOpenApiSpecException extends RuntimeException` and routes every `OpenApiRefResolver` throw through it. Non-ref loader errors (file-not-found, JSON/YAML parse, non-mapping root) keep emitting plain `RuntimeException`, so legacy warn-and-continue UX for those cases is preserved.
- `OpenApiCoverageExtension` now **eager-loads every registered spec during `bootstrap()`**. A broken spec → FATAL line on stderr + fatal block appended to `GITHUB_STEP_SUMMARY` (when set) + `exit(1)`. A missing spec file → unchanged stderr WARNING and continue.
- PHPUnit's `ExtensionBootstrapper::bootstrap()` wraps the call in `catch (Throwable)` and converts to `testRunnerTriggeredPhpunitWarning`, which does not fail the run unless `failOnPhpunitWarning="true"` is set. Relying on that flag would re-open the silent-pass hole, so `bootstrap()` explicitly `exit(1)`s after writing diagnostics.

## Why bootstrap-time (not subscriber-time)

- PHPUnit 11/12/13 `DirectDispatcher` catches throws from subscribers and similarly demotes them to warnings.
- Failing at bootstrap means the broken spec surfaces **before any test runs**. As a side benefit, a broken spec with zero tests exercising it still hard-fails — closing the `$hasCoverage` short-circuit silent-pass path too.

## Test plan

- [x] `vendor/bin/phpunit` — 660 tests / 1379 assertions green (4 new).
- [x] `vendor/bin/phpstan analyse` — level 6 clean.
- [x] `vendor/bin/php-cs-fixer fix --dry-run --diff` — no fixes.
- [x] Manual integration check (throw-away `phpunit.xml`):
  - `specs="refs-unresolvable"` → exit 1, FATAL on stderr, fatal block appended to `GITHUB_STEP_SUMMARY`.
  - `specs="does-not-exist"` → exit 0 for a passing test suite, single `WARNING` line on stderr, tests continue normally.
- [x] `OpenApiCoverageExtensionTest` pins both paths at the unit level (throw on `refs-unresolvable`, warn-only on missing spec file, no noise on `refs-valid`, FATAL block appended to `GITHUB_STEP_SUMMARY`).

## Notes on scope

- `InvalidOpenApiSpecException` is intentionally scoped to ref errors only; `OpenApiSpecLoader::load()` keeps throwing plain `RuntimeException` for file-not-found / parse / non-mapping root. Widening the hierarchy can be a follow-up if needed.
- `OpenApiCoverageExtension` retains defensive `InvalidOpenApiSpecException` / `RuntimeException` catches inside the anonymous subscriber for the (now practically unreachable) case where a spec is evicted and reloaded after bootstrap.