### PR TITLE
feat(response-validator): validate response headers against spec (#110)

### DIFF
--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -466,6 +466,10 @@ trait ValidatesOpenApiSchema
             $response->getStatusCode(),
             $this->extractJsonBody($response, $content, $contentType),
             $contentType !== '' ? $contentType : null,
+            // Symfony's HeaderBag::all() returns array<string, list<string>>
+            // with lower-cased keys; the validator's HeaderNormalizer is
+            // idempotent so this is safe to pass through unchanged.
+            $response->headers->all(),
         );
 
         // Record coverage for any matched endpoint, including those where body

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -466,9 +466,8 @@ trait ValidatesOpenApiSchema
             $response->getStatusCode(),
             $this->extractJsonBody($response, $content, $contentType),
             $contentType !== '' ? $contentType : null,
-            // Symfony's HeaderBag::all() returns array<string, list<string>>
-            // with lower-cased keys; the validator's HeaderNormalizer is
-            // idempotent so this is safe to pass through unchanged.
+            // HeaderNormalizer is idempotent; HeaderBag's already-lower-cased
+            // keys pass through unchanged.
             $response->headers->all(),
         );
 

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -12,6 +12,7 @@ use Studio\OpenApiContractTesting\Validation\Support\ValidatorErrorBoundary;
 
 use function array_keys;
 use function array_merge;
+use function get_debug_type;
 use function is_array;
 use function preg_last_error_msg;
 use function preg_match;
@@ -136,6 +137,9 @@ final class OpenApiResponseValidator
             $version,
         );
 
+        // Order is body errors first, headers second. Tests that pin
+        // specific positions rely on this; reordering would silently
+        // change diagnostic flow without breaking behaviour.
         $errors = array_merge($bodyErrors, $headerErrors);
 
         if ($errors === []) {
@@ -256,8 +260,26 @@ final class OpenApiResponseValidator
             return [];
         }
 
-        $headersSpec = $responseSpec['headers'] ?? [];
-        if (!is_array($headersSpec) || $headersSpec === []) {
+        if (!isset($responseSpec['headers'])) {
+            return [];
+        }
+
+        $headersSpec = $responseSpec['headers'];
+
+        // A `headers` block that decoded to a non-mapping is a malformed
+        // spec (e.g. YAML scalar where an object was expected). Surface
+        // it as an error so the spec author notices instead of getting
+        // a silent pass that hides every header from validation.
+        if (!is_array($headersSpec)) {
+            return [sprintf(
+                "[response-header] spec 'headers' must be an object for %s %s; got %s.",
+                $method,
+                $matchedPath,
+                get_debug_type($headersSpec),
+            )];
+        }
+
+        if ($headersSpec === []) {
             return [];
         }
 

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -6,10 +6,13 @@ namespace Studio\OpenApiContractTesting;
 
 use InvalidArgumentException;
 use Studio\OpenApiContractTesting\Validation\Response\ResponseBodyValidator;
+use Studio\OpenApiContractTesting\Validation\Response\ResponseHeaderValidator;
 use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
 use Studio\OpenApiContractTesting\Validation\Support\ValidatorErrorBoundary;
 
 use function array_keys;
+use function array_merge;
+use function is_array;
 use function preg_last_error_msg;
 use function preg_match;
 use function sprintf;
@@ -27,6 +30,7 @@ final class OpenApiResponseValidator
     /** @var array<string, OpenApiPathMatcher> */
     private array $pathMatchers = [];
     private readonly ResponseBodyValidator $bodyValidator;
+    private readonly ResponseHeaderValidator $headerValidator;
 
     /** @var array<string, string> Raw pattern (as supplied) => anchored pattern ready for preg_match. */
     private readonly array $skipPatterns;
@@ -43,9 +47,18 @@ final class OpenApiResponseValidator
         array $skipResponseCodes = self::DEFAULT_SKIP_RESPONSE_CODES,
     ) {
         $this->skipPatterns = self::compileSkipPatterns($skipResponseCodes);
-        $this->bodyValidator = new ResponseBodyValidator(new SchemaValidatorRunner($maxErrors));
+        $runner = new SchemaValidatorRunner($maxErrors);
+        $this->bodyValidator = new ResponseBodyValidator($runner);
+        $this->headerValidator = new ResponseHeaderValidator($runner);
     }
 
+    /**
+     * @param null|array<array-key, mixed> $responseHeaders the response's actual headers
+     *                                                      (as returned by HeaderBag::all() — a map of name to list-of-values
+     *                                                      or to a single string). When null, header validation is skipped
+     *                                                      entirely; pass `[]` to validate against a spec that requires
+     *                                                      headers but the response sent none.
+     */
     public function validate(
         string $specName,
         string $method,
@@ -53,6 +66,7 @@ final class OpenApiResponseValidator
         int $statusCode,
         mixed $responseBody,
         ?string $responseContentType = null,
+        ?array $responseHeaders = null,
     ): OpenApiValidationResult {
         $spec = OpenApiSpecLoader::load($specName);
 
@@ -102,36 +116,27 @@ final class OpenApiResponseValidator
 
         $responseSpec = $responses[$statusCodeStr];
 
-        // If no content is defined for this response, skip body validation (e.g. 204 No Content)
-        if (!isset($responseSpec['content'])) {
-            return OpenApiValidationResult::success($matchedPath);
-        }
-
-        /** @var array<string, array<string, mixed>> $content */
-        $content = $responseSpec['content'];
-
-        // ValidatorErrorBoundary::safely() converts a RuntimeException thrown from
-        // body validation (e.g. opis/json-schema SchemaException — InvalidKeywordException,
-        // UnresolvedReferenceException, ...) into an error-string entry rather than
-        // letting it abort the orchestrator. Preserves observability symmetry with
-        // OpenApiRequestValidator. \LogicException and \Error still bubble so
-        // programmer bugs are not masked.
-        $errors = ValidatorErrorBoundary::safely(
-            'response-body',
+        $bodyErrors = $this->validateBody(
             $specName,
             $method,
             $matchedPath,
-            fn(): array => $this->bodyValidator->validate(
-                $specName,
-                $method,
-                $matchedPath,
-                $statusCode,
-                $content,
-                $responseBody,
-                $responseContentType,
-                $version,
-            ),
+            $statusCode,
+            $responseSpec,
+            $responseBody,
+            $responseContentType,
+            $version,
         );
+
+        $headerErrors = $this->validateHeaders(
+            $specName,
+            $method,
+            $matchedPath,
+            $responseSpec,
+            $responseHeaders,
+            $version,
+        );
+
+        $errors = array_merge($bodyErrors, $headerErrors);
 
         if ($errors === []) {
             return OpenApiValidationResult::success($matchedPath);
@@ -178,6 +183,92 @@ final class OpenApiResponseValidator
         }
 
         return $compiled;
+    }
+
+    /**
+     * @param array<string, mixed> $responseSpec
+     *
+     * @return string[]
+     */
+    private function validateBody(
+        string $specName,
+        string $method,
+        string $matchedPath,
+        int $statusCode,
+        array $responseSpec,
+        mixed $responseBody,
+        ?string $responseContentType,
+        OpenApiVersion $version,
+    ): array {
+        // 204 No Content (and similar) declare no `content` block. Nothing
+        // to validate — return empty so the result aggregates cleanly.
+        if (!isset($responseSpec['content'])) {
+            return [];
+        }
+
+        /** @var array<string, array<string, mixed>> $content */
+        $content = $responseSpec['content'];
+
+        // ValidatorErrorBoundary::safely() converts a RuntimeException thrown from
+        // body validation (e.g. opis/json-schema SchemaException — InvalidKeywordException,
+        // UnresolvedReferenceException, ...) into an error-string entry rather than
+        // letting it abort the orchestrator. Preserves observability symmetry with
+        // OpenApiRequestValidator. \LogicException and \Error still bubble so
+        // programmer bugs are not masked.
+        return ValidatorErrorBoundary::safely(
+            'response-body',
+            $specName,
+            $method,
+            $matchedPath,
+            fn(): array => $this->bodyValidator->validate(
+                $specName,
+                $method,
+                $matchedPath,
+                $statusCode,
+                $content,
+                $responseBody,
+                $responseContentType,
+                $version,
+            ),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $responseSpec
+     * @param null|array<array-key, mixed> $responseHeaders
+     *
+     * @return string[]
+     */
+    private function validateHeaders(
+        string $specName,
+        string $method,
+        string $matchedPath,
+        array $responseSpec,
+        ?array $responseHeaders,
+        OpenApiVersion $version,
+    ): array {
+        // Header validation is opt-in: callers that pre-date the parameter
+        // (or framework-agnostic adapters that never see headers) pass null
+        // and get the historical body-only behaviour. An explicit empty
+        // array means "the response has no headers" and still triggers
+        // required-header checks against the spec.
+        if ($responseHeaders === null) {
+            return [];
+        }
+
+        $headersSpec = $responseSpec['headers'] ?? [];
+        if (!is_array($headersSpec) || $headersSpec === []) {
+            return [];
+        }
+
+        /** @var array<string, mixed> $headersSpec */
+        return ValidatorErrorBoundary::safely(
+            'response-header',
+            $specName,
+            $method,
+            $matchedPath,
+            fn(): array => $this->headerValidator->validate($headersSpec, $responseHeaders, $version),
+        );
     }
 
     /**

--- a/src/Validation/Response/ResponseHeaderValidator.php
+++ b/src/Validation/Response/ResponseHeaderValidator.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Validation\Response;
+
+use Studio\OpenApiContractTesting\OpenApiSchemaConverter;
+use Studio\OpenApiContractTesting\OpenApiVersion;
+use Studio\OpenApiContractTesting\SchemaContext;
+use Studio\OpenApiContractTesting\Validation\Support\HeaderNormalizer;
+use Studio\OpenApiContractTesting\Validation\Support\ObjectConverter;
+use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
+use Studio\OpenApiContractTesting\Validation\Support\TypeCoercer;
+
+use function array_key_first;
+use function count;
+use function get_debug_type;
+use function in_array;
+use function is_array;
+use function is_scalar;
+use function sprintf;
+use function strtolower;
+
+/**
+ * Validate the response-side `headers` block against the OpenAPI spec.
+ *
+ * HTTP header names are case-insensitive (RFC 7230) so both spec keys
+ * and caller-supplied header keys are lower-cased before matching.
+ * Error messages preserve the spec's original casing so authors can
+ * grep their OpenAPI document directly. The `[response-header.<Name>]`
+ * prefix distinguishes these errors from request-side `[header.<Name>]`
+ * and body `[body]` errors when they share an `OpenApiValidationResult`.
+ *
+ * Per OAS 3.0/3.1, a `Content-Type` entry under `responses.<code>.headers`
+ * SHALL be ignored — the response's actual content type is governed by
+ * content negotiation, not arbitrary header definitions. The validator
+ * skips it explicitly so a misplaced spec definition cannot fail tests.
+ *
+ * Header values arriving as `array<string>` (Laravel/Symfony's HeaderBag
+ * models repeated occurrences this way) are unwrapped to a single value
+ * when the array holds exactly one element. Multi-value arrays against
+ * scalar schemas produce a hard error — frameworks disagree on which of
+ * the repeated values "wins" (Laravel: first, Symfony: last), so silently
+ * picking one would mask a drift the contract test exists to expose.
+ * Empty arrays are treated as missing.
+ */
+final class ResponseHeaderValidator
+{
+    /**
+     * Per OAS 3.0/3.1: response headers map "Content-Type" SHALL be ignored.
+     * Lower-cased so the lookup is case-insensitive.
+     */
+    private const IGNORED_HEADER_NAMES = ['content-type'];
+
+    public function __construct(
+        private readonly SchemaValidatorRunner $runner,
+    ) {}
+
+    /**
+     * @param array<string, mixed> $headersSpec the `responses.<code>.headers` map
+     * @param array<array-key, mixed> $actualHeaders the response's actual headers, as returned by HeaderBag::all()
+     *
+     * @return string[]
+     */
+    public function validate(array $headersSpec, array $actualHeaders, OpenApiVersion $version): array
+    {
+        if ($headersSpec === []) {
+            return [];
+        }
+
+        $errors = [];
+        $normalizedHeaders = HeaderNormalizer::normalize($actualHeaders);
+
+        foreach ($headersSpec as $name => $headerObject) {
+            // Spec keys are always strings per OAS, but the parameter type
+            // is array<string, mixed> so the static analyser sees them as
+            // already-typed strings; skip non-arrays only.
+            if (!is_array($headerObject)) {
+                continue;
+            }
+
+            $lowerName = strtolower($name);
+
+            if (in_array($lowerName, self::IGNORED_HEADER_NAMES, true)) {
+                continue;
+            }
+
+            $required = ($headerObject['required'] ?? false) === true;
+
+            // Required headers without a schema would silently pass every
+            // response, so surface as a hard spec error. Optional entries
+            // without a schema have nothing to validate — let them through.
+            if (!isset($headerObject['schema']) || !is_array($headerObject['schema'])) {
+                if ($required) {
+                    $errors[] = sprintf(
+                        '[response-header.%s] required header has no schema — cannot validate.',
+                        $name,
+                    );
+                }
+
+                continue;
+            }
+
+            /** @var array<string, mixed> $schema */
+            $schema = $headerObject['schema'];
+
+            $rawValue = $normalizedHeaders[$lowerName] ?? null;
+
+            // `null` and `[]` (empty repeated-header array) both collapse to
+            // "missing". A repeated header that arrived zero times is
+            // semantically absent.
+            if ($rawValue === null || $rawValue === []) {
+                if ($required) {
+                    $errors[] = sprintf('[response-header.%s] required header is missing.', $name);
+                }
+
+                continue;
+            }
+
+            if (is_array($rawValue)) {
+                if (count($rawValue) > 1) {
+                    $errors[] = sprintf(
+                        '[response-header.%s] multiple values received (count=%d) but schema expects a single value; refusing to pick one silently.',
+                        $name,
+                        count($rawValue),
+                    );
+
+                    continue;
+                }
+
+                $rawValue = $rawValue[array_key_first($rawValue)];
+            }
+
+            // Same post-unwrap missing guard as the pre-unwrap branch:
+            // `['X-Foo' => [null]]` is shaped identically to an absent
+            // header. Letting it through would either silently pass against
+            // a `nullable` schema or surface as a `/` type mismatch from opis.
+            if ($rawValue === null) {
+                if ($required) {
+                    $errors[] = sprintf('[response-header.%s] required header is missing.', $name);
+                }
+
+                continue;
+            }
+
+            if (!is_scalar($rawValue)) {
+                $errors[] = sprintf(
+                    '[response-header.%s] value must be a scalar (string|int|bool|float); got %s.',
+                    $name,
+                    get_debug_type($rawValue),
+                );
+
+                continue;
+            }
+
+            $coerced = TypeCoercer::coercePrimitive($rawValue, $schema);
+            $jsonSchema = OpenApiSchemaConverter::convert($schema, $version, SchemaContext::Response);
+
+            $schemaObject = ObjectConverter::convert($jsonSchema);
+            $dataObject = ObjectConverter::convert($coerced);
+
+            $formatted = $this->runner->validate($schemaObject, $dataObject);
+            foreach ($formatted as $path => $messages) {
+                $suffix = $path === '/' ? '' : $path;
+                foreach ($messages as $message) {
+                    $errors[] = sprintf('[response-header.%s%s] %s', $name, $suffix, $message);
+                }
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/src/Validation/Response/ResponseHeaderValidator.php
+++ b/src/Validation/Response/ResponseHeaderValidator.php
@@ -20,6 +20,7 @@ use function is_array;
 use function is_scalar;
 use function sprintf;
 use function strtolower;
+use function trim;
 
 /**
  * Validate the response-side `headers` block against the OpenAPI spec.
@@ -29,7 +30,8 @@ use function strtolower;
  * Error messages preserve the spec's original casing so authors can
  * grep their OpenAPI document directly. The `[response-header.<Name>]`
  * prefix distinguishes these errors from request-side `[header.<Name>]`
- * and body `[body]` errors when they share an `OpenApiValidationResult`.
+ * and body `[/<json-pointer>]` errors when they share an
+ * `OpenApiValidationResult`.
  *
  * Per OAS 3.0/3.1, a `Content-Type` entry under `responses.<code>.headers`
  * SHALL be ignored — the response's actual content type is governed by
@@ -42,7 +44,12 @@ use function strtolower;
  * scalar schemas produce a hard error — frameworks disagree on which of
  * the repeated values "wins" (Laravel: first, Symfony: last), so silently
  * picking one would mask a drift the contract test exists to expose.
- * Empty arrays are treated as missing.
+ * Empty arrays are treated as missing. `style: simple` with
+ * `type: array | object` is out of scope; such schemas will fail with a
+ * type mismatch because header values are coerced as scalars.
+ *
+ * @phpstan-type HeaderObject array{required?: bool, schema?: array<string, mixed>}
+ * @phpstan-type HeadersSpec array<string, HeaderObject|mixed>
  */
 final class ResponseHeaderValidator
 {
@@ -57,7 +64,7 @@ final class ResponseHeaderValidator
     ) {}
 
     /**
-     * @param array<string, mixed> $headersSpec the `responses.<code>.headers` map
+     * @param HeadersSpec $headersSpec the `responses.<code>.headers` map
      * @param array<array-key, mixed> $actualHeaders the response's actual headers, as returned by HeaderBag::all()
      *
      * @return string[]
@@ -72,14 +79,24 @@ final class ResponseHeaderValidator
         $normalizedHeaders = HeaderNormalizer::normalize($actualHeaders);
 
         foreach ($headersSpec as $name => $headerObject) {
-            // Spec keys are always strings per OAS, but the parameter type
-            // is array<string, mixed> so the static analyser sees them as
-            // already-typed strings; skip non-arrays only.
+            // Malformed entry (e.g. `Location: "string"` from a YAML
+            // authoring slip) must surface — silent skip would hide
+            // every header from validation.
             if (!is_array($headerObject)) {
+                $errors[] = sprintf(
+                    '[response-header.%s] header definition must be an object; got %s.',
+                    $name,
+                    get_debug_type($headerObject),
+                );
+
                 continue;
             }
 
-            $lowerName = strtolower($name);
+            // Trim defensively before matching the IGNORED list so a spec
+            // key like `"Content-Type "` (trailing whitespace from a
+            // YAML/JSON authoring slip) still gets the OAS-mandated skip
+            // instead of unexpectedly running schema validation.
+            $lowerName = strtolower(trim($name));
 
             if (in_array($lowerName, self::IGNORED_HEADER_NAMES, true)) {
                 continue;
@@ -89,7 +106,9 @@ final class ResponseHeaderValidator
 
             // Required headers without a schema would silently pass every
             // response, so surface as a hard spec error. Optional entries
-            // without a schema have nothing to validate — let them through.
+            // without a schema have nothing to validate against — there is
+            // no contract to check, so the header is effectively
+            // unconstrained even if a value is present.
             if (!isset($headerObject['schema']) || !is_array($headerObject['schema'])) {
                 if ($required) {
                     $errors[] = sprintf(

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -1128,4 +1128,112 @@ class OpenApiResponseValidatorTest extends TestCase
         $this->assertStringContainsString('[response-body]', $joined);
         $this->assertStringContainsString('InvalidKeywordException', $joined);
     }
+
+    // ========================================
+    // Response header validation
+    // ========================================
+
+    #[Test]
+    public function null_response_headers_argument_preserves_legacy_body_only_behaviour(): void
+    {
+        // Existing callers that pre-date the headers parameter pass null (or
+        // omit it entirely). The spec defines a required Location header, but
+        // because `null` opts out of header validation, the body-only path
+        // continues to pass.
+        $result = $this->validator->validate(
+            'response-headers',
+            'POST',
+            '/pets',
+            201,
+            ['id' => 1],
+            'application/json',
+        );
+
+        $this->assertTrue($result->isValid());
+    }
+
+    #[Test]
+    public function detects_missing_required_response_header(): void
+    {
+        $result = $this->validator->validate(
+            'response-headers',
+            'POST',
+            '/pets',
+            201,
+            ['id' => 1],
+            'application/json',
+            [],
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertContains(
+            '[response-header.Location] required header is missing.',
+            $result->errors(),
+        );
+    }
+
+    #[Test]
+    public function passes_when_required_header_is_present_and_optional_is_valid(): void
+    {
+        $result = $this->validator->validate(
+            'response-headers',
+            'POST',
+            '/pets',
+            201,
+            ['id' => 1],
+            'application/json',
+            [
+                'Location' => 'https://example.com/pets/1',
+                'X-RateLimit-Remaining' => '42',
+            ],
+        );
+
+        $this->assertTrue($result->isValid());
+    }
+
+    #[Test]
+    public function detects_optional_header_schema_violation(): void
+    {
+        $result = $this->validator->validate(
+            'response-headers',
+            'POST',
+            '/pets',
+            201,
+            ['id' => 1],
+            'application/json',
+            [
+                'Location' => 'https://example.com/pets/1',
+                'X-RateLimit-Remaining' => '-5',
+            ],
+        );
+
+        $this->assertFalse($result->isValid());
+        $joined = implode(' | ', $result->errors());
+        $this->assertStringContainsString('[response-header.X-RateLimit-Remaining]', $joined);
+    }
+
+    #[Test]
+    public function combines_body_and_header_errors_in_single_result(): void
+    {
+        // Body fails (missing required `id`) AND headers fail (missing Location).
+        // Both error sets must surface so the developer sees the full picture
+        // in one assertion failure rather than chasing them sequentially.
+        $result = $this->validator->validate(
+            'response-headers',
+            'POST',
+            '/pets',
+            201,
+            ['name' => 'fido'],
+            'application/json',
+            [],
+        );
+
+        $this->assertFalse($result->isValid());
+        $joined = implode(' | ', $result->errors());
+        // Body errors use the opis JSON-Pointer prefix (`[/]`); header errors
+        // use the `[response-header.<Name>]` prefix. Both categories must
+        // appear so the developer sees the full picture in one assertion.
+        $this->assertStringContainsString('id', $joined);
+        $this->assertStringContainsString('[response-header.Location]', $joined);
+    }
 }

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -1136,10 +1136,8 @@ class OpenApiResponseValidatorTest extends TestCase
     #[Test]
     public function null_response_headers_argument_preserves_legacy_body_only_behaviour(): void
     {
-        // Existing callers that pre-date the headers parameter pass null (or
-        // omit it entirely). The spec defines a required Location header, but
-        // because `null` opts out of header validation, the body-only path
-        // continues to pass.
+        // The spec defines a required Location header, but `null` opts
+        // out of header validation entirely so the body-only path passes.
         $result = $this->validator->validate(
             'response-headers',
             'POST',
@@ -1235,5 +1233,194 @@ class OpenApiResponseValidatorTest extends TestCase
         // appear so the developer sees the full picture in one assertion.
         $this->assertStringContainsString('id', $joined);
         $this->assertStringContainsString('[response-header.Location]', $joined);
+    }
+
+    #[Test]
+    public function no_content_response_with_required_header_runs_header_validation(): void
+    {
+        // The body validator returns no errors for the empty `content`
+        // block; this pins that the orchestrator nevertheless runs header
+        // validation so 204 + required `Location` (a real-world POST/DELETE
+        // pattern) doesn't silently bypass the contract.
+        $result = $this->validator->validate(
+            'response-headers-edge',
+            'DELETE',
+            '/items',
+            204,
+            null,
+            null,
+            [],
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertContains(
+            '[response-header.X-Audit-Id] required header is missing.',
+            $result->errors(),
+        );
+    }
+
+    #[Test]
+    public function skip_by_status_code_short_circuits_header_validation(): void
+    {
+        // The default 5xx skip suppresses both body and header checks —
+        // covered endpoints that only ever return 5xx in tests should
+        // not accumulate `[response-header]` errors against required-header
+        // declarations.
+        $result = $this->validator->validate(
+            'response-headers-edge',
+            'GET',
+            '/items/never-thrown',
+            500,
+            null,
+            null,
+            [],
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertTrue($result->isSkipped());
+    }
+
+    #[Test]
+    public function header_validator_exception_is_caught_by_error_boundary(): void
+    {
+        // A spec with an unterminated regex pattern in a header schema
+        // makes opis throw a SchemaException at validation time. The
+        // ValidatorErrorBoundary wrap converts it to a `[response-header]`
+        // error string instead of letting the exception abort the test.
+        $result = $this->validator->validate(
+            'response-headers-edge',
+            'GET',
+            '/items/throws',
+            200,
+            (object) [],
+            'application/json',
+            ['X-Bad-Pattern' => 'value'],
+        );
+
+        $this->assertFalse($result->isValid());
+        $joined = implode(' | ', $result->errors());
+        $this->assertStringContainsString('[response-header]', $joined);
+    }
+
+    #[Test]
+    public function ref_resolved_header_definition_is_validated_against_inlined_schema(): void
+    {
+        // `$ref` headers are inlined by OpenApiRefResolver before validation.
+        // Pin that the inlined schema (here, `format: uuid`) actually flows
+        // through and fails on a non-UUID value.
+        $result = $this->validator->validate(
+            'response-headers-edge',
+            'GET',
+            '/items/ref-headers',
+            200,
+            (object) [],
+            'application/json',
+            ['X-Trace-Id' => 'not-a-uuid'],
+        );
+
+        $this->assertFalse($result->isValid());
+        $joined = implode(' | ', $result->errors());
+        $this->assertStringContainsString('[response-header.X-Trace-Id', $joined);
+    }
+
+    #[Test]
+    public function v31_nullable_integer_header_accepts_clean_value(): void
+    {
+        // Pin the OAS 3.1 `type: ["integer", "null"]` path. The 3.0 fixture
+        // suite doesn't exercise multi-type declarations, so without this
+        // a regression in the version arg's flow-through would go silent.
+        $result = $this->validator->validate(
+            'response-headers-edge',
+            'GET',
+            '/items/v31',
+            200,
+            (object) [],
+            'application/json',
+            ['X-Tags-Count' => '5'],
+        );
+
+        $this->assertTrue($result->isValid());
+    }
+
+    #[Test]
+    public function malformed_headers_block_surfaces_as_spec_error(): void
+    {
+        // `headers: "string"` (a YAML/JSON authoring slip) used to
+        // silently disable validation for the entire response. Now it
+        // produces a `[response-header]` spec error so the spec author
+        // notices.
+        $result = $this->validator->validate(
+            'response-headers-malformed',
+            'GET',
+            '/items/non-object',
+            200,
+            (object) [],
+            'application/json',
+            [],
+        );
+
+        $this->assertFalse($result->isValid());
+        $joined = implode(' | ', $result->errors());
+        $this->assertStringContainsString('[response-header]', $joined);
+        $this->assertStringContainsString('must be an object', $joined);
+    }
+
+    #[Test]
+    public function empty_headers_block_passes_validation(): void
+    {
+        // `headers: {}` is a legitimate "this response has no documented
+        // headers" declaration. No errors should surface.
+        $result = $this->validator->validate(
+            'response-headers-malformed',
+            'GET',
+            '/items/empty',
+            200,
+            (object) [],
+            'application/json',
+            [],
+        );
+
+        $this->assertTrue($result->isValid());
+    }
+
+    #[Test]
+    public function scalar_header_entry_is_reported_per_header(): void
+    {
+        // A non-array header object inside an otherwise-valid headers map
+        // surfaces a per-name error so the spec author can pinpoint which
+        // entry needs fixing.
+        $result = $this->validator->validate(
+            'response-headers-malformed',
+            'GET',
+            '/items/scalar-entry',
+            200,
+            (object) [],
+            'application/json',
+            ['X-Misdefined' => 'whatever'],
+        );
+
+        $this->assertFalse($result->isValid());
+        $joined = implode(' | ', $result->errors());
+        $this->assertStringContainsString('[response-header.X-Misdefined]', $joined);
+        $this->assertStringContainsString('must be an object', $joined);
+    }
+
+    #[Test]
+    public function optional_header_with_no_schema_passes_silently_when_value_present(): void
+    {
+        // Documented behaviour: optional headers with no schema have
+        // nothing to validate against. A garbage value flows through
+        // without error because there is no contract to violate.
+        $result = $this->validator->validate(
+            'response-headers-edge',
+            'GET',
+            '/items/optional-no-schema',
+            200,
+            (object) [],
+            'application/json',
+            ['X-Loose' => 'literally-anything'],
+        );
+
+        $this->assertTrue($result->isValid());
     }
 }

--- a/tests/Unit/ValidatesOpenApiSchemaResponseHeaderTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaResponseHeaderTest.php
@@ -87,4 +87,29 @@ class ValidatesOpenApiSchemaResponseHeaderTest extends TestCase
             $this->assertStringContainsString('[response-header.X-RateLimit-Remaining]', $e->getMessage());
         }
     }
+
+    #[Test]
+    public function fails_with_only_header_errors_when_body_is_valid(): void
+    {
+        // Pin that header validation runs INDEPENDENTLY of body validation.
+        // Without this guarantee a regression that only triggers headers
+        // when body fails would slip through — both prior tests have body
+        // and header errors covarying.
+        $body = (string) json_encode(['id' => 1], JSON_THROW_ON_ERROR);
+        $response = $this->makeTestResponse($body, 201, [
+            'Content-Type' => 'application/json',
+            // Location intentionally omitted; body is otherwise valid.
+        ]);
+
+        try {
+            $this->assertResponseMatchesOpenApiSchema($response, HttpMethod::POST, '/pets');
+            $this->fail('expected AssertionFailedError');
+        } catch (AssertionFailedError $e) {
+            $message = $e->getMessage();
+            $this->assertStringContainsString('[response-header.Location]', $message);
+            // No body-shaped errors should appear in the same failure.
+            $this->assertStringNotContainsString('[/]', $message);
+            $this->assertStringNotContainsString('[response-body]', $message);
+        }
+    }
 }

--- a/tests/Unit/ValidatesOpenApiSchemaResponseHeaderTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaResponseHeaderTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use const JSON_THROW_ON_ERROR;
+
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\HttpMethod;
+use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
+use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\OpenApiSpec;
+use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\Tests\Helpers\CreatesTestResponse;
+
+use function json_encode;
+
+#[OpenApiSpec('response-headers')]
+class ValidatesOpenApiSchemaResponseHeaderTest extends TestCase
+{
+    use CreatesTestResponse;
+    use ValidatesOpenApiSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs');
+        OpenApiCoverageTracker::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        self::resetValidatorCache();
+        OpenApiSpecLoader::reset();
+        OpenApiCoverageTracker::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function passes_when_response_has_required_header(): void
+    {
+        $body = (string) json_encode(['id' => 1], JSON_THROW_ON_ERROR);
+        $response = $this->makeTestResponse($body, 201, [
+            'Content-Type' => 'application/json',
+            'Location' => 'https://example.com/pets/1',
+            'X-RateLimit-Remaining' => '42',
+        ]);
+
+        $this->assertResponseMatchesOpenApiSchema($response, HttpMethod::POST, '/pets');
+    }
+
+    #[Test]
+    public function fails_when_required_response_header_is_missing(): void
+    {
+        $body = (string) json_encode(['id' => 1], JSON_THROW_ON_ERROR);
+        $response = $this->makeTestResponse($body, 201, [
+            'Content-Type' => 'application/json',
+        ]);
+
+        try {
+            $this->assertResponseMatchesOpenApiSchema($response, HttpMethod::POST, '/pets');
+            $this->fail('expected AssertionFailedError');
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString('[response-header.Location]', $e->getMessage());
+            $this->assertStringContainsString('required header is missing', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function fails_when_response_header_violates_schema(): void
+    {
+        $body = (string) json_encode(['id' => 1], JSON_THROW_ON_ERROR);
+        $response = $this->makeTestResponse($body, 201, [
+            'Content-Type' => 'application/json',
+            'Location' => 'https://example.com/pets/1',
+            'X-RateLimit-Remaining' => '-5',
+        ]);
+
+        try {
+            $this->assertResponseMatchesOpenApiSchema($response, HttpMethod::POST, '/pets');
+            $this->fail('expected AssertionFailedError');
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString('[response-header.X-RateLimit-Remaining]', $e->getMessage());
+        }
+    }
+}

--- a/tests/Unit/Validation/Response/ResponseHeaderValidatorTest.php
+++ b/tests/Unit/Validation/Response/ResponseHeaderValidatorTest.php
@@ -1,0 +1,291 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Validation\Response;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\OpenApiVersion;
+use Studio\OpenApiContractTesting\Validation\Response\ResponseHeaderValidator;
+use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
+
+class ResponseHeaderValidatorTest extends TestCase
+{
+    #[Test]
+    public function returns_no_errors_when_spec_defines_no_headers(): void
+    {
+        $errors = $this->validator()->validate([], ['Location' => 'https://example.com/pets/1'], OpenApiVersion::V3_0);
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function passes_when_required_header_is_present(): void
+    {
+        $headersSpec = [
+            'Location' => [
+                'required' => true,
+                'schema' => ['type' => 'string'],
+            ],
+        ];
+
+        $errors = $this->validator()->validate(
+            $headersSpec,
+            ['Location' => 'https://example.com/pets/1'],
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function reports_missing_required_header(): void
+    {
+        $headersSpec = [
+            'Location' => [
+                'required' => true,
+                'schema' => ['type' => 'string'],
+            ],
+        ];
+
+        $errors = $this->validator()->validate($headersSpec, [], OpenApiVersion::V3_0);
+
+        $this->assertSame(['[response-header.Location] required header is missing.'], $errors);
+    }
+
+    #[Test]
+    public function passes_when_optional_header_is_absent(): void
+    {
+        $headersSpec = [
+            'X-RateLimit-Remaining' => [
+                'schema' => ['type' => 'integer'],
+            ],
+        ];
+
+        $errors = $this->validator()->validate($headersSpec, [], OpenApiVersion::V3_0);
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function matches_header_names_case_insensitively(): void
+    {
+        // Spec uses canonical casing; actual response uses lower-case (Symfony's HeaderBag does this).
+        $headersSpec = [
+            'Location' => [
+                'required' => true,
+                'schema' => ['type' => 'string'],
+            ],
+        ];
+
+        $errors = $this->validator()->validate(
+            $headersSpec,
+            ['location' => 'https://example.com/pets/1'],
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function reports_schema_mismatch_with_response_header_prefix(): void
+    {
+        $headersSpec = [
+            'X-RateLimit-Remaining' => [
+                'schema' => ['type' => 'integer', 'minimum' => 0],
+            ],
+        ];
+
+        $errors = $this->validator()->validate(
+            $headersSpec,
+            ['X-RateLimit-Remaining' => '-5'],
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertNotSame([], $errors);
+        $this->assertStringStartsWith('[response-header.X-RateLimit-Remaining]', $errors[0]);
+    }
+
+    #[Test]
+    public function coerces_string_value_to_integer_for_schema_check(): void
+    {
+        // HTTP header values are always strings; the validator must coerce
+        // a clean integer-shaped string before checking against type: integer.
+        $headersSpec = [
+            'X-Count' => [
+                'schema' => ['type' => 'integer'],
+            ],
+        ];
+
+        $errors = $this->validator()->validate(
+            $headersSpec,
+            ['X-Count' => '42'],
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function reports_format_violation(): void
+    {
+        $headersSpec = [
+            'X-Issued-At' => [
+                'schema' => ['type' => 'string', 'format' => 'date-time'],
+            ],
+        ];
+
+        $errors = $this->validator()->validate(
+            $headersSpec,
+            ['X-Issued-At' => 'not-a-date'],
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertNotSame([], $errors);
+        $this->assertStringStartsWith('[response-header.X-Issued-At]', $errors[0]);
+    }
+
+    #[Test]
+    public function skips_content_type_header_per_oas_spec(): void
+    {
+        // Per OAS 3.0/3.1, "If a response header is defined with the name
+        // 'Content-Type', it SHALL be ignored." Even with an absurd schema
+        // mismatch, no error must surface.
+        $headersSpec = [
+            'Content-Type' => [
+                'required' => true,
+                'schema' => ['type' => 'integer'],
+            ],
+        ];
+
+        $errors = $this->validator()->validate(
+            $headersSpec,
+            ['Content-Type' => 'application/json'],
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function skips_content_type_case_insensitively(): void
+    {
+        $headersSpec = [
+            'content-type' => [
+                'required' => true,
+                'schema' => ['type' => 'integer'],
+            ],
+        ];
+
+        $errors = $this->validator()->validate($headersSpec, [], OpenApiVersion::V3_0);
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function unwraps_single_element_array_value_from_header_bag(): void
+    {
+        // Symfony HeaderBag::all() returns array<string, list<string>>.
+        $headersSpec = [
+            'X-Count' => [
+                'schema' => ['type' => 'integer'],
+            ],
+        ];
+
+        $errors = $this->validator()->validate(
+            $headersSpec,
+            ['X-Count' => ['42']],
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function reports_multi_value_header_against_scalar_schema(): void
+    {
+        // Sending the same header more than once with a scalar schema is
+        // ambiguous (Laravel picks first, Symfony picks last). Refusing
+        // to silently choose mirrors the request-side behaviour.
+        $headersSpec = [
+            'X-Foo' => [
+                'schema' => ['type' => 'string'],
+            ],
+        ];
+
+        $errors = $this->validator()->validate(
+            $headersSpec,
+            ['X-Foo' => ['a', 'b']],
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertNotSame([], $errors);
+        $this->assertStringContainsString('multiple values', $errors[0]);
+        $this->assertStringStartsWith('[response-header.X-Foo]', $errors[0]);
+    }
+
+    #[Test]
+    public function treats_empty_array_value_as_absent_header(): void
+    {
+        $headersSpec = [
+            'X-Optional' => [
+                'schema' => ['type' => 'string'],
+            ],
+        ];
+
+        $errors = $this->validator()->validate(
+            $headersSpec,
+            ['X-Optional' => []],
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function reports_required_with_no_schema_as_spec_error(): void
+    {
+        // Required headers with no schema would silently pass every response,
+        // mirroring the request-side guard rail.
+        $headersSpec = [
+            'X-Token' => ['required' => true],
+        ];
+
+        $errors = $this->validator()->validate(
+            $headersSpec,
+            ['X-Token' => 'abc'],
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertNotSame([], $errors);
+        $this->assertStringContainsString('no schema', $errors[0]);
+        $this->assertStringStartsWith('[response-header.X-Token]', $errors[0]);
+    }
+
+    #[Test]
+    public function preserves_original_spec_casing_in_error_messages(): void
+    {
+        // Even when the actual header arrives lower-cased, the error
+        // message must echo the spec's casing so authors can grep their
+        // OpenAPI document directly.
+        $headersSpec = [
+            'X-RateLimit-Remaining' => [
+                'required' => true,
+                'schema' => ['type' => 'integer'],
+            ],
+        ];
+
+        $errors = $this->validator()->validate($headersSpec, [], OpenApiVersion::V3_0);
+
+        $this->assertSame(
+            ['[response-header.X-RateLimit-Remaining] required header is missing.'],
+            $errors,
+        );
+    }
+
+    private function validator(): ResponseHeaderValidator
+    {
+        return new ResponseHeaderValidator(new SchemaValidatorRunner(20));
+    }
+}

--- a/tests/Unit/Validation/Response/ResponseHeaderValidatorTest.php
+++ b/tests/Unit/Validation/Response/ResponseHeaderValidatorTest.php
@@ -71,7 +71,6 @@ class ResponseHeaderValidatorTest extends TestCase
     #[Test]
     public function matches_header_names_case_insensitively(): void
     {
-        // Spec uses canonical casing; actual response uses lower-case (Symfony's HeaderBag does this).
         $headersSpec = [
             'Location' => [
                 'required' => true,
@@ -186,7 +185,6 @@ class ResponseHeaderValidatorTest extends TestCase
     #[Test]
     public function unwraps_single_element_array_value_from_header_bag(): void
     {
-        // Symfony HeaderBag::all() returns array<string, list<string>>.
         $headersSpec = [
             'X-Count' => [
                 'schema' => ['type' => 'integer'],
@@ -264,11 +262,137 @@ class ResponseHeaderValidatorTest extends TestCase
     }
 
     #[Test]
+    public function reports_non_array_header_definition_as_spec_error(): void
+    {
+        // YAML/JSON authoring slips that produce e.g. `Location: "string"`
+        // would silently disable validation otherwise. Surfacing it ensures
+        // the spec author notices.
+        $headersSpec = ['X-Misdefined' => 'string'];
+
+        $errors = $this->validator()->validate(
+            $headersSpec,
+            ['X-Misdefined' => 'whatever'],
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertNotSame([], $errors);
+        $this->assertStringStartsWith('[response-header.X-Misdefined]', $errors[0]);
+        $this->assertStringContainsString('must be an object', $errors[0]);
+    }
+
+    #[Test]
+    public function skips_content_type_with_trailing_whitespace_in_spec_key(): void
+    {
+        // Defensive: a YAML/JSON authoring slip that produces a trailing
+        // space on the Content-Type key must still trigger the OAS-mandated
+        // skip rather than running schema validation.
+        $headersSpec = [
+            'Content-Type ' => [
+                'required' => true,
+                'schema' => ['type' => 'integer'],
+            ],
+        ];
+
+        $errors = $this->validator()->validate($headersSpec, [], OpenApiVersion::V3_0);
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function passes_when_zero_string_satisfies_minimum_zero_integer_schema(): void
+    {
+        // The missing-check is `=== null || === []`, not `empty()`. Pin
+        // that a literal '0' does NOT collapse to "missing" so a future
+        // refactor can't silently turn `X-RateLimit-Remaining: 0` into
+        // a "header is missing" error.
+        $headersSpec = [
+            'X-Count' => [
+                'required' => true,
+                'schema' => ['type' => 'integer', 'minimum' => 0],
+            ],
+        ];
+
+        $errors = $this->validator()->validate(
+            $headersSpec,
+            ['X-Count' => '0'],
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function passes_when_empty_string_value_is_present_for_string_schema(): void
+    {
+        // An empty string is a real (though unusual) header value. It must
+        // not collapse to "missing" — the schema decides whether empty
+        // strings are valid via `minLength`.
+        $headersSpec = [
+            'X-Comment' => [
+                'schema' => ['type' => 'string'],
+            ],
+        ];
+
+        $errors = $this->validator()->validate(
+            $headersSpec,
+            ['X-Comment' => ''],
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function v31_type_array_with_null_validates_against_nullable_integer(): void
+    {
+        // Pin that the OpenApiVersion argument actually flows through and
+        // a 3.1 multi-type declaration `["integer", "null"]` correctly
+        // accepts a clean integer-shaped string. This branch is invisible
+        // to V3_0-only tests because the schema converter handles 3.0's
+        // `nullable: true` differently.
+        $headersSpec = [
+            'X-Tags-Count' => [
+                'schema' => ['type' => ['integer', 'null']],
+            ],
+        ];
+
+        $errors = $this->validator()->validate(
+            $headersSpec,
+            ['X-Tags-Count' => '7'],
+            OpenApiVersion::V3_1,
+        );
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function array_typed_header_schema_documents_known_limitation(): void
+    {
+        // The validator coerces header values as scalars (matching the
+        // request-side `style: simple` policy), so a `type: array` header
+        // schema cannot succeed: a single-element value gets unwrapped
+        // and fed to opis as a string, which fails the array type check.
+        // This pin documents the known limitation; if array support is
+        // ever added the test will start failing and force a review.
+        $headersSpec = [
+            'X-Tags' => [
+                'schema' => ['type' => 'array', 'items' => ['type' => 'string']],
+            ],
+        ];
+
+        $errors = $this->validator()->validate(
+            $headersSpec,
+            ['X-Tags' => ['a']],
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertNotSame([], $errors);
+        $this->assertStringStartsWith('[response-header.X-Tags', $errors[0]);
+    }
+
+    #[Test]
     public function preserves_original_spec_casing_in_error_messages(): void
     {
-        // Even when the actual header arrives lower-cased, the error
-        // message must echo the spec's casing so authors can grep their
-        // OpenAPI document directly.
         $headersSpec = [
             'X-RateLimit-Remaining' => [
                 'required' => true,

--- a/tests/fixtures/specs/response-headers-edge.json
+++ b/tests/fixtures/specs/response-headers-edge.json
@@ -1,0 +1,128 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "Response headers edge cases (3.1)",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/items": {
+            "delete": {
+                "operationId": "deleteItem",
+                "responses": {
+                    "204": {
+                        "description": "Deleted",
+                        "headers": {
+                            "X-Audit-Id": {
+                                "required": true,
+                                "schema": { "type": "string" }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/items/ref-headers": {
+            "get": {
+                "operationId": "getItemViaRef",
+                "responses": {
+                    "200": {
+                        "description": "Item",
+                        "headers": {
+                            "X-Trace-Id": { "$ref": "#/components/headers/TraceId" }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": { "type": "object" }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/items/never-thrown": {
+            "get": {
+                "operationId": "getItemServerError",
+                "responses": {
+                    "500": {
+                        "description": "Server error",
+                        "headers": {
+                            "X-Error-Id": {
+                                "required": true,
+                                "schema": { "type": "string" }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/items/v31": {
+            "get": {
+                "operationId": "getItemV31",
+                "responses": {
+                    "200": {
+                        "description": "Item",
+                        "headers": {
+                            "X-Tags-Count": {
+                                "schema": { "type": ["integer", "null"] }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": { "type": "object" }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/items/throws": {
+            "get": {
+                "operationId": "getItemHeaderThrows",
+                "responses": {
+                    "200": {
+                        "description": "ok",
+                        "headers": {
+                            "X-Bad-Pattern": {
+                                "schema": {
+                                    "type": "string",
+                                    "pattern": "[unterminated"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": { "type": "object" }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/items/optional-no-schema": {
+            "get": {
+                "operationId": "getItemOptionalNoSchema",
+                "responses": {
+                    "200": {
+                        "description": "ok",
+                        "headers": {
+                            "X-Loose": {}
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": { "type": "object" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "headers": {
+            "TraceId": {
+                "required": true,
+                "schema": { "type": "string", "format": "uuid" }
+            }
+        }
+    }
+}

--- a/tests/fixtures/specs/response-headers-malformed.json
+++ b/tests/fixtures/specs/response-headers-malformed.json
@@ -1,0 +1,59 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Response headers malformed",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/items/non-object": {
+            "get": {
+                "operationId": "getItemNonObjectHeaders",
+                "responses": {
+                    "200": {
+                        "description": "ok",
+                        "headers": "this should be an object",
+                        "content": {
+                            "application/json": {
+                                "schema": { "type": "object" }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/items/empty": {
+            "get": {
+                "operationId": "getItemEmptyHeaders",
+                "responses": {
+                    "200": {
+                        "description": "ok",
+                        "headers": {},
+                        "content": {
+                            "application/json": {
+                                "schema": { "type": "object" }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/items/scalar-entry": {
+            "get": {
+                "operationId": "getItemScalarHeader",
+                "responses": {
+                    "200": {
+                        "description": "ok",
+                        "headers": {
+                            "X-Misdefined": "string"
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": { "type": "object" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/fixtures/specs/response-headers.json
+++ b/tests/fixtures/specs/response-headers.json
@@ -1,0 +1,39 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Response headers fixture",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/pets": {
+            "post": {
+                "operationId": "createPet",
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "headers": {
+                            "Location": {
+                                "required": true,
+                                "schema": { "type": "string" }
+                            },
+                            "X-RateLimit-Remaining": {
+                                "schema": { "type": "integer", "minimum": 0 }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": ["id"],
+                                    "properties": {
+                                        "id": { "type": "integer" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the third leg of contract validation to the response side. The library already enforces status code, content-type, and body schema; this PR adds `responses.<code>.headers.*` enforcement.

```yaml
responses:
  '201':
    headers:
      Location:
        required: true
        schema: { type: string }
      X-RateLimit-Remaining:
        schema: { type: integer, minimum: 0 }
```

If the response is missing `Location`, or `X-RateLimit-Remaining` is `-5`, the test fails with:

```
- [response-header.Location] required header is missing.
- [response-header.X-RateLimit-Remaining{/}] Number must be greater than or equal to 0.
```

## Design decisions (chat-confirmed)

- **Error prefix `[response-header.<Name>]`** — distinguishes from request-side `[header.<Name>]` and body errors at a glance when they share an `OpenApiValidationResult`.
- **`Content-Type` skipped per OAS spec** — "If a response header is defined with the name 'Content-Type', it SHALL be ignored." All other headers are validated when listed.
- **No transport-level header allowlist** — `Content-Length`, `Transfer-Encoding`, etc. are validated if the spec author lists them. Spec compliance over sympathy.

## Implementation

- New **`Validation/Response/ResponseHeaderValidator`** mirrors the request-side `HeaderParameterValidator`. Reuses `HeaderNormalizer`, `TypeCoercer`, `ObjectConverter`, `SchemaValidatorRunner` — no new helpers.
- **`OpenApiResponseValidator::validate()`** gains an optional `?array $responseHeaders = null` parameter. Existing callers that omit it preserve historical body-only behaviour. The orchestrator combines body and header errors into a single `OpenApiValidationResult`.
- The body-validation path is extracted into its own private method for symmetry with the new header path; both go through `ValidatorErrorBoundary::safely()`.
- **Laravel's `ValidatesOpenApiSchema`** now passes `$response->headers->all()` automatically — trait users get header validation with zero test-code changes.
- **HeaderBag multi-value handling** matches the request side: single-element arrays unwrapped, multi-element refused as ambiguous (Laravel picks first / Symfony picks last), empty-array treated as absent.

## Test plan

- [x] **`ResponseHeaderValidator`** — 15 unit tests covering required/optional, schema mismatch, format violation, case-insensitive matching, `Content-Type` skip (uppercase + lowercase variants), multi-value arrays, no-schema spec errors, original-casing preservation in messages
- [x] **`OpenApiResponseValidator`** — 5 integration tests covering the new parameter (null = legacy behaviour, `[]` = triggers required checks, body+header errors combine, schema violation surfaces with the right prefix)
- [x] **`ValidatesOpenApiSchemaResponseHeaderTest`** — 3 Laravel trait integration tests (`assertResponseMatchesOpenApiSchema` flows headers through automatically)
- [x] New fixture `tests/fixtures/specs/response-headers.json` with one required + one optional header
- [x] **PHPUnit:** 701 tests / 1408 assertions pass
- [x] **PHPStan level 6:** 0 errors
- [x] **PHP-CS-Fixer:** 0 violations
- [x] Existing 690+ tests untouched (backward-compat via `?array = null` default)

## Out of scope (next PRs)

- README / `#112` competitor comparison table refresh (`Response header validation: ❌ → ✅`) — bundled with end-of-Sprint A docs update
- `headers[Name].content[<mediaType>].schema` (OAS Header Object only supports `schema` directly — non-issue per spec)
- `Content-Length` / `Transfer-Encoding` hardcode skip (intentionally NOT done; spec compliance wins)

## Closes

Closes #110