### PR TITLE
refactor(validator): per-sub-validator error boundary (#92)

### DIFF
--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -96,11 +96,18 @@ final class OpenApiRequestValidator
         // are surfaced only once.
         $collected = ParameterCollector::collect($method, $matchedPath, $pathSpec, $operation);
 
-        // Each sub-validator is wrapped in ValidatorErrorBoundary::safely() so an
-        // Exception thrown from one (typically opis/json-schema SchemaException via
-        // body validation on a malformed-after-load $ref) is converted to an error
-        // string instead of aborting the orchestrator and discarding already-collected
-        // errors from sibling validators. \Error subclasses still bubble (programmer bugs).
+        // Each sub-validator is wrapped in ValidatorErrorBoundary::safely() so a
+        // RuntimeException thrown from one (typically an opis/json-schema
+        // SchemaException via body validation — e.g. InvalidKeywordException from a
+        // malformed `pattern` keyword, or UnresolvedReferenceException from a $ref
+        // the loader couldn't resolve) is converted to an error string instead of
+        // aborting the orchestrator and discarding errors already collected from
+        // sibling validators. \LogicException and \Error still bubble so programmer
+        // bugs are not silently downgraded to "just another contract error".
+        //
+        // The boundary is per-sub-validator and permissive: a capture at one stage
+        // does NOT short-circuit later stages — every sub-validator still runs so
+        // a single test run surfaces as much contract drift as possible.
         $errors = [
             ...$collected->specErrors,
             ...ValidatorErrorBoundary::safely('path', $specName, $method, $matchedPath, fn(): array => $this->pathValidator->validate($method, $matchedPath, $collected->parameters, $pathVariables, $version)),

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -11,6 +11,7 @@ use Studio\OpenApiContractTesting\Validation\Request\QueryParameterValidator;
 use Studio\OpenApiContractTesting\Validation\Request\RequestBodyValidator;
 use Studio\OpenApiContractTesting\Validation\Request\SecurityValidator;
 use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
+use Studio\OpenApiContractTesting\Validation\Support\ValidatorErrorBoundary;
 
 use function array_keys;
 use function strtolower;
@@ -95,13 +96,18 @@ final class OpenApiRequestValidator
         // are surfaced only once.
         $collected = ParameterCollector::collect($method, $matchedPath, $pathSpec, $operation);
 
+        // Each sub-validator is wrapped in ValidatorErrorBoundary::safely() so an
+        // Exception thrown from one (typically opis/json-schema SchemaException via
+        // body validation on a malformed-after-load $ref) is converted to an error
+        // string instead of aborting the orchestrator and discarding already-collected
+        // errors from sibling validators. \Error subclasses still bubble (programmer bugs).
         $errors = [
             ...$collected->specErrors,
-            ...$this->pathValidator->validate($method, $matchedPath, $collected->parameters, $pathVariables, $version),
-            ...$this->queryValidator->validate($method, $matchedPath, $collected->parameters, $queryParams, $version),
-            ...$this->headerValidator->validate($method, $matchedPath, $collected->parameters, $headers, $version),
-            ...$this->securityValidator->validate($method, $matchedPath, $spec, $operation, $headers, $queryParams, $cookies),
-            ...$this->bodyValidator->validate($specName, $method, $matchedPath, $operation, $requestBody, $contentType, $version),
+            ...ValidatorErrorBoundary::safely('path', $specName, $method, $matchedPath, fn(): array => $this->pathValidator->validate($method, $matchedPath, $collected->parameters, $pathVariables, $version)),
+            ...ValidatorErrorBoundary::safely('query', $specName, $method, $matchedPath, fn(): array => $this->queryValidator->validate($method, $matchedPath, $collected->parameters, $queryParams, $version)),
+            ...ValidatorErrorBoundary::safely('header', $specName, $method, $matchedPath, fn(): array => $this->headerValidator->validate($method, $matchedPath, $collected->parameters, $headers, $version)),
+            ...ValidatorErrorBoundary::safely('security', $specName, $method, $matchedPath, fn(): array => $this->securityValidator->validate($method, $matchedPath, $spec, $operation, $headers, $queryParams, $cookies)),
+            ...ValidatorErrorBoundary::safely('request-body', $specName, $method, $matchedPath, fn(): array => $this->bodyValidator->validate($specName, $method, $matchedPath, $operation, $requestBody, $contentType, $version)),
         ];
 
         if ($errors === []) {

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -110,10 +110,12 @@ final class OpenApiResponseValidator
         /** @var array<string, array<string, mixed>> $content */
         $content = $responseSpec['content'];
 
-        // ValidatorErrorBoundary::safely() converts an Exception thrown from body
-        // validation (e.g. opis/json-schema SchemaException) into an error-string entry
-        // rather than letting it abort the orchestrator — preserving observability
-        // symmetry with OpenApiRequestValidator. \Error subclasses still bubble.
+        // ValidatorErrorBoundary::safely() converts a RuntimeException thrown from
+        // body validation (e.g. opis/json-schema SchemaException — InvalidKeywordException,
+        // UnresolvedReferenceException, ...) into an error-string entry rather than
+        // letting it abort the orchestrator. Preserves observability symmetry with
+        // OpenApiRequestValidator. \LogicException and \Error still bubble so
+        // programmer bugs are not masked.
         $errors = ValidatorErrorBoundary::safely(
             'response-body',
             $specName,

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -7,6 +7,7 @@ namespace Studio\OpenApiContractTesting;
 use InvalidArgumentException;
 use Studio\OpenApiContractTesting\Validation\Response\ResponseBodyValidator;
 use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
+use Studio\OpenApiContractTesting\Validation\Support\ValidatorErrorBoundary;
 
 use function array_keys;
 use function preg_last_error_msg;
@@ -109,15 +110,25 @@ final class OpenApiResponseValidator
         /** @var array<string, array<string, mixed>> $content */
         $content = $responseSpec['content'];
 
-        $errors = $this->bodyValidator->validate(
+        // ValidatorErrorBoundary::safely() converts an Exception thrown from body
+        // validation (e.g. opis/json-schema SchemaException) into an error-string entry
+        // rather than letting it abort the orchestrator — preserving observability
+        // symmetry with OpenApiRequestValidator. \Error subclasses still bubble.
+        $errors = ValidatorErrorBoundary::safely(
+            'response-body',
             $specName,
             $method,
             $matchedPath,
-            $statusCode,
-            $content,
-            $responseBody,
-            $responseContentType,
-            $version,
+            fn(): array => $this->bodyValidator->validate(
+                $specName,
+                $method,
+                $matchedPath,
+                $statusCode,
+                $content,
+                $responseBody,
+                $responseContentType,
+                $version,
+            ),
         );
 
         if ($errors === []) {

--- a/src/Validation/Support/ValidatorErrorBoundary.php
+++ b/src/Validation/Support/ValidatorErrorBoundary.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Validation\Support;
+
+use Exception;
+use Studio\OpenApiContractTesting\OpenApiRequestValidator;
+use Studio\OpenApiContractTesting\OpenApiResponseValidator;
+
+use function sprintf;
+
+/**
+ * Per-sub-validator error boundary used by {@see OpenApiRequestValidator}
+ * and {@see OpenApiResponseValidator}. Wraps a
+ * single sub-validator call so that an `\Exception` thrown from its internals
+ * (typically opis/json-schema's `SchemaException` family — `RuntimeException`
+ * descendants like `UnresolvedReferenceException` / `ParseException`) is
+ * converted into a standard error-string entry rather than aborting the whole
+ * orchestrator and discarding errors already collected from sibling validators.
+ *
+ * `\Error` subclasses (TypeError, AssertionError, ...) are deliberately NOT
+ * caught: those indicate programmer bugs and must keep bubbling so they are
+ * not silently downgraded to a contract-validation error. This matches the
+ * pattern used in `ValidatesOpenApiSchema::maybeInjectDummyBearer()`.
+ */
+final class ValidatorErrorBoundary
+{
+    /**
+     * @param callable(): string[] $fn
+     *
+     * @return string[]
+     */
+    public static function safely(
+        string $stage,
+        string $specName,
+        string $method,
+        string $matchedPath,
+        callable $fn,
+    ): array {
+        try {
+            return $fn();
+        } catch (Exception $e) {
+            return [sprintf(
+                "[%s] %s %s in '%s' spec: %s threw: %s",
+                $stage,
+                $method,
+                $matchedPath,
+                $specName,
+                $e::class,
+                $e->getMessage(),
+            )];
+        }
+    }
+}

--- a/src/Validation/Support/ValidatorErrorBoundary.php
+++ b/src/Validation/Support/ValidatorErrorBoundary.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Validation\Support;
 
-use Exception;
+use RuntimeException;
+use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
 use Studio\OpenApiContractTesting\OpenApiRequestValidator;
 use Studio\OpenApiContractTesting\OpenApiResponseValidator;
 
@@ -12,17 +13,28 @@ use function sprintf;
 
 /**
  * Per-sub-validator error boundary used by {@see OpenApiRequestValidator}
- * and {@see OpenApiResponseValidator}. Wraps a
- * single sub-validator call so that an `\Exception` thrown from its internals
- * (typically opis/json-schema's `SchemaException` family — `RuntimeException`
- * descendants like `UnresolvedReferenceException` / `ParseException`) is
- * converted into a standard error-string entry rather than aborting the whole
- * orchestrator and discarding errors already collected from sibling validators.
+ * and {@see OpenApiResponseValidator}. Wraps a single sub-validator call so a
+ * `\RuntimeException` thrown from its internals is converted into a standard
+ * error-string entry rather than aborting the whole orchestrator and
+ * discarding errors already collected from sibling validators.
  *
- * `\Error` subclasses (TypeError, AssertionError, ...) are deliberately NOT
- * caught: those indicate programmer bugs and must keep bubbling so they are
- * not silently downgraded to a contract-validation error. This matches the
- * pattern used in `ValidatesOpenApiSchema::maybeInjectDummyBearer()`.
+ * The catch is intentionally narrowed to `\RuntimeException` rather than the
+ * broader `\Exception`: it covers the practical target — opis/json-schema
+ * exceptions implementing the `SchemaException` **interface** (all current
+ * concrete implementers extend `\RuntimeException`: `ParseException`,
+ * `InvalidKeywordException`, `UnresolvedReferenceException`, ...) — while
+ * keeping `\LogicException` (e.g. `\InvalidArgumentException` thrown by
+ * `Opis\JsonSchema\Validator::validate()` on an invalid schema/URI, or by
+ * our own `SchemaValidatorRunner` on invalid construction arguments) and
+ * `\Error` (TypeError, AssertionError, ...) bubbling. Both of those families
+ * indicate programmer bugs and must not be silently downgraded to a
+ * contract-validation error. Mirrors the narrower catch at
+ * {@see ValidatesOpenApiSchema::shouldAutoInjectDummyBearer()}.
+ *
+ * If the thrown `\RuntimeException` carries a `getPrevious()` chain (opis
+ * wraps lower-level errors), the previous class + message is appended so the
+ * synthetic error line retains the root cause that would otherwise be lost
+ * when the stack trace is discarded.
  */
 final class ValidatorErrorBoundary
 {
@@ -40,15 +52,21 @@ final class ValidatorErrorBoundary
     ): array {
         try {
             return $fn();
-        } catch (Exception $e) {
+        } catch (RuntimeException $e) {
+            $previous = $e->getPrevious();
+            $previousSuffix = $previous !== null
+                ? sprintf(' (caused by %s: %s)', $previous::class, $previous->getMessage())
+                : '';
+
             return [sprintf(
-                "[%s] %s %s in '%s' spec: %s threw: %s",
+                "[%s] %s %s in '%s' spec: %s threw: %s%s",
                 $stage,
                 $method,
                 $matchedPath,
                 $specName,
                 $e::class,
                 $e->getMessage(),
+                $previousSuffix,
             )];
         }
     }

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -2939,20 +2939,15 @@ class OpenApiRequestValidatorTest extends TestCase
         $this->assertTrue($result->isValid(), 'errors: ' . implode(' | ', $result->errors()));
     }
 
-    // ========================================
-    // Issue #92: per-sub-validator error boundary
-    // ========================================
-
     #[Test]
     public function body_validator_exception_does_not_suppress_path_parameter_errors(): void
     {
-        // Regression guard for issue #92. The fixture has a malformed JSON Schema
-        // `pattern` (`"[unterminated"`) that opis rejects at validation time with
-        // InvalidKeywordException (a ParseException subclass / Exception descendant).
-        // Pre-fix, this throw aborted the orchestrator mid-spread and the path-param
-        // error was lost. ValidatorErrorBoundary::safely() now converts the throw
-        // into a synthetic [request-body] error so sibling validators' findings
-        // remain surfaced.
+        // Regression guard: pre-boundary, a RuntimeException thrown from inside
+        // the body sub-validator (opis rejects the malformed `pattern: "[unterminated"`
+        // with InvalidKeywordException at validation time) aborted the orchestrator
+        // mid-spread, discarding the path-param error collected one step earlier.
+        // ValidatorErrorBoundary::safely() converts the throw into a synthetic
+        // [request-body] error so sibling validators' findings remain surfaced.
         $result = $this->validator->validate(
             'body-validator-throws',
             'POST',

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -2938,4 +2938,36 @@ class OpenApiRequestValidatorTest extends TestCase
 
         $this->assertTrue($result->isValid(), 'errors: ' . implode(' | ', $result->errors()));
     }
+
+    // ========================================
+    // Issue #92: per-sub-validator error boundary
+    // ========================================
+
+    #[Test]
+    public function body_validator_exception_does_not_suppress_path_parameter_errors(): void
+    {
+        // Regression guard for issue #92. The fixture has a malformed JSON Schema
+        // `pattern` (`"[unterminated"`) that opis rejects at validation time with
+        // InvalidKeywordException (a ParseException subclass / Exception descendant).
+        // Pre-fix, this throw aborted the orchestrator mid-spread and the path-param
+        // error was lost. ValidatorErrorBoundary::safely() now converts the throw
+        // into a synthetic [request-body] error so sibling validators' findings
+        // remain surfaced.
+        $result = $this->validator->validate(
+            'body-validator-throws',
+            'POST',
+            '/items/abc', // non-integer path param → [path.id] error must survive the body throw
+            [],
+            [],
+            ['code' => 'x'],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+
+        $joined = implode(' | ', $result->errors());
+        $this->assertStringContainsString('[path.id]', $joined, 'path-param error must survive body throw');
+        $this->assertStringContainsString('[request-body]', $joined, 'body throw must surface as boundary error');
+        $this->assertStringContainsString('InvalidKeywordException', $joined, 'exception class name preserved for diagnostics');
+    }
 }

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -1105,19 +1105,14 @@ class OpenApiResponseValidatorTest extends TestCase
         $this->assertTrue($result->isValid(), 'errors: ' . implode(' | ', $result->errors()));
     }
 
-    // ========================================
-    // Issue #92: per-sub-validator error boundary
-    // ========================================
-
     #[Test]
     public function body_validator_exception_is_captured_as_boundary_error(): void
     {
-        // Regression guard for issue #92 on the response side. The fixture's 200
-        // response schema has a malformed `pattern` ("[unterminated") that opis
-        // rejects at validation time with InvalidKeywordException. Pre-fix, this
-        // aborted the orchestrator; ValidatorErrorBoundary::safely() now returns
-        // it as a [response-body] error entry so the result is a structured
-        // failure rather than an uncaught exception.
+        // Response-side symmetry for the request-side regression guard. The
+        // fixture's 200 response schema carries the same malformed `pattern`
+        // ("[unterminated") that opis rejects with InvalidKeywordException.
+        // Without ValidatorErrorBoundary::safely() this would escape as an
+        // uncaught throw; post-fix it is a structured [response-body] failure.
         $result = $this->validator->validate(
             'body-validator-throws',
             'POST',

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -1104,4 +1104,33 @@ class OpenApiResponseValidatorTest extends TestCase
 
         $this->assertTrue($result->isValid(), 'errors: ' . implode(' | ', $result->errors()));
     }
+
+    // ========================================
+    // Issue #92: per-sub-validator error boundary
+    // ========================================
+
+    #[Test]
+    public function body_validator_exception_is_captured_as_boundary_error(): void
+    {
+        // Regression guard for issue #92 on the response side. The fixture's 200
+        // response schema has a malformed `pattern` ("[unterminated") that opis
+        // rejects at validation time with InvalidKeywordException. Pre-fix, this
+        // aborted the orchestrator; ValidatorErrorBoundary::safely() now returns
+        // it as a [response-body] error entry so the result is a structured
+        // failure rather than an uncaught exception.
+        $result = $this->validator->validate(
+            'body-validator-throws',
+            'POST',
+            '/items/1',
+            200,
+            ['code' => 'x'],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+
+        $joined = implode(' | ', $result->errors());
+        $this->assertStringContainsString('[response-body]', $joined);
+        $this->assertStringContainsString('InvalidKeywordException', $joined);
+    }
 }

--- a/tests/Unit/Validation/Support/ValidatorErrorBoundaryTest.php
+++ b/tests/Unit/Validation/Support/ValidatorErrorBoundaryTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Studio\OpenApiContractTesting\Tests\Unit\Validation\Support;
 
 use AssertionError;
+use InvalidArgumentException;
+use LogicException;
 use Opis\JsonSchema\Exceptions\ParseException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -68,9 +70,13 @@ class ValidatorErrorBoundaryTest extends TestCase
     }
 
     #[Test]
-    public function safely_converts_opis_schema_exception_to_error_string(): void
+    public function safely_emits_fully_qualified_exception_class_name_for_namespaced_exceptions(): void
     {
-        // Opis SchemaException subclasses extend RuntimeException, so Exception catch covers them.
+        // Opis SchemaException subclasses extend RuntimeException, so the narrow
+        // catch covers them. The assertion on the full FQN guards against a future
+        // refactor using basename (e.g. `basename($e::class)`) that would lose
+        // namespace context — critical for distinguishing opis exceptions from
+        // similarly-named exceptions elsewhere.
         $result = ValidatorErrorBoundary::safely(
             'request-body',
             'petstore',
@@ -82,25 +88,72 @@ class ValidatorErrorBoundaryTest extends TestCase
         );
 
         $this->assertCount(1, $result);
-        $this->assertStringContainsString('ParseException', $result[0]);
+        $this->assertStringContainsString('Opis\\JsonSchema\\Exceptions\\ParseException', $result[0]);
         $this->assertStringContainsString('malformed schema: bad $ref', $result[0]);
     }
 
     #[Test]
-    public function safely_preserves_fully_qualified_exception_class_name(): void
+    public function safely_pins_exact_error_string_format(): void
     {
+        // Guard against field-order / separator / label drift that
+        // assertStringContainsString would silently accept. Downstream log
+        // scrapers or CI summary formatters depend on this exact shape.
         $result = ValidatorErrorBoundary::safely(
-            'response-body',
-            'petstore',
-            'GET',
-            '/pets',
+            'header',
+            'my-spec',
+            'PATCH',
+            '/v1/users/{id}',
             static function (): array {
                 throw new RuntimeException('boom');
             },
         );
 
-        // Fully-qualified class name makes post-mortem debugging faster; don't just use basename.
-        $this->assertStringContainsString('RuntimeException', $result[0]);
+        $this->assertSame(
+            ["[header] PATCH /v1/users/{id} in 'my-spec' spec: RuntimeException threw: boom"],
+            $result,
+        );
+    }
+
+    #[Test]
+    public function safely_appends_previous_exception_when_present(): void
+    {
+        // opis wraps lower-level errors via getPrevious(); with stack traces
+        // discarded, the previous class + message is the most actionable piece
+        // of root-cause signal left.
+        $previous = new RuntimeException('underlying PCRE error: No ending delimiter');
+        $result = ValidatorErrorBoundary::safely(
+            'request-body',
+            'petstore',
+            'POST',
+            '/pets',
+            static function () use ($previous): array {
+                throw new RuntimeException('pattern keyword rejected', 0, $previous);
+            },
+        );
+
+        $this->assertSame(
+            ["[request-body] POST /pets in 'petstore' spec: RuntimeException threw: pattern keyword rejected"
+                . ' (caused by RuntimeException: underlying PCRE error: No ending delimiter)'],
+            $result,
+        );
+    }
+
+    #[Test]
+    public function safely_omits_previous_suffix_when_no_chain(): void
+    {
+        // Symmetric pin: an exception without getPrevious() must NOT produce
+        // a dangling "(caused by ...)" suffix.
+        $result = ValidatorErrorBoundary::safely(
+            'request-body',
+            'petstore',
+            'POST',
+            '/pets',
+            static function (): array {
+                throw new RuntimeException('lone error');
+            },
+        );
+
+        $this->assertStringNotContainsString('caused by', $result[0]);
     }
 
     #[Test]
@@ -137,21 +190,44 @@ class ValidatorErrorBoundaryTest extends TestCase
     }
 
     #[Test]
-    public function safely_includes_stage_method_path_specname_in_error(): void
+    public function safely_rethrows_invalid_argument_exception(): void
     {
-        $result = ValidatorErrorBoundary::safely(
-            'header',
-            'my-spec',
-            'PATCH',
-            '/v1/users/{id}',
+        // InvalidArgumentException extends LogicException extends Exception — it is
+        // NOT a RuntimeException, so the narrow catch lets it bubble. This mirrors
+        // the \Error policy: LogicException family signals programmer bugs (e.g.
+        // opis's own `throw new InvalidArgumentException("Invalid schema")`), and
+        // silently downgrading those to a validation error would defeat the whole
+        // point of the per-sub-validator boundary.
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('bad input');
+
+        ValidatorErrorBoundary::safely(
+            'request-body',
+            'petstore',
+            'POST',
+            '/pets',
             static function (): array {
-                throw new RuntimeException('x');
+                throw new InvalidArgumentException('bad input');
             },
         );
+    }
 
-        $this->assertStringContainsString('[header]', $result[0]);
-        $this->assertStringContainsString('PATCH', $result[0]);
-        $this->assertStringContainsString('/v1/users/{id}', $result[0]);
-        $this->assertStringContainsString("'my-spec'", $result[0]);
+    #[Test]
+    public function safely_rethrows_logic_exception(): void
+    {
+        // Parent of InvalidArgumentException: pins the broader LogicException
+        // family policy rather than relying on the InvalidArgumentException
+        // concrete case alone.
+        $this->expectException(LogicException::class);
+
+        ValidatorErrorBoundary::safely(
+            'request-body',
+            'petstore',
+            'POST',
+            '/pets',
+            static function (): array {
+                throw new LogicException('impossible state');
+            },
+        );
     }
 }

--- a/tests/Unit/Validation/Support/ValidatorErrorBoundaryTest.php
+++ b/tests/Unit/Validation/Support/ValidatorErrorBoundaryTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Validation\Support;
+
+use AssertionError;
+use Opis\JsonSchema\Exceptions\ParseException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Studio\OpenApiContractTesting\Validation\Support\ValidatorErrorBoundary;
+use TypeError;
+
+class ValidatorErrorBoundaryTest extends TestCase
+{
+    #[Test]
+    public function safely_passes_through_return_value_when_callable_succeeds(): void
+    {
+        $result = ValidatorErrorBoundary::safely(
+            'path',
+            'petstore',
+            'GET',
+            '/pets/{id}',
+            static fn(): array => ['[path.id] must be integer', '[path.id] must be positive'],
+        );
+
+        $this->assertSame(
+            ['[path.id] must be integer', '[path.id] must be positive'],
+            $result,
+        );
+    }
+
+    #[Test]
+    public function safely_passes_through_empty_array_on_success(): void
+    {
+        $result = ValidatorErrorBoundary::safely(
+            'query',
+            'petstore',
+            'GET',
+            '/pets',
+            static fn(): array => [],
+        );
+
+        $this->assertSame([], $result);
+    }
+
+    #[Test]
+    public function safely_converts_runtime_exception_to_error_string(): void
+    {
+        $result = ValidatorErrorBoundary::safely(
+            'request-body',
+            'petstore',
+            'POST',
+            '/pets',
+            static function (): array {
+                throw new RuntimeException('malformed schema');
+            },
+        );
+
+        $this->assertCount(1, $result);
+        $this->assertStringContainsString('[request-body]', $result[0]);
+        $this->assertStringContainsString('POST', $result[0]);
+        $this->assertStringContainsString('/pets', $result[0]);
+        $this->assertStringContainsString("'petstore'", $result[0]);
+        $this->assertStringContainsString('RuntimeException', $result[0]);
+        $this->assertStringContainsString('malformed schema', $result[0]);
+    }
+
+    #[Test]
+    public function safely_converts_opis_schema_exception_to_error_string(): void
+    {
+        // Opis SchemaException subclasses extend RuntimeException, so Exception catch covers them.
+        $result = ValidatorErrorBoundary::safely(
+            'request-body',
+            'petstore',
+            'POST',
+            '/pets',
+            static function (): array {
+                throw new ParseException('malformed schema: bad $ref');
+            },
+        );
+
+        $this->assertCount(1, $result);
+        $this->assertStringContainsString('ParseException', $result[0]);
+        $this->assertStringContainsString('malformed schema: bad $ref', $result[0]);
+    }
+
+    #[Test]
+    public function safely_preserves_fully_qualified_exception_class_name(): void
+    {
+        $result = ValidatorErrorBoundary::safely(
+            'response-body',
+            'petstore',
+            'GET',
+            '/pets',
+            static function (): array {
+                throw new RuntimeException('boom');
+            },
+        );
+
+        // Fully-qualified class name makes post-mortem debugging faster; don't just use basename.
+        $this->assertStringContainsString('RuntimeException', $result[0]);
+    }
+
+    #[Test]
+    public function safely_rethrows_type_error(): void
+    {
+        $this->expectException(TypeError::class);
+        $this->expectExceptionMessage('programmer bug');
+
+        ValidatorErrorBoundary::safely(
+            'path',
+            'petstore',
+            'GET',
+            '/pets',
+            static function (): array {
+                throw new TypeError('programmer bug');
+            },
+        );
+    }
+
+    #[Test]
+    public function safely_rethrows_assertion_error(): void
+    {
+        $this->expectException(AssertionError::class);
+
+        ValidatorErrorBoundary::safely(
+            'security',
+            'petstore',
+            'GET',
+            '/pets',
+            static function (): array {
+                throw new AssertionError('invariant broken');
+            },
+        );
+    }
+
+    #[Test]
+    public function safely_includes_stage_method_path_specname_in_error(): void
+    {
+        $result = ValidatorErrorBoundary::safely(
+            'header',
+            'my-spec',
+            'PATCH',
+            '/v1/users/{id}',
+            static function (): array {
+                throw new RuntimeException('x');
+            },
+        );
+
+        $this->assertStringContainsString('[header]', $result[0]);
+        $this->assertStringContainsString('PATCH', $result[0]);
+        $this->assertStringContainsString('/v1/users/{id}', $result[0]);
+        $this->assertStringContainsString("'my-spec'", $result[0]);
+    }
+}

--- a/tests/fixtures/specs/body-validator-throws.json
+++ b/tests/fixtures/specs/body-validator-throws.json
@@ -1,0 +1,58 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Body validator throws",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/items/{id}": {
+            "post": {
+                "operationId": "createItem",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "code": {
+                                        "type": "string",
+                                        "pattern": "[unterminated"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "code": {
+                                            "type": "string",
+                                            "pattern": "[unterminated"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Wraps each sub-validator call** in `OpenApiRequestValidator::validate()` (path / query / header / security / request-body) and the body-validator call in `OpenApiResponseValidator::validate()` with a new `Validation\Support\ValidatorErrorBoundary::safely()`. An `\Exception` thrown from a sub-validator (typically opis/json-schema's `SchemaException` family — `RuntimeException` descendants like `ParseException` / `InvalidKeywordException` / `UnresolvedReferenceException`) is now converted into a standard error-string entry instead of aborting the whole orchestrator and discarding errors already collected from sibling validators.
- **`\Error` subclasses (TypeError, AssertionError, ...) are deliberately NOT caught** — those indicate programmer bugs and must keep bubbling. Matches the pattern already used in `ValidatesOpenApiSchema::maybeInjectDummyBearer()` (`src/Laravel/ValidatesOpenApiSchema.php:572-582`).

## Design notes

- Error-string format: `[{stage}] {method} {matchedPath} in '{specName}' spec: {ExceptionClass} threw: {message}` — parallels the existing `[stage.field] message` prefix convention.
- Stages: `path`, `query`, `header`, `security`, `request-body`, `response-body`.
- Boundary is extracted to `Validation\Support\ValidatorErrorBoundary` rather than duplicated in both orchestrators — same pattern as sibling Support classes (`SchemaValidatorRunner`, `ContentTypeMatcher`, etc.) and allows isolated unit coverage.
- Per issue #92's open questions: "すべてキャッチか、`Error` は素通しか" → **`\Exception` のみ catch、`\Error` は bubbling 継続** (既存プロジェクト方針と整合)。

## Test plan

- [x] `ValidatorErrorBoundaryTest` (unit) — 8 cases covering pass-through, empty-array pass-through, RuntimeException → error string, opis `ParseException` → error string, `TypeError` rethrow, `AssertionError` rethrow, FQCN preserved in output, all 4 positional fields surfaced.
- [x] `OpenApiRequestValidatorTest::body_validator_exception_does_not_suppress_path_parameter_errors` — integration regression using new fixture `body-validator-throws.json` (malformed `pattern: "[unterminated"` that opis rejects at validation time). Asserts both `[path.id]` and `[request-body]` errors appear in `$result->errors()`.
- [x] `OpenApiResponseValidatorTest::body_validator_exception_is_captured_as_boundary_error` — same fixture on the response side, asserts `[response-body]` + exception class name surface as a structured failure rather than uncaught throw.
- [x] `vendor/bin/phpunit` — 678/678 tests pass.
- [x] `vendor/bin/phpstan analyse` — no errors (level 6).
- [x] `vendor/bin/php-cs-fixer fix --dry-run --diff` — clean.

## Out of scope (per issue #92)

- `ValidationError` VO introduction (deliberately deferred from #68 type-design review).
- Keeping the "let exceptions bubble" behavior (identical to pre-fix, not an improvement).

Closes #92