### PR TITLE
docs(result): clarify vacuous error entries policy in failure()

### DIFF
--- a/src/OpenApiValidationResult.php
+++ b/src/OpenApiValidationResult.php
@@ -37,6 +37,16 @@ final class OpenApiValidationResult
      * `non-empty-array` surfaces empty-literal callers in PHPStan; the
      * runtime guard covers consumers without static analysis.
      *
+     * Contract note: only literal emptiness (`$errors === []`) is rejected.
+     * Vacuous string entries such as `['']`, `['   ']`, or `['', '']` are
+     * NOT rejected — the caller is responsible for emitting meaningful,
+     * non-empty error messages. This keeps the guard cheap and avoids
+     * `trim()`-based heuristics whose correctness depends on validator
+     * output conventions (e.g. whether multi-line error messages may
+     * legitimately begin with whitespace). If a future validator is
+     * observed to emit whitespace-only errors in practice, tightening
+     * this guard (e.g. rejecting all-blank arrays) can be reconsidered.
+     *
      * @param non-empty-array<string> $errors
      *
      * @throws InvalidArgumentException when $errors is empty


### PR DESCRIPTION
## Summary

- Document in `OpenApiValidationResult::failure()` that vacuous string entries (`['']`, `['   ']`, `['', '']` etc.) are intentionally **not** rejected at runtime — only literal emptiness (`$errors === []`) throws.
- Record the rationale (avoid `trim()`-based heuristics whose correctness depends on validator output conventions such as multi-line errors that may legitimately start with whitespace) and leave the door open for tightening the guard if a future validator is observed to emit whitespace-only errors in practice.

This is the Option (A) approach recommended in #98: finalize the contract left under-specified by #96 without changing runtime behavior.

## Rationale

- All 7 existing call sites pass non-empty strings (verified via grep): the two orchestrator call sites are gated by `if (\$errors === [])` short-circuits, and the literal-message call sites use hard-coded non-empty strings. No behavior change.
- `non-empty-array<string>` in the PHPDoc already surfaces empty-literal callers via PHPStan; this PR complements it with an explicit prose contract for consumers without static analysis.
- Option (B) (stricter runtime guard via `trim()`) is intentionally deferred until real-world whitespace-only errors are observed. Documented in the docblock so a future maintainer has the context.

## Test plan

- [x] `vendor/bin/phpunit` — 681 tests, 1440 assertions, all green
- [x] `vendor/bin/phpstan analyse` — no errors
- [x] `vendor/bin/php-cs-fixer fix --dry-run --diff` — 0 of 97 files need fixing
- [x] Docblock-only change, no runtime behavior delta; existing `failure_with_empty_errors_throws` test remains the authoritative runtime guard spec.

Closes #98