### PR TITLE
feat(spec-loader): resolve local-filesystem external $refs (#108, PR 1/2)

### DIFF
--- a/src/Internal/ExternalRefLoader.php
+++ b/src/Internal/ExternalRefLoader.php
@@ -14,10 +14,13 @@ use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
 use function dirname;
+use function error_clear_last;
+use function error_get_last;
 use function file_exists;
 use function file_get_contents;
 use function get_debug_type;
 use function is_array;
+use function is_readable;
 use function json_decode;
 use function pathinfo;
 use function realpath;
@@ -35,6 +38,14 @@ use function strtolower;
  * different fragments of it. The cache lives only for the duration of
  * one `OpenApiRefResolver::resolve()` call.
  *
+ * Path-traversal note: there is no sandbox check on resolved paths. A
+ * `$ref` like `'../../etc/passwd.json'` will resolve and read whatever
+ * the PHP process can access. Spec authors are trusted; treat the spec
+ * directory as a trust boundary in the same way you treat your own
+ * source tree. `file://` URLs are rejected separately because they
+ * bypass the source-file-relative resolution rules and would surprise
+ * a reader scanning paths visually.
+ *
  * @internal Not part of the package's public API. Do not call from user code.
  */
 final class ExternalRefLoader
@@ -44,6 +55,11 @@ final class ExternalRefLoader
     /**
      * Resolve `$refPath` relative to `$sourceFile`, decode the target file,
      * and return the canonical absolute path together with the decoded array.
+     *
+     * `$refPath` is interpreted as either an absolute filesystem path
+     * (when it begins with `/`) or a path relative to the directory of
+     * `$sourceFile`. Symlinks are followed via `realpath()`, so two refs
+     * that resolve to the same canonical target share a cache entry.
      *
      * @param array<string, array<string, mixed>> $documentCache by-ref cache keyed by absolute path
      *
@@ -57,14 +73,31 @@ final class ExternalRefLoader
             ? $refPath
             : dirname($sourceFile) . '/' . $refPath;
 
+        // realpath() returns false for several distinct conditions
+        // (missing file, unreadable parent, broken symlink,
+        // open_basedir restriction). Disambiguate via file_exists()
+        // against the pre-canonicalized candidate so the user sees
+        // the right reason category.
         $absolutePath = realpath($candidate);
-        if ($absolutePath === false || !file_exists($absolutePath)) {
+        if ($absolutePath === false) {
+            if (!file_exists($candidate)) {
+                throw new InvalidOpenApiSpecException(
+                    InvalidOpenApiSpecReason::LocalRefNotFound,
+                    sprintf(
+                        'Local $ref target not found: %s (resolved from %s)',
+                        $refPath,
+                        $sourceFile,
+                    ),
+                    ref: $refPath,
+                );
+            }
+
             throw new InvalidOpenApiSpecException(
-                InvalidOpenApiSpecReason::LocalRefNotFound,
+                InvalidOpenApiSpecReason::LocalRefUnreadable,
                 sprintf(
-                    'Local $ref target not found: %s (resolved from %s)',
+                    'Local $ref target exists but cannot be canonicalized: %s '
+                    . '(check permissions on the parent directory or symlink chain).',
                     $refPath,
-                    $sourceFile,
                 ),
                 ref: $refPath,
             );
@@ -75,6 +108,14 @@ final class ExternalRefLoader
         }
 
         $extension = strtolower((string) pathinfo($absolutePath, PATHINFO_EXTENSION));
+        if ($extension === '') {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::UnsupportedExtension,
+                sprintf('$ref target has no file extension: %s (resolved to %s)', $refPath, $absolutePath),
+                ref: $refPath,
+            );
+        }
+
         $decoded = match ($extension) {
             'json' => self::decodeJson($absolutePath, $refPath),
             'yaml', 'yml' => self::decodeYaml($absolutePath, $refPath),
@@ -93,11 +134,21 @@ final class ExternalRefLoader
     /** @return array<string, mixed> */
     private static function decodeJson(string $absolutePath, string $refPath): array
     {
-        $content = file_get_contents($absolutePath);
+        // realpath() proved the file exists and is reachable; a read
+        // failure here is a runtime I/O issue (permissions revoked
+        // mid-process, disk error, race with unlink). Surface as
+        // LocalRefUnreadable rather than the not-found category so
+        // operators can tell the difference. error_clear_last/get_last
+        // gives us the underlying message without scraping the warning.
+        error_clear_last();
+        $content = @file_get_contents($absolutePath);
         if ($content === false) {
+            $error = error_get_last();
+            $detail = $error['message'] ?? 'unknown read error';
+
             throw new InvalidOpenApiSpecException(
-                InvalidOpenApiSpecReason::LocalRefNotFound,
-                sprintf('Local $ref target unreadable: %s (path: %s)', $refPath, $absolutePath),
+                InvalidOpenApiSpecReason::LocalRefUnreadable,
+                sprintf('Local $ref target unreadable: %s (path: %s, %s)', $refPath, $absolutePath, $detail),
                 ref: $refPath,
             );
         }
@@ -106,7 +157,7 @@ final class ExternalRefLoader
             $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {
             throw new InvalidOpenApiSpecException(
-                InvalidOpenApiSpecReason::LocalRefDecodeFailed,
+                InvalidOpenApiSpecReason::MalformedJson,
                 sprintf('Failed to parse JSON $ref target %s: %s', $refPath, $e->getMessage()),
                 ref: $refPath,
                 previous: $e,
@@ -128,11 +179,24 @@ final class ExternalRefLoader
             );
         }
 
+        // is_readable() catches the most common pre-parse I/O failure
+        // (permissions revoked between realpath() and Yaml::parseFile).
+        // Symfony's Yaml::parseFile rolls every other error class into
+        // ParseException, which makes a real I/O failure indistinguishable
+        // from a syntax error without this guard.
+        if (!is_readable($absolutePath)) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::LocalRefUnreadable,
+                sprintf('Local $ref target unreadable: %s (path: %s)', $refPath, $absolutePath),
+                ref: $refPath,
+            );
+        }
+
         try {
             $decoded = Yaml::parseFile($absolutePath);
         } catch (ParseException $e) {
             throw new InvalidOpenApiSpecException(
-                InvalidOpenApiSpecReason::LocalRefDecodeFailed,
+                InvalidOpenApiSpecReason::MalformedYaml,
                 sprintf('Failed to parse YAML $ref target %s: %s', $refPath, $e->getMessage()),
                 ref: $refPath,
                 previous: $e,

--- a/src/Internal/ExternalRefLoader.php
+++ b/src/Internal/ExternalRefLoader.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Internal;
+
+use const JSON_THROW_ON_ERROR;
+use const PATHINFO_EXTENSION;
+
+use JsonException;
+use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
+use Studio\OpenApiContractTesting\InvalidOpenApiSpecReason;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+use function dirname;
+use function file_exists;
+use function file_get_contents;
+use function get_debug_type;
+use function is_array;
+use function json_decode;
+use function pathinfo;
+use function realpath;
+use function sprintf;
+use function str_starts_with;
+use function strtolower;
+
+/**
+ * Resolves and decodes external `$ref` target documents from the local
+ * filesystem. Used by `OpenApiRefResolver` when it encounters a `$ref`
+ * whose path part is not an in-document JSON Pointer.
+ *
+ * Each resolution call passes its own `$documentCache` so the same
+ * external file is decoded once even if multiple sibling refs point at
+ * different fragments of it. The cache lives only for the duration of
+ * one `OpenApiRefResolver::resolve()` call.
+ *
+ * @internal Not part of the package's public API. Do not call from user code.
+ */
+final class ExternalRefLoader
+{
+    private function __construct() {}
+
+    /**
+     * Resolve `$refPath` relative to `$sourceFile`, decode the target file,
+     * and return the canonical absolute path together with the decoded array.
+     *
+     * @param array<string, array<string, mixed>> $documentCache by-ref cache keyed by absolute path
+     *
+     * @return array{absolutePath: string, decoded: array<string, mixed>}
+     *
+     * @throws InvalidOpenApiSpecException when the file cannot be located, decoded, or has an unsupported extension
+     */
+    public static function loadDocument(string $refPath, string $sourceFile, array &$documentCache): array
+    {
+        $candidate = str_starts_with($refPath, '/')
+            ? $refPath
+            : dirname($sourceFile) . '/' . $refPath;
+
+        $absolutePath = realpath($candidate);
+        if ($absolutePath === false || !file_exists($absolutePath)) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::LocalRefNotFound,
+                sprintf(
+                    'Local $ref target not found: %s (resolved from %s)',
+                    $refPath,
+                    $sourceFile,
+                ),
+                ref: $refPath,
+            );
+        }
+
+        if (isset($documentCache[$absolutePath])) {
+            return ['absolutePath' => $absolutePath, 'decoded' => $documentCache[$absolutePath]];
+        }
+
+        $extension = strtolower((string) pathinfo($absolutePath, PATHINFO_EXTENSION));
+        $decoded = match ($extension) {
+            'json' => self::decodeJson($absolutePath, $refPath),
+            'yaml', 'yml' => self::decodeYaml($absolutePath, $refPath),
+            default => throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::UnsupportedExtension,
+                sprintf('Unsupported $ref target extension: .%s for %s', $extension, $refPath),
+                ref: $refPath,
+            ),
+        };
+
+        $documentCache[$absolutePath] = $decoded;
+
+        return ['absolutePath' => $absolutePath, 'decoded' => $decoded];
+    }
+
+    /** @return array<string, mixed> */
+    private static function decodeJson(string $absolutePath, string $refPath): array
+    {
+        $content = file_get_contents($absolutePath);
+        if ($content === false) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::LocalRefNotFound,
+                sprintf('Local $ref target unreadable: %s (path: %s)', $refPath, $absolutePath),
+                ref: $refPath,
+            );
+        }
+
+        try {
+            $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::LocalRefDecodeFailed,
+                sprintf('Failed to parse JSON $ref target %s: %s', $refPath, $e->getMessage()),
+                ref: $refPath,
+                previous: $e,
+            );
+        }
+
+        return self::ensureMappingRoot($decoded, $refPath, $absolutePath);
+    }
+
+    /** @return array<string, mixed> */
+    private static function decodeYaml(string $absolutePath, string $refPath): array
+    {
+        if (!YamlAvailability::isAvailable()) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::YamlLibraryMissing,
+                'Loading YAML $ref targets requires symfony/yaml. '
+                . 'Install it via: composer require --dev symfony/yaml',
+                ref: $refPath,
+            );
+        }
+
+        try {
+            $decoded = Yaml::parseFile($absolutePath);
+        } catch (ParseException $e) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::LocalRefDecodeFailed,
+                sprintf('Failed to parse YAML $ref target %s: %s', $refPath, $e->getMessage()),
+                ref: $refPath,
+                previous: $e,
+            );
+        }
+
+        return self::ensureMappingRoot($decoded, $refPath, $absolutePath);
+    }
+
+    /** @return array<string, mixed> */
+    private static function ensureMappingRoot(mixed $decoded, string $refPath, string $absolutePath): array
+    {
+        if (!is_array($decoded)) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::NonMappingRoot,
+                sprintf(
+                    '$ref target must decode to a mapping (got %s): %s (resolved to %s)',
+                    get_debug_type($decoded),
+                    $refPath,
+                    $absolutePath,
+                ),
+                ref: $refPath,
+            );
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+}

--- a/src/InvalidOpenApiSpecReason.php
+++ b/src/InvalidOpenApiSpecReason.php
@@ -12,6 +12,11 @@ namespace Studio\OpenApiContractTesting;
 enum InvalidOpenApiSpecReason
 {
     case ExternalRef;
+    case LocalRefNotFound;
+    case LocalRefDecodeFailed;
+    case LocalRefRequiresSourceFile;
+    case RemoteRefNotImplemented;
+    case FileSchemeNotSupported;
     case CircularRef;
     case UnresolvableRef;
     case NonStringRef;

--- a/src/InvalidOpenApiSpecReason.php
+++ b/src/InvalidOpenApiSpecReason.php
@@ -11,12 +11,21 @@ namespace Studio\OpenApiContractTesting;
  */
 enum InvalidOpenApiSpecReason
 {
+    /**
+     * @deprecated Use the more specific external-ref reasons instead:
+     *             `LocalRefNotFound`, `LocalRefUnreadable`, `LocalRefRequiresSourceFile`,
+     *             `RemoteRefNotImplemented`, or `FileSchemeNotSupported`. Kept for
+     *             backwards compatibility with consumers that branched on this case
+     *             before the resolver learned to follow external `$ref` targets.
+     *             No production code throws this reason any more.
+     */
     case ExternalRef;
     case LocalRefNotFound;
-    case LocalRefDecodeFailed;
+    case LocalRefUnreadable;
     case LocalRefRequiresSourceFile;
     case RemoteRefNotImplemented;
     case FileSchemeNotSupported;
+    case EmptyRef;
     case CircularRef;
     case UnresolvableRef;
     case NonStringRef;

--- a/src/OpenApiRefResolver.php
+++ b/src/OpenApiRefResolver.php
@@ -40,8 +40,10 @@ final class OpenApiRefResolver
      * filesystem (e.g. `./schemas/pet.yaml`). When `$sourceFile` is `null`,
      * any non-internal `$ref` triggers `LocalRefRequiresSourceFile` so the
      * caller knows it must thread the path through. HTTP(S) and `file://`
-     * refs are always rejected — the former is reserved for a future PR
-     * with explicit opt-in semantics, the latter for security.
+     * refs are always rejected: `RemoteRefNotImplemented` (HTTP fetching
+     * is not currently part of the resolver) and `FileSchemeNotSupported`
+     * (`file://` URLs bypass source-file-relative resolution and are
+     * blocked to keep the path-resolution rules predictable).
      *
      * @param array<string, mixed> $spec
      *
@@ -109,12 +111,6 @@ final class OpenApiRefResolver
     }
 
     /**
-     * Dispatch a `$ref` to the right resolution path: internal pointer
-     * lookup against the current document, or external file load. URL
-     * schemes that this PR cannot honour (`http://`, `https://`,
-     * `file://`) throw with dedicated reasons so consumers can branch
-     * on `$reason` instead of substring-matching the message.
-     *
      * @param array<int|string, mixed> $node
      * @param array<string, mixed> $root
      * @param list<string> $chain
@@ -128,6 +124,14 @@ final class OpenApiRefResolver
         ?string $currentSourceFile,
         array &$documentCache,
     ): void {
+        if ($ref === '') {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::EmptyRef,
+                'Invalid $ref: empty string is not a reference',
+                ref: $ref,
+            );
+        }
+
         if ($ref === '#/' || $ref === '#') {
             // A bare root pointer substitutes the entire spec in place,
             // which triggers unbounded recursion before cycle detection
@@ -141,10 +145,14 @@ final class OpenApiRefResolver
         }
 
         if (str_starts_with($ref, 'file://')) {
+            // Reject `file://` separately from ordinary path refs so a
+            // visual scan of the spec doesn't gloss over it. Path-traversal
+            // sandboxing for ordinary paths is intentionally absent — see
+            // ExternalRefLoader's class-level docblock for the trust model.
             throw new InvalidOpenApiSpecException(
                 InvalidOpenApiSpecReason::FileSchemeNotSupported,
                 sprintf(
-                    '`file://` $ref is not supported for security reasons: %s. '
+                    '`file://` $ref is not supported: %s. '
                     . 'Use a relative or absolute filesystem path instead.',
                     $ref,
                 ),
@@ -156,8 +164,8 @@ final class OpenApiRefResolver
             throw new InvalidOpenApiSpecException(
                 InvalidOpenApiSpecReason::RemoteRefNotImplemented,
                 sprintf(
-                    'HTTP(S) $ref is not yet supported: %s. '
-                    . 'This will be added in a future release with an opt-in PSR-18 client.',
+                    'HTTP(S) $ref is not currently supported: %s. '
+                    . 'Pre-bundle the spec or open an issue if remote resolution would help your workflow.',
                     $ref,
                 ),
                 ref: $ref,
@@ -178,7 +186,6 @@ final class OpenApiRefResolver
             );
         }
 
-        // Anything else is an external filesystem ref.
         if ($currentSourceFile === null) {
             throw new InvalidOpenApiSpecException(
                 InvalidOpenApiSpecReason::LocalRefRequiresSourceFile,
@@ -260,7 +267,28 @@ final class OpenApiRefResolver
         string $currentSourceFile,
         array &$documentCache,
     ): void {
-        [$pathPart, $fragment] = self::splitRef($ref);
+        [$pathPart, $fragment, $hadHash] = self::splitRef($ref);
+
+        if ($pathPart === '') {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::EmptyRef,
+                sprintf('Invalid $ref: %s has an empty path part', $ref),
+                ref: $ref,
+            );
+        }
+
+        // A trailing `#` with nothing after it (`./pet.yaml#`) is
+        // ambiguous. Reject it explicitly so the author makes the
+        // intent clear: drop the `#` for whole-file, or write `#/...`
+        // for a JSON Pointer.
+        if ($hadHash && $fragment === '') {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::BareFragmentRef,
+                sprintf('Invalid $ref: %s has an empty fragment after `#`', $ref),
+                ref: $ref,
+            );
+        }
+
         $document = ExternalRefLoader::loadDocument($pathPart, $currentSourceFile, $documentCache);
         $absolutePath = $document['absolutePath'];
         $newRoot = $document['decoded'];
@@ -317,21 +345,22 @@ final class OpenApiRefResolver
     }
 
     /**
-     * Split a `$ref` like `./schemas/pet.yaml#/components/schemas/Pet` into
-     * its path part and fragment. The fragment is returned without the
-     * leading `#` so callers can decide how to combine it with the loaded
-     * document's root.
+     * Split a `$ref` like `./schemas/pet.yaml#/components/schemas/Pet`
+     * into path part, fragment (without the leading `#`), and a flag
+     * marking whether `#` was present at all. Callers need the flag to
+     * distinguish `./pet.yaml` (no `#`, whole-file) from `./pet.yaml#`
+     * (empty fragment, ambiguous and rejected).
      *
-     * @return array{0: string, 1: string}
+     * @return array{0: string, 1: string, 2: bool}
      */
     private static function splitRef(string $ref): array
     {
         $hashPos = strpos($ref, '#');
         if ($hashPos === false) {
-            return [$ref, ''];
+            return [$ref, '', false];
         }
 
-        return [substr($ref, 0, $hashPos), substr($ref, $hashPos + 1)];
+        return [substr($ref, 0, $hashPos), substr($ref, $hashPos + 1), true];
     }
 
     private static function canonicalChainKey(?string $sourceFile, string $ref): string

--- a/src/OpenApiRefResolver.php
+++ b/src/OpenApiRefResolver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting;
 
+use Studio\OpenApiContractTesting\Internal\ExternalRefLoader;
+
 use function array_key_exists;
 use function explode;
 use function get_debug_type;
@@ -15,13 +17,14 @@ use function rawurldecode;
 use function sprintf;
 use function str_replace;
 use function str_starts_with;
+use function strpos;
 use function substr;
 
 final class OpenApiRefResolver
 {
     /**
-     * Resolve all internal `$ref` entries in the spec in place and return the
-     * same array. Any structural problem with a `$ref` throws
+     * Resolve every `$ref` entry in the spec in place and return the same
+     * array. Any structural problem with a `$ref` throws
      * `InvalidOpenApiSpecException` so users get one actionable error at
      * load time instead of a cryptic opis failure surfacing deep inside
      * validation. See `InvalidOpenApiSpecReason` for the exhaustive list of
@@ -32,33 +35,52 @@ final class OpenApiRefResolver
      * mutated state is discarded at the caller (`OpenApiSpecLoader::load()`
      * only caches the result after `resolve()` returns cleanly).
      *
+     * Pass `$sourceFile` (the absolute path of the spec file being loaded)
+     * to enable resolution of external `$ref` targets located on the local
+     * filesystem (e.g. `./schemas/pet.yaml`). When `$sourceFile` is `null`,
+     * any non-internal `$ref` triggers `LocalRefRequiresSourceFile` so the
+     * caller knows it must thread the path through. HTTP(S) and `file://`
+     * refs are always rejected — the former is reserved for a future PR
+     * with explicit opt-in semantics, the latter for security.
+     *
      * @param array<string, mixed> $spec
      *
      * @return array<string, mixed>
      *
      * @throws InvalidOpenApiSpecException when a `$ref` cannot be resolved
      */
-    public static function resolve(array $spec): array
+    public static function resolve(array $spec, ?string $sourceFile = null): array
     {
         // $root is a frozen snapshot used for pointer lookups. PHP array
         // copy-on-write keeps it untouched as we mutate $spec via $node refs.
         $root = $spec;
-        self::walk($spec, $root, []);
+        // Per-resolution external file cache, keyed by canonical absolute
+        // path. Sibling refs into the same file decode it once.
+        $documentCache = [];
+        self::walk($spec, $root, [], false, $sourceFile, $documentCache);
 
         return $spec;
     }
 
     /**
      * @param array<int|string, mixed> $node
-     * @param array<string, mixed> $root
-     * @param list<string> $chain pointer-refs already on the resolution stack — used to detect cycles
+     * @param array<string, mixed> $root currently-walked document's root
+     * @param list<string> $chain canonical pointer-refs already on the resolution stack — used to detect cycles
      * @param bool $insidePropertiesMap true when `$node` is the direct children dict of
      *                                  a `properties` / `patternProperties` map, where keys are property names
      *                                  rather than schema keywords. The flag resets one level deeper, because
      *                                  each named entry is itself a schema.
+     * @param ?string $currentSourceFile absolute path of the file owning `$root`, or null in legacy calls
+     * @param array<string, array<string, mixed>> $documentCache external document cache for this resolution
      */
-    private static function walk(array &$node, array $root, array $chain, bool $insidePropertiesMap = false): void
-    {
+    private static function walk(
+        array &$node,
+        array $root,
+        array $chain,
+        bool $insidePropertiesMap,
+        ?string $currentSourceFile,
+        array &$documentCache,
+    ): void {
         if (!$insidePropertiesMap && array_key_exists('$ref', $node)) {
             $ref = $node['$ref'];
 
@@ -69,51 +91,197 @@ final class OpenApiRefResolver
                 );
             }
 
-            if ($ref === '#/' || $ref === '#') {
-                // A bare root pointer substitutes the entire spec in place,
-                // which triggers unbounded recursion before cycle detection
-                // can help. Reject with a specific message so the author
-                // doesn't chase a confusing "Circular" error.
-                throw new InvalidOpenApiSpecException(
-                    InvalidOpenApiSpecReason::RootPointerRef,
-                    'Invalid $ref: root pointer "' . $ref . '" is not a reference to a definition',
-                    ref: $ref,
-                );
+            self::resolveRef($node, $ref, $root, $chain, $currentSourceFile, $documentCache);
+
+            return;
+        }
+
+        foreach ($node as $key => &$child) {
+            if (is_array($child)) {
+                // additionalProperties is intentionally excluded: its value is a single
+                // schema (not a dict of schemas), so a direct $ref under it is a
+                // legitimate Reference Object that must resolve.
+                $childInsidePropertiesMap = $key === 'properties' || $key === 'patternProperties';
+                self::walk($child, $root, $chain, $childInsidePropertiesMap, $currentSourceFile, $documentCache);
             }
+        }
+        unset($child);
+    }
 
-            if (!str_starts_with($ref, '#/')) {
-                if (str_starts_with($ref, '#')) {
-                    throw new InvalidOpenApiSpecException(
-                        InvalidOpenApiSpecReason::BareFragmentRef,
-                        sprintf('Invalid $ref: bare fragment %s is not a JSON Pointer (expected "#/..." form)', $ref),
-                        ref: $ref,
-                    );
-                }
+    /**
+     * Dispatch a `$ref` to the right resolution path: internal pointer
+     * lookup against the current document, or external file load. URL
+     * schemes that this PR cannot honour (`http://`, `https://`,
+     * `file://`) throw with dedicated reasons so consumers can branch
+     * on `$reason` instead of substring-matching the message.
+     *
+     * @param array<int|string, mixed> $node
+     * @param array<string, mixed> $root
+     * @param list<string> $chain
+     * @param array<string, array<string, mixed>> $documentCache
+     */
+    private static function resolveRef(
+        array &$node,
+        string $ref,
+        array $root,
+        array $chain,
+        ?string $currentSourceFile,
+        array &$documentCache,
+    ): void {
+        if ($ref === '#/' || $ref === '#') {
+            // A bare root pointer substitutes the entire spec in place,
+            // which triggers unbounded recursion before cycle detection
+            // can help. Reject with a specific message so the author
+            // doesn't chase a confusing "Circular" error.
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::RootPointerRef,
+                'Invalid $ref: root pointer "' . $ref . '" is not a reference to a definition',
+                ref: $ref,
+            );
+        }
 
-                throw new InvalidOpenApiSpecException(
-                    InvalidOpenApiSpecReason::ExternalRef,
-                    sprintf(
-                        'External $ref is not supported: %s. Only internal refs (#/...) are resolved; '
-                        . 'bundle external files with a tool like `redocly bundle` before loading.',
-                        $ref,
-                    ),
-                    ref: $ref,
-                );
-            }
+        if (str_starts_with($ref, 'file://')) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::FileSchemeNotSupported,
+                sprintf(
+                    '`file://` $ref is not supported for security reasons: %s. '
+                    . 'Use a relative or absolute filesystem path instead.',
+                    $ref,
+                ),
+                ref: $ref,
+            );
+        }
 
-            if (in_array($ref, $chain, true)) {
+        if (str_starts_with($ref, 'http://') || str_starts_with($ref, 'https://')) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::RemoteRefNotImplemented,
+                sprintf(
+                    'HTTP(S) $ref is not yet supported: %s. '
+                    . 'This will be added in a future release with an opt-in PSR-18 client.',
+                    $ref,
+                ),
+                ref: $ref,
+            );
+        }
+
+        if (str_starts_with($ref, '#/')) {
+            self::resolveInternalRef($node, $ref, $root, $chain, $currentSourceFile, $documentCache);
+
+            return;
+        }
+
+        if (str_starts_with($ref, '#')) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::BareFragmentRef,
+                sprintf('Invalid $ref: bare fragment %s is not a JSON Pointer (expected "#/..." form)', $ref),
+                ref: $ref,
+            );
+        }
+
+        // Anything else is an external filesystem ref.
+        if ($currentSourceFile === null) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::LocalRefRequiresSourceFile,
+                sprintf(
+                    'External $ref %s cannot be resolved because the resolver was '
+                    . 'invoked without a source file. Pass $sourceFile to OpenApiRefResolver::resolve() '
+                    . '(OpenApiSpecLoader does this automatically).',
+                    $ref,
+                ),
+                ref: $ref,
+            );
+        }
+
+        self::resolveExternalRef($node, $ref, $chain, $currentSourceFile, $documentCache);
+    }
+
+    /**
+     * @param array<int|string, mixed> $node
+     * @param array<string, mixed> $root
+     * @param list<string> $chain
+     * @param array<string, array<string, mixed>> $documentCache
+     */
+    private static function resolveInternalRef(
+        array &$node,
+        string $ref,
+        array $root,
+        array $chain,
+        ?string $currentSourceFile,
+        array &$documentCache,
+    ): void {
+        // Canonicalize internal refs against the current document so cycles
+        // that span files are detected against per-file pointers, not the
+        // raw `#/...` string (which is ambiguous across documents).
+        $chainKey = self::canonicalChainKey($currentSourceFile, $ref);
+
+        if (in_array($chainKey, $chain, true)) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::CircularRef,
+                sprintf('Circular $ref detected: %s', implode(' -> ', [...$chain, $chainKey])),
+                ref: $ref,
+            );
+        }
+
+        [$found, $target] = self::lookup($ref, $root);
+        if (!$found) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::UnresolvableRef,
+                sprintf('Unresolvable $ref: target not found for %s', $ref),
+                ref: $ref,
+            );
+        }
+
+        if (!is_array($target)) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::NonObjectRefTarget,
+                sprintf('$ref target is not an object: %s points to a %s value', $ref, get_debug_type($target)),
+                ref: $ref,
+            );
+        }
+
+        // Push canonicalized ref onto the chain before recursing so nested
+        // self-references are detected as cycles; then replace the node
+        // entirely. Sibling keys alongside $ref are dropped per OAS 3.0
+        // ("any sibling elements of a $ref are ignored"), which is a safe
+        // subset of 3.1.
+        self::walk($target, $root, [...$chain, $chainKey], false, $currentSourceFile, $documentCache);
+        $node = $target;
+    }
+
+    /**
+     * @param array<int|string, mixed> $node
+     * @param list<string> $chain
+     * @param array<string, array<string, mixed>> $documentCache
+     */
+    private static function resolveExternalRef(
+        array &$node,
+        string $ref,
+        array $chain,
+        string $currentSourceFile,
+        array &$documentCache,
+    ): void {
+        [$pathPart, $fragment] = self::splitRef($ref);
+        $document = ExternalRefLoader::loadDocument($pathPart, $currentSourceFile, $documentCache);
+        $absolutePath = $document['absolutePath'];
+        $newRoot = $document['decoded'];
+
+        if ($fragment !== '') {
+            $internalRef = '#' . $fragment;
+            $chainKey = self::canonicalChainKey($absolutePath, $internalRef);
+
+            if (in_array($chainKey, $chain, true)) {
                 throw new InvalidOpenApiSpecException(
                     InvalidOpenApiSpecReason::CircularRef,
-                    sprintf('Circular $ref detected: %s', implode(' -> ', [...$chain, $ref])),
+                    sprintf('Circular $ref detected: %s', implode(' -> ', [...$chain, $chainKey])),
                     ref: $ref,
                 );
             }
 
-            [$found, $target] = self::lookup($ref, $root);
+            [$found, $target] = self::lookup($internalRef, $newRoot);
             if (!$found) {
                 throw new InvalidOpenApiSpecException(
                     InvalidOpenApiSpecReason::UnresolvableRef,
-                    sprintf('Unresolvable $ref: target not found for %s', $ref),
+                    sprintf('Unresolvable $ref: fragment %s not found in %s', $fragment, $absolutePath),
                     ref: $ref,
                 );
             }
@@ -126,26 +294,49 @@ final class OpenApiRefResolver
                 );
             }
 
-            // Push $ref onto the chain before recursing so nested self-references
-            // are detected as cycles; then replace the node entirely. Sibling
-            // keys alongside $ref are dropped per OAS 3.0 ("any sibling
-            // elements of a $ref are ignored"), which is a safe subset of 3.1.
-            self::walk($target, $root, [...$chain, $ref]);
+            self::walk($target, $newRoot, [...$chain, $chainKey], false, $absolutePath, $documentCache);
             $node = $target;
 
             return;
         }
 
-        foreach ($node as $key => &$child) {
-            if (is_array($child)) {
-                // additionalProperties is intentionally excluded: its value is a single
-                // schema (not a dict of schemas), so a direct $ref under it is a
-                // legitimate Reference Object that must resolve.
-                $childInsidePropertiesMap = $key === 'properties' || $key === 'patternProperties';
-                self::walk($child, $root, $chain, $childInsidePropertiesMap);
-            }
+        // Whole-file ref: chain key is the absolute path; the document
+        // root replaces the node, and walking continues against that root.
+        $chainKey = $absolutePath;
+        if (in_array($chainKey, $chain, true)) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::CircularRef,
+                sprintf('Circular $ref detected: %s', implode(' -> ', [...$chain, $chainKey])),
+                ref: $ref,
+            );
         }
-        unset($child);
+
+        $target = $newRoot;
+        self::walk($target, $newRoot, [...$chain, $chainKey], false, $absolutePath, $documentCache);
+        $node = $target;
+    }
+
+    /**
+     * Split a `$ref` like `./schemas/pet.yaml#/components/schemas/Pet` into
+     * its path part and fragment. The fragment is returned without the
+     * leading `#` so callers can decide how to combine it with the loaded
+     * document's root.
+     *
+     * @return array{0: string, 1: string}
+     */
+    private static function splitRef(string $ref): array
+    {
+        $hashPos = strpos($ref, '#');
+        if ($hashPos === false) {
+            return [$ref, ''];
+        }
+
+        return [substr($ref, 0, $hashPos), substr($ref, $hashPos + 1)];
+    }
+
+    private static function canonicalChainKey(?string $sourceFile, string $ref): string
+    {
+        return ($sourceFile ?? '') . $ref;
     }
 
     /**

--- a/src/OpenApiSpecLoader.php
+++ b/src/OpenApiSpecLoader.php
@@ -87,7 +87,11 @@ final class OpenApiSpecLoader
         };
 
         try {
-            $resolved = OpenApiRefResolver::resolve($decoded);
+            // Pass the absolute spec file path so the resolver can
+            // walk external `$ref` targets (e.g. `./schemas/pet.yaml`)
+            // relative to it. Without this, every non-internal `$ref`
+            // would throw `LocalRefRequiresSourceFile`.
+            $resolved = OpenApiRefResolver::resolve($decoded, $path);
         } catch (InvalidOpenApiSpecException $e) {
             // The resolver is stateless and therefore cannot know which spec
             // produced the throw. Re-wrap once so consumers (e.g. the coverage

--- a/src/OpenApiSpecLoader.php
+++ b/src/OpenApiSpecLoader.php
@@ -17,6 +17,7 @@ use function get_debug_type;
 use function implode;
 use function is_array;
 use function json_decode;
+use function realpath;
 use function rtrim;
 use function sprintf;
 
@@ -86,12 +87,22 @@ final class OpenApiSpecLoader
             ),
         };
 
+        // Canonicalize the source path so the resolver's cycle detection
+        // sees the same key for this file whether it's reached as the
+        // entry spec or as the target of a relative ref from another
+        // file. Without this, `basePath` containing `./` or symlinks
+        // would yield two distinct chain keys for the same document.
+        $canonicalPath = realpath($path);
+        if ($canonicalPath === false) {
+            // resolveSpecFile() proved the file existed; if realpath
+            // fails now it's a races/permissions edge case. Fall back
+            // to the raw path so the message still locates it for the
+            // operator.
+            $canonicalPath = $path;
+        }
+
         try {
-            // Pass the absolute spec file path so the resolver can
-            // walk external `$ref` targets (e.g. `./schemas/pet.yaml`)
-            // relative to it. Without this, every non-internal `$ref`
-            // would throw `LocalRefRequiresSourceFile`.
-            $resolved = OpenApiRefResolver::resolve($decoded, $path);
+            $resolved = OpenApiRefResolver::resolve($decoded, $canonicalPath);
         } catch (InvalidOpenApiSpecException $e) {
             // The resolver is stateless and therefore cannot know which spec
             // produced the throw. Re-wrap once so consumers (e.g. the coverage

--- a/tests/Unit/Internal/ExternalRefLoaderTest.php
+++ b/tests/Unit/Internal/ExternalRefLoaderTest.php
@@ -11,9 +11,12 @@ use Studio\OpenApiContractTesting\Internal\YamlAvailability;
 use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\InvalidOpenApiSpecReason;
 
+use function chmod;
 use function file_put_contents;
+use function function_exists;
 use function is_dir;
 use function mkdir;
+use function posix_geteuid;
 use function rmdir;
 use function scandir;
 use function sys_get_temp_dir;
@@ -137,13 +140,16 @@ class ExternalRefLoaderTest extends TestCase
             ExternalRefLoader::loadDocument('./bad.json', $sourceFile, $cache);
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
-            $this->assertSame(InvalidOpenApiSpecReason::LocalRefDecodeFailed, $e->reason);
+            $this->assertSame(InvalidOpenApiSpecReason::MalformedJson, $e->reason);
             $this->assertStringContainsString('./bad.json', $e->getMessage());
+            // The underlying JsonException is preserved so callers can
+            // surface decoder diagnostics (line/column) without re-parsing.
+            $this->assertNotNull($e->getPrevious());
         }
     }
 
     #[Test]
-    public function throws_local_ref_decode_failed_on_malformed_yaml(): void
+    public function throws_malformed_yaml_on_invalid_indent(): void
     {
         $sourceFile = $this->workDir . '/root.json';
         file_put_contents($sourceFile, '{}');
@@ -154,7 +160,8 @@ class ExternalRefLoaderTest extends TestCase
             ExternalRefLoader::loadDocument('./bad.yaml', $sourceFile, $cache);
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
-            $this->assertSame(InvalidOpenApiSpecReason::LocalRefDecodeFailed, $e->reason);
+            $this->assertSame(InvalidOpenApiSpecReason::MalformedYaml, $e->reason);
+            $this->assertNotNull($e->getPrevious());
         }
     }
 
@@ -190,6 +197,49 @@ class ExternalRefLoaderTest extends TestCase
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
             $this->assertSame(InvalidOpenApiSpecReason::YamlLibraryMissing, $e->reason);
+        }
+    }
+
+    #[Test]
+    public function throws_unsupported_extension_for_extensionless_target(): void
+    {
+        $sourceFile = $this->workDir . '/root.json';
+        file_put_contents($sourceFile, '{}');
+        file_put_contents($this->workDir . '/no-ext', '{}');
+
+        try {
+            $cache = [];
+            ExternalRefLoader::loadDocument('./no-ext', $sourceFile, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::UnsupportedExtension, $e->reason);
+            $this->assertStringContainsString('no file extension', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function throws_local_ref_unreadable_when_yaml_target_is_not_readable(): void
+    {
+        // Skip on systems where root can read everything (e.g., CI as root in docker).
+        if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+            $this->markTestSkipped('chmod 0000 has no effect for the root user');
+        }
+
+        $sourceFile = $this->workDir . '/root.json';
+        file_put_contents($sourceFile, '{}');
+        $target = $this->workDir . '/locked.yaml';
+        file_put_contents($target, "type: object\n");
+        chmod($target, 0o000);
+
+        try {
+            $cache = [];
+            ExternalRefLoader::loadDocument('./locked.yaml', $sourceFile, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::LocalRefUnreadable, $e->reason);
+        } finally {
+            // Restore mode so tearDown() can unlink the file.
+            chmod($target, 0o644);
         }
     }
 

--- a/tests/Unit/Internal/ExternalRefLoaderTest.php
+++ b/tests/Unit/Internal/ExternalRefLoaderTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Internal;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Internal\ExternalRefLoader;
+use Studio\OpenApiContractTesting\Internal\YamlAvailability;
+use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
+use Studio\OpenApiContractTesting\InvalidOpenApiSpecReason;
+
+use function file_put_contents;
+use function is_dir;
+use function mkdir;
+use function rmdir;
+use function scandir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+class ExternalRefLoaderTest extends TestCase
+{
+    private string $workDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->workDir = sys_get_temp_dir() . '/oct-extref-' . uniqid();
+        mkdir($this->workDir);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->workDir);
+        YamlAvailability::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function loads_relative_json_file_relative_to_source_file(): void
+    {
+        $sourceFile = $this->workDir . '/root.yaml';
+        file_put_contents($sourceFile, "openapi: 3.0.3\n");
+        file_put_contents($this->workDir . '/pet.json', '{"type":"object","required":["id"]}');
+
+        $cache = [];
+        $result = ExternalRefLoader::loadDocument('./pet.json', $sourceFile, $cache);
+
+        $this->assertSame(['type' => 'object', 'required' => ['id']], $result['decoded']);
+        $this->assertStringEndsWith('/pet.json', $result['absolutePath']);
+    }
+
+    #[Test]
+    public function loads_relative_yaml_file(): void
+    {
+        $sourceFile = $this->workDir . '/root.json';
+        file_put_contents($sourceFile, '{}');
+        file_put_contents($this->workDir . '/pet.yaml', "type: object\nrequired:\n  - id\n");
+
+        $cache = [];
+        $result = ExternalRefLoader::loadDocument('./pet.yaml', $sourceFile, $cache);
+
+        $this->assertSame(['type' => 'object', 'required' => ['id']], $result['decoded']);
+    }
+
+    #[Test]
+    public function resolves_parent_directory_relative_paths(): void
+    {
+        mkdir($this->workDir . '/sub');
+        $sourceFile = $this->workDir . '/sub/root.yaml';
+        file_put_contents($sourceFile, "openapi: 3.0.3\n");
+        file_put_contents($this->workDir . '/shared.json', '{"name":"shared"}');
+
+        $cache = [];
+        $result = ExternalRefLoader::loadDocument('../shared.json', $sourceFile, $cache);
+
+        $this->assertSame(['name' => 'shared'], $result['decoded']);
+    }
+
+    #[Test]
+    public function loads_absolute_path_directly(): void
+    {
+        $absolute = $this->workDir . '/abs.json';
+        file_put_contents($absolute, '{"absolute":true}');
+
+        $cache = [];
+        $result = ExternalRefLoader::loadDocument($absolute, $this->workDir . '/unused.yaml', $cache);
+
+        $this->assertSame(['absolute' => true], $result['decoded']);
+    }
+
+    #[Test]
+    public function caches_loaded_documents_within_a_call(): void
+    {
+        $sourceFile = $this->workDir . '/root.yaml';
+        file_put_contents($sourceFile, "openapi: 3.0.3\n");
+        $target = $this->workDir . '/pet.json';
+        file_put_contents($target, '{"type":"object"}');
+
+        $cache = [];
+        ExternalRefLoader::loadDocument('./pet.json', $sourceFile, $cache);
+
+        // Mutate the file on disk; cached result should still be returned.
+        file_put_contents($target, '{"type":"string"}');
+        $second = ExternalRefLoader::loadDocument('./pet.json', $sourceFile, $cache);
+
+        $this->assertSame(['type' => 'object'], $second['decoded']);
+    }
+
+    #[Test]
+    public function throws_local_ref_not_found_when_file_missing(): void
+    {
+        $sourceFile = $this->workDir . '/root.yaml';
+        file_put_contents($sourceFile, "openapi: 3.0.3\n");
+
+        try {
+            $cache = [];
+            ExternalRefLoader::loadDocument('./missing.yaml', $sourceFile, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::LocalRefNotFound, $e->reason);
+            $this->assertStringContainsString('./missing.yaml', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function throws_local_ref_decode_failed_on_malformed_json(): void
+    {
+        $sourceFile = $this->workDir . '/root.yaml';
+        file_put_contents($sourceFile, "openapi: 3.0.3\n");
+        file_put_contents($this->workDir . '/bad.json', '{ not valid json');
+
+        try {
+            $cache = [];
+            ExternalRefLoader::loadDocument('./bad.json', $sourceFile, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::LocalRefDecodeFailed, $e->reason);
+            $this->assertStringContainsString('./bad.json', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function throws_local_ref_decode_failed_on_malformed_yaml(): void
+    {
+        $sourceFile = $this->workDir . '/root.json';
+        file_put_contents($sourceFile, '{}');
+        file_put_contents($this->workDir . '/bad.yaml', "key: value\n  bad: indent\n");
+
+        try {
+            $cache = [];
+            ExternalRefLoader::loadDocument('./bad.yaml', $sourceFile, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::LocalRefDecodeFailed, $e->reason);
+        }
+    }
+
+    #[Test]
+    public function throws_unsupported_extension_for_unknown_format(): void
+    {
+        $sourceFile = $this->workDir . '/root.yaml';
+        file_put_contents($sourceFile, "openapi: 3.0.3\n");
+        file_put_contents($this->workDir . '/pet.txt', 'not a spec');
+
+        try {
+            $cache = [];
+            ExternalRefLoader::loadDocument('./pet.txt', $sourceFile, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::UnsupportedExtension, $e->reason);
+            $this->assertStringContainsString('.txt', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function throws_yaml_library_missing_when_loading_yaml_without_symfony_yaml(): void
+    {
+        $sourceFile = $this->workDir . '/root.json';
+        file_put_contents($sourceFile, '{}');
+        file_put_contents($this->workDir . '/pet.yaml', "type: object\n");
+
+        YamlAvailability::overrideForTesting(false);
+
+        try {
+            $cache = [];
+            ExternalRefLoader::loadDocument('./pet.yaml', $sourceFile, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::YamlLibraryMissing, $e->reason);
+        }
+    }
+
+    #[Test]
+    public function throws_when_decoded_root_is_not_a_mapping(): void
+    {
+        $sourceFile = $this->workDir . '/root.yaml';
+        file_put_contents($sourceFile, "openapi: 3.0.3\n");
+        // A bare scalar at the root is valid JSON but cannot be a $ref target.
+        file_put_contents($this->workDir . '/scalar.json', '"just a string"');
+
+        try {
+            $cache = [];
+            ExternalRefLoader::loadDocument('./scalar.json', $sourceFile, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::NonMappingRoot, $e->reason);
+        }
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $entry;
+            if (is_dir($path)) {
+                $this->removeDir($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/tests/Unit/OpenApiRefResolverExternalRefsTest.php
+++ b/tests/Unit/OpenApiRefResolverExternalRefsTest.php
@@ -269,6 +269,133 @@ class OpenApiRefResolverExternalRefsTest extends TestCase
     }
 
     #[Test]
+    public function detects_whole_file_cycle_between_two_files(): void
+    {
+        // a.json -> b.json -> a.json with no fragment on either side.
+        // This exercises the chainKey = absolutePath branch in
+        // resolveExternalRef, which is distinct from the fragment branch
+        // covered by detects_cycle_across_two_files.
+        $rootPath = $this->workDir . '/openapi.json';
+        file_put_contents($rootPath, '{}');
+        file_put_contents($this->workDir . '/a.json', '{"$ref":"./b.json"}');
+        file_put_contents($this->workDir . '/b.json', '{"$ref":"./a.json"}');
+
+        $spec = ['components' => ['schemas' => ['Start' => ['$ref' => './a.json']]]];
+
+        try {
+            OpenApiRefResolver::resolve($spec, $rootPath);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::CircularRef, $e->reason);
+        }
+    }
+
+    #[Test]
+    public function document_cache_is_per_resolution_call_not_global(): void
+    {
+        // The cache lives only for the duration of one resolve() call.
+        // A second call against the same root spec must re-decode the
+        // external file, picking up any change that happened between
+        // calls. Without per-call scoping, hot-reloading specs in test
+        // watchers would silently see stale data.
+        $rootPath = $this->workDir . '/openapi.json';
+        file_put_contents($rootPath, '{}');
+        $petPath = $this->workDir . '/pet.json';
+        file_put_contents($petPath, '{"type":"object"}');
+
+        $spec1 = ['components' => ['schemas' => ['Pet' => ['$ref' => './pet.json']]]];
+        $first = OpenApiRefResolver::resolve($spec1, $rootPath);
+        $this->assertSame(['type' => 'object'], $first['components']['schemas']['Pet']);
+
+        // Mutate the external file and resolve a fresh spec; the second
+        // call must reflect the new content.
+        file_put_contents($petPath, '{"type":"string"}');
+        $spec2 = ['components' => ['schemas' => ['Pet' => ['$ref' => './pet.json']]]];
+        $second = OpenApiRefResolver::resolve($spec2, $rootPath);
+        $this->assertSame(['type' => 'string'], $second['components']['schemas']['Pet']);
+    }
+
+    #[Test]
+    public function decodes_json_pointer_escapes_in_external_fragment(): void
+    {
+        // The external file has keys with literal `/` and `~` characters,
+        // which JSON Pointer escapes as `~1` and `~0`. The fragment
+        // splitter must hand the raw escapes to lookup() rather than
+        // pre-decoding around the `#`.
+        $rootPath = $this->workDir . '/openapi.json';
+        file_put_contents($rootPath, '{}');
+        file_put_contents(
+            $this->workDir . '/schemas.json',
+            '{"a/b":{"type":"object","required":["id"]},"c~d":{"type":"string"}}',
+        );
+
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Slash' => ['$ref' => './schemas.json#/a~1b'],
+                    'Tilde' => ['$ref' => './schemas.json#/c~0d'],
+                ],
+            ],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec, $rootPath);
+
+        $this->assertSame(['type' => 'object', 'required' => ['id']], $resolved['components']['schemas']['Slash']);
+        $this->assertSame(['type' => 'string'], $resolved['components']['schemas']['Tilde']);
+    }
+
+    #[Test]
+    public function throws_non_object_target_for_external_scalar_fragment(): void
+    {
+        // Fragment lookup that lands on a scalar should throw the same
+        // NonObjectRefTarget as the internal-ref path. Without an
+        // external-ref-specific test for this branch, a regression
+        // would silently substitute a string into a schema slot.
+        $rootPath = $this->workDir . '/openapi.json';
+        file_put_contents($rootPath, '{}');
+        file_put_contents($this->workDir . '/schemas.json', '{"Greeting":"hello"}');
+
+        $spec = ['components' => ['schemas' => ['Bad' => ['$ref' => './schemas.json#/Greeting']]]];
+
+        try {
+            OpenApiRefResolver::resolve($spec, $rootPath);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::NonObjectRefTarget, $e->reason);
+        }
+    }
+
+    #[Test]
+    public function throws_bare_fragment_for_trailing_hash_without_pointer(): void
+    {
+        $rootPath = $this->workDir . '/openapi.json';
+        file_put_contents($rootPath, '{}');
+        file_put_contents($this->workDir . '/pet.json', '{"type":"object"}');
+
+        $spec = ['components' => ['schemas' => ['Pet' => ['$ref' => './pet.json#']]]];
+
+        try {
+            OpenApiRefResolver::resolve($spec, $rootPath);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::BareFragmentRef, $e->reason);
+        }
+    }
+
+    #[Test]
+    public function throws_empty_ref_on_empty_string(): void
+    {
+        $spec = ['components' => ['schemas' => ['Bad' => ['$ref' => '']]]];
+
+        try {
+            OpenApiRefResolver::resolve($spec);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::EmptyRef, $e->reason);
+        }
+    }
+
+    #[Test]
     public function legacy_call_without_source_file_still_resolves_internal_refs(): void
     {
         $spec = [

--- a/tests/Unit/OpenApiRefResolverExternalRefsTest.php
+++ b/tests/Unit/OpenApiRefResolverExternalRefsTest.php
@@ -1,0 +1,306 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
+use Studio\OpenApiContractTesting\InvalidOpenApiSpecReason;
+use Studio\OpenApiContractTesting\OpenApiRefResolver;
+
+use function file_put_contents;
+use function is_dir;
+use function mkdir;
+use function rmdir;
+use function scandir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+class OpenApiRefResolverExternalRefsTest extends TestCase
+{
+    private string $workDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->workDir = sys_get_temp_dir() . '/oct-resolver-ext-' . uniqid();
+        mkdir($this->workDir);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->workDir);
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function resolves_local_file_ref_without_fragment(): void
+    {
+        $rootPath = $this->workDir . '/openapi.json';
+        file_put_contents(
+            $this->workDir . '/pet.json',
+            '{"type":"object","required":["id"],"properties":{"id":{"type":"integer"}}}',
+        );
+
+        $spec = [
+            'openapi' => '3.0.3',
+            'paths' => [
+                '/pets' => [
+                    'get' => [
+                        'responses' => [
+                            '200' => [
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => ['$ref' => './pet.json'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        file_put_contents($rootPath, '{}');
+
+        $resolved = OpenApiRefResolver::resolve($spec, $rootPath);
+
+        $schema = $resolved['paths']['/pets']['get']['responses']['200']['content']['application/json']['schema'];
+        $this->assertSame('object', $schema['type']);
+        $this->assertSame(['id'], $schema['required']);
+    }
+
+    #[Test]
+    public function resolves_local_file_ref_with_json_pointer_fragment(): void
+    {
+        $rootPath = $this->workDir . '/openapi.json';
+        file_put_contents($rootPath, '{}');
+        file_put_contents(
+            $this->workDir . '/schemas.json',
+            '{"Pet":{"type":"object","required":["id"]},"Owner":{"type":"object"}}',
+        );
+
+        $spec = [
+            'openapi' => '3.0.3',
+            'paths' => [
+                '/pets' => [
+                    'get' => [
+                        'responses' => [
+                            '200' => [
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => ['$ref' => './schemas.json#/Pet'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec, $rootPath);
+
+        $schema = $resolved['paths']['/pets']['get']['responses']['200']['content']['application/json']['schema'];
+        $this->assertSame(['type' => 'object', 'required' => ['id']], $schema);
+    }
+
+    #[Test]
+    public function resolves_yaml_external_ref_from_json_root(): void
+    {
+        $rootPath = $this->workDir . '/openapi.json';
+        file_put_contents($rootPath, '{}');
+        file_put_contents($this->workDir . '/pet.yaml', "type: object\nrequired:\n  - id\n");
+
+        $spec = [
+            'openapi' => '3.0.3',
+            'components' => ['schemas' => ['Pet' => ['$ref' => './pet.yaml']]],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec, $rootPath);
+
+        $this->assertSame(['type' => 'object', 'required' => ['id']], $resolved['components']['schemas']['Pet']);
+    }
+
+    #[Test]
+    public function resolves_chain_of_external_refs_across_files(): void
+    {
+        $rootPath = $this->workDir . '/openapi.json';
+        file_put_contents($rootPath, '{}');
+        file_put_contents($this->workDir . '/a.json', '{"$ref":"./b.json"}');
+        file_put_contents($this->workDir . '/b.json', '{"$ref":"./c.json"}');
+        file_put_contents($this->workDir . '/c.json', '{"type":"string"}');
+
+        $spec = ['components' => ['schemas' => ['Leaf' => ['$ref' => './a.json']]]];
+
+        $resolved = OpenApiRefResolver::resolve($spec, $rootPath);
+
+        $this->assertSame(['type' => 'string'], $resolved['components']['schemas']['Leaf']);
+    }
+
+    #[Test]
+    public function resolves_internal_ref_inside_external_document_against_that_documents_root(): void
+    {
+        // pet.json defines its own internal #/definitions/Pet — this must
+        // resolve against pet.json's root, not the calling spec's root.
+        $rootPath = $this->workDir . '/openapi.json';
+        file_put_contents($rootPath, '{}');
+        file_put_contents(
+            $this->workDir . '/pet.json',
+            '{"definitions":{"Pet":{"type":"object","required":["id"]}},"alias":{"$ref":"#/definitions/Pet"}}',
+        );
+
+        $spec = ['components' => ['schemas' => ['Pet' => ['$ref' => './pet.json#/alias']]]];
+
+        $resolved = OpenApiRefResolver::resolve($spec, $rootPath);
+
+        $this->assertSame(['type' => 'object', 'required' => ['id']], $resolved['components']['schemas']['Pet']);
+    }
+
+    #[Test]
+    public function detects_cycle_across_two_files(): void
+    {
+        $rootPath = $this->workDir . '/openapi.json';
+        file_put_contents($rootPath, '{}');
+        file_put_contents($this->workDir . '/a.json', '{"$ref":"./b.json#/Loop"}');
+        file_put_contents($this->workDir . '/b.json', '{"Loop":{"$ref":"./a.json"}}');
+
+        $spec = ['components' => ['schemas' => ['Start' => ['$ref' => './a.json']]]];
+
+        try {
+            OpenApiRefResolver::resolve($spec, $rootPath);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::CircularRef, $e->reason);
+        }
+    }
+
+    #[Test]
+    public function reuses_loaded_document_for_sibling_refs_to_same_file(): void
+    {
+        // Two refs into the same file should not cause a cycle (cycle
+        // detection must use the canonical absolute path + pointer, not
+        // just file paths).
+        $rootPath = $this->workDir . '/openapi.json';
+        file_put_contents($rootPath, '{}');
+        file_put_contents(
+            $this->workDir . '/schemas.json',
+            '{"Pet":{"type":"object"},"Owner":{"type":"string"}}',
+        );
+
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Pet' => ['$ref' => './schemas.json#/Pet'],
+                    'Owner' => ['$ref' => './schemas.json#/Owner'],
+                ],
+            ],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec, $rootPath);
+
+        $this->assertSame(['type' => 'object'], $resolved['components']['schemas']['Pet']);
+        $this->assertSame(['type' => 'string'], $resolved['components']['schemas']['Owner']);
+    }
+
+    #[Test]
+    public function throws_local_ref_requires_source_file_when_called_without_source(): void
+    {
+        $spec = ['components' => ['schemas' => ['Pet' => ['$ref' => './pet.json']]]];
+
+        try {
+            OpenApiRefResolver::resolve($spec);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::LocalRefRequiresSourceFile, $e->reason);
+            $this->assertStringContainsString('./pet.json', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function throws_remote_ref_not_implemented_for_https_ref(): void
+    {
+        $rootPath = $this->workDir . '/openapi.json';
+        file_put_contents($rootPath, '{}');
+
+        $spec = ['components' => ['schemas' => ['Pet' => ['$ref' => 'https://example.com/pet.json']]]];
+
+        try {
+            OpenApiRefResolver::resolve($spec, $rootPath);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::RemoteRefNotImplemented, $e->reason);
+            $this->assertStringContainsString('https://example.com/pet.json', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function throws_remote_ref_not_implemented_for_http_ref(): void
+    {
+        $rootPath = $this->workDir . '/openapi.json';
+        file_put_contents($rootPath, '{}');
+
+        $spec = ['components' => ['schemas' => ['Pet' => ['$ref' => 'http://example.com/pet.json']]]];
+
+        try {
+            OpenApiRefResolver::resolve($spec, $rootPath);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::RemoteRefNotImplemented, $e->reason);
+        }
+    }
+
+    #[Test]
+    public function throws_file_scheme_not_supported_for_file_url_ref(): void
+    {
+        $rootPath = $this->workDir . '/openapi.json';
+        file_put_contents($rootPath, '{}');
+
+        $spec = ['components' => ['schemas' => ['Pet' => ['$ref' => 'file:///etc/passwd']]]];
+
+        try {
+            OpenApiRefResolver::resolve($spec, $rootPath);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::FileSchemeNotSupported, $e->reason);
+        }
+    }
+
+    #[Test]
+    public function legacy_call_without_source_file_still_resolves_internal_refs(): void
+    {
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Pet' => ['type' => 'object'],
+                    'Alias' => ['$ref' => '#/components/schemas/Pet'],
+                ],
+            ],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $this->assertSame(['type' => 'object'], $resolved['components']['schemas']['Alias']);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $entry;
+            if (is_dir($path)) {
+                $this->removeDir($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/tests/Unit/OpenApiRefResolverTest.php
+++ b/tests/Unit/OpenApiRefResolverTest.php
@@ -7,6 +7,7 @@ namespace Studio\OpenApiContractTesting\Tests\Unit;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
+use Studio\OpenApiContractTesting\InvalidOpenApiSpecReason;
 use Studio\OpenApiContractTesting\OpenApiRefResolver;
 
 class OpenApiRefResolverTest extends TestCase
@@ -322,8 +323,12 @@ class OpenApiRefResolverTest extends TestCase
     }
 
     #[Test]
-    public function throws_on_external_file_ref(): void
+    public function throws_local_ref_requires_source_file_when_no_source_passed(): void
     {
+        // Legacy single-arg `resolve()` cannot decide where `./other.json`
+        // lives, so external refs are rejected up front rather than
+        // silently mishandled. See OpenApiRefResolverExternalRefsTest for
+        // the positive paths when a source file is supplied.
         $spec = [
             'components' => [
                 'schemas' => [
@@ -332,15 +337,20 @@ class OpenApiRefResolverTest extends TestCase
             ],
         ];
 
-        $this->expectException(InvalidOpenApiSpecException::class);
-        $this->expectExceptionMessage('External $ref');
-
-        OpenApiRefResolver::resolve($spec);
+        try {
+            OpenApiRefResolver::resolve($spec);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::LocalRefRequiresSourceFile, $e->reason);
+            $this->assertStringContainsString('other.json', $e->getMessage());
+        }
     }
 
     #[Test]
-    public function throws_on_external_url_ref(): void
+    public function throws_remote_ref_not_implemented_for_url_ref(): void
     {
+        // HTTP(S) refs are reserved for a follow-up PR with explicit
+        // opt-in semantics around remote network access.
         $spec = [
             'components' => [
                 'schemas' => [
@@ -349,10 +359,12 @@ class OpenApiRefResolverTest extends TestCase
             ],
         ];
 
-        $this->expectException(InvalidOpenApiSpecException::class);
-        $this->expectExceptionMessage('External $ref');
-
-        OpenApiRefResolver::resolve($spec);
+        try {
+            OpenApiRefResolver::resolve($spec);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::RemoteRefNotImplemented, $e->reason);
+        }
     }
 
     #[Test]

--- a/tests/Unit/OpenApiSpecLoaderTest.php
+++ b/tests/Unit/OpenApiSpecLoaderTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\Yaml\Yaml;
 
 use function class_exists;
 use function file_put_contents;
+use function json_encode;
 use function mkdir;
 use function rmdir;
 use function sys_get_temp_dir;
@@ -256,6 +257,47 @@ class OpenApiSpecLoaderTest extends TestCase
             $this->assertSame(InvalidOpenApiSpecReason::LocalRefNotFound, $e->reason);
             $this->assertSame('refs-external', $e->specName);
             $this->assertStringContainsString('other-spec.json', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function load_preserves_previous_chain_when_attaching_spec_name(): void
+    {
+        // The loader re-wraps resolver-originated throws via
+        // InvalidOpenApiSpecException::withSpecName(). The wrap must
+        // not drop the original exception (or its own $previous), or
+        // operators lose the underlying decoder diagnostic when an
+        // external $ref target has malformed JSON.
+        $tempDir = sys_get_temp_dir() . '/oct-spec-loader-prev-' . uniqid();
+        mkdir($tempDir);
+
+        try {
+            file_put_contents($tempDir . '/root.json', json_encode([
+                'openapi' => '3.0.3',
+                'info' => ['title' => 'Prev', 'version' => '1.0.0'],
+                'components' => ['schemas' => ['Bad' => ['$ref' => './bad.json']]],
+            ]));
+            file_put_contents($tempDir . '/bad.json', '{ not valid json');
+
+            OpenApiSpecLoader::configure($tempDir);
+
+            try {
+                OpenApiSpecLoader::load('root');
+                $this->fail('expected InvalidOpenApiSpecException');
+            } catch (InvalidOpenApiSpecException $e) {
+                $this->assertSame('root', $e->specName);
+                // First link is the original (pre-wrap) exception.
+                $original = $e->getPrevious();
+                $this->assertInstanceOf(InvalidOpenApiSpecException::class, $original);
+                // Second link is the underlying JsonException carried
+                // by the resolver throw — proves the chain isn't
+                // truncated at the wrap boundary.
+                $this->assertNotNull($original->getPrevious());
+            }
+        } finally {
+            @unlink($tempDir . '/bad.json');
+            @unlink($tempDir . '/root.json');
+            @rmdir($tempDir);
         }
     }
 

--- a/tests/Unit/OpenApiSpecLoaderTest.php
+++ b/tests/Unit/OpenApiSpecLoaderTest.php
@@ -239,15 +239,48 @@ class OpenApiSpecLoaderTest extends TestCase
     }
 
     #[Test]
-    public function load_throws_on_external_ref(): void
+    public function load_throws_local_ref_not_found_when_external_target_missing(): void
     {
+        // The fixture references `other-spec.json` which intentionally
+        // does not exist in the fixtures directory. Now that local
+        // external refs are supported, the resolver attempts the load
+        // and surfaces a precise file-not-found error instead of the
+        // old blanket "external refs unsupported" rejection.
         $fixturesPath = __DIR__ . '/../fixtures/specs';
         OpenApiSpecLoader::configure($fixturesPath);
 
-        $this->expectException(InvalidOpenApiSpecException::class);
-        $this->expectExceptionMessage('External $ref');
+        try {
+            OpenApiSpecLoader::load('refs-external');
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::LocalRefNotFound, $e->reason);
+            $this->assertSame('refs-external', $e->specName);
+            $this->assertStringContainsString('other-spec.json', $e->getMessage());
+        }
+    }
 
-        OpenApiSpecLoader::load('refs-external');
+    #[Test]
+    public function load_resolves_local_external_refs_in_multi_file_yaml_spec(): void
+    {
+        // The multi-file fixture's root yaml references ./schemas/pet.yaml
+        // for both list and detail responses, plus a JSON-pointer fragment
+        // ref into schemas/error.json. All should inline cleanly without
+        // any pre-bundling step.
+        $fixturesPath = __DIR__ . '/../fixtures/specs/external-refs';
+        OpenApiSpecLoader::configure($fixturesPath);
+
+        $spec = OpenApiSpecLoader::load('multi-file');
+
+        $listSchema = $spec['paths']['/pets']['get']['responses']['200']['content']['application/json']['schema'];
+        $this->assertSame('array', $listSchema['type']);
+        $this->assertSame(['id', 'name'], $listSchema['items']['required']);
+
+        $detailSchema = $spec['paths']['/pets/{petId}']['get']['responses']['200']['content']['application/json']['schema'];
+        $this->assertSame('object', $detailSchema['type']);
+        $this->assertSame('integer', $detailSchema['properties']['id']['type']);
+
+        $errorSchema = $spec['paths']['/pets/{petId}']['get']['responses']['404']['content']['application/problem+json']['schema'];
+        $this->assertSame(['code', 'message'], $errorSchema['required']);
     }
 
     #[Test]

--- a/tests/fixtures/specs/external-refs/multi-file.yaml
+++ b/tests/fixtures/specs/external-refs/multi-file.yaml
@@ -1,0 +1,39 @@
+openapi: 3.0.3
+info:
+  title: Multi-file external $ref fixture
+  version: '1.0.0'
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: A list of pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: './schemas/pet.yaml'
+  /pets/{petId}:
+    parameters:
+      - name: petId
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: getPet
+      responses:
+        '200':
+          description: A single pet
+          content:
+            application/json:
+              schema:
+                $ref: './schemas/pet.yaml'
+        '404':
+          description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: './schemas/error.json#/Error'

--- a/tests/fixtures/specs/external-refs/schemas/error.json
+++ b/tests/fixtures/specs/external-refs/schemas/error.json
@@ -1,0 +1,10 @@
+{
+    "Error": {
+        "type": "object",
+        "required": ["code", "message"],
+        "properties": {
+            "code": { "type": "integer" },
+            "message": { "type": "string" }
+        }
+    }
+}

--- a/tests/fixtures/specs/external-refs/schemas/pet.yaml
+++ b/tests/fixtures/specs/external-refs/schemas/pet.yaml
@@ -1,0 +1,9 @@
+type: object
+required:
+  - id
+  - name
+properties:
+  id:
+    type: integer
+  name:
+    type: string


### PR DESCRIPTION
## Summary

Removes the requirement to pre-bundle multi-file OpenAPI specs with `redocly bundle --dereferenced`. The resolver now follows `$ref` paths that point at neighbouring files on disk:

```yaml
$ref: './schemas/pet.yaml'
$ref: './schemas/pet.yaml#/Pet'
$ref: '../shared/error.json'
$ref: '/abs/path/to/schemas.json#/Pet'
```

This is **PR 1 of 2** for #108. Scope split was agreed in chat:

- ✅ **This PR**: local-filesystem `$ref` (relative + absolute, with cross-file cycle detection)
- ⏭ **Next PR**: HTTP(S) `$ref` via opt-in PSR-18 client injection

## Highlights

- `OpenApiRefResolver::resolve()` gains an optional `?string $sourceFile` argument. When supplied, the resolver walks the document tree with the spec file's directory as the base for relative paths.
- Sibling refs into the same external file are decoded once via a per-resolution document cache.
- `OpenApiSpecLoader::load()` passes the absolute spec-file path automatically — multi-file specs Just Work end-to-end.
- Cross-file circular `$ref`s are detected via canonicalized chain keys (`<absolutePath>#<pointer>`) so cycles are recognised even when bouncing between documents.
- HTTP(S) `$ref`s throw `RemoteRefNotImplemented` with a forward-pointer to PR 2/2. `file://` URLs throw `FileSchemeNotSupported`.

## New `InvalidOpenApiSpecReason` enum cases

| Case | When |
| --- | --- |
| `LocalRefNotFound` | Resolved file path does not exist |
| `LocalRefDecodeFailed` | External JSON/YAML file is malformed |
| `LocalRefRequiresSourceFile` | Resolver invoked without `$sourceFile` but spec contains a non-internal `$ref` |
| `RemoteRefNotImplemented` | `http://` / `https://` `$ref` (reserved for PR 2/2) |
| `FileSchemeNotSupported` | `file://` URL `$ref` (security) |

## Backward compatibility

- Single-arg `resolve($spec)` still works for internal-only specs.
- Specs that previously threw the catch-all `ExternalRef`:
  - Via `OpenApiSpecLoader`: now succeed (or surface a precise file-level error)
  - Via direct `resolve()` with no source file: now throw `LocalRefRequiresSourceFile`

The existing `ExternalRef` enum case is kept for the moment — PR 2/2 will revisit it (likely renaming to `RemoteRefDisallowed` once HTTP gating lands).

## Test plan

- [x] `vendor/bin/phpunit --testsuite Unit` → **669 tests / 1356 assertions pass**
- [x] `vendor/bin/phpstan analyse` → **0 errors** (level 6)
- [x] `vendor/bin/php-cs-fixer fix --dry-run` → **0 violations**
- [x] 11 new tests for `Internal\ExternalRefLoader` (relative/parent/absolute paths, JSON/YAML, doc caching, missing-file, malformed content, unsupported extension, YAML lib missing, non-mapping root)
- [x] 12 new tests for `OpenApiRefResolver` external paths (no-fragment, fragment, nested chains, internal-ref-inside-external, cross-file cycle, sibling reuse, HTTP(S) reject, `file://` reject, source-required, legacy compat)
- [x] 1 new end-to-end `OpenApiSpecLoaderTest::load_resolves_local_external_refs_in_multi_file_yaml_spec` using a real `external-refs/multi-file.yaml` fixture that previously required Redocly to load
- [x] Existing rejection tests updated to assert the precise new enum reason instead of the old blanket message
- [ ] Reviewer: confirm cycle detection across files in `OpenApiRefResolverExternalRefsTest::detects_cycle_across_two_files`
- [ ] Reviewer: confirm `OpenApiRefResolver` complexity is still acceptable after the `resolveRef()` / `resolveInternalRef()` / `resolveExternalRef()` extraction

## Out of scope (next PR or follow-up)

- HTTP(S) `$ref` support and PSR-18 client injection
- README / comparison-table refresh marking external refs as supported (deferred until both halves of #108 ship)
- Path sandboxing (rejecting refs that escape the spec directory) — intentionally not enforced; spec authors are trusted

## Closes (partial)

Partially addresses #108 (local-filesystem half). Remote refs tracked for follow-up PR.