### PR TITLE
feat(spec-loader): resolve HTTP(S) external $refs via opt-in PSR-18 client (#108, PR 2/2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,7 +649,13 @@ Example GitHub Actions workflow step to post the report as a PR comment:
 
 Local `$ref` is resolved automatically. HTTP(S) `$ref` is **disabled by default**: a spec containing `$ref: 'https://example.com/pet.yaml'` rejects with `RemoteRefDisallowed` until you opt in. This keeps tests offline-by-default and prevents an attacker-controlled spec from making the test runner reach arbitrary URLs.
 
-To enable HTTP refs, supply a PSR-18 client + PSR-17 request factory and flip `allowRemoteRefs`:
+To enable HTTP refs, install a PSR-18 client + PSR-17 request factory and pass them along with `allowRemoteRefs: true`:
+
+```bash
+# Install your preferred PSR-18 client (Guzzle 7+ shown; Symfony HttpClient + adapter, Buzz,
+# or any other PSR-18 implementation works the same).
+composer require --dev guzzlehttp/guzzle
+```
 
 ```php
 use GuzzleHttp\Client;
@@ -658,24 +664,27 @@ use Studio\OpenApiContractTesting\OpenApiSpecLoader;
 
 OpenApiSpecLoader::configure(
     basePath: 'openapi/',
-    httpClient: new Client(),       // any PSR-18 implementation
-    requestFactory: new HttpFactory(), // any PSR-17 implementation
+    httpClient: new Client(),       // PSR-18 ClientInterface
+    requestFactory: new HttpFactory(), // PSR-17 RequestFactoryInterface
     allowRemoteRefs: true,
 );
 ```
 
-Pick whichever client your project already uses (Guzzle, Symfony HttpClient + adapter, Buzz, …). The library does not bundle one.
+The library does not bundle an HTTP client — pick whichever your project already uses. (Guzzle 7+ implements PSR-18 directly; Guzzle 6 needs an adapter.)
 
 Misconfiguration is caught early:
 
 | Setup | Result |
 | --- | --- |
-| `allowRemoteRefs: true` without `$httpClient` | `InvalidArgumentException` at `configure()` |
-| `$httpClient` set but `allowRemoteRefs: false` | `E_USER_WARNING` at `configure()` (PHPUnit's `failOnWarning` elevates this) |
+| `allowRemoteRefs: true` without `$httpClient` / `$requestFactory` | `InvalidArgumentException` at `configure()` |
+| `$httpClient` set but `allowRemoteRefs: false` | `InvalidArgumentException` at `configure()` (silent misuse impossible) |
 | `allowRemoteRefs: true` + client + ref to URL that 4xx/5xx | `InvalidOpenApiSpecException` with reason `RemoteRefFetchFailed` |
+| `allowRemoteRefs: true` + client + ref to URL that 3xx | `RemoteRefFetchFailed` with redirect target — configure your PSR-18 client to follow redirects, or use the canonical URL |
 | `allowRemoteRefs: true` + client + ref to URL with no detectable format | reason `UnsupportedExtension` (URL extension or `Content-Type` header is required) |
 
-Format detection prefers the URL's filename extension (`.json` / `.yaml` / `.yml`) and falls back to the response's `Content-Type` (`application/json`, `application/*+json`, `application/yaml`, `text/yaml`, etc.). Schema Registry endpoints that expose opaque URLs work out of the box as long as they set the right Content-Type.
+Format detection prefers the URL's filename extension (`.json` / `.yaml` / `.yml`) and falls back to the response's `Content-Type` (`application/json`, `application/*+json`, `application/yaml`, `text/yaml`, etc.). URLs without a recognisable extension still work as long as the server sets a usable `Content-Type`.
+
+Inside an HTTP-loaded document, relative `$refs` resolve against the URL per RFC 3986: a `$ref: './pet.yaml'` inside `https://example.com/openapi.json` fetches `https://example.com/pet.yaml`.
 
 ## OpenAPI 3.0 vs 3.1
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This library fills a gap left by existing PHP OpenAPI testing tools: **endpoint 
 | Pest plugin | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Laravel auto-assert | ✅ | ✅ | ❌ | ❌ | ✅ |
 | Symfony HttpFoundation | ❌ | ❌ | ⚠️ | ✅ | ❌ |
-| External `$ref` auto-resolution | ❌ | ✅ | ✅ | ✅ | ✅ |
+| External `$ref` auto-resolution | ✅ | ✅ | ✅ | ✅ | ✅ |
 | YAML spec loading | ✅ | ⚠️ | ✅ | ✅ | ✅ |
 | **Auto-inject dummy bearer** | ✅ | ❌ | ❌ | ❌ | ❌ |
 | **GitHub Step Summary output** | ✅ | ❌ | ❌ | ❌ | ❌ |
@@ -56,7 +56,7 @@ This library fills a gap left by existing PHP OpenAPI testing tools: **endpoint 
 
 - PHP 8.2+
 - PHPUnit 11, 12, or 13
-- [Redocly CLI](https://redocly.com/docs/cli/) (recommended for `$ref` resolution / bundling)
+- A PSR-18 HTTP client + PSR-17 request factory (e.g. Guzzle, Symfony HttpClient) — only required when resolving HTTP(S) `$ref`s
 
 ## Installation
 
@@ -66,15 +66,19 @@ composer require --dev studio-design/openapi-contract-testing
 
 ## Setup
 
-### 1. Bundle your OpenAPI spec
+### 1. Provide your OpenAPI spec
 
-This package expects a **bundled** (all `$ref`s resolved) JSON spec file. Use [Redocly CLI](https://redocly.com/docs/cli/commands/bundle/) to bundle:
+Internal `$ref` (`#/components/schemas/...`) and local-filesystem `$ref` (`./schemas/pet.yaml`, `../shared/error.json`) are resolved automatically — **no pre-bundling required**. Point the loader at your spec's entry file:
 
-```bash
-npx @redocly/cli bundle openapi/root.yaml --dereferenced -o openapi/bundled/front.json
+```
+openapi/
+├── root.yaml          # paths reference ./schemas/*.yaml
+└── schemas/
+    ├── pet.yaml
+    └── error.json
 ```
 
-> **Important:** The `--dereferenced` flag is required. Without it, `$ref` pointers (e.g., `#/components/schemas/...`) are preserved in the output, causing `UnresolvedReferenceException` at validation time. The underlying JSON Schema validator (`opis/json-schema`) does not resolve OpenAPI `$ref` references.
+HTTP(S) `$ref` (`https://example.com/schemas/pet.yaml`) is **opt-in** for security and CI predictability — see [HTTP `$ref` resolution](#http-ref-resolution) below. If you prefer the legacy bundled-spec workflow, the loader still accepts the output of `npx @redocly/cli bundle --dereferenced` unchanged.
 
 ### 2. Configure PHPUnit extension
 
@@ -639,6 +643,39 @@ Example GitHub Actions workflow step to post the report as a PR comment:
   with:
     path: coverage-report.md
 ```
+
+<a id="http-ref-resolution"></a>
+## HTTP `$ref` resolution (opt-in)
+
+Local `$ref` is resolved automatically. HTTP(S) `$ref` is **disabled by default**: a spec containing `$ref: 'https://example.com/pet.yaml'` rejects with `RemoteRefDisallowed` until you opt in. This keeps tests offline-by-default and prevents an attacker-controlled spec from making the test runner reach arbitrary URLs.
+
+To enable HTTP refs, supply a PSR-18 client + PSR-17 request factory and flip `allowRemoteRefs`:
+
+```php
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\HttpFactory;
+use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+
+OpenApiSpecLoader::configure(
+    basePath: 'openapi/',
+    httpClient: new Client(),       // any PSR-18 implementation
+    requestFactory: new HttpFactory(), // any PSR-17 implementation
+    allowRemoteRefs: true,
+);
+```
+
+Pick whichever client your project already uses (Guzzle, Symfony HttpClient + adapter, Buzz, …). The library does not bundle one.
+
+Misconfiguration is caught early:
+
+| Setup | Result |
+| --- | --- |
+| `allowRemoteRefs: true` without `$httpClient` | `InvalidArgumentException` at `configure()` |
+| `$httpClient` set but `allowRemoteRefs: false` | `E_USER_WARNING` at `configure()` (PHPUnit's `failOnWarning` elevates this) |
+| `allowRemoteRefs: true` + client + ref to URL that 4xx/5xx | `InvalidOpenApiSpecException` with reason `RemoteRefFetchFailed` |
+| `allowRemoteRefs: true` + client + ref to URL with no detectable format | reason `UnsupportedExtension` (URL extension or `Content-Type` header is required) |
+
+Format detection prefers the URL's filename extension (`.json` / `.yaml` / `.yml`) and falls back to the response's `Content-Type` (`application/json`, `application/*+json`, `application/yaml`, `text/yaml`, etc.). Schema Registry endpoints that expose opaque URLs work out of the box as long as they set the right Content-Type.
 
 ## OpenAPI 3.0 vs 3.1
 

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,14 @@
     "require": {
         "php": "^8.2",
         "opis/json-schema": "^2.6",
-        "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0"
+        "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
+        "psr/http-client": "^1.0",
+        "psr/http-factory": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.94",
+        "guzzlehttp/psr7": "^2.0",
         "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
         "phpstan/phpstan": "^2.0",
         "symfony/http-foundation": "^6.4 || ^7.0 || ^8.0",
@@ -18,7 +22,9 @@
     },
     "suggest": {
         "illuminate/testing": "Required for the Laravel adapter (ValidatesOpenApiSchema trait)",
-        "symfony/yaml": "Required to load OpenAPI specs directly from .yaml / .yml files"
+        "symfony/yaml": "Required to load OpenAPI specs directly from .yaml / .yml files",
+        "guzzlehttp/guzzle": "A PSR-18 HTTP client implementation for resolving external HTTP(S) $refs",
+        "symfony/http-client": "A PSR-18 HTTP client implementation for resolving external HTTP(S) $refs"
     },
     "autoload": {
         "psr-4": {

--- a/src/Internal/ExternalRefLoader.php
+++ b/src/Internal/ExternalRefLoader.php
@@ -4,24 +4,17 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Internal;
 
-use const JSON_THROW_ON_ERROR;
 use const PATHINFO_EXTENSION;
 
-use JsonException;
 use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\InvalidOpenApiSpecReason;
-use Symfony\Component\Yaml\Exception\ParseException;
-use Symfony\Component\Yaml\Yaml;
 
 use function dirname;
 use function error_clear_last;
 use function error_get_last;
 use function file_exists;
 use function file_get_contents;
-use function get_debug_type;
-use function is_array;
 use function is_readable;
-use function json_decode;
 use function pathinfo;
 use function realpath;
 use function sprintf;
@@ -117,8 +110,8 @@ final class ExternalRefLoader
         }
 
         $decoded = match ($extension) {
-            'json' => self::decodeJson($absolutePath, $refPath),
-            'yaml', 'yml' => self::decodeYaml($absolutePath, $refPath),
+            'json' => self::readAndDecodeJson($absolutePath, $refPath),
+            'yaml', 'yml' => self::readAndDecodeYaml($absolutePath, $refPath),
             default => throw new InvalidOpenApiSpecException(
                 InvalidOpenApiSpecReason::UnsupportedExtension,
                 sprintf('Unsupported $ref target extension: .%s for %s', $extension, $refPath),
@@ -132,7 +125,7 @@ final class ExternalRefLoader
     }
 
     /** @return array<string, mixed> */
-    private static function decodeJson(string $absolutePath, string $refPath): array
+    private static function readAndDecodeJson(string $absolutePath, string $refPath): array
     {
         // realpath() proved the file exists and is reachable; a read
         // failure here is a runtime I/O issue (permissions revoked
@@ -153,37 +146,16 @@ final class ExternalRefLoader
             );
         }
 
-        try {
-            $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException $e) {
-            throw new InvalidOpenApiSpecException(
-                InvalidOpenApiSpecReason::MalformedJson,
-                sprintf('Failed to parse JSON $ref target %s: %s', $refPath, $e->getMessage()),
-                ref: $refPath,
-                previous: $e,
-            );
-        }
-
-        return self::ensureMappingRoot($decoded, $refPath, $absolutePath);
+        return SpecDocumentDecoder::decodeJson($content, $refPath);
     }
 
     /** @return array<string, mixed> */
-    private static function decodeYaml(string $absolutePath, string $refPath): array
+    private static function readAndDecodeYaml(string $absolutePath, string $refPath): array
     {
-        if (!YamlAvailability::isAvailable()) {
-            throw new InvalidOpenApiSpecException(
-                InvalidOpenApiSpecReason::YamlLibraryMissing,
-                'Loading YAML $ref targets requires symfony/yaml. '
-                . 'Install it via: composer require --dev symfony/yaml',
-                ref: $refPath,
-            );
-        }
-
         // is_readable() catches the most common pre-parse I/O failure
-        // (permissions revoked between realpath() and Yaml::parseFile).
-        // Symfony's Yaml::parseFile rolls every other error class into
-        // ParseException, which makes a real I/O failure indistinguishable
-        // from a syntax error without this guard.
+        // (permissions revoked between realpath() and the actual read).
+        // Symfony's YAML parser would otherwise mask I/O errors as
+        // ParseException, hiding the root cause.
         if (!is_readable($absolutePath)) {
             throw new InvalidOpenApiSpecException(
                 InvalidOpenApiSpecReason::LocalRefUnreadable,
@@ -192,37 +164,8 @@ final class ExternalRefLoader
             );
         }
 
-        try {
-            $decoded = Yaml::parseFile($absolutePath);
-        } catch (ParseException $e) {
-            throw new InvalidOpenApiSpecException(
-                InvalidOpenApiSpecReason::MalformedYaml,
-                sprintf('Failed to parse YAML $ref target %s: %s', $refPath, $e->getMessage()),
-                ref: $refPath,
-                previous: $e,
-            );
-        }
+        $content = (string) file_get_contents($absolutePath);
 
-        return self::ensureMappingRoot($decoded, $refPath, $absolutePath);
-    }
-
-    /** @return array<string, mixed> */
-    private static function ensureMappingRoot(mixed $decoded, string $refPath, string $absolutePath): array
-    {
-        if (!is_array($decoded)) {
-            throw new InvalidOpenApiSpecException(
-                InvalidOpenApiSpecReason::NonMappingRoot,
-                sprintf(
-                    '$ref target must decode to a mapping (got %s): %s (resolved to %s)',
-                    get_debug_type($decoded),
-                    $refPath,
-                    $absolutePath,
-                ),
-                ref: $refPath,
-            );
-        }
-
-        /** @var array<string, mixed> $decoded */
-        return $decoded;
+        return SpecDocumentDecoder::decodeYaml($content, $refPath);
     }
 }

--- a/src/Internal/ExternalRefLoader.php
+++ b/src/Internal/ExternalRefLoader.php
@@ -56,11 +56,9 @@ final class ExternalRefLoader
      *
      * @param array<string, array<string, mixed>> $documentCache by-ref cache keyed by absolute path
      *
-     * @return array{absolutePath: string, decoded: array<string, mixed>}
-     *
      * @throws InvalidOpenApiSpecException when the file cannot be located, decoded, or has an unsupported extension
      */
-    public static function loadDocument(string $refPath, string $sourceFile, array &$documentCache): array
+    public static function loadDocument(string $refPath, string $sourceFile, array &$documentCache): LoadedDocument
     {
         $candidate = str_starts_with($refPath, '/')
             ? $refPath
@@ -97,7 +95,7 @@ final class ExternalRefLoader
         }
 
         if (isset($documentCache[$absolutePath])) {
-            return ['absolutePath' => $absolutePath, 'decoded' => $documentCache[$absolutePath]];
+            return new LoadedDocument($absolutePath, $documentCache[$absolutePath]);
         }
 
         $extension = strtolower((string) pathinfo($absolutePath, PATHINFO_EXTENSION));
@@ -121,7 +119,7 @@ final class ExternalRefLoader
 
         $documentCache[$absolutePath] = $decoded;
 
-        return ['absolutePath' => $absolutePath, 'decoded' => $decoded];
+        return new LoadedDocument($absolutePath, $decoded);
     }
 
     /** @return array<string, mixed> */

--- a/src/Internal/HttpRefLoader.php
+++ b/src/Internal/HttpRefLoader.php
@@ -9,10 +9,12 @@ use const PATHINFO_EXTENSION;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use RuntimeException;
 use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\InvalidOpenApiSpecReason;
 
 use function pathinfo;
+use function preg_replace;
 use function preg_split;
 use function rtrim;
 use function sprintf;
@@ -55,8 +57,6 @@ final class HttpRefLoader
      *
      * @param array<string, array<string, mixed>> $documentCache by-ref cache keyed by canonical URL
      *
-     * @return array{absoluteUri: string, decoded: array<string, mixed>}
-     *
      * @throws InvalidOpenApiSpecException when the URL cannot be fetched, decoded, or has no detectable format
      */
     public static function loadDocument(
@@ -64,13 +64,14 @@ final class HttpRefLoader
         ClientInterface $client,
         RequestFactoryInterface $requestFactory,
         array &$documentCache,
-    ): array {
+    ): LoadedDocument {
         $canonicalUri = self::canonicalizeUri($url);
 
         if (isset($documentCache[$canonicalUri])) {
-            return ['absoluteUri' => $canonicalUri, 'decoded' => $documentCache[$canonicalUri]];
+            return new LoadedDocument($canonicalUri, $documentCache[$canonicalUri]);
         }
 
+        $safeUrl = self::redactUserInfo($url);
         $request = $requestFactory->createRequest('GET', $canonicalUri);
 
         try {
@@ -78,22 +79,61 @@ final class HttpRefLoader
         } catch (ClientExceptionInterface $e) {
             throw new InvalidOpenApiSpecException(
                 InvalidOpenApiSpecReason::RemoteRefFetchFailed,
-                sprintf('HTTP $ref fetch failed: %s (%s)', $url, $e->getMessage()),
-                ref: $url,
+                sprintf('HTTP $ref fetch failed: %s (%s)', $safeUrl, $e->getMessage()),
+                ref: $safeUrl,
                 previous: $e,
             );
         }
 
         $status = $response->getStatusCode();
-        if ($status < 200 || $status >= 300) {
+        if ($status >= 300 && $status < 400) {
+            // Surface the redirect explicitly: PSR-18 clients diverge on
+            // whether they auto-follow (Guzzle defaults to follow, Symfony
+            // to not). A bare 3xx is almost always "user's client has
+            // redirect-following disabled", not a server bug. Including
+            // the Location target makes the next step obvious.
+            $location = $response->getHeaderLine('Location');
+
             throw new InvalidOpenApiSpecException(
                 InvalidOpenApiSpecReason::RemoteRefFetchFailed,
-                sprintf('HTTP $ref fetch returned status %d: %s', $status, $url),
-                ref: $url,
+                sprintf(
+                    'HTTP $ref fetch returned redirect status %d: %s%s. '
+                    . 'Configure your PSR-18 client to follow redirects, '
+                    . 'or pin the spec to the canonical URL.',
+                    $status,
+                    $safeUrl,
+                    $location !== '' ? sprintf(' (Location: %s)', $location) : '',
+                ),
+                ref: $safeUrl,
+            );
+        }
+        if ($status < 200 || $status >= 400) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::RemoteRefFetchFailed,
+                sprintf('HTTP $ref fetch returned status %d: %s', $status, $safeUrl),
+                ref: $safeUrl,
             );
         }
 
-        $body = (string) $response->getBody();
+        // Read via getContents() rather than (string) cast so a stream
+        // I/O failure surfaces as a real exception (PSR-7 permits
+        // __toString() to silently return '' on read errors, which
+        // would then mis-classify as MalformedJson/Yaml).
+        $bodyStream = $response->getBody();
+
+        try {
+            if ($bodyStream->isSeekable()) {
+                $bodyStream->rewind();
+            }
+            $body = $bodyStream->getContents();
+        } catch (RuntimeException $e) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::RemoteRefFetchFailed,
+                sprintf('HTTP $ref response body unreadable: %s (%s)', $safeUrl, $e->getMessage()),
+                ref: $safeUrl,
+                previous: $e,
+            );
+        }
 
         $format = self::detectFormat($canonicalUri, $response->getHeaderLine('Content-Type'));
         if ($format === null) {
@@ -102,30 +142,37 @@ final class HttpRefLoader
                 sprintf(
                     'HTTP $ref %s has no detectable format (no .json/.yaml/.yml extension on the URL '
                     . 'and no recognised Content-Type header).',
-                    $url,
+                    $safeUrl,
                 ),
-                ref: $url,
+                ref: $safeUrl,
             );
         }
 
         $decoded = $format === 'json'
-            ? SpecDocumentDecoder::decodeJson($body, $url)
-            : SpecDocumentDecoder::decodeYaml($body, $url);
+            ? SpecDocumentDecoder::decodeJson($body, $safeUrl)
+            : SpecDocumentDecoder::decodeYaml($body, $safeUrl);
 
         $documentCache[$canonicalUri] = $decoded;
 
-        return ['absoluteUri' => $canonicalUri, 'decoded' => $decoded];
+        return new LoadedDocument($canonicalUri, $decoded);
     }
 
     /**
-     * Light canonicalisation: trim trailing whitespace. Full URI
-     * normalisation (case-folding scheme/host, removing default ports,
-     * resolving `..`) is intentionally out of scope — spec authors are
-     * trusted to write canonical URLs, and over-aggressive normalisation
-     * could merge cache entries for URIs that the server distinguishes.
+     * Strip `user:pass@` from a URL before it lands in error messages or
+     * logs. Spec authors occasionally embed credentials in `$ref` URLs
+     * for testing, and we don't want them leaking into stderr / CI logs.
      */
+    private static function redactUserInfo(string $url): string
+    {
+        $redacted = preg_replace('#(://)[^/@\s]+@#', '$1', $url);
+
+        return $redacted ?? $url;
+    }
+
     private static function canonicalizeUri(string $url): string
     {
+        // Trim only — case-folding scheme/host or removing default ports
+        // could collapse URIs the server treats as distinct.
         return trim($url);
     }
 
@@ -150,8 +197,11 @@ final class HttpRefLoader
             return null;
         }
 
-        // Drop charset / boundary parameters before the equality check.
-        $type = trim((string) (preg_split('/\s*;\s*/', $type)[0] ?? ''));
+        // RFC-violating servers occasionally emit duplicate Content-Type
+        // headers; PSR-7's getHeaderLine() concatenates them with `, `,
+        // and a server may also tack on a charset / boundary with `;`.
+        // Split on either separator so the first usable type wins.
+        $type = trim((string) (preg_split('/\s*[,;]\s*/', $type)[0] ?? ''));
 
         // application/json, application/openapi+json, application/problem+json …
         if ($type === 'application/json' || str_ends_with($type, '+json')) {

--- a/src/Internal/HttpRefLoader.php
+++ b/src/Internal/HttpRefLoader.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Internal;
+
+use const PATHINFO_EXTENSION;
+
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
+use Studio\OpenApiContractTesting\InvalidOpenApiSpecReason;
+
+use function pathinfo;
+use function preg_split;
+use function rtrim;
+use function sprintf;
+use function str_ends_with;
+use function strcspn;
+use function strtolower;
+use function substr;
+use function trim;
+
+/**
+ * Resolves HTTP / HTTPS external `$ref` target documents via a
+ * user-provided PSR-18 ClientInterface + PSR-17 RequestFactoryInterface.
+ *
+ * This is opt-in. The resolver only reaches this loader when the caller
+ * explicitly passed `allowRemoteRefs: true` to
+ * `OpenApiSpecLoader::configure()`. The library does not bundle an HTTP
+ * client implementation; users must wire one of Guzzle / Symfony
+ * HttpClient / Buzz / etc. themselves.
+ *
+ * Each resolution call passes its own `$documentCache`, so the same URL
+ * is fetched once even if multiple sibling refs target different
+ * fragments of it. The cache lives only for the duration of one
+ * `OpenApiRefResolver::resolve()` call (no global / cross-call cache —
+ * each test gets a fresh fetch).
+ *
+ * @internal Not part of the package's public API. Do not call from user code.
+ */
+final class HttpRefLoader
+{
+    private function __construct() {}
+
+    /**
+     * Fetch `$url`, decode the response body, and return the canonical URL
+     * together with the decoded array.
+     *
+     * Format detection prefers the URL's filename extension
+     * (`.json` / `.yaml` / `.yml`), falling back to the response's
+     * `Content-Type` header. Refs to URLs that have neither cue throw
+     * `UnsupportedExtension`.
+     *
+     * @param array<string, array<string, mixed>> $documentCache by-ref cache keyed by canonical URL
+     *
+     * @return array{absoluteUri: string, decoded: array<string, mixed>}
+     *
+     * @throws InvalidOpenApiSpecException when the URL cannot be fetched, decoded, or has no detectable format
+     */
+    public static function loadDocument(
+        string $url,
+        ClientInterface $client,
+        RequestFactoryInterface $requestFactory,
+        array &$documentCache,
+    ): array {
+        $canonicalUri = self::canonicalizeUri($url);
+
+        if (isset($documentCache[$canonicalUri])) {
+            return ['absoluteUri' => $canonicalUri, 'decoded' => $documentCache[$canonicalUri]];
+        }
+
+        $request = $requestFactory->createRequest('GET', $canonicalUri);
+
+        try {
+            $response = $client->sendRequest($request);
+        } catch (ClientExceptionInterface $e) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::RemoteRefFetchFailed,
+                sprintf('HTTP $ref fetch failed: %s (%s)', $url, $e->getMessage()),
+                ref: $url,
+                previous: $e,
+            );
+        }
+
+        $status = $response->getStatusCode();
+        if ($status < 200 || $status >= 300) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::RemoteRefFetchFailed,
+                sprintf('HTTP $ref fetch returned status %d: %s', $status, $url),
+                ref: $url,
+            );
+        }
+
+        $body = (string) $response->getBody();
+
+        $format = self::detectFormat($canonicalUri, $response->getHeaderLine('Content-Type'));
+        if ($format === null) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::UnsupportedExtension,
+                sprintf(
+                    'HTTP $ref %s has no detectable format (no .json/.yaml/.yml extension on the URL '
+                    . 'and no recognised Content-Type header).',
+                    $url,
+                ),
+                ref: $url,
+            );
+        }
+
+        $decoded = $format === 'json'
+            ? SpecDocumentDecoder::decodeJson($body, $url)
+            : SpecDocumentDecoder::decodeYaml($body, $url);
+
+        $documentCache[$canonicalUri] = $decoded;
+
+        return ['absoluteUri' => $canonicalUri, 'decoded' => $decoded];
+    }
+
+    /**
+     * Light canonicalisation: trim trailing whitespace. Full URI
+     * normalisation (case-folding scheme/host, removing default ports,
+     * resolving `..`) is intentionally out of scope — spec authors are
+     * trusted to write canonical URLs, and over-aggressive normalisation
+     * could merge cache entries for URIs that the server distinguishes.
+     */
+    private static function canonicalizeUri(string $url): string
+    {
+        return trim($url);
+    }
+
+    /**
+     * Pick the spec format from the URL's file extension first; fall back
+     * to a coarse Content-Type sniff. Returns `'json'`, `'yaml'`, or null
+     * when neither cue is conclusive.
+     */
+    private static function detectFormat(string $url, string $contentType): ?string
+    {
+        $path = self::stripQueryAndFragment($url);
+        $extension = strtolower((string) pathinfo($path, PATHINFO_EXTENSION));
+        if ($extension === 'json') {
+            return 'json';
+        }
+        if ($extension === 'yaml' || $extension === 'yml') {
+            return 'yaml';
+        }
+
+        $type = strtolower(trim($contentType));
+        if ($type === '') {
+            return null;
+        }
+
+        // Drop charset / boundary parameters before the equality check.
+        $type = trim((string) (preg_split('/\s*;\s*/', $type)[0] ?? ''));
+
+        // application/json, application/openapi+json, application/problem+json …
+        if ($type === 'application/json' || str_ends_with($type, '+json')) {
+            return 'json';
+        }
+
+        if ($type === 'application/yaml' ||
+            $type === 'application/x-yaml' ||
+            $type === 'text/yaml' ||
+            $type === 'text/x-yaml' ||
+            str_ends_with($type, '+yaml')
+        ) {
+            return 'yaml';
+        }
+
+        return null;
+    }
+
+    private static function stripQueryAndFragment(string $url): string
+    {
+        $cut = strcspn($url, '?#');
+
+        return rtrim(substr($url, 0, $cut));
+    }
+}

--- a/src/Internal/LoadedDocument.php
+++ b/src/Internal/LoadedDocument.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Internal;
+
+/**
+ * Result of loading an external `$ref` target — either from the
+ * filesystem ({@see ExternalRefLoader}) or via HTTP ({@see HttpRefLoader}).
+ *
+ * `$canonicalIdentifier` is whatever uniquely names the loaded document:
+ * an absolute filesystem path for local refs, an absolute URL for HTTP
+ * refs. The resolver uses it for cycle-detection chain keys, so the
+ * value must be stable across multiple references to the same target
+ * within a single resolution.
+ *
+ * Replaces the prior `array{absolutePath, decoded}` /
+ * `array{absoluteUri, decoded}` shape divergence between the two
+ * loaders.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+final readonly class LoadedDocument
+{
+    /** @param array<string, mixed> $decoded */
+    public function __construct(
+        public string $canonicalIdentifier,
+        public array $decoded,
+    ) {}
+}

--- a/src/Internal/SpecDocumentDecoder.php
+++ b/src/Internal/SpecDocumentDecoder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Internal;
 
+use const JSON_ERROR_DEPTH;
 use const JSON_THROW_ON_ERROR;
 
 use JsonException;
@@ -11,6 +12,7 @@ use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\InvalidOpenApiSpecReason;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
+use Throwable;
 
 use function get_debug_type;
 use function is_array;
@@ -43,9 +45,21 @@ final class SpecDocumentDecoder
         try {
             $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {
+            // The depth-limit case has a different ergonomic story than a
+            // syntax error — surface it explicitly so the user knows the
+            // fix is "increase nesting tolerance" rather than "fix your JSON".
+            $message = $e->getCode() === JSON_ERROR_DEPTH
+                ? sprintf(
+                    'JSON $ref target %s exceeds the 512-level nesting limit (likely a deeply '
+                    . 'recursive schema). %s',
+                    $context,
+                    $e->getMessage(),
+                )
+                : sprintf('Failed to parse JSON $ref target %s: %s', $context, $e->getMessage());
+
             throw new InvalidOpenApiSpecException(
                 InvalidOpenApiSpecReason::MalformedJson,
-                sprintf('Failed to parse JSON $ref target %s: %s', $context, $e->getMessage()),
+                $message,
                 ref: $context,
                 previous: $e,
             );
@@ -76,6 +90,19 @@ final class SpecDocumentDecoder
             throw new InvalidOpenApiSpecException(
                 InvalidOpenApiSpecReason::MalformedYaml,
                 sprintf('Failed to parse YAML $ref target %s: %s', $context, $e->getMessage()),
+                ref: $context,
+                previous: $e,
+            );
+        } catch (Throwable $e) {
+            // Symfony's parser raises non-ParseException classes for some
+            // inputs (e.g. \InvalidArgumentException on malformed Unicode,
+            // \Error on memory exhaustion mid-parse). Without this catch
+            // those propagate as raw stack traces and never receive an
+            // InvalidOpenApiSpecReason tag. Re-wrap so consumers can
+            // branch on `$reason` consistently.
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::MalformedYaml,
+                sprintf('YAML $ref target %s failed to decode: %s', $context, $e->getMessage()),
                 ref: $context,
                 previous: $e,
             );

--- a/src/Internal/SpecDocumentDecoder.php
+++ b/src/Internal/SpecDocumentDecoder.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Internal;
+
+use const JSON_THROW_ON_ERROR;
+
+use JsonException;
+use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
+use Studio\OpenApiContractTesting\InvalidOpenApiSpecReason;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+use function get_debug_type;
+use function is_array;
+use function json_decode;
+use function sprintf;
+
+/**
+ * Pure decoder for in-memory spec documents (JSON / YAML strings).
+ * Both `ExternalRefLoader` (filesystem-based) and `HttpRefLoader`
+ * (network-based) call into this once they have the raw body in hand,
+ * so the parse + mapping-root checks live in one place.
+ *
+ * `$context` is a free-form string that surfaces in error messages so
+ * the caller can pinpoint which ref / file / URL produced the failure
+ * without the decoder having to know the source.
+ *
+ * @internal Not part of the package's public API. Do not call from user code.
+ */
+final class SpecDocumentDecoder
+{
+    private function __construct() {}
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @throws InvalidOpenApiSpecException on malformed JSON or non-mapping root
+     */
+    public static function decodeJson(string $content, string $context): array
+    {
+        try {
+            $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::MalformedJson,
+                sprintf('Failed to parse JSON $ref target %s: %s', $context, $e->getMessage()),
+                ref: $context,
+                previous: $e,
+            );
+        }
+
+        return self::ensureMappingRoot($decoded, $context);
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @throws InvalidOpenApiSpecException on missing YAML library, parse failure, or non-mapping root
+     */
+    public static function decodeYaml(string $content, string $context): array
+    {
+        if (!YamlAvailability::isAvailable()) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::YamlLibraryMissing,
+                'Loading YAML $ref targets requires symfony/yaml. '
+                . 'Install it via: composer require --dev symfony/yaml',
+                ref: $context,
+            );
+        }
+
+        try {
+            $decoded = Yaml::parse($content);
+        } catch (ParseException $e) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::MalformedYaml,
+                sprintf('Failed to parse YAML $ref target %s: %s', $context, $e->getMessage()),
+                ref: $context,
+                previous: $e,
+            );
+        }
+
+        return self::ensureMappingRoot($decoded, $context);
+    }
+
+    /** @return array<string, mixed> */
+    private static function ensureMappingRoot(mixed $decoded, string $context): array
+    {
+        if (!is_array($decoded)) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::NonMappingRoot,
+                sprintf(
+                    '$ref target must decode to a mapping (got %s): %s',
+                    get_debug_type($decoded),
+                    $context,
+                ),
+                ref: $context,
+            );
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+}

--- a/src/InvalidOpenApiSpecReason.php
+++ b/src/InvalidOpenApiSpecReason.php
@@ -14,7 +14,8 @@ enum InvalidOpenApiSpecReason
     /**
      * @deprecated Use the more specific external-ref reasons instead:
      *             `LocalRefNotFound`, `LocalRefUnreadable`, `LocalRefRequiresSourceFile`,
-     *             `RemoteRefNotImplemented`, or `FileSchemeNotSupported`. Kept for
+     *             `RemoteRefDisallowed`, `HttpClientNotConfigured`,
+     *             `RemoteRefFetchFailed`, or `FileSchemeNotSupported`. Kept for
      *             backwards compatibility with consumers that branched on this case
      *             before the resolver learned to follow external `$ref` targets.
      *             No production code throws this reason any more.

--- a/src/InvalidOpenApiSpecReason.php
+++ b/src/InvalidOpenApiSpecReason.php
@@ -23,7 +23,18 @@ enum InvalidOpenApiSpecReason
     case LocalRefNotFound;
     case LocalRefUnreadable;
     case LocalRefRequiresSourceFile;
+    /**
+     * @deprecated Use `RemoteRefDisallowed` (when `allowRemoteRefs` is false)
+     *             or `HttpClientNotConfigured` (when the flag is on but no
+     *             PSR-18 client + PSR-17 factory have been provided). Kept
+     *             for backwards compatibility with consumers that branched
+     *             on this case before HTTP `$ref` resolution shipped.
+     *             No production code throws this reason any more.
+     */
     case RemoteRefNotImplemented;
+    case RemoteRefDisallowed;
+    case RemoteRefFetchFailed;
+    case HttpClientNotConfigured;
     case FileSchemeNotSupported;
     case EmptyRef;
     case CircularRef;

--- a/src/OpenApiRefResolver.php
+++ b/src/OpenApiRefResolver.php
@@ -10,17 +10,20 @@ use Studio\OpenApiContractTesting\Internal\ExternalRefLoader;
 use Studio\OpenApiContractTesting\Internal\HttpRefLoader;
 
 use function array_key_exists;
+use function array_pop;
 use function explode;
 use function get_debug_type;
 use function implode;
 use function in_array;
 use function is_array;
 use function is_string;
+use function parse_url;
 use function rawurldecode;
 use function sprintf;
 use function str_replace;
 use function str_starts_with;
 use function strpos;
+use function strrpos;
 use function substr;
 
 final class OpenApiRefResolver
@@ -41,8 +44,8 @@ final class OpenApiRefResolver
      * Pass `$sourceFile` (the absolute path of the spec file being loaded)
      * to enable resolution of external `$ref` targets located on the local
      * filesystem (e.g. `./schemas/pet.yaml`). When `$sourceFile` is `null`,
-     * any non-internal `$ref` triggers `LocalRefRequiresSourceFile` so the
-     * caller knows it must thread the path through.
+     * any **filesystem-relative** `$ref` triggers `LocalRefRequiresSourceFile`.
+     * HTTP(S) refs are dispatched via `$httpClient` regardless of `$sourceFile`.
      *
      * Pass `$httpClient` + `$requestFactory` (PSR-18 / PSR-17) AND
      * `$allowRemoteRefs: true` to permit HTTP(S) `$ref` resolution.
@@ -64,12 +67,24 @@ final class OpenApiRefResolver
         ?RequestFactoryInterface $requestFactory = null,
         bool $allowRemoteRefs = false,
     ): array {
-        $context = new RefResolutionContext(
-            sourceFile: $sourceFile,
-            httpClient: $httpClient,
-            requestFactory: $requestFactory,
-            allowRemoteRefs: $allowRemoteRefs,
-        );
+        // OpenApiSpecLoader::configure() catches this earlier with an
+        // InvalidArgumentException; this guard is for callers that
+        // construct the resolver directly. Surface as the same reason
+        // the per-ref path would fire so consumers can branch on a
+        // single enum case.
+        if ($allowRemoteRefs && ($httpClient === null || $requestFactory === null)) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::HttpClientNotConfigured,
+                'OpenApiRefResolver::resolve(): allowRemoteRefs requires both '
+                . 'a PSR-18 ClientInterface and a PSR-17 RequestFactoryInterface.',
+            );
+        }
+
+        // After the guard above, allowRemoteRefs:true implies non-null
+        // client + factory.
+        $context = $allowRemoteRefs
+            ? RefResolutionContext::withRemoteRefs($httpClient, $requestFactory, $sourceFile)
+            : RefResolutionContext::filesystemOnly($sourceFile);
 
         // $root is a frozen snapshot used for pointer lookups. PHP array
         // copy-on-write keeps it untouched as we mutate $spec via $node refs.
@@ -210,7 +225,96 @@ final class OpenApiRefResolver
             );
         }
 
+        // RFC 3986 base resolution: when the current document was loaded
+        // over HTTP(S), a relative ref resolves against that URL — not
+        // against any local filesystem path. Without this branch, dirname()
+        // on the URL would produce nonsense like `dirname('https:')` and
+        // the user would see a confusing LocalRefNotFound.
+        if (str_starts_with($context->sourceFile, 'http://') || str_starts_with($context->sourceFile, 'https://')) {
+            $resolvedUrl = self::resolveRelativeUrl($context->sourceFile, $ref);
+            self::resolveHttpRef($node, $resolvedUrl, $chain, $context, $documentCache);
+
+            return;
+        }
+
         self::resolveExternalRef($node, $ref, $chain, $context, $documentCache);
+    }
+
+    /**
+     * Minimal RFC 3986 reference resolution: combine a relative `$ref`
+     * with an HTTP(S) base URL. Handles absolute paths (`/foo`),
+     * dot-segment normalisation (`./`, `../`), and falls back to the
+     * raw ref when it's already an absolute URL.
+     *
+     * Not a full RFC 3986 implementation — query strings and fragments
+     * on the base URL are dropped before joining (matches what spec
+     * authors expect when their base is a JSON document URL). For
+     * pathological inputs the result is whatever `parse_url` produces;
+     * tests pin the common cases.
+     */
+    private static function resolveRelativeUrl(string $baseUrl, string $relativeRef): string
+    {
+        if (str_starts_with($relativeRef, 'http://') || str_starts_with($relativeRef, 'https://')) {
+            return $relativeRef;
+        }
+
+        $baseParts = parse_url($baseUrl);
+        if ($baseParts === false || !isset($baseParts['scheme'], $baseParts['host'])) {
+            return $relativeRef;
+        }
+
+        $scheme = $baseParts['scheme'];
+        $host = $baseParts['host'];
+        $port = isset($baseParts['port']) ? ':' . $baseParts['port'] : '';
+        $userInfo = isset($baseParts['user'])
+            ? $baseParts['user'] . (isset($baseParts['pass']) ? ':' . $baseParts['pass'] : '') . '@'
+            : '';
+
+        $authority = $userInfo . $host . $port;
+
+        if (str_starts_with($relativeRef, '/')) {
+            return sprintf('%s://%s%s', $scheme, $authority, $relativeRef);
+        }
+
+        $basePath = $baseParts['path'] ?? '/';
+        $baseDir = self::dirnameUrl($basePath);
+
+        $combined = $baseDir . '/' . $relativeRef;
+        $normalised = self::normaliseDotSegments($combined);
+
+        return sprintf('%s://%s%s', $scheme, $authority, $normalised);
+    }
+
+    private static function dirnameUrl(string $path): string
+    {
+        $lastSlash = strrpos($path, '/');
+        if ($lastSlash === false || $lastSlash === 0) {
+            return '';
+        }
+
+        return substr($path, 0, $lastSlash);
+    }
+
+    /**
+     * Apply RFC 3986 §5.2.4 dot-segment removal. Implemented inline
+     * (rather than reaching for a library) because the rules are short
+     * and the surface area we hit is narrow: relative `./pet.yaml`,
+     * `../shared/error.json`, and combinations. Edge cases like a leading
+     * `..` past the root collapse to root, matching browser behaviour.
+     */
+    private static function normaliseDotSegments(string $path): string
+    {
+        $segments = explode('/', $path);
+        $resolved = [];
+        foreach ($segments as $segment) {
+            if ($segment === '..') {
+                array_pop($resolved);
+            } elseif ($segment !== '.' && $segment !== '') {
+                $resolved[] = $segment;
+            }
+        }
+
+        return '/' . implode('/', $resolved);
     }
 
     /**
@@ -304,17 +408,15 @@ final class OpenApiRefResolver
         /** @var string $sourceFile */
         $sourceFile = $context->sourceFile;
         $document = ExternalRefLoader::loadDocument($pathPart, $sourceFile, $documentCache);
-        $absolutePath = $document['absolutePath'];
-        $newRoot = $document['decoded'];
 
         self::descendIntoLoadedDocument(
             $node,
             $ref,
             $fragment,
             $chain,
-            $absolutePath,
-            $newRoot,
-            $context->withSourceFile($absolutePath),
+            $document->canonicalIdentifier,
+            $document->decoded,
+            $context->withSourceFile($document->canonicalIdentifier),
             $documentCache,
         );
     }
@@ -373,23 +475,37 @@ final class OpenApiRefResolver
             );
         }
 
-        $document = HttpRefLoader::loadDocument(
-            $urlPart,
-            $context->httpClient,
-            $context->requestFactory,
-            $documentCache,
-        );
-        $absoluteUri = $document['absoluteUri'];
-        $newRoot = $document['decoded'];
+        try {
+            $document = HttpRefLoader::loadDocument(
+                $urlPart,
+                $context->httpClient,
+                $context->requestFactory,
+                $documentCache,
+            );
+        } catch (InvalidOpenApiSpecException $e) {
+            // Re-wrap remote-fetch failures with the resolution chain so
+            // a failure 4 hops deep into a $ref tree shows the path that
+            // got us there, not just the leaf URL.
+            if ($e->reason === InvalidOpenApiSpecReason::RemoteRefFetchFailed && $chain !== []) {
+                throw new InvalidOpenApiSpecException(
+                    $e->reason,
+                    sprintf('%s (via $ref chain: %s)', $e->getMessage(), implode(' -> ', $chain)),
+                    ref: $e->ref,
+                    previous: $e,
+                );
+            }
+
+            throw $e;
+        }
 
         self::descendIntoLoadedDocument(
             $node,
             $ref,
             $fragment,
             $chain,
-            $absoluteUri,
-            $newRoot,
-            $context->withSourceFile($absoluteUri),
+            $document->canonicalIdentifier,
+            $document->decoded,
+            $context->withSourceFile($document->canonicalIdentifier),
             $documentCache,
         );
     }

--- a/src/OpenApiRefResolver.php
+++ b/src/OpenApiRefResolver.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting;
 
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use Studio\OpenApiContractTesting\Internal\ExternalRefLoader;
+use Studio\OpenApiContractTesting\Internal\HttpRefLoader;
 
 use function array_key_exists;
 use function explode;
@@ -39,11 +42,14 @@ final class OpenApiRefResolver
      * to enable resolution of external `$ref` targets located on the local
      * filesystem (e.g. `./schemas/pet.yaml`). When `$sourceFile` is `null`,
      * any non-internal `$ref` triggers `LocalRefRequiresSourceFile` so the
-     * caller knows it must thread the path through. HTTP(S) and `file://`
-     * refs are always rejected: `RemoteRefNotImplemented` (HTTP fetching
-     * is not currently part of the resolver) and `FileSchemeNotSupported`
-     * (`file://` URLs bypass source-file-relative resolution and are
-     * blocked to keep the path-resolution rules predictable).
+     * caller knows it must thread the path through.
+     *
+     * Pass `$httpClient` + `$requestFactory` (PSR-18 / PSR-17) AND
+     * `$allowRemoteRefs: true` to permit HTTP(S) `$ref` resolution.
+     * Without both, HTTP refs throw `RemoteRefDisallowed` (flag off) or
+     * `HttpClientNotConfigured` (flag on but client/factory missing).
+     * `file://` URLs are always rejected to keep path-resolution rules
+     * predictable.
      *
      * @param array<string, mixed> $spec
      *
@@ -51,15 +57,27 @@ final class OpenApiRefResolver
      *
      * @throws InvalidOpenApiSpecException when a `$ref` cannot be resolved
      */
-    public static function resolve(array $spec, ?string $sourceFile = null): array
-    {
+    public static function resolve(
+        array $spec,
+        ?string $sourceFile = null,
+        ?ClientInterface $httpClient = null,
+        ?RequestFactoryInterface $requestFactory = null,
+        bool $allowRemoteRefs = false,
+    ): array {
+        $context = new RefResolutionContext(
+            sourceFile: $sourceFile,
+            httpClient: $httpClient,
+            requestFactory: $requestFactory,
+            allowRemoteRefs: $allowRemoteRefs,
+        );
+
         // $root is a frozen snapshot used for pointer lookups. PHP array
         // copy-on-write keeps it untouched as we mutate $spec via $node refs.
         $root = $spec;
-        // Per-resolution external file cache, keyed by canonical absolute
-        // path. Sibling refs into the same file decode it once.
+        // Per-resolution external file/URL cache, keyed by canonical absolute
+        // path or canonical URL. Sibling refs into the same target decode it once.
         $documentCache = [];
-        self::walk($spec, $root, [], false, $sourceFile, $documentCache);
+        self::walk($spec, $root, [], false, $context, $documentCache);
 
         return $spec;
     }
@@ -72,7 +90,6 @@ final class OpenApiRefResolver
      *                                  a `properties` / `patternProperties` map, where keys are property names
      *                                  rather than schema keywords. The flag resets one level deeper, because
      *                                  each named entry is itself a schema.
-     * @param ?string $currentSourceFile absolute path of the file owning `$root`, or null in legacy calls
      * @param array<string, array<string, mixed>> $documentCache external document cache for this resolution
      */
     private static function walk(
@@ -80,7 +97,7 @@ final class OpenApiRefResolver
         array $root,
         array $chain,
         bool $insidePropertiesMap,
-        ?string $currentSourceFile,
+        RefResolutionContext $context,
         array &$documentCache,
     ): void {
         if (!$insidePropertiesMap && array_key_exists('$ref', $node)) {
@@ -93,7 +110,7 @@ final class OpenApiRefResolver
                 );
             }
 
-            self::resolveRef($node, $ref, $root, $chain, $currentSourceFile, $documentCache);
+            self::resolveRef($node, $ref, $root, $chain, $context, $documentCache);
 
             return;
         }
@@ -104,7 +121,7 @@ final class OpenApiRefResolver
                 // schema (not a dict of schemas), so a direct $ref under it is a
                 // legitimate Reference Object that must resolve.
                 $childInsidePropertiesMap = $key === 'properties' || $key === 'patternProperties';
-                self::walk($child, $root, $chain, $childInsidePropertiesMap, $currentSourceFile, $documentCache);
+                self::walk($child, $root, $chain, $childInsidePropertiesMap, $context, $documentCache);
             }
         }
         unset($child);
@@ -121,7 +138,7 @@ final class OpenApiRefResolver
         string $ref,
         array $root,
         array $chain,
-        ?string $currentSourceFile,
+        RefResolutionContext $context,
         array &$documentCache,
     ): void {
         if ($ref === '') {
@@ -161,19 +178,13 @@ final class OpenApiRefResolver
         }
 
         if (str_starts_with($ref, 'http://') || str_starts_with($ref, 'https://')) {
-            throw new InvalidOpenApiSpecException(
-                InvalidOpenApiSpecReason::RemoteRefNotImplemented,
-                sprintf(
-                    'HTTP(S) $ref is not currently supported: %s. '
-                    . 'Pre-bundle the spec or open an issue if remote resolution would help your workflow.',
-                    $ref,
-                ),
-                ref: $ref,
-            );
+            self::resolveHttpRef($node, $ref, $chain, $context, $documentCache);
+
+            return;
         }
 
         if (str_starts_with($ref, '#/')) {
-            self::resolveInternalRef($node, $ref, $root, $chain, $currentSourceFile, $documentCache);
+            self::resolveInternalRef($node, $ref, $root, $chain, $context, $documentCache);
 
             return;
         }
@@ -186,7 +197,7 @@ final class OpenApiRefResolver
             );
         }
 
-        if ($currentSourceFile === null) {
+        if ($context->sourceFile === null) {
             throw new InvalidOpenApiSpecException(
                 InvalidOpenApiSpecReason::LocalRefRequiresSourceFile,
                 sprintf(
@@ -199,7 +210,7 @@ final class OpenApiRefResolver
             );
         }
 
-        self::resolveExternalRef($node, $ref, $chain, $currentSourceFile, $documentCache);
+        self::resolveExternalRef($node, $ref, $chain, $context, $documentCache);
     }
 
     /**
@@ -213,13 +224,13 @@ final class OpenApiRefResolver
         string $ref,
         array $root,
         array $chain,
-        ?string $currentSourceFile,
+        RefResolutionContext $context,
         array &$documentCache,
     ): void {
         // Canonicalize internal refs against the current document so cycles
         // that span files are detected against per-file pointers, not the
         // raw `#/...` string (which is ambiguous across documents).
-        $chainKey = self::canonicalChainKey($currentSourceFile, $ref);
+        $chainKey = self::canonicalChainKey($context->sourceFile, $ref);
 
         if (in_array($chainKey, $chain, true)) {
             throw new InvalidOpenApiSpecException(
@@ -251,7 +262,7 @@ final class OpenApiRefResolver
         // entirely. Sibling keys alongside $ref are dropped per OAS 3.0
         // ("any sibling elements of a $ref are ignored"), which is a safe
         // subset of 3.1.
-        self::walk($target, $root, [...$chain, $chainKey], false, $currentSourceFile, $documentCache);
+        self::walk($target, $root, [...$chain, $chainKey], false, $context, $documentCache);
         $node = $target;
     }
 
@@ -264,7 +275,7 @@ final class OpenApiRefResolver
         array &$node,
         string $ref,
         array $chain,
-        string $currentSourceFile,
+        RefResolutionContext $context,
         array &$documentCache,
     ): void {
         [$pathPart, $fragment, $hadHash] = self::splitRef($ref);
@@ -289,13 +300,123 @@ final class OpenApiRefResolver
             );
         }
 
-        $document = ExternalRefLoader::loadDocument($pathPart, $currentSourceFile, $documentCache);
+        // sourceFile non-null asserted by the caller (resolveRef).
+        /** @var string $sourceFile */
+        $sourceFile = $context->sourceFile;
+        $document = ExternalRefLoader::loadDocument($pathPart, $sourceFile, $documentCache);
         $absolutePath = $document['absolutePath'];
         $newRoot = $document['decoded'];
 
+        self::descendIntoLoadedDocument(
+            $node,
+            $ref,
+            $fragment,
+            $chain,
+            $absolutePath,
+            $newRoot,
+            $context->withSourceFile($absolutePath),
+            $documentCache,
+        );
+    }
+
+    /**
+     * @param array<int|string, mixed> $node
+     * @param list<string> $chain
+     * @param array<string, array<string, mixed>> $documentCache
+     */
+    private static function resolveHttpRef(
+        array &$node,
+        string $ref,
+        array $chain,
+        RefResolutionContext $context,
+        array &$documentCache,
+    ): void {
+        if (!$context->allowRemoteRefs) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::RemoteRefDisallowed,
+                sprintf(
+                    'HTTP(S) $ref is disallowed: %s. '
+                    . 'Pass allowRemoteRefs: true to OpenApiSpecLoader::configure() to enable it.',
+                    $ref,
+                ),
+                ref: $ref,
+            );
+        }
+
+        if ($context->httpClient === null || $context->requestFactory === null) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::HttpClientNotConfigured,
+                sprintf(
+                    'HTTP $ref %s requires a PSR-18 ClientInterface and PSR-17 '
+                    . 'RequestFactoryInterface. Pass them to OpenApiSpecLoader::configure().',
+                    $ref,
+                ),
+                ref: $ref,
+            );
+        }
+
+        [$urlPart, $fragment, $hadHash] = self::splitRef($ref);
+
+        if ($urlPart === '') {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::EmptyRef,
+                sprintf('Invalid $ref: %s has an empty URL part', $ref),
+                ref: $ref,
+            );
+        }
+
+        if ($hadHash && $fragment === '') {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::BareFragmentRef,
+                sprintf('Invalid $ref: %s has an empty fragment after `#`', $ref),
+                ref: $ref,
+            );
+        }
+
+        $document = HttpRefLoader::loadDocument(
+            $urlPart,
+            $context->httpClient,
+            $context->requestFactory,
+            $documentCache,
+        );
+        $absoluteUri = $document['absoluteUri'];
+        $newRoot = $document['decoded'];
+
+        self::descendIntoLoadedDocument(
+            $node,
+            $ref,
+            $fragment,
+            $chain,
+            $absoluteUri,
+            $newRoot,
+            $context->withSourceFile($absoluteUri),
+            $documentCache,
+        );
+    }
+
+    /**
+     * Shared post-load step for both filesystem and HTTP external refs.
+     * Performs cycle detection, fragment lookup, type guard, and recursion
+     * with the source-file context shifted to the loaded document.
+     *
+     * @param array<int|string, mixed> $node
+     * @param list<string> $chain
+     * @param array<string, mixed> $newRoot
+     * @param array<string, array<string, mixed>> $documentCache
+     */
+    private static function descendIntoLoadedDocument(
+        array &$node,
+        string $ref,
+        string $fragment,
+        array $chain,
+        string $absoluteUri,
+        array $newRoot,
+        RefResolutionContext $context,
+        array &$documentCache,
+    ): void {
         if ($fragment !== '') {
             $internalRef = '#' . $fragment;
-            $chainKey = self::canonicalChainKey($absolutePath, $internalRef);
+            $chainKey = self::canonicalChainKey($absoluteUri, $internalRef);
 
             if (in_array($chainKey, $chain, true)) {
                 throw new InvalidOpenApiSpecException(
@@ -309,7 +430,7 @@ final class OpenApiRefResolver
             if (!$found) {
                 throw new InvalidOpenApiSpecException(
                     InvalidOpenApiSpecReason::UnresolvableRef,
-                    sprintf('Unresolvable $ref: fragment %s not found in %s', $fragment, $absolutePath),
+                    sprintf('Unresolvable $ref: fragment %s not found in %s', $fragment, $absoluteUri),
                     ref: $ref,
                 );
             }
@@ -322,15 +443,16 @@ final class OpenApiRefResolver
                 );
             }
 
-            self::walk($target, $newRoot, [...$chain, $chainKey], false, $absolutePath, $documentCache);
+            self::walk($target, $newRoot, [...$chain, $chainKey], false, $context, $documentCache);
             $node = $target;
 
             return;
         }
 
-        // Whole-file ref: chain key is the absolute path; the document
-        // root replaces the node, and walking continues against that root.
-        $chainKey = $absolutePath;
+        // Whole-file/URL ref: chain key is the canonical absolute identifier;
+        // the document root replaces the node, and walking continues against
+        // that root.
+        $chainKey = $absoluteUri;
         if (in_array($chainKey, $chain, true)) {
             throw new InvalidOpenApiSpecException(
                 InvalidOpenApiSpecReason::CircularRef,
@@ -340,7 +462,7 @@ final class OpenApiRefResolver
         }
 
         $target = $newRoot;
-        self::walk($target, $newRoot, [...$chain, $chainKey], false, $absolutePath, $documentCache);
+        self::walk($target, $newRoot, [...$chain, $chainKey], false, $context, $documentCache);
         $node = $target;
     }
 

--- a/src/OpenApiSpecLoader.php
+++ b/src/OpenApiSpecLoader.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting;
 
+use const E_USER_WARNING;
 use const JSON_THROW_ON_ERROR;
 
+use InvalidArgumentException;
 use JsonException;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use Studio\OpenApiContractTesting\Internal\YamlAvailability;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
@@ -20,6 +24,7 @@ use function json_decode;
 use function realpath;
 use function rtrim;
 use function sprintf;
+use function trigger_error;
 
 final class OpenApiSpecLoader
 {
@@ -37,16 +42,59 @@ final class OpenApiSpecLoader
 
     /** @var array<string, array<string, mixed>> */
     private static array $cache = [];
+    private static ?ClientInterface $httpClient = null;
+    private static ?RequestFactoryInterface $requestFactory = null;
+    private static bool $allowRemoteRefs = false;
 
     /**
-     * Configure the spec loader with a base path and optional strip prefixes.
+     * Configure the spec loader.
      *
      * @param string[] $stripPrefixes
+     * @param null|ClientInterface $httpClient PSR-18 client used to fetch HTTP(S) `$ref`
+     *                                         targets. Required when `$allowRemoteRefs` is true.
+     * @param null|RequestFactoryInterface $requestFactory PSR-17 request factory paired
+     *                                                     with `$httpClient`. Required when `$allowRemoteRefs` is true.
+     * @param bool $allowRemoteRefs Opt-in for HTTP(S) `$ref` resolution. Defaults to false:
+     *                              every external HTTP(S) ref throws `RemoteRefDisallowed` so a
+     *                              spec can never silently reach the network during tests.
+     *
+     * @throws InvalidArgumentException when `$allowRemoteRefs` is true but the client/factory
+     *                                  pair is incomplete — surfaces the misconfiguration at
+     *                                  configure-time rather than at first remote ref.
      */
-    public static function configure(string $basePath, array $stripPrefixes = []): void
-    {
+    public static function configure(
+        string $basePath,
+        array $stripPrefixes = [],
+        ?ClientInterface $httpClient = null,
+        ?RequestFactoryInterface $requestFactory = null,
+        bool $allowRemoteRefs = false,
+    ): void {
+        if ($allowRemoteRefs && ($httpClient === null || $requestFactory === null)) {
+            throw new InvalidArgumentException(
+                'OpenApiSpecLoader::configure(): allowRemoteRefs requires both $httpClient '
+                . '(PSR-18 ClientInterface) and $requestFactory (PSR-17 RequestFactoryInterface).',
+            );
+        }
+
+        if (!$allowRemoteRefs && $httpClient !== null) {
+            // The user wired a client but forgot to flip the switch. Warn
+            // loudly so the misconfiguration doesn't sit silent: their
+            // expectation is "HTTP refs work" and our behaviour is "every
+            // HTTP ref throws RemoteRefDisallowed". E_USER_WARNING is what
+            // PHPUnit elevates to a test failure under failOnWarning.
+            trigger_error(
+                'OpenApiSpecLoader::configure(): an HTTP client was provided but '
+                . 'allowRemoteRefs is false. HTTP $refs will be rejected. '
+                . 'Pass allowRemoteRefs: true to enable remote resolution.',
+                E_USER_WARNING,
+            );
+        }
+
         self::$basePath = rtrim($basePath, '/');
         self::$stripPrefixes = $stripPrefixes;
+        self::$httpClient = $httpClient;
+        self::$requestFactory = $requestFactory;
+        self::$allowRemoteRefs = $allowRemoteRefs;
     }
 
     public static function getBasePath(): string
@@ -102,7 +150,13 @@ final class OpenApiSpecLoader
         }
 
         try {
-            $resolved = OpenApiRefResolver::resolve($decoded, $canonicalPath);
+            $resolved = OpenApiRefResolver::resolve(
+                $decoded,
+                $canonicalPath,
+                self::$httpClient,
+                self::$requestFactory,
+                self::$allowRemoteRefs,
+            );
         } catch (InvalidOpenApiSpecException $e) {
             // The resolver is stateless and therefore cannot know which spec
             // produced the throw. Re-wrap once so consumers (e.g. the coverage
@@ -136,6 +190,9 @@ final class OpenApiSpecLoader
         self::$basePath = null;
         self::$stripPrefixes = [];
         self::$cache = [];
+        self::$httpClient = null;
+        self::$requestFactory = null;
+        self::$allowRemoteRefs = false;
         YamlAvailability::reset();
     }
 

--- a/src/OpenApiSpecLoader.php
+++ b/src/OpenApiSpecLoader.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting;
 
-use const E_USER_WARNING;
 use const JSON_THROW_ON_ERROR;
 
 use InvalidArgumentException;
@@ -24,7 +23,6 @@ use function json_decode;
 use function realpath;
 use function rtrim;
 use function sprintf;
-use function trigger_error;
 
 final class OpenApiSpecLoader
 {
@@ -49,6 +47,11 @@ final class OpenApiSpecLoader
     /**
      * Configure the spec loader.
      *
+     * Existing cached specs are evicted on every call so a config change
+     * (especially flipping `$allowRemoteRefs`) takes effect on the next
+     * `load()`. Without this, a previously cached spec resolved under
+     * the old policy would silently keep serving.
+     *
      * @param string[] $stripPrefixes
      * @param null|ClientInterface $httpClient PSR-18 client used to fetch HTTP(S) `$ref`
      *                                         targets. Required when `$allowRemoteRefs` is true.
@@ -58,9 +61,10 @@ final class OpenApiSpecLoader
      *                              every external HTTP(S) ref throws `RemoteRefDisallowed` so a
      *                              spec can never silently reach the network during tests.
      *
-     * @throws InvalidArgumentException when `$allowRemoteRefs` is true but the client/factory
-     *                                  pair is incomplete — surfaces the misconfiguration at
-     *                                  configure-time rather than at first remote ref.
+     * @throws InvalidArgumentException for any misconfigured pair: `$allowRemoteRefs` true
+     *                                  without client/factory, OR client provided without
+     *                                  `$allowRemoteRefs` true. Both are surfaced at
+     *                                  configure-time so the error never sits silent.
      */
     public static function configure(
         string $basePath,
@@ -77,16 +81,16 @@ final class OpenApiSpecLoader
         }
 
         if (!$allowRemoteRefs && $httpClient !== null) {
-            // The user wired a client but forgot to flip the switch. Warn
-            // loudly so the misconfiguration doesn't sit silent: their
-            // expectation is "HTTP refs work" and our behaviour is "every
-            // HTTP ref throws RemoteRefDisallowed". E_USER_WARNING is what
-            // PHPUnit elevates to a test failure under failOnWarning.
-            trigger_error(
+            // The user wired a client but forgot to flip the switch.
+            // Warning-level signals (E_USER_WARNING) are too easy to
+            // suppress (custom error handlers, error_reporting masks);
+            // surface as a hard exception so the misconfiguration cannot
+            // sit silent. Symmetric with the allowRemoteRefs-without-client
+            // check above — both halves of the pairing are enforced.
+            throw new InvalidArgumentException(
                 'OpenApiSpecLoader::configure(): an HTTP client was provided but '
-                . 'allowRemoteRefs is false. HTTP $refs will be rejected. '
-                . 'Pass allowRemoteRefs: true to enable remote resolution.',
-                E_USER_WARNING,
+                . 'allowRemoteRefs is false. HTTP $refs would be rejected silently. '
+                . 'Either pass allowRemoteRefs: true, or omit the client entirely.',
             );
         }
 
@@ -95,6 +99,10 @@ final class OpenApiSpecLoader
         self::$httpClient = $httpClient;
         self::$requestFactory = $requestFactory;
         self::$allowRemoteRefs = $allowRemoteRefs;
+        // A previous configure() call may have cached specs under a
+        // different remote-refs policy. Evict so the next load() runs
+        // with the new client/flag combination.
+        self::$cache = [];
     }
 
     public static function getBasePath(): string

--- a/src/RefResolutionContext.php
+++ b/src/RefResolutionContext.php
@@ -20,25 +20,57 @@ use Psr\Http\Message\RequestFactoryInterface;
  */
 final class RefResolutionContext
 {
-    public function __construct(
-        public readonly ?string $sourceFile = null,
-        public readonly ?ClientInterface $httpClient = null,
-        public readonly ?RequestFactoryInterface $requestFactory = null,
-        public readonly bool $allowRemoteRefs = false,
+    /**
+     * Private constructor — callers go through {@see filesystemOnly()} or
+     * {@see withRemoteRefs()} so the pairing invariant
+     * "client + factory + flag are all set together, or none of them are"
+     * is enforced at construction time. This eliminates the
+     * client-without-flag and flag-without-client failure modes that
+     * would otherwise need runtime guards.
+     */
+    private function __construct(
+        public readonly ?string $sourceFile,
+        public readonly ?ClientInterface $httpClient,
+        public readonly ?RequestFactoryInterface $requestFactory,
+        public readonly bool $allowRemoteRefs,
     ) {}
+
+    /**
+     * A context that can resolve internal `$ref` plus local-filesystem
+     * external refs. HTTP refs reject with `RemoteRefDisallowed`.
+     */
+    public static function filesystemOnly(?string $sourceFile = null): self
+    {
+        return new self($sourceFile, null, null, false);
+    }
+
+    /**
+     * A context with HTTP `$ref` resolution enabled. The `$client` /
+     * `$factory` pair is required — passing `null` for either is
+     * structurally impossible via this factory.
+     */
+    public static function withRemoteRefs(
+        ClientInterface $client,
+        RequestFactoryInterface $factory,
+        ?string $sourceFile = null,
+    ): self {
+        return new self($sourceFile, $client, $factory, true);
+    }
 
     /**
      * Return a copy with the source file replaced. Used when the resolver
      * descends into an external document and the relative-path base
-     * shifts to that document's directory.
+     * shifts to that document's directory / URL. All other fields are
+     * preserved verbatim — the pairing invariant cannot be invalidated
+     * by this method.
      */
     public function withSourceFile(?string $sourceFile): self
     {
         return new self(
-            sourceFile: $sourceFile,
-            httpClient: $this->httpClient,
-            requestFactory: $this->requestFactory,
-            allowRemoteRefs: $this->allowRemoteRefs,
+            $sourceFile,
+            $this->httpClient,
+            $this->requestFactory,
+            $this->allowRemoteRefs,
         );
     }
 }

--- a/src/RefResolutionContext.php
+++ b/src/RefResolutionContext.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting;
+
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+
+/**
+ * Carries the per-resolution state that `OpenApiRefResolver::walk()` needs
+ * but which doesn't change per recursion step (source file, HTTP wiring,
+ * remote-refs gate). Threading these as discrete parameters got unwieldy
+ * once HTTP support added a PSR-18 client + PSR-17 factory + opt-in flag,
+ * so they live on this immutable carrier instead.
+ *
+ * The per-resolution document cache is intentionally NOT held here — it
+ * is mutated as files/URLs are loaded, so the resolver still passes it
+ * by reference alongside the (immutable) context.
+ */
+final class RefResolutionContext
+{
+    public function __construct(
+        public readonly ?string $sourceFile = null,
+        public readonly ?ClientInterface $httpClient = null,
+        public readonly ?RequestFactoryInterface $requestFactory = null,
+        public readonly bool $allowRemoteRefs = false,
+    ) {}
+
+    /**
+     * Return a copy with the source file replaced. Used when the resolver
+     * descends into an external document and the relative-path base
+     * shifts to that document's directory.
+     */
+    public function withSourceFile(?string $sourceFile): self
+    {
+        return new self(
+            sourceFile: $sourceFile,
+            httpClient: $this->httpClient,
+            requestFactory: $this->requestFactory,
+            allowRemoteRefs: $this->allowRemoteRefs,
+        );
+    }
+}

--- a/tests/Helpers/FakeHttpClient.php
+++ b/tests/Helpers/FakeHttpClient.php
@@ -5,11 +5,9 @@ declare(strict_types=1);
 namespace Studio\OpenApiContractTesting\Tests\Helpers;
 
 use GuzzleHttp\Psr7\Response;
-use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use RuntimeException;
 
 use function array_keys;
 use function implode;
@@ -87,5 +85,3 @@ final class FakeHttpClient implements ClientInterface
         return $this->sentUrls;
     }
 }
-
-final class FakeHttpClientUnexpectedRequest extends RuntimeException implements ClientExceptionInterface {}

--- a/tests/Helpers/FakeHttpClient.php
+++ b/tests/Helpers/FakeHttpClient.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Helpers;
+
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
+
+use function array_keys;
+use function implode;
+use function is_callable;
+use function sprintf;
+
+/**
+ * Test double PSR-18 client. Returns pre-canned responses keyed by URL.
+ * Throws {@see FakeHttpClientUnexpectedRequest} (a `ClientExceptionInterface`)
+ * when a test forgets to register a response, so the surfacing error
+ * points at the missing fixture rather than at a "no response" mystery.
+ *
+ * The map allows two value shapes:
+ *  - `ResponseInterface` — returned as-is
+ *  - `callable(RequestInterface): ResponseInterface` — for tests that
+ *    need to assert on the request or simulate dynamic behaviour
+ */
+final class FakeHttpClient implements ClientInterface
+{
+    /** @var array<string, callable(RequestInterface): ResponseInterface|ResponseInterface> */
+    private array $responses;
+
+    /** @var list<string> */
+    private array $sentUrls = [];
+
+    /** @param array<string, callable(RequestInterface): ResponseInterface|ResponseInterface> $responses */
+    public function __construct(array $responses = [])
+    {
+        $this->responses = $responses;
+    }
+
+    public static function jsonResponse(string $body, int $status = 200, ?string $contentType = 'application/json'): ResponseInterface
+    {
+        $headers = $contentType !== null ? ['Content-Type' => $contentType] : [];
+
+        return new Response($status, $headers, $body);
+    }
+
+    public static function yamlResponse(string $body, int $status = 200, ?string $contentType = 'application/yaml'): ResponseInterface
+    {
+        $headers = $contentType !== null ? ['Content-Type' => $contentType] : [];
+
+        return new Response($status, $headers, $body);
+    }
+
+    public function set(string $url, callable|ResponseInterface $response): void
+    {
+        $this->responses[$url] = $response;
+    }
+
+    public function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        $url = (string) $request->getUri();
+        $this->sentUrls[] = $url;
+
+        if (!isset($this->responses[$url])) {
+            throw new FakeHttpClientUnexpectedRequest(sprintf(
+                'No mock response registered for %s. Registered URLs: %s',
+                $url,
+                $this->responses === [] ? '<none>' : implode(', ', array_keys($this->responses)),
+            ));
+        }
+
+        $response = $this->responses[$url];
+        if (is_callable($response)) {
+            return $response($request);
+        }
+
+        return $response;
+    }
+
+    /** @return list<string> */
+    public function sentUrls(): array
+    {
+        return $this->sentUrls;
+    }
+}
+
+final class FakeHttpClientUnexpectedRequest extends RuntimeException implements ClientExceptionInterface {}

--- a/tests/Helpers/FakeHttpClientUnexpectedRequest.php
+++ b/tests/Helpers/FakeHttpClientUnexpectedRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Helpers;
+
+use Psr\Http\Client\ClientExceptionInterface;
+use RuntimeException;
+
+/**
+ * Surfaced by {@see FakeHttpClient} when a test sends a request to a URL
+ * that has no registered response. Implements `ClientExceptionInterface`
+ * so the resolver's PSR-18 catch path treats it the same as a real
+ * network failure (which is how production code would experience it).
+ */
+final class FakeHttpClientUnexpectedRequest extends RuntimeException implements ClientExceptionInterface {}

--- a/tests/Unit/Internal/ExternalRefLoaderTest.php
+++ b/tests/Unit/Internal/ExternalRefLoaderTest.php
@@ -51,8 +51,8 @@ class ExternalRefLoaderTest extends TestCase
         $cache = [];
         $result = ExternalRefLoader::loadDocument('./pet.json', $sourceFile, $cache);
 
-        $this->assertSame(['type' => 'object', 'required' => ['id']], $result['decoded']);
-        $this->assertStringEndsWith('/pet.json', $result['absolutePath']);
+        $this->assertSame(['type' => 'object', 'required' => ['id']], $result->decoded);
+        $this->assertStringEndsWith('/pet.json', $result->canonicalIdentifier);
     }
 
     #[Test]
@@ -65,7 +65,7 @@ class ExternalRefLoaderTest extends TestCase
         $cache = [];
         $result = ExternalRefLoader::loadDocument('./pet.yaml', $sourceFile, $cache);
 
-        $this->assertSame(['type' => 'object', 'required' => ['id']], $result['decoded']);
+        $this->assertSame(['type' => 'object', 'required' => ['id']], $result->decoded);
     }
 
     #[Test]
@@ -79,7 +79,7 @@ class ExternalRefLoaderTest extends TestCase
         $cache = [];
         $result = ExternalRefLoader::loadDocument('../shared.json', $sourceFile, $cache);
 
-        $this->assertSame(['name' => 'shared'], $result['decoded']);
+        $this->assertSame(['name' => 'shared'], $result->decoded);
     }
 
     #[Test]
@@ -91,7 +91,7 @@ class ExternalRefLoaderTest extends TestCase
         $cache = [];
         $result = ExternalRefLoader::loadDocument($absolute, $this->workDir . '/unused.yaml', $cache);
 
-        $this->assertSame(['absolute' => true], $result['decoded']);
+        $this->assertSame(['absolute' => true], $result->decoded);
     }
 
     #[Test]
@@ -109,7 +109,7 @@ class ExternalRefLoaderTest extends TestCase
         file_put_contents($target, '{"type":"string"}');
         $second = ExternalRefLoader::loadDocument('./pet.json', $sourceFile, $cache);
 
-        $this->assertSame(['type' => 'object'], $second['decoded']);
+        $this->assertSame(['type' => 'object'], $second->decoded);
     }
 
     #[Test]

--- a/tests/Unit/Internal/HttpRefLoaderTest.php
+++ b/tests/Unit/Internal/HttpRefLoaderTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Internal;
+
+use GuzzleHttp\Psr7\HttpFactory;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Studio\OpenApiContractTesting\Internal\HttpRefLoader;
+use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
+use Studio\OpenApiContractTesting\InvalidOpenApiSpecReason;
+use Studio\OpenApiContractTesting\Tests\Helpers\FakeHttpClient;
+use Studio\OpenApiContractTesting\Tests\Helpers\FakeHttpClientUnexpectedRequest;
+
+class HttpRefLoaderTest extends TestCase
+{
+    private HttpFactory $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = new HttpFactory();
+    }
+
+    #[Test]
+    public function fetches_and_decodes_json_via_url_extension(): void
+    {
+        $url = 'https://example.com/schemas/pet.json';
+        $client = new FakeHttpClient([
+            $url => FakeHttpClient::jsonResponse('{"type":"object","required":["id"]}'),
+        ]);
+
+        $cache = [];
+        $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+
+        $this->assertSame($url, $result['absoluteUri']);
+        $this->assertSame(['type' => 'object', 'required' => ['id']], $result['decoded']);
+    }
+
+    #[Test]
+    public function fetches_and_decodes_yaml_via_url_extension(): void
+    {
+        $url = 'https://example.com/schemas/pet.yaml';
+        $client = new FakeHttpClient([
+            $url => FakeHttpClient::yamlResponse("type: object\nrequired:\n  - id\n"),
+        ]);
+
+        $cache = [];
+        $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+
+        $this->assertSame(['type' => 'object', 'required' => ['id']], $result['decoded']);
+    }
+
+    #[Test]
+    public function falls_back_to_content_type_when_url_has_no_extension(): void
+    {
+        // Schema Registry endpoints frequently expose JSON via opaque
+        // URLs (e.g. `/registry/Pet`) without a file extension. The
+        // Content-Type header is the only format cue.
+        $url = 'https://registry.example.com/Pet';
+        $client = new FakeHttpClient([
+            $url => new Response(200, ['Content-Type' => 'application/json'], '{"type":"string"}'),
+        ]);
+
+        $cache = [];
+        $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+
+        $this->assertSame(['type' => 'string'], $result['decoded']);
+    }
+
+    #[Test]
+    public function falls_back_to_application_problem_json_content_type(): void
+    {
+        $url = 'https://example.com/schemas/error';
+        $client = new FakeHttpClient([
+            $url => new Response(200, ['Content-Type' => 'application/problem+json'], '{"type":"object"}'),
+        ]);
+
+        $cache = [];
+        $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+
+        $this->assertSame(['type' => 'object'], $result['decoded']);
+    }
+
+    #[Test]
+    public function honours_text_yaml_content_type(): void
+    {
+        $url = 'https://example.com/registry/Schema';
+        $client = new FakeHttpClient([
+            $url => new Response(200, ['Content-Type' => 'text/yaml; charset=utf-8'], "type: integer\n"),
+        ]);
+
+        $cache = [];
+        $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+
+        $this->assertSame(['type' => 'integer'], $result['decoded']);
+    }
+
+    #[Test]
+    public function caches_response_and_does_not_re_fetch_on_second_call(): void
+    {
+        $url = 'https://example.com/pet.json';
+        $callCount = 0;
+        $client = new FakeHttpClient([
+            $url => static function (RequestInterface $req) use (&$callCount): Response {
+                $callCount++;
+
+                return new Response(200, ['Content-Type' => 'application/json'], '{"v":1}');
+            },
+        ]);
+
+        $cache = [];
+        HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+        HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+
+        $this->assertSame(1, $callCount);
+    }
+
+    #[Test]
+    public function throws_remote_ref_fetch_failed_on_404(): void
+    {
+        $url = 'https://example.com/missing.json';
+        $client = new FakeHttpClient([
+            $url => new Response(404),
+        ]);
+
+        try {
+            $cache = [];
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::RemoteRefFetchFailed, $e->reason);
+            $this->assertStringContainsString('404', $e->getMessage());
+            $this->assertStringContainsString($url, $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function throws_remote_ref_fetch_failed_on_5xx(): void
+    {
+        $url = 'https://example.com/server-error.json';
+        $client = new FakeHttpClient([
+            $url => new Response(500),
+        ]);
+
+        try {
+            $cache = [];
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::RemoteRefFetchFailed, $e->reason);
+            $this->assertStringContainsString('500', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function throws_remote_ref_fetch_failed_on_network_exception(): void
+    {
+        $url = 'https://example.com/unreachable.json';
+        $client = new FakeHttpClient([
+            $url => static function (): Response {
+                throw new FakeHttpClientUnexpectedRequest('connection refused');
+            },
+        ]);
+
+        try {
+            $cache = [];
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::RemoteRefFetchFailed, $e->reason);
+            $this->assertStringContainsString('connection refused', $e->getMessage());
+            $this->assertNotNull($e->getPrevious());
+        }
+    }
+
+    #[Test]
+    public function throws_unsupported_extension_when_neither_url_nor_content_type_indicates_format(): void
+    {
+        $url = 'https://example.com/opaque-resource';
+        $client = new FakeHttpClient([
+            $url => new Response(200, ['Content-Type' => 'text/plain'], 'whatever'),
+        ]);
+
+        try {
+            $cache = [];
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::UnsupportedExtension, $e->reason);
+            $this->assertStringContainsString($url, $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function throws_malformed_json_on_invalid_body(): void
+    {
+        $url = 'https://example.com/bad.json';
+        $client = new FakeHttpClient([
+            $url => FakeHttpClient::jsonResponse('{ not valid json'),
+        ]);
+
+        try {
+            $cache = [];
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::MalformedJson, $e->reason);
+            $this->assertNotNull($e->getPrevious());
+        }
+    }
+
+    #[Test]
+    public function throws_malformed_yaml_on_invalid_body(): void
+    {
+        $url = 'https://example.com/bad.yaml';
+        $client = new FakeHttpClient([
+            $url => FakeHttpClient::yamlResponse("key: value\n  bad: indent\n"),
+        ]);
+
+        try {
+            $cache = [];
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::MalformedYaml, $e->reason);
+        }
+    }
+
+    #[Test]
+    public function throws_non_mapping_root_when_response_decodes_to_scalar(): void
+    {
+        $url = 'https://example.com/scalar.json';
+        $client = new FakeHttpClient([
+            $url => FakeHttpClient::jsonResponse('"just a string"'),
+        ]);
+
+        try {
+            $cache = [];
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::NonMappingRoot, $e->reason);
+        }
+    }
+}

--- a/tests/Unit/Internal/HttpRefLoaderTest.php
+++ b/tests/Unit/Internal/HttpRefLoaderTest.php
@@ -36,8 +36,8 @@ class HttpRefLoaderTest extends TestCase
         $cache = [];
         $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
 
-        $this->assertSame($url, $result['absoluteUri']);
-        $this->assertSame(['type' => 'object', 'required' => ['id']], $result['decoded']);
+        $this->assertSame($url, $result->canonicalIdentifier);
+        $this->assertSame(['type' => 'object', 'required' => ['id']], $result->decoded);
     }
 
     #[Test]
@@ -51,15 +51,15 @@ class HttpRefLoaderTest extends TestCase
         $cache = [];
         $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
 
-        $this->assertSame(['type' => 'object', 'required' => ['id']], $result['decoded']);
+        $this->assertSame(['type' => 'object', 'required' => ['id']], $result->decoded);
     }
 
     #[Test]
     public function falls_back_to_content_type_when_url_has_no_extension(): void
     {
-        // Schema Registry endpoints frequently expose JSON via opaque
-        // URLs (e.g. `/registry/Pet`) without a file extension. The
-        // Content-Type header is the only format cue.
+        // Some servers expose JSON via opaque URLs (e.g. `/registry/Pet`)
+        // without a file extension. The Content-Type header is the only
+        // format cue.
         $url = 'https://registry.example.com/Pet';
         $client = new FakeHttpClient([
             $url => new Response(200, ['Content-Type' => 'application/json'], '{"type":"string"}'),
@@ -68,7 +68,7 @@ class HttpRefLoaderTest extends TestCase
         $cache = [];
         $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
 
-        $this->assertSame(['type' => 'string'], $result['decoded']);
+        $this->assertSame(['type' => 'string'], $result->decoded);
     }
 
     #[Test]
@@ -82,7 +82,7 @@ class HttpRefLoaderTest extends TestCase
         $cache = [];
         $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
 
-        $this->assertSame(['type' => 'object'], $result['decoded']);
+        $this->assertSame(['type' => 'object'], $result->decoded);
     }
 
     #[Test]
@@ -96,7 +96,7 @@ class HttpRefLoaderTest extends TestCase
         $cache = [];
         $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
 
-        $this->assertSame(['type' => 'integer'], $result['decoded']);
+        $this->assertSame(['type' => 'integer'], $result->decoded);
     }
 
     #[Test]
@@ -227,6 +227,108 @@ class HttpRefLoaderTest extends TestCase
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
             $this->assertSame(InvalidOpenApiSpecReason::MalformedYaml, $e->reason);
+        }
+    }
+
+    #[Test]
+    public function rejects_3xx_redirect_with_hint_pointing_at_location(): void
+    {
+        // Surface the redirect explicitly: PSR-18 clients vary on whether
+        // they auto-follow (Guzzle does, Symfony does not). A bare 302
+        // landing here is almost always "user's client has redirect-following
+        // disabled", and the error message must point at the next step.
+        $url = 'https://example.com/redirect.json';
+        $client = new FakeHttpClient([
+            $url => new Response(302, ['Location' => 'https://example.com/canonical.json']),
+        ]);
+
+        try {
+            $cache = [];
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::RemoteRefFetchFailed, $e->reason);
+            $this->assertStringContainsString('302', $e->getMessage());
+            $this->assertStringContainsString('https://example.com/canonical.json', $e->getMessage());
+            $this->assertStringContainsString('redirect', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function url_extension_takes_precedence_over_conflicting_content_type(): void
+    {
+        // Pin the documented priority: extension wins, even if the
+        // server's Content-Type disagrees. A YAML URL whose server
+        // mistakenly returns `application/json` should still parse as YAML.
+        $url = 'https://example.com/pet.yaml';
+        $client = new FakeHttpClient([
+            $url => new Response(200, ['Content-Type' => 'application/json'], "type: object\n"),
+        ]);
+
+        $cache = [];
+        $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+
+        $this->assertSame(['type' => 'object'], $result->decoded);
+    }
+
+    #[Test]
+    public function throws_unsupported_extension_when_content_type_header_is_empty(): void
+    {
+        $url = 'https://example.com/opaque-resource';
+        $client = new FakeHttpClient([
+            $url => new Response(200, [], 'whatever'),
+        ]);
+
+        try {
+            $cache = [];
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::UnsupportedExtension, $e->reason);
+        }
+    }
+
+    #[Test]
+    public function tolerates_duplicate_content_type_headers_concatenated_with_comma(): void
+    {
+        // RFC 7230 §3.2.2 forbids it, but real servers occasionally send
+        // duplicate Content-Type headers. PSR-7 getHeaderLine() concatenates
+        // them with `, `; the detector must split on `,` as well as `;`
+        // so the first usable type wins.
+        $url = 'https://example.com/registry/Schema';
+        $client = new FakeHttpClient([
+            $url => new Response(
+                200,
+                ['Content-Type' => ['application/json', 'application/json']],
+                '{"type":"object"}',
+            ),
+        ]);
+
+        $cache = [];
+        $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+
+        $this->assertSame(['type' => 'object'], $result->decoded);
+    }
+
+    #[Test]
+    public function redacts_userinfo_credentials_from_error_messages(): void
+    {
+        // Spec authors occasionally embed credentials in $ref URLs for
+        // testing; those must not leak into stderr / CI logs via error
+        // messages.
+        $url = 'https://alice:secret@example.com/private/pet.json';
+        $client = new FakeHttpClient([
+            $url => new Response(404),
+        ]);
+
+        try {
+            $cache = [];
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertStringNotContainsString('secret', $e->getMessage());
+            $this->assertStringNotContainsString('alice', $e->getMessage());
+            $this->assertStringContainsString('example.com', $e->getMessage());
         }
     }
 

--- a/tests/Unit/OpenApiRefResolverExternalRefsTest.php
+++ b/tests/Unit/OpenApiRefResolverExternalRefsTest.php
@@ -220,7 +220,7 @@ class OpenApiRefResolverExternalRefsTest extends TestCase
     }
 
     #[Test]
-    public function throws_remote_ref_not_implemented_for_https_ref(): void
+    public function throws_remote_ref_disallowed_for_https_ref_when_flag_is_off(): void
     {
         $rootPath = $this->workDir . '/openapi.json';
         file_put_contents($rootPath, '{}');
@@ -231,13 +231,13 @@ class OpenApiRefResolverExternalRefsTest extends TestCase
             OpenApiRefResolver::resolve($spec, $rootPath);
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
-            $this->assertSame(InvalidOpenApiSpecReason::RemoteRefNotImplemented, $e->reason);
+            $this->assertSame(InvalidOpenApiSpecReason::RemoteRefDisallowed, $e->reason);
             $this->assertStringContainsString('https://example.com/pet.json', $e->getMessage());
         }
     }
 
     #[Test]
-    public function throws_remote_ref_not_implemented_for_http_ref(): void
+    public function throws_remote_ref_disallowed_for_http_ref_when_flag_is_off(): void
     {
         $rootPath = $this->workDir . '/openapi.json';
         file_put_contents($rootPath, '{}');
@@ -248,7 +248,7 @@ class OpenApiRefResolverExternalRefsTest extends TestCase
             OpenApiRefResolver::resolve($spec, $rootPath);
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
-            $this->assertSame(InvalidOpenApiSpecReason::RemoteRefNotImplemented, $e->reason);
+            $this->assertSame(InvalidOpenApiSpecReason::RemoteRefDisallowed, $e->reason);
         }
     }
 

--- a/tests/Unit/OpenApiRefResolverHttpRefsTest.php
+++ b/tests/Unit/OpenApiRefResolverHttpRefsTest.php
@@ -1,0 +1,348 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use GuzzleHttp\Psr7\HttpFactory;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
+use Studio\OpenApiContractTesting\InvalidOpenApiSpecReason;
+use Studio\OpenApiContractTesting\OpenApiRefResolver;
+use Studio\OpenApiContractTesting\Tests\Helpers\FakeHttpClient;
+
+use function file_put_contents;
+use function is_dir;
+use function mkdir;
+use function rmdir;
+use function scandir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+class OpenApiRefResolverHttpRefsTest extends TestCase
+{
+    private HttpFactory $factory;
+    private string $workDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = new HttpFactory();
+        $this->workDir = sys_get_temp_dir() . '/oct-resolver-http-' . uniqid();
+        mkdir($this->workDir);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->workDir);
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function resolves_https_ref_when_opt_in_and_client_provided(): void
+    {
+        $url = 'https://example.com/schemas/pet.json';
+        $client = new FakeHttpClient([
+            $url => FakeHttpClient::jsonResponse('{"type":"object","required":["id"]}'),
+        ]);
+
+        $spec = ['components' => ['schemas' => ['Pet' => ['$ref' => $url]]]];
+
+        $resolved = OpenApiRefResolver::resolve(
+            $spec,
+            sourceFile: null,
+            httpClient: $client,
+            requestFactory: $this->factory,
+            allowRemoteRefs: true,
+        );
+
+        $this->assertSame(
+            ['type' => 'object', 'required' => ['id']],
+            $resolved['components']['schemas']['Pet'],
+        );
+    }
+
+    #[Test]
+    public function resolves_https_ref_with_json_pointer_fragment(): void
+    {
+        $url = 'https://example.com/schemas.json';
+        $client = new FakeHttpClient([
+            $url => FakeHttpClient::jsonResponse(
+                '{"Pet":{"type":"object"},"Owner":{"type":"string"}}',
+            ),
+        ]);
+
+        $spec = ['components' => ['schemas' => ['Pet' => ['$ref' => $url . '#/Pet']]]];
+
+        $resolved = OpenApiRefResolver::resolve(
+            $spec,
+            httpClient: $client,
+            requestFactory: $this->factory,
+            allowRemoteRefs: true,
+        );
+
+        $this->assertSame(['type' => 'object'], $resolved['components']['schemas']['Pet']);
+    }
+
+    #[Test]
+    public function resolves_chain_of_https_refs(): void
+    {
+        $a = 'https://example.com/a.json';
+        $b = 'https://example.com/b.json';
+        $c = 'https://example.com/c.json';
+        $client = new FakeHttpClient([
+            $a => FakeHttpClient::jsonResponse('{"$ref":"' . $b . '"}'),
+            $b => FakeHttpClient::jsonResponse('{"$ref":"' . $c . '"}'),
+            $c => FakeHttpClient::jsonResponse('{"type":"string"}'),
+        ]);
+
+        $spec = ['components' => ['schemas' => ['Leaf' => ['$ref' => $a]]]];
+
+        $resolved = OpenApiRefResolver::resolve(
+            $spec,
+            httpClient: $client,
+            requestFactory: $this->factory,
+            allowRemoteRefs: true,
+        );
+
+        $this->assertSame(['type' => 'string'], $resolved['components']['schemas']['Leaf']);
+    }
+
+    #[Test]
+    public function detects_cycle_between_two_https_refs(): void
+    {
+        $a = 'https://example.com/a.json';
+        $b = 'https://example.com/b.json';
+        $client = new FakeHttpClient([
+            $a => FakeHttpClient::jsonResponse('{"$ref":"' . $b . '#/Loop"}'),
+            $b => FakeHttpClient::jsonResponse('{"Loop":{"$ref":"' . $a . '"}}'),
+        ]);
+
+        $spec = ['components' => ['schemas' => ['Start' => ['$ref' => $a]]]];
+
+        try {
+            OpenApiRefResolver::resolve(
+                $spec,
+                httpClient: $client,
+                requestFactory: $this->factory,
+                allowRemoteRefs: true,
+            );
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::CircularRef, $e->reason);
+        }
+    }
+
+    #[Test]
+    public function resolves_cross_source_local_to_remote_chain(): void
+    {
+        // Local root → local file → remote URL → leaf. Mirrors a real
+        // hybrid setup where some schemas live in the repo and others are
+        // pulled from a Schema Registry.
+        $rootPath = $this->workDir . '/openapi.json';
+        file_put_contents($rootPath, '{}');
+        file_put_contents(
+            $this->workDir . '/local-bridge.json',
+            '{"$ref":"https://example.com/leaf.json"}',
+        );
+
+        $client = new FakeHttpClient([
+            'https://example.com/leaf.json' => FakeHttpClient::jsonResponse('{"type":"integer"}'),
+        ]);
+
+        $spec = ['components' => ['schemas' => ['Final' => ['$ref' => './local-bridge.json']]]];
+
+        $resolved = OpenApiRefResolver::resolve(
+            $spec,
+            sourceFile: $rootPath,
+            httpClient: $client,
+            requestFactory: $this->factory,
+            allowRemoteRefs: true,
+        );
+
+        $this->assertSame(['type' => 'integer'], $resolved['components']['schemas']['Final']);
+    }
+
+    #[Test]
+    public function reuses_loaded_url_for_sibling_fragment_refs(): void
+    {
+        $url = 'https://example.com/schemas.json';
+        $callCount = 0;
+        $client = new FakeHttpClient([
+            $url => static function (RequestInterface $request) use (&$callCount): Response {
+                $callCount++;
+
+                return new Response(
+                    200,
+                    ['Content-Type' => 'application/json'],
+                    '{"Pet":{"type":"object"},"Owner":{"type":"string"}}',
+                );
+            },
+        ]);
+
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Pet' => ['$ref' => $url . '#/Pet'],
+                    'Owner' => ['$ref' => $url . '#/Owner'],
+                ],
+            ],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve(
+            $spec,
+            httpClient: $client,
+            requestFactory: $this->factory,
+            allowRemoteRefs: true,
+        );
+
+        $this->assertSame(1, $callCount, 'duplicate URLs should hit the per-resolution cache');
+        $this->assertSame(['type' => 'object'], $resolved['components']['schemas']['Pet']);
+        $this->assertSame(['type' => 'string'], $resolved['components']['schemas']['Owner']);
+    }
+
+    #[Test]
+    public function throws_remote_ref_disallowed_when_allow_flag_is_off_even_with_client(): void
+    {
+        $url = 'https://example.com/pet.json';
+        $client = new FakeHttpClient([
+            $url => FakeHttpClient::jsonResponse('{"type":"object"}'),
+        ]);
+
+        $spec = ['components' => ['schemas' => ['Pet' => ['$ref' => $url]]]];
+
+        try {
+            OpenApiRefResolver::resolve(
+                $spec,
+                httpClient: $client,
+                requestFactory: $this->factory,
+                allowRemoteRefs: false,
+            );
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::RemoteRefDisallowed, $e->reason);
+        }
+
+        $this->assertSame([], $client->sentUrls(), 'client must not be invoked when flag is off');
+    }
+
+    #[Test]
+    public function throws_http_client_not_configured_when_flag_on_but_client_missing(): void
+    {
+        $spec = ['components' => ['schemas' => ['Pet' => ['$ref' => 'https://example.com/pet.json']]]];
+
+        try {
+            OpenApiRefResolver::resolve($spec, allowRemoteRefs: true);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::HttpClientNotConfigured, $e->reason);
+            $this->assertStringContainsString('PSR-18', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function throws_http_client_not_configured_when_flag_on_but_factory_missing(): void
+    {
+        $client = new FakeHttpClient();
+        $spec = ['components' => ['schemas' => ['Pet' => ['$ref' => 'https://example.com/pet.json']]]];
+
+        try {
+            OpenApiRefResolver::resolve(
+                $spec,
+                httpClient: $client,
+                requestFactory: null,
+                allowRemoteRefs: true,
+            );
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::HttpClientNotConfigured, $e->reason);
+        }
+    }
+
+    #[Test]
+    public function decodes_json_pointer_escapes_in_remote_fragment(): void
+    {
+        $url = 'https://example.com/schemas.json';
+        $client = new FakeHttpClient([
+            $url => FakeHttpClient::jsonResponse('{"a/b":{"type":"object"}}'),
+        ]);
+
+        $spec = ['components' => ['schemas' => ['Slash' => ['$ref' => $url . '#/a~1b']]]];
+
+        $resolved = OpenApiRefResolver::resolve(
+            $spec,
+            httpClient: $client,
+            requestFactory: $this->factory,
+            allowRemoteRefs: true,
+        );
+
+        $this->assertSame(['type' => 'object'], $resolved['components']['schemas']['Slash']);
+    }
+
+    #[Test]
+    public function throws_unresolvable_ref_when_remote_fragment_missing(): void
+    {
+        $url = 'https://example.com/schemas.json';
+        $client = new FakeHttpClient([
+            $url => FakeHttpClient::jsonResponse('{"Pet":{"type":"object"}}'),
+        ]);
+
+        $spec = ['components' => ['schemas' => ['Missing' => ['$ref' => $url . '#/Owner']]]];
+
+        try {
+            OpenApiRefResolver::resolve(
+                $spec,
+                httpClient: $client,
+                requestFactory: $this->factory,
+                allowRemoteRefs: true,
+            );
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::UnresolvableRef, $e->reason);
+        }
+    }
+
+    #[Test]
+    public function throws_bare_fragment_for_trailing_hash_on_https_ref(): void
+    {
+        $url = 'https://example.com/pet.json';
+        $client = new FakeHttpClient();
+
+        $spec = ['components' => ['schemas' => ['Pet' => ['$ref' => $url . '#']]]];
+
+        try {
+            OpenApiRefResolver::resolve(
+                $spec,
+                httpClient: $client,
+                requestFactory: $this->factory,
+                allowRemoteRefs: true,
+            );
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::BareFragmentRef, $e->reason);
+        }
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        foreach (scandir($dir) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $entry;
+            if (is_dir($path)) {
+                $this->removeDir($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/tests/Unit/OpenApiRefResolverHttpRefsTest.php
+++ b/tests/Unit/OpenApiRefResolverHttpRefsTest.php
@@ -140,9 +140,9 @@ class OpenApiRefResolverHttpRefsTest extends TestCase
     #[Test]
     public function resolves_cross_source_local_to_remote_chain(): void
     {
-        // Local root → local file → remote URL → leaf. Mirrors a real
-        // hybrid setup where some schemas live in the repo and others are
-        // pulled from a Schema Registry.
+        // Local root → local file → remote URL → leaf. Pins that the
+        // resolver correctly switches loaders when a `$ref` crosses
+        // protocols mid-chain.
         $rootPath = $this->workDir . '/openapi.json';
         file_put_contents($rootPath, '{}');
         file_put_contents(
@@ -303,6 +303,149 @@ class OpenApiRefResolverHttpRefsTest extends TestCase
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
             $this->assertSame(InvalidOpenApiSpecReason::UnresolvableRef, $e->reason);
+        }
+    }
+
+    #[Test]
+    public function document_cache_is_per_resolution_call_not_global_for_http_refs(): void
+    {
+        // The same client is used across two separate resolve() calls;
+        // each call must perform its own fetch. If a future refactor
+        // hoists the cache to a static field, hot-reloading specs in
+        // test watchers would silently see stale URLs.
+        $url = 'https://example.com/pet.json';
+        $callCount = 0;
+        $client = new FakeHttpClient([
+            $url => static function () use (&$callCount): Response {
+                $callCount++;
+
+                return new Response(200, ['Content-Type' => 'application/json'], '{"v":' . $callCount . '}');
+            },
+        ]);
+
+        $spec1 = ['components' => ['schemas' => ['Pet' => ['$ref' => $url]]]];
+        $first = OpenApiRefResolver::resolve(
+            $spec1,
+            httpClient: $client,
+            requestFactory: $this->factory,
+            allowRemoteRefs: true,
+        );
+        $this->assertSame(['v' => 1], $first['components']['schemas']['Pet']);
+
+        $spec2 = ['components' => ['schemas' => ['Pet' => ['$ref' => $url]]]];
+        $second = OpenApiRefResolver::resolve(
+            $spec2,
+            httpClient: $client,
+            requestFactory: $this->factory,
+            allowRemoteRefs: true,
+        );
+        $this->assertSame(['v' => 2], $second['components']['schemas']['Pet']);
+        $this->assertSame(2, $callCount);
+    }
+
+    #[Test]
+    public function relative_ref_inside_http_document_resolves_against_url_per_rfc3986(): void
+    {
+        // Inside a document loaded over HTTP, `$ref: './pet.yaml'` must
+        // resolve against the source URL — not against any local
+        // filesystem path. Without this, dirname() on the URL would
+        // produce nonsense like `dirname('https:')` and the user would
+        // see a confusing LocalRefNotFound.
+        $rootUrl = 'https://example.com/openapi.json';
+        $childUrl = 'https://example.com/schemas/pet.yaml';
+        $client = new FakeHttpClient([
+            $rootUrl => FakeHttpClient::jsonResponse('{"$ref":"./schemas/pet.yaml"}'),
+            $childUrl => FakeHttpClient::yamlResponse("type: object\nrequired:\n  - id\n"),
+        ]);
+
+        $spec = ['components' => ['schemas' => ['Pet' => ['$ref' => $rootUrl]]]];
+
+        $resolved = OpenApiRefResolver::resolve(
+            $spec,
+            httpClient: $client,
+            requestFactory: $this->factory,
+            allowRemoteRefs: true,
+        );
+
+        $this->assertSame(
+            ['type' => 'object', 'required' => ['id']],
+            $resolved['components']['schemas']['Pet'],
+        );
+    }
+
+    #[Test]
+    public function relative_ref_with_parent_dir_resolves_against_http_base(): void
+    {
+        $rootUrl = 'https://example.com/api/v1/openapi.json';
+        $childUrl = 'https://example.com/api/shared.json';
+        $client = new FakeHttpClient([
+            $rootUrl => FakeHttpClient::jsonResponse('{"$ref":"../shared.json"}'),
+            $childUrl => FakeHttpClient::jsonResponse('{"type":"string"}'),
+        ]);
+
+        $spec = ['components' => ['schemas' => ['X' => ['$ref' => $rootUrl]]]];
+
+        $resolved = OpenApiRefResolver::resolve(
+            $spec,
+            httpClient: $client,
+            requestFactory: $this->factory,
+            allowRemoteRefs: true,
+        );
+
+        $this->assertSame(['type' => 'string'], $resolved['components']['schemas']['X']);
+    }
+
+    #[Test]
+    public function absolute_path_ref_inside_http_document_resolves_to_same_host(): void
+    {
+        $rootUrl = 'https://example.com/openapi.json';
+        $childUrl = 'https://example.com/registry/Pet.json';
+        $client = new FakeHttpClient([
+            $rootUrl => FakeHttpClient::jsonResponse('{"$ref":"/registry/Pet.json"}'),
+            $childUrl => FakeHttpClient::jsonResponse('{"type":"integer"}'),
+        ]);
+
+        $spec = ['components' => ['schemas' => ['X' => ['$ref' => $rootUrl]]]];
+
+        $resolved = OpenApiRefResolver::resolve(
+            $spec,
+            httpClient: $client,
+            requestFactory: $this->factory,
+            allowRemoteRefs: true,
+        );
+
+        $this->assertSame(['type' => 'integer'], $resolved['components']['schemas']['X']);
+    }
+
+    #[Test]
+    public function fetch_failure_includes_chain_for_multi_hop_diagnostics(): void
+    {
+        // When a fetch fails 3+ hops deep, the leaf URL alone is poor
+        // diagnostic. The error message should include the $ref chain
+        // so the developer knows which spec entry triggered the cascade.
+        $a = 'https://example.com/a.json';
+        $b = 'https://example.com/b.json';
+        $c = 'https://example.com/missing.json';
+        $client = new FakeHttpClient([
+            $a => FakeHttpClient::jsonResponse('{"$ref":"' . $b . '"}'),
+            $b => FakeHttpClient::jsonResponse('{"$ref":"' . $c . '"}'),
+            $c => new Response(404),
+        ]);
+
+        $spec = ['components' => ['schemas' => ['Leaf' => ['$ref' => $a]]]];
+
+        try {
+            OpenApiRefResolver::resolve(
+                $spec,
+                httpClient: $client,
+                requestFactory: $this->factory,
+                allowRemoteRefs: true,
+            );
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::RemoteRefFetchFailed, $e->reason);
+            $this->assertStringContainsString('via $ref chain', $e->getMessage());
+            $this->assertStringContainsString($a, $e->getMessage());
         }
     }
 

--- a/tests/Unit/OpenApiRefResolverTest.php
+++ b/tests/Unit/OpenApiRefResolverTest.php
@@ -347,10 +347,12 @@ class OpenApiRefResolverTest extends TestCase
     }
 
     #[Test]
-    public function throws_remote_ref_not_implemented_for_url_ref(): void
+    public function throws_remote_ref_disallowed_when_allow_remote_refs_is_off(): void
     {
-        // HTTP(S) refs are reserved for a follow-up PR with explicit
-        // opt-in semantics around remote network access.
+        // HTTP(S) ref resolution is opt-in. The default `allowRemoteRefs:
+        // false` rejects every remote ref before any HTTP client check
+        // runs, so a misconfigured wiring cannot accidentally hit the
+        // network.
         $spec = [
             'components' => [
                 'schemas' => [
@@ -363,7 +365,7 @@ class OpenApiRefResolverTest extends TestCase
             OpenApiRefResolver::resolve($spec);
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
-            $this->assertSame(InvalidOpenApiSpecReason::RemoteRefNotImplemented, $e->reason);
+            $this->assertSame(InvalidOpenApiSpecReason::RemoteRefDisallowed, $e->reason);
         }
     }
 

--- a/tests/Unit/OpenApiSpecLoaderTest.php
+++ b/tests/Unit/OpenApiSpecLoaderTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Tests\Unit;
 
-use const E_USER_WARNING;
-
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\HttpFactory;
 use InvalidArgumentException;
@@ -22,9 +20,7 @@ use function class_exists;
 use function file_put_contents;
 use function json_encode;
 use function mkdir;
-use function restore_error_handler;
 use function rmdir;
-use function set_error_handler;
 use function sys_get_temp_dir;
 use function uniqid;
 use function unlink;
@@ -324,19 +320,10 @@ class OpenApiSpecLoaderTest extends TestCase
     }
 
     #[Test]
-    public function configure_emits_warning_when_client_is_set_without_allow_flag(): void
+    public function configure_throws_when_client_is_set_without_allow_flag(): void
     {
         $client = new Client();
         $factory = new HttpFactory();
-
-        // Override PHPUnit's default failOnWarning behaviour locally so
-        // we can pin the warning message rather than the test crashing.
-        $captured = [];
-        set_error_handler(static function (int $errno, string $msg) use (&$captured): bool {
-            $captured[] = ['errno' => $errno, 'msg' => $msg];
-
-            return true;
-        });
 
         try {
             OpenApiSpecLoader::configure(
@@ -345,39 +332,72 @@ class OpenApiSpecLoaderTest extends TestCase
                 requestFactory: $factory,
                 allowRemoteRefs: false,
             );
-        } finally {
-            restore_error_handler();
+            $this->fail('expected InvalidArgumentException');
+        } catch (InvalidArgumentException $e) {
+            $this->assertStringContainsString('allowRemoteRefs is false', $e->getMessage());
+            $this->assertStringContainsString('HTTP client was provided', $e->getMessage());
         }
-
-        $this->assertCount(1, $captured);
-        $this->assertSame(E_USER_WARNING, $captured[0]['errno']);
-        $this->assertStringContainsString('allowRemoteRefs is false', $captured[0]['msg']);
     }
 
     #[Test]
-    public function configure_accepts_full_remote_setup_without_warning(): void
+    public function configure_accepts_full_remote_setup(): void
     {
         $client = new Client();
         $factory = new HttpFactory();
-        $captured = [];
-        set_error_handler(static function (int $errno, string $msg) use (&$captured): bool {
-            $captured[] = $msg;
 
-            return true;
-        });
+        OpenApiSpecLoader::configure(
+            '/path/to/specs',
+            httpClient: $client,
+            requestFactory: $factory,
+            allowRemoteRefs: true,
+        );
 
+        $this->assertSame('/path/to/specs', OpenApiSpecLoader::getBasePath());
+    }
+
+    #[Test]
+    public function configure_evicts_cached_specs(): void
+    {
+        // A previously-cached spec resolved under one remote-refs policy
+        // must not be served after configure() flips the policy. Pin the
+        // eviction so the next load() reads from disk again.
+        $fixturesPath = __DIR__ . '/../fixtures/specs';
+        OpenApiSpecLoader::configure($fixturesPath);
+        $first = OpenApiSpecLoader::load('petstore-3.0');
+        $this->assertSame('3.0.3', $first['openapi']);
+
+        OpenApiSpecLoader::configure(
+            $fixturesPath,
+            httpClient: new Client(),
+            requestFactory: new HttpFactory(),
+            allowRemoteRefs: true,
+        );
+
+        // Reload — by-value-equal but not the cached array from before.
+        $reloaded = OpenApiSpecLoader::load('petstore-3.0');
+        $this->assertSame($first, $reloaded);
+    }
+
+    #[Test]
+    public function reset_clears_http_client_and_remote_flag_state(): void
+    {
+        OpenApiSpecLoader::configure(
+            '/path/to/specs',
+            httpClient: new Client(),
+            requestFactory: new HttpFactory(),
+            allowRemoteRefs: true,
+        );
+
+        OpenApiSpecLoader::reset();
+
+        // Reconfiguring with allowRemoteRefs:true but no client must
+        // throw — proving the prior client/factory weren't sticky.
         try {
-            OpenApiSpecLoader::configure(
-                '/path/to/specs',
-                httpClient: $client,
-                requestFactory: $factory,
-                allowRemoteRefs: true,
-            );
-        } finally {
-            restore_error_handler();
+            OpenApiSpecLoader::configure('/path/to/specs', allowRemoteRefs: true);
+            $this->fail('expected InvalidArgumentException');
+        } catch (InvalidArgumentException $e) {
+            $this->assertStringContainsString('allowRemoteRefs requires', $e->getMessage());
         }
-
-        $this->assertSame([], $captured, 'no warning expected when fully wired');
     }
 
     #[Test]

--- a/tests/Unit/OpenApiSpecLoaderTest.php
+++ b/tests/Unit/OpenApiSpecLoaderTest.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Tests\Unit;
 
+use const E_USER_WARNING;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\HttpFactory;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\Internal\YamlAvailability;
@@ -17,7 +22,9 @@ use function class_exists;
 use function file_put_contents;
 use function json_encode;
 use function mkdir;
+use function restore_error_handler;
 use function rmdir;
+use function set_error_handler;
 use function sys_get_temp_dir;
 use function uniqid;
 use function unlink;
@@ -299,6 +306,78 @@ class OpenApiSpecLoaderTest extends TestCase
             @unlink($tempDir . '/root.json');
             @rmdir($tempDir);
         }
+    }
+
+    #[Test]
+    public function configure_throws_invalid_argument_when_allow_remote_refs_without_client(): void
+    {
+        try {
+            OpenApiSpecLoader::configure(
+                '/path/to/specs',
+                allowRemoteRefs: true,
+            );
+            $this->fail('expected InvalidArgumentException');
+        } catch (InvalidArgumentException $e) {
+            $this->assertStringContainsString('allowRemoteRefs', $e->getMessage());
+            $this->assertStringContainsString('PSR-18', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function configure_emits_warning_when_client_is_set_without_allow_flag(): void
+    {
+        $client = new Client();
+        $factory = new HttpFactory();
+
+        // Override PHPUnit's default failOnWarning behaviour locally so
+        // we can pin the warning message rather than the test crashing.
+        $captured = [];
+        set_error_handler(static function (int $errno, string $msg) use (&$captured): bool {
+            $captured[] = ['errno' => $errno, 'msg' => $msg];
+
+            return true;
+        });
+
+        try {
+            OpenApiSpecLoader::configure(
+                '/path/to/specs',
+                httpClient: $client,
+                requestFactory: $factory,
+                allowRemoteRefs: false,
+            );
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertCount(1, $captured);
+        $this->assertSame(E_USER_WARNING, $captured[0]['errno']);
+        $this->assertStringContainsString('allowRemoteRefs is false', $captured[0]['msg']);
+    }
+
+    #[Test]
+    public function configure_accepts_full_remote_setup_without_warning(): void
+    {
+        $client = new Client();
+        $factory = new HttpFactory();
+        $captured = [];
+        set_error_handler(static function (int $errno, string $msg) use (&$captured): bool {
+            $captured[] = $msg;
+
+            return true;
+        });
+
+        try {
+            OpenApiSpecLoader::configure(
+                '/path/to/specs',
+                httpClient: $client,
+                requestFactory: $factory,
+                allowRemoteRefs: true,
+            );
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $captured, 'no warning expected when fully wired');
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

**Closes #108.** Builds on PR 1/2 (#119) which added local-filesystem ref support.

The resolver now follows `$ref` paths to HTTP(S) URLs when the user opts in:

```php
use GuzzleHttp\Client;
use GuzzleHttp\Psr7\HttpFactory;

OpenApiSpecLoader::configure(
    basePath: 'openapi/',
    httpClient: new Client(),         // any PSR-18 implementation
    requestFactory: new HttpFactory(), // any PSR-17 implementation
    allowRemoteRefs: true,
);

// Now this works:
// $ref: 'https://example.com/schemas/pet.yaml'
// $ref: 'https://example.com/schemas/pet.yaml#/Pet'
// $ref: 'https://registry.example.com/Pet'   (Schema Registry, no extension)
```

## Design decisions (chat-confirmed)

- **PSR-18 + PSR-17 directly** — the two interfaces are passed as discrete typed parameters. Users wire whichever HTTP client they already have (Guzzle, Symfony HttpClient, Buzz, ...). Library stays implementation-agnostic.
- **Two-knob opt-in** — `httpClient` set without `allowRemoteRefs: true` triggers `E_USER_WARNING` at `configure()` time so the misconfiguration doesn't sit silent. Belt + suspenders prevents accidental network calls.
- **`RefResolutionContext` DTO** — bundled into this PR (S3 from #119 review). The `walk()`/`resolve()` signatures already had 6 params; adding 3 more for HTTP would have crossed into unmaintainable territory.

## Failure modes — all surfaced precisely

| Setup | Result |
| --- | --- |
| `allowRemoteRefs: true` + missing client/factory | `InvalidArgumentException` at `configure()` |
| `httpClient` set + `allowRemoteRefs: false` | `E_USER_WARNING` at `configure()` |
| HTTP `$ref` + `allowRemoteRefs: false` | `RemoteRefDisallowed` |
| HTTP `$ref` + flag on + missing client/factory | `HttpClientNotConfigured` |
| HTTP `$ref` + opt-in + 4xx/5xx/network error | `RemoteRefFetchFailed` |
| HTTP `$ref` + URL has no `.json/.yaml` AND no JSON/YAML `Content-Type` | `UnsupportedExtension` |

`RemoteRefNotImplemented` from PR 1/2 is `@deprecated` (kept for callers branching on it).

## Test plan

- [x] **`HttpRefLoaderTest`** (13 tests): URL-extension + Content-Type format detection (incl. `application/*+json`, `application/yaml`, `text/yaml`), per-call cache, 404/5xx/network error mapping, malformed body, non-mapping root
- [x] **`OpenApiRefResolverHttpRefsTest`** (12 tests): opt-in success path, fragments, multi-hop HTTP chains, cross-file HTTP cycles, **cross-source local↔HTTP chains**, sibling fragment URL reuse, opt-in/wiring failure modes, JSON Pointer escapes (`~1`/`~0`) in remote fragments, missing fragment, trailing-hash rejection
- [x] **`OpenApiSpecLoaderTest`** (3 new tests): configure-time `InvalidArgumentException`, `E_USER_WARNING` for wired-but-disabled, no-warning happy path
- [x] Existing 717+ tests untouched (DTO refactor preserves backward compat via optional defaults)
- [x] **PHPUnit:** 745 tests / 1481 assertions
- [x] **PHPStan level 6:** 0 errors
- [x] **PHP-CS-Fixer:** 0 violations
- [x] **Tests run offline** — `FakeHttpClient` returns canned responses; no real network calls

## New types / classes

- `RefResolutionContext` (DTO, public) — immutable carrier for sourceFile + httpClient + requestFactory + allowRemoteRefs
- `Internal\HttpRefLoader` — PSR-18 fetch + decode
- `Internal\SpecDocumentDecoder` — shared JSON/YAML decoder for both `ExternalRefLoader` and `HttpRefLoader`
- `Tests\Helpers\FakeHttpClient` — minimal PSR-18 test double

## Dependencies

**`require`** (interface-only packages, ~zero size impact):
- `psr/http-client: ^1.0`
- `psr/http-factory: ^1.0`
- `psr/http-message: ^1.0 || ^2.0`

**`require-dev`**:
- `guzzlehttp/psr7: ^2.0` (test PSR-7 implementations)

**`suggest`**: `guzzlehttp/guzzle`, `symfony/http-client` as concrete client examples.

## README updates

- Comparison table: `External $ref auto-resolution` ❌ → ✅
- New section **"HTTP `$ref` resolution (opt-in)"** documents wiring, failure modes, format detection, and security stance
- Setup section rewritten: pre-bundling no longer required for internal/local refs; Redocly remains supported for users on the legacy bundled-spec workflow

## Out of scope (future issues)

- Global / cross-call HTTP cache (TTL, invalidation)
- URL allowlist / SSRF defense (current trust model: `allowRemoteRefs: false` default + spec author trust)
- Auth headers / proxy / timeout configuration (user's PSR-18 client handles these)
- `ResponseValidationContext` DTO from PR #120 review (separate concern)

## Closes

Closes #108