### PR TITLE
docs(readme): add competitor comparison table (#112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,39 @@ Validate your API responses against your OpenAPI specification during testing, a
 - **Laravel adapter** — Optional trait for seamless integration with Laravel's `TestResponse`
 - **Zero runtime overhead** — Only used in test suites
 
+## Why this library?
+
+This library fills a gap left by existing PHP OpenAPI testing tools: **endpoint coverage tracking** and **first-class OpenAPI 3.1 support**, combined with Laravel auto-assert DX. If you already use Spectator and don't need coverage reports, this library won't offer much. If you want to see which endpoints your test suite actually exercises, or you're writing OpenAPI 3.1 specs, this is likely the best choice today.
+
+### Feature comparison (as of 2026-04)
+
+|  | **This library** | [Spectator][spectator] | [league/psr7][league] | [osteel][osteel] | [kirschbaum][kirschbaum] |
+| --- | :---: | :---: | :---: | :---: | :---: |
+| OpenAPI 3.0 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| OpenAPI 3.1 | ✅ | ⚠️ | ❌ | ⚠️ | ⚠️ |
+| Response body validation | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Request validation (body + params) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Response header validation | ❌ | ⚠️ | ✅ | ✅ | ✅ |
+| **Endpoint coverage tracking** | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **Skip-by-status-code (default 5xx)** | ✅ | ❌ | ❌ | ❌ | ✅ |
+| PHPUnit integration | ✅ | ✅ | ❌ | ⚠️ | ✅ |
+| Pest plugin | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Laravel auto-assert | ✅ | ✅ | ❌ | ❌ | ✅ |
+| Symfony HttpFoundation | ❌ | ❌ | ⚠️ | ✅ | ❌ |
+| External `$ref` auto-resolution | ❌ | ✅ | ✅ | ✅ | ✅ |
+| YAML spec loading | ✅ | ⚠️ | ✅ | ✅ | ✅ |
+| **Auto-inject dummy bearer** | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **GitHub Step Summary output** | ✅ | ❌ | ❌ | ❌ | ❌ |
+
+**Legend**: ✅ fully supported · ⚠️ partial, delegated to an underlying library, or not explicitly documented · ❌ not supported
+
+**Methodology**: Cells reflect what each library's public documentation and source explicitly guarantee as of 2026-04-25. Competitor versions checked: Spectator v2.2.0, league/openapi-psr7-validator v0.22, osteel/openapi-httpfoundation-testing v0.14, kirschbaum-development/laravel-openapi-validator v2.0.
+
+[spectator]: https://github.com/hotmeteor/spectator
+[league]: https://github.com/thephpleague/openapi-psr7-validator
+[osteel]: https://github.com/osteel/openapi-httpfoundation-testing
+[kirschbaum]: https://github.com/kirschbaum-development/laravel-openapi-validator
+
 ## Requirements
 
 - PHP 8.2+


### PR DESCRIPTION
## Summary

Adds a **"Why this library?"** section to `README.md` (between `Features` and `Requirements`) that positions the library against the four closest PHP OSS alternatives:

- [hotmeteor/spectator](https://github.com/hotmeteor/spectator)
- [thephpleague/openapi-psr7-validator](https://github.com/thephpleague/openapi-psr7-validator)
- [osteel/openapi-httpfoundation-testing](https://github.com/osteel/openapi-httpfoundation-testing)
- [kirschbaum-development/laravel-openapi-validator](https://github.com/kirschbaum-development/laravel-openapi-validator)

## Rendered preview

The new section looks like:

> ## Why this library?
>
> This library fills a gap left by existing PHP OpenAPI testing tools: **endpoint coverage tracking** and **first-class OpenAPI 3.1 support**, combined with Laravel auto-assert DX. …
>
> ### Feature comparison (as of 2026-04)
> 
> |   | **This library** | Spectator | league/psr7 | osteel | kirschbaum |
> | --- | :---: | :---: | :---: | :---: | :---: |
> | OpenAPI 3.1 | ✅ | ⚠️ | ❌ | ⚠️ | ⚠️ |
> | **Endpoint coverage tracking** | ✅ | ❌ | ❌ | ❌ | ❌ |
> | **Skip-by-status-code (default 5xx)** | ✅ | ❌ | ❌ | ❌ | ✅ |
> | External `\$ref` auto-resolution | ❌ | ✅ | ✅ | ✅ | ✅ |
> | Pest plugin | ❌ | ❌ | ❌ | ❌ | ❌ |
> | … |

(15 axes total; full table in the diff.)

## Key design decisions

- **English only** — matches the existing README; `docs/comparison.ja.md` is left for a future follow-up.
- **Current state only** — unimplemented features (#108 external `\$ref`, #109 Pest, #110 response headers) are marked `❌` rather than "planned". This keeps the table honest; entries flip to `✅` as issues land.
- **Methodology footnote** — pins competitor versions (Spectator v2.2.0, league v0.22, osteel v0.14, kirschbaum v2.0) and the verification date (2026-04-25) so future maintainers can re-audit.
- **`⚠️` definition** — "delegated to an underlying library, or not explicitly documented" — makes the legend unambiguous.
- **Reference-style link definitions** at the bottom of the section keep the table cells compact and easy to update.

## Verification method for each cell

| Library | Source |
| --- | --- |
| **This library** | Direct source read (e.g. `src/OpenApiSchemaConverter.php:67-70` for OAS 3.1, `src/Laravel/ValidatesOpenApiSchema.php:54-58,450-492` for dummy bearer, `src/PHPUnit/OpenApiCoverageExtension.php` for Step Summary) |
| Spectator | README + composer.json (cebe/php-openapi + opis/json-schema, no 3.1 docs, no coverage docs) |
| league/psr7 | README + TODO section (3.0.x only stated explicitly) |
| osteel | README + delegates to league |
| kirschbaum | README (default 5xx skip documented, delegates to league) |

## Test plan

- [x] `git diff` confirms only `README.md` is touched (33 insertions, 0 deletions)
- [x] Heading hierarchy preserved: `## Features` → **`## Why this library?`** → `## Requirements` (no gap or depth jump)
- [x] Legend symbols (`✅` / `⚠️` / `❌`) match every cell rendered in the table
- [x] All four competitor links use canonical GitHub URLs
- [ ] Reviewer: visually confirm GitHub renders the table correctly on the PR preview
- [ ] Reviewer: sanity-check any cell you disagree with; the methodology note invites audits

## Closes

Closes #112

## Follow-ups not in this PR

- `docs/comparison.md` with per-cell source links — deferred to a separate issue
- Japanese translation — deferred
- Updating cells as #108 / #109 / #110 land