### PR TITLE
refactor(result): tighten failure() param to non-empty-array<string>

### DIFF
--- a/src/OpenApiValidationResult.php
+++ b/src/OpenApiValidationResult.php
@@ -34,13 +34,17 @@ final class OpenApiValidationResult
      * Reject `failure([])` so a Failure always carries at least one error
      * message. Without this guard, `errorMessage()` would return an empty
      * string and the Failure would surface as a silent assertion failure.
+     * The `non-empty-array` bound lifts that invariant into the signature so
+     * PHPStan flags empty-literal callers at analyse time; the runtime guard
+     * remains as defense-in-depth for consumers without static analysis.
      *
-     * @param string[] $errors
+     * @param non-empty-array<string> $errors
      *
      * @throws InvalidArgumentException when $errors is empty
      */
     public static function failure(array $errors, ?string $matchedPath = null): self
     {
+        // @phpstan-ignore-next-line identical.alwaysFalse — PHPDoc bound is not enforced at runtime; keep guard for consumers without static analysis
         if ($errors === []) {
             throw new InvalidArgumentException(
                 'OpenApiValidationResult::failure() requires at least one error message.',

--- a/src/OpenApiValidationResult.php
+++ b/src/OpenApiValidationResult.php
@@ -34,9 +34,8 @@ final class OpenApiValidationResult
      * Reject `failure([])` so a Failure always carries at least one error
      * message. Without this guard, `errorMessage()` would return an empty
      * string and the Failure would surface as a silent assertion failure.
-     * The `non-empty-array` bound lifts that invariant into the signature so
-     * PHPStan flags empty-literal callers at analyse time; the runtime guard
-     * remains as defense-in-depth for consumers without static analysis.
+     * `non-empty-array` surfaces empty-literal callers in PHPStan; the
+     * runtime guard covers consumers without static analysis.
      *
      * @param non-empty-array<string> $errors
      *

--- a/tests/Unit/OpenApiValidationResultTest.php
+++ b/tests/Unit/OpenApiValidationResultTest.php
@@ -55,6 +55,7 @@ class OpenApiValidationResultTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('failure() requires at least one error message');
 
+        // @phpstan-ignore-next-line argument.type — intentionally empty to verify the runtime guard still fires for consumers without static analysis
         OpenApiValidationResult::failure([]);
     }
 


### PR DESCRIPTION
## Summary

- `OpenApiValidationResult::failure()` のパラメータを `@param string[]` → `@param non-empty-array<string>` に強化し、空配列リテラルを **PHPStan レベルで静的検出** できるようにする
- #96 で入れた runtime guard（`failure([])` を throw）は defense-in-depth として維持。PHPDoc bound は runtime には効かないため、PHPStan を使わない consumer への保険として value がある
- Issue #97 の Option (A)：`errors()` の戻り値（`string[]`）は据え置き（3 outcome 共通アクセサなので無条件 non-empty は嘘になる）

## 変更内容

### `src/OpenApiValidationResult.php`
- `failure()` の `@param string[]` → `@param non-empty-array<string>`
- runtime guard `if (\$errors === [])` に `@phpstan-ignore-next-line identical.alwaysFalse` を付与（PHPDoc は runtime 未強制なため guard を残す意図を明示）
- docblock に型強化の意図を追記

### `tests/Unit/OpenApiValidationResultTest.php`
- 既存の negative test `failure_with_empty_errors_throws`（runtime guard を検証）に `@phpstan-ignore-next-line argument.type` を付与
- テスト自体は runtime 振る舞いの保険として維持
- 既存前例（`ValidatesOpenApiSchemaSkipResponseCodeTest.php:331`）と同じパターン

## 受け入れ条件

- [x] `failure()` のパラメータが `non-empty-array<string>` で注釈されている
- [x] `vendor/bin/phpstan analyse` が pass する（新規 ignore は意図明示のための 2 箇所のみ — src の runtime guard と test の negative case）
- [x] 空配列リテラル `failure([])` が PHPStan エラーとして検出される
  - 型強化前に src へ一時的に `failure([])` を仕込んで `[OK] No errors` を確認（baseline = failing test 相当）
  - 型強化後に再度仕込んで `argument.type: expects non-empty-array<string>, array{} given` を確認、その後 revert
- [x] 既存の `failure(['...'])` 呼び出し7箇所が PHPStan に通る（request×3 / response×4、いずれも literal または pre-guard 済み）

## スコープ外（Issue 明記）

- `errors()` の conditional return type / 専用アクセサ案 ((B), (C))
- `Success` / `Skipped` ファクトリの引数強化（そもそも引数を取らない）

## Test plan

- [x] `vendor/bin/phpstan analyse` — `[OK] No errors`
- [x] `vendor/bin/phpunit` — 681 tests / 1440 assertions pass
- [x] `vendor/bin/php-cs-fixer fix --dry-run --diff` — clean
- [x] probe 実験で、型強化が実際に `argument.type` を発火することを確認

## Refs

- Closes #97
- Parent issue: #73
- Implementation PR: #96