### PR TITLE
Refactoring: YAML 可用性チェックのテストシームを Internal\ パッケージ private scope へ切り出す

### DIFF
--- a/src/Internal/YamlAvailability.php
+++ b/src/Internal/YamlAvailability.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Internal;
+
+use Symfony\Component\Yaml\Yaml;
+
+use function class_exists;
+
+/**
+ * Package-private gate for the `symfony/yaml` availability check.
+ *
+ * This class exists purely so the production `OpenApiSpecLoader` no longer
+ * has to carry a test-only setter on its public API surface. The override
+ * state, the real check, and the reset helper all live here instead.
+ *
+ * @internal Not part of the package's public API. Do not call from user code.
+ */
+final class YamlAvailability
+{
+    private static ?bool $override = null;
+
+    public static function isAvailable(): bool
+    {
+        return self::$override ?? class_exists(Yaml::class);
+    }
+
+    /**
+     * Force the availability check to return the given value, for tests that
+     * need to exercise the missing-dependency error path. Pass null to
+     * restore the real `class_exists()` lookup.
+     *
+     * @internal
+     */
+    public static function overrideForTesting(?bool $available): void
+    {
+        self::$override = $available;
+    }
+
+    /** @internal */
+    public static function reset(): void
+    {
+        self::$override = null;
+    }
+}

--- a/src/Internal/YamlAvailability.php
+++ b/src/Internal/YamlAvailability.php
@@ -21,6 +21,8 @@ final class YamlAvailability
 {
     private static ?bool $override = null;
 
+    private function __construct() {}
+
     public static function isAvailable(): bool
     {
         return self::$override ?? class_exists(Yaml::class);
@@ -30,15 +32,12 @@ final class YamlAvailability
      * Force the availability check to return the given value, for tests that
      * need to exercise the missing-dependency error path. Pass null to
      * restore the real `class_exists()` lookup.
-     *
-     * @internal
      */
     public static function overrideForTesting(?bool $available): void
     {
         self::$override = $available;
     }
 
-    /** @internal */
     public static function reset(): void
     {
         self::$override = null;

--- a/src/OpenApiSpecLoader.php
+++ b/src/OpenApiSpecLoader.php
@@ -7,10 +7,10 @@ namespace Studio\OpenApiContractTesting;
 use const JSON_THROW_ON_ERROR;
 
 use JsonException;
+use Studio\OpenApiContractTesting\Internal\YamlAvailability;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
-use function class_exists;
 use function file_exists;
 use function file_get_contents;
 use function get_debug_type;
@@ -36,12 +36,6 @@ final class OpenApiSpecLoader
 
     /** @var array<string, array<string, mixed>> */
     private static array $cache = [];
-
-    /**
-     * Test-only override for the `symfony/yaml` availability check.
-     * null means "ask the real class_exists()". true/false forces the answer.
-     */
-    private static ?bool $yamlAvailableOverride = null;
 
     /**
      * Configure the spec loader with a base path and optional strip prefixes.
@@ -127,18 +121,7 @@ final class OpenApiSpecLoader
         self::$basePath = null;
         self::$stripPrefixes = [];
         self::$cache = [];
-        self::$yamlAvailableOverride = null;
-    }
-
-    /**
-     * Force `symfony/yaml` to appear installed / missing, for tests that cover
-     * the missing-dependency error path. Pass null to restore the real check.
-     *
-     * @internal
-     */
-    public static function overrideYamlAvailabilityForTesting(?bool $available): void
-    {
-        self::$yamlAvailableOverride = $available;
+        YamlAvailability::reset();
     }
 
     /** @return array{path: string, extension: string} */
@@ -208,7 +191,7 @@ final class OpenApiSpecLoader
     /** @return array<string, mixed> */
     private static function decodeYamlSpec(string $path, string $specName): array
     {
-        if (!self::isYamlLibraryAvailable()) {
+        if (!YamlAvailability::isAvailable()) {
             throw new InvalidOpenApiSpecException(
                 InvalidOpenApiSpecReason::YamlLibraryMissing,
                 'Loading YAML OpenAPI specs requires symfony/yaml. '
@@ -240,10 +223,5 @@ final class OpenApiSpecLoader
 
         /** @var array<string, mixed> $decoded */
         return $decoded;
-    }
-
-    private static function isYamlLibraryAvailable(): bool
-    {
-        return self::$yamlAvailableOverride ?? class_exists(Yaml::class);
     }
 }

--- a/tests/Unit/OpenApiSpecLoaderTest.php
+++ b/tests/Unit/OpenApiSpecLoaderTest.php
@@ -6,6 +6,7 @@ namespace Studio\OpenApiContractTesting\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Internal\YamlAvailability;
 use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\InvalidOpenApiSpecReason;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
@@ -428,7 +429,7 @@ class OpenApiSpecLoaderTest extends TestCase
     {
         $fixturesPath = __DIR__ . '/../fixtures/specs';
         OpenApiSpecLoader::configure($fixturesPath);
-        OpenApiSpecLoader::overrideYamlAvailabilityForTesting(false);
+        YamlAvailability::overrideForTesting(false);
 
         try {
             OpenApiSpecLoader::load('petstore-yaml');
@@ -438,6 +439,26 @@ class OpenApiSpecLoaderTest extends TestCase
             $this->assertStringContainsString('symfony/yaml', $e->getMessage());
             $this->assertStringContainsString('composer require', $e->getMessage());
         }
+    }
+
+    #[Test]
+    public function reset_clears_yaml_availability_override_to_prevent_leaks_between_tests(): void
+    {
+        YamlAvailability::overrideForTesting(false);
+        $this->assertFalse(
+            YamlAvailability::isAvailable(),
+            'sanity: override(false) should force isAvailable() to false',
+        );
+
+        OpenApiSpecLoader::reset();
+
+        // symfony/yaml is a require-dev dependency, so once the override is
+        // cleared the real class_exists() lookup must report it as available.
+        $this->assertTrue(
+            YamlAvailability::isAvailable(),
+            'OpenApiSpecLoader::reset() must clear the YAML availability override '
+            . 'so it cannot leak into other tests via the shared static state.',
+        );
     }
 
     #[Test]

--- a/tests/Unit/OpenApiSpecLoaderTest.php
+++ b/tests/Unit/OpenApiSpecLoaderTest.php
@@ -11,7 +11,9 @@ use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\InvalidOpenApiSpecReason;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\SpecFileNotFoundException;
+use Symfony\Component\Yaml\Yaml;
 
+use function class_exists;
 use function file_put_contents;
 use function mkdir;
 use function rmdir;
@@ -452,9 +454,13 @@ class OpenApiSpecLoaderTest extends TestCase
 
         OpenApiSpecLoader::reset();
 
-        // symfony/yaml is a require-dev dependency, so once the override is
-        // cleared the real class_exists() lookup must report it as available.
-        $this->assertTrue(
+        // After reset, the override must be cleared so isAvailable() falls
+        // through to the real class_exists() probe. Compare against the probe
+        // result directly rather than a hard-coded true/false, so this test
+        // stays meaningful even if symfony/yaml ever moves out of require-dev
+        // or the suite is run with --no-dev.
+        $this->assertSame(
+            class_exists(Yaml::class),
             YamlAvailability::isAvailable(),
             'OpenApiSpecLoader::reset() must clear the YAML availability override '
             . 'so it cannot leak into other tests via the shared static state.',


### PR DESCRIPTION
# 概要

`OpenApiSpecLoader::overrideYamlAvailabilityForTesting()` という test-only な `public static` 関数を production class から撤去し、新設した `Studio\OpenApiContractTesting\Internal\YamlAvailability` へ機能ごと移しました。これにより本 class の公開 API 面からテスト専用 knob が物理的に消え、`Internal\` サブ名前空間が "package-private scope" の慣習として新たに確立されます。

## 変更内容

- **`src/Internal/YamlAvailability.php` を新規追加**: `symfony/yaml` 可用性判定 (`isAvailable()`) と、そのテスト用 override (`overrideForTesting()`) / リセット (`reset()`) をこの class に集約。class PHPDoc に `@internal` を付記し、ユーザーコードから呼ばないよう明示。
- **`src/OpenApiSpecLoader.php` から test-only surface を撤去**: `$yamlAvailableOverride` プロパティ、`overrideYamlAvailabilityForTesting()` メソッド、`isYamlLibraryAvailable()` private helper を削除。`decodeYamlSpec()` は `YamlAvailability::isAvailable()` を直接呼ぶ形に。`reset()` は `YamlAvailability::reset()` に委譲するので、既存テストの `setUp`/`tearDown` はそのまま機能する。
- **`tests/Unit/OpenApiSpecLoaderTest.php`**:
  - 既存テスト `load_yaml_throws_with_install_hint_when_symfony_yaml_missing` を新しい seam (`YamlAvailability::overrideForTesting(false)`) に差し替え、挙動維持を確認。
  - 新規テスト `reset_clears_yaml_availability_override_to_prevent_leaks_between_tests` を追加。`OpenApiSpecLoader::reset()` が override をクリアすることを明示的に pin し、テスト間の state 漏れを防ぐ仕様を固定化。

### 検証

- `vendor/bin/phpunit` — **667 tests / 1402 assertions 全グリーン**
- `vendor/bin/phpstan analyse` (level 6) — No errors
- `vendor/bin/php-cs-fixer fix --dry-run --diff` — 0 fixable files
- `grep -rn "overrideYamlAvailabilityForTesting\|yamlAvailableOverride" src/` — ヒット 0 件（production surface からの撤去を確認）

### 受け入れ条件

- [x] production class から `overrideYamlAvailabilityForTesting()` が消える
- [x] 既存テスト `load_yaml_throws_with_install_hint_when_symfony_yaml_missing` が挙動を維持したままグリーン
- [x] テスト間で override が漏れないことをカバーするテストがある

## 関連情報

- Closes #81
- 関連: PR #80（YAML 読み込み追加時のレビューで follow-up 指摘）

### スコープ外（follow-up 候補）

- `OpenApiCoverageExtension::overrideStderrForTesting()` も同じ test-seam パターン。今後 `Internal\` 配下に寄せる余地あり（別 issue で検討）。