### PR TITLE
feat(coverage): expand granularity to (method, path, status, contentType) (#111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,77 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+This project is **pre-1.0**, so breaking changes may land in any minor release
+until 1.0.0 ships. Each entry below tags whether it is breaking.
+
+## Unreleased
+
+### Breaking
+
+- **Coverage granularity expanded** to `(method, path, statusCode, contentType)`
+  ([#111](https://github.com/studio-design/openapi-contract-testing/issues/111)).
+  - `OpenApiCoverageTracker::record()` is **removed**. Use the new
+    `recordRequest(spec, method, path)` and
+    `recordResponse(spec, method, path, statusKey, contentTypeKey, schemaValidated, skipReason?)`.
+    Library-internal call sites (the Laravel trait) are updated automatically;
+    direct callers must migrate.
+  - `OpenApiCoverageTracker::computeCoverage()` returns a new shape with
+    per-endpoint sub-rows (one per declared `(status, content-type)` pair),
+    response-level totals, an `EndpointSummary['state']` field
+    (`all-covered` | `partial` | `uncovered` | `request-only`), and an
+    `unexpectedObservations` list. Old keys (`covered`, `uncovered`, `total`,
+    `coveredCount`, `skippedOnly`, `skippedOnlyCount`) are gone.
+  - `OpenApiCoverageTracker::getCovered()` is retained as a diagnostic shim
+    returning `array<spec, array<"METHOD path", true>>`. Prefer
+    `hasAnyCoverage(spec): bool` for presence checks and `computeCoverage()`
+    for full results.
+  - `MarkdownCoverageRenderer` and `ConsoleCoverageRenderer` produce
+    visibly different output (per-endpoint sub-rows, partial/skipped
+    markers). Consumers that scrape these outputs may need updates.
+  - Coverage rates are now reported at **two granularities** — endpoint
+    (`endpointFullyCovered / endpointTotal`) and response definition
+    (`responseCovered / responseTotal`).
+
+### Added
+
+- `OpenApiValidationResult::matchedStatusCode()` and `matchedContentType()`
+  expose which spec response key and media-type key the validator selected,
+  so coverage tracking can record per-pair granularity. For skipped
+  responses, `matchedStatusCode()` is the **literal HTTP status string**
+  (e.g. `"503"`) and is reconciled to spec range keys (`5XX` / `5xx` /
+  `default`) at compute time.
+- `OpenApiCoverageTracker::ANY_CONTENT_TYPE` (`"*"`) sentinel for responses
+  recorded before content-type lookup (skipped, 204, non-JSON-only).
+- `Validation/Response/ResponseBodyValidationResult` DTO carries the body
+  validator's errors plus the matched spec content-type key. Replaces the
+  bare `string[]` return.
+- New fixture `tests/fixtures/specs/range-keys.json` exercising spec-side
+  `5XX` and `default` response keys for reconciliation tests.
+- `CoverageReportSubscriber` extracted from the inline anonymous subscriber
+  in `OpenApiCoverageExtension` so PHPStan can resolve the imported
+  `CoverageResult` shape end-to-end.
+
+### Changed
+
+- `Validation/Response/ResponseBodyValidator::validate()` returns
+  `ResponseBodyValidationResult` instead of `string[]`. Internal class —
+  external callers were not expected, but if you instantiated it directly,
+  unwrap `->errors` from the new return value.
+- `Validation/Support/ContentTypeMatcher::findContentTypeKey()` is added
+  to surface the spec's literal media-type key (with original casing)
+  matching a normalized content-type. Used by the body validator and
+  coverage tracker so the spec author's casing is preserved in reports.
+
+### Notes
+
+- Spec-undefined statuses observed at runtime (e.g. real `503` against a
+  spec that declares neither `503` nor `5XX`) now appear in
+  `EndpointSummary['unexpectedObservations']` rather than silently inflating
+  endpoint coverage. Behavior change worth flagging for users that relied
+  on the old loose counting.
+- Skip-by-status-code remains opt-in via `skip_response_codes`; matched
+  literal statuses (e.g. `"503"`) reconcile against any spec range key
+  declared on the same endpoint via the
+  `OpenApiCoverageTracker::statusKeyMatches()` helper.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,14 @@ until 1.0.0 ships. Each entry below tags whether it is breaking.
     `recordRequest(spec, method, path)` and
     `recordResponse(spec, method, path, statusKey, contentTypeKey, schemaValidated, skipReason?)`.
     Library-internal call sites (the Laravel trait) are updated automatically;
-    direct callers must migrate.
+    direct callers must migrate. `$contentTypeKey` is `?string`: pass `null`
+    when no content-type lookup applies (e.g. the response was skipped before
+    content negotiation, or it is a 204-style entry) — null is internally
+    stored under the `*` sentinel and reconciled against spec declarations
+    that have no `content` block.
+  - `OpenApiCoverageTracker::__construct` is now `private`. The class was
+    static-only in practice but you could previously call `new` on it; that
+    now raises `Error`. Use the static API directly.
   - `OpenApiCoverageTracker::computeCoverage()` returns a new shape with
     per-endpoint sub-rows (one per declared `(status, content-type)` pair),
     response-level totals, an `EndpointSummary['state']` field
@@ -30,6 +37,13 @@ until 1.0.0 ships. Each entry below tags whether it is breaking.
   - `MarkdownCoverageRenderer` and `ConsoleCoverageRenderer` produce
     visibly different output (per-endpoint sub-rows, partial/skipped
     markers). Consumers that scrape these outputs may need updates.
+  - `OpenApiResponseValidator::validate()` now returns
+    `OpenApiValidationResult::skipped()` (was: silent `success()`) when the
+    spec declares only non-JSON content types and the caller did not supply
+    a `responseContentType` — there is no schema engine to validate against,
+    so coverage records the response as `skipped` instead of crediting it
+    as validated. Callers that pass the actual response Content-Type
+    continue to be marked `validated` whenever the type is in the spec.
   - Coverage rates are now reported at **two granularities** — endpoint
     (`endpointFullyCovered / endpointTotal`) and response definition
     (`responseCovered / responseTotal`).
@@ -73,5 +87,15 @@ until 1.0.0 ships. Each entry below tags whether it is breaking.
   on the old loose counting.
 - Skip-by-status-code remains opt-in via `skip_response_codes`; matched
   literal statuses (e.g. `"503"`) reconcile against any spec range key
-  declared on the same endpoint via the
-  `OpenApiCoverageTracker::statusKeyMatches()` helper.
+  (`5XX` / `5xx` / `default`) declared on the same endpoint at compute
+  time, so a `5\d\d` skip on an endpoint declaring `5XX: application/json`
+  surfaces as `skipped` rather than `uncovered`.
+- A spec that declares both `default` and `5XX` for the same content-type
+  on the same endpoint is treated as **two distinct response definitions**
+  in the totals — a single `503` recording credits both. Spec authors
+  rarely write both; if they do, response-level totals reflect that.
+- `OpenApiCoverageTracker::computeCoverage()` emits `E_USER_WARNING`
+  (visible to PHPUnit) when the spec contains structurally invalid
+  branches inside `paths` (e.g. `responses: 200` as a scalar). Coverage
+  proceeds with the malformed entries omitted; without the warning the
+  user would silently see a smaller `responseTotal` than reality.

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Notes:
 - Skipped endpoints count as covered — the endpoint was exercised, just not schema-validated. Coverage semantics here match how non-JSON content types and schema-less `204` responses are handled, but `OpenApiValidationResult::isSkipped()` returns `true` **only** for status-code skips; the other no-body-validation branches still return a plain `success()`.
 - `OpenApiValidationResult::isSkipped()` is exposed for callers who want to distinguish a skip from a genuine success. `skipReason()` identifies the matched pattern. `outcome()` returns an `OpenApiValidationOutcome` enum (`Success` / `Failure` / `Skipped`) for callers who want exhaustive `match` handling instead of two bool predicates.
 - **Observability trade-off**: a real regression that causes an unrelated `500` will not fail this assertion. Keep your HTTP-level assertions (`$response->assertOk()`, status-code expectations in the test) alongside the contract check so a stray 5xx still surfaces — the contract assertion alone is not a substitute for status-code assertions on happy paths.
-- **Coverage signal**: endpoints that were only ever exercised via a skipped response are rendered with `⚠` in the console report (header gains `, N skipped-only`) and with `:warning:` in the Markdown report. `coveredCount` and the coverage percentage stay unchanged — the marker is a quality signal layered on top so a happy-path regression that silently returns `500` in every test is visible at a glance. `skipReason()` is available on each `OpenApiValidationResult` for callers who want to log the matched pattern from a custom renderer.
+- **Coverage signal**: skipped responses surface as their own row inside each endpoint's response table — `⚠` (`:warning:` in Markdown) on the per-`(status, content-type)` line, with the matched skip pattern shown inline. The endpoint marker becomes `◐` (partial) when other responses are still validated, or stays `✓` only when every declared response is covered. The response-level rate (`responseCovered / responseTotal`) excludes skipped definitions, so a happy-path regression that silently returns `500` in every test no longer hides behind a 100% endpoint count. `skipReason()` is available on each `OpenApiValidationResult` for callers who want to log the matched pattern from a custom renderer.
 
 #### Auto-assert every response
 
@@ -556,31 +556,33 @@ OpenAPI Contract Test Coverage
         responses: 38/120 covered (31.7%), 4 skipped, 78 uncovered
 --------------------------------------------------
 Legend: ✓=validated  ⚠=skipped  ✗=uncovered  ◐=partial  ·=request-only  *=any/no content-type
-  ✓ GET /v1/pets                    (3/3 responses)
-  ◐ POST /v1/pets                   (1/2 responses)
-  ⚠ DELETE /v1/pets/{petId}         (1/2 responses, 1 skipped)
-  ✗ PUT /v1/pets/{petId}            (0/2 responses)
+  ✓ GET /v1/pets  (3/3 responses)
+  ◐ POST /v1/pets  (1/2 responses)
+  ◐ DELETE /v1/pets/{petId}  (1/2 responses, 1 skipped)
+  ✗ PUT /v1/pets/{petId}  (0/2 responses)
 ```
+
+> Endpoint markers come from a fixed set: `✓` all-covered, `◐` partial (any combination of validated, skipped, uncovered short of full coverage), `·` request-only, `✗` uncovered. The `⚠` marker is reserved for per-response sub-rows (skipped responses), never for endpoint summary lines.
 
 ### `all` mode
 
-Shows endpoint summaries with per-response sub-rows:
+Shows endpoint summaries with per-response sub-rows. Sub-row whitespace is illustrative — the renderer pads `statusKey` to 5 chars and `contentTypeKey` to 32 chars:
 
 ```
 [front] endpoints: 12/45 fully covered (26.7%), 8 partial, 25 uncovered
         responses: 38/120 covered (31.7%), 4 skipped, 78 uncovered
 --------------------------------------------------
 Legend: ✓=validated  ⚠=skipped  ✗=uncovered  ◐=partial  ·=request-only  *=any/no content-type
-  ✓ GET /v1/pets                    (3/3 responses)
-      ✓ 200  application/json                 [12]
-      ✓ 400  application/problem+json         [1]
-      ✓ 422  Application/Problem+JSON         [1]
-  ◐ POST /v1/pets                   (1/2 responses)
-      ✓ 201  application/json                 [3]
-      ✗ 422  application/problem+json         uncovered
-  ⚠ DELETE /v1/pets/{petId}         (1/2 responses, 1 skipped)
-      ✓ 204  *                                [2]
-      ⚠ 5XX  *                                skipped: status 503 matched skip pattern 5\d\d
+  ✓ GET /v1/pets  (3/3 responses)
+      ✓ 200    application/json                  [12]
+      ✓ 400    application/problem+json          [1]
+      ✓ 422    Application/Problem+JSON          [1]
+  ◐ POST /v1/pets  (1/2 responses)
+      ✓ 201    application/json                  [3]
+      ✗ 422    application/problem+json          uncovered
+  ◐ DELETE /v1/pets/{petId}  (1/2 responses, 1 skipped)
+      ✓ 204    *                                 [2]
+      ⚠ 5XX    *                                 skipped: status 503 matched skip pattern 5\d\d
 ```
 
 ### `uncovered_only` mode
@@ -592,12 +594,12 @@ Shows sub-rows only for partial / uncovered endpoints, keeping fully-covered one
         responses: 38/120 covered (31.7%), 4 skipped, 78 uncovered
 --------------------------------------------------
 Legend: ✓=validated  ⚠=skipped  ✗=uncovered  ◐=partial  ·=request-only  *=any/no content-type
-  ✓ GET /v1/pets                    (3/3 responses)
-  ◐ POST /v1/pets                   (1/2 responses)
-      ✗ 422  application/problem+json         uncovered
-  ✗ PUT /v1/pets/{petId}            (0/2 responses)
-      ✗ 200  application/json                 uncovered
-      ✗ 404  application/problem+json         uncovered
+  ✓ GET /v1/pets  (3/3 responses)
+  ◐ POST /v1/pets  (1/2 responses)
+      ✗ 422    application/problem+json          uncovered
+  ✗ PUT /v1/pets/{petId}  (0/2 responses)
+      ✗ 200    application/json                  uncovered
+      ✗ 404    application/problem+json          uncovered
 ```
 
 You can set the mode via `phpunit.xml`:

--- a/README.md
+++ b/README.md
@@ -532,60 +532,72 @@ Notes:
 
 After running tests, the PHPUnit extension prints a coverage report. The output format is controlled by the `console_output` parameter (or `OPENAPI_CONSOLE_OUTPUT` environment variable).
 
+Coverage is tracked at **`(method, path, statusCode, contentType)` granularity**: a `GET /v1/pets` test that only exercises `200 application/json` does not count `404` or `application/problem+json` as covered. Per-endpoint markers reflect the resolved state across all declared response definitions:
+
+| Marker | Meaning |
+|--------|---------|
+| `✓` / `:white_check_mark:` | All declared `(status, content-type)` pairs validated |
+| `◐` / `:large_orange_diamond:` | Some pairs validated, others uncovered |
+| `⚠` / `:warning:` | Pair was skipped (e.g. `5XX` matched the default skip pattern) |
+| `✗` / `:x:` | No pair validated for this endpoint |
+| `·` / `:information_source:` | Endpoint reached via request-validation but no response asserted |
+
+The report also breaks the coverage rate into two numbers — the strict endpoint rate (all declared responses validated) and the response-level rate (`responseCovered / responseTotal`).
+
 ### `default` mode (default)
 
-Shows covered endpoints individually and uncovered as a count:
+Shows endpoint summary lines only:
 
 ```
 OpenAPI Contract Test Coverage
 ==================================================
 
-[front] 12/45 endpoints (26.7%)
+[front] endpoints: 12/45 fully covered (26.7%), 8 partial, 25 uncovered
+        responses: 38/120 covered (31.7%), 4 skipped, 78 uncovered
 --------------------------------------------------
-Covered:
-  ✓ GET /v1/pets
-  ✓ POST /v1/pets
-  ✓ GET /v1/pets/{petId}
-  ✓ DELETE /v1/pets/{petId}
-Uncovered: 41 endpoints
+Legend: ✓=validated  ⚠=skipped  ✗=uncovered  ◐=partial  ·=request-only  *=any/no content-type
+  ✓ GET /v1/pets                    (3/3 responses)
+  ◐ POST /v1/pets                   (1/2 responses)
+  ⚠ DELETE /v1/pets/{petId}         (1/2 responses, 1 skipped)
+  ✗ PUT /v1/pets/{petId}            (0/2 responses)
 ```
 
 ### `all` mode
 
-Shows both covered and uncovered endpoints individually:
+Shows endpoint summaries with per-response sub-rows:
 
 ```
-OpenAPI Contract Test Coverage
-==================================================
-
-[front] 12/45 endpoints (26.7%)
+[front] endpoints: 12/45 fully covered (26.7%), 8 partial, 25 uncovered
+        responses: 38/120 covered (31.7%), 4 skipped, 78 uncovered
 --------------------------------------------------
-Covered:
-  ✓ GET /v1/pets
-  ✓ POST /v1/pets
-  ✓ GET /v1/pets/{petId}
-  ✓ DELETE /v1/pets/{petId}
-Uncovered:
-  ✗ PUT /v1/pets/{petId}
-  ✗ GET /v1/owners
-  ...
+Legend: ✓=validated  ⚠=skipped  ✗=uncovered  ◐=partial  ·=request-only  *=any/no content-type
+  ✓ GET /v1/pets                    (3/3 responses)
+      ✓ 200  application/json                 [12]
+      ✓ 400  application/problem+json         [1]
+      ✓ 422  Application/Problem+JSON         [1]
+  ◐ POST /v1/pets                   (1/2 responses)
+      ✓ 201  application/json                 [3]
+      ✗ 422  application/problem+json         uncovered
+  ⚠ DELETE /v1/pets/{petId}         (1/2 responses, 1 skipped)
+      ✓ 204  *                                [2]
+      ⚠ 5XX  *                                skipped: status 503 matched skip pattern 5\d\d
 ```
 
 ### `uncovered_only` mode
 
-Shows uncovered endpoints individually and covered as a count — useful for large APIs where you want to focus on missing coverage:
+Shows sub-rows only for partial / uncovered endpoints, keeping fully-covered ones compact:
 
 ```
-OpenAPI Contract Test Coverage
-==================================================
-
-[front] 12/45 endpoints (26.7%)
+[front] endpoints: 12/45 fully covered (26.7%), 8 partial, 25 uncovered
+        responses: 38/120 covered (31.7%), 4 skipped, 78 uncovered
 --------------------------------------------------
-Covered: 12 endpoints
-Uncovered:
-  ✗ PUT /v1/pets/{petId}
-  ✗ GET /v1/owners
-  ...
+Legend: ✓=validated  ⚠=skipped  ✗=uncovered  ◐=partial  ·=request-only  *=any/no content-type
+  ✓ GET /v1/pets                    (3/3 responses)
+  ◐ POST /v1/pets                   (1/2 responses)
+      ✗ 422  application/problem+json         uncovered
+  ✗ PUT /v1/pets/{petId}            (0/2 responses)
+      ✗ 200  application/json                 uncovered
+      ✗ 404  application/problem+json         uncovered
 ```
 
 You can set the mode via `phpunit.xml`:
@@ -762,13 +774,39 @@ OpenApiSpecLoader::reset(); // For testing
 
 ### `OpenApiCoverageTracker`
 
-Tracks which endpoints have been validated.
+Tracks which endpoints have been exercised, at `(method, path, statusCode, contentType)` granularity. The Laravel trait records via the tracker automatically; framework-agnostic adapters call it directly.
 
 ```php
-OpenApiCoverageTracker::record('front', 'GET', '/v1/pets');
+// Request-side: an endpoint was reached without a response assertion
+OpenApiCoverageTracker::recordRequest('front', 'GET', '/v1/pets');
+
+// Response-side: full granularity (status + content-type spec keys)
+OpenApiCoverageTracker::recordResponse(
+    specName: 'front',
+    method: 'GET',
+    path: '/v1/pets',
+    statusKey: '200',                  // spec key, or literal status when skipped
+    contentTypeKey: 'application/json',// spec key (case preserved); null → "*"
+    schemaValidated: true,             // false → state=skipped
+    skipReason: null,
+);
+
 $coverage = OpenApiCoverageTracker::computeCoverage('front');
-// ['covered' => [...], 'uncovered' => [...], 'total' => 45, 'coveredCount' => 12]
+// [
+//   'endpoints' => [...per-endpoint EndpointSummary, includes per-response sub-rows...],
+//   'endpointTotal' => 45,
+//   'endpointFullyCovered' => 12,
+//   'endpointPartial' => 8,
+//   'endpointUncovered' => 25,
+//   'responseTotal' => 120,
+//   'responseCovered' => 38,
+//   'responseSkipped' => 4,
+//   'responseUncovered' => 78,
+//   ...
+// ]
 ```
+
+`hasAnyCoverage(spec): bool` is a fast presence check. `getCovered()` is retained as a diagnostic shim returning `array<spec, array<"METHOD path", true>>`. See [CHANGELOG.md](CHANGELOG.md) for the migration from the pre-#111 endpoint-level shape.
 
 ## Development
 

--- a/src/EndpointCoverageState.php
+++ b/src/EndpointCoverageState.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting;
+
+/**
+ * Resolved coverage state for a single (method, path) operation —
+ * exposed on `CoverageResult.endpoints[].state`.
+ *
+ * - {@see self::AllCovered}: every declared `(status, content-type)` pair
+ *   was validated.
+ * - {@see self::Partial}: at least one pair validated, at least one not.
+ *   Skipped pairs count as not-validated, so `2 validated + 1 skipped`
+ *   is `Partial`.
+ * - {@see self::Uncovered}: no pairs validated, no pairs skipped, and the
+ *   request hook never fired.
+ * - {@see self::RequestOnly}: the spec declares no responses for the
+ *   operation, OR every response observation reconciled only to
+ *   `unexpectedObservations`. Test traffic touched the endpoint, but
+ *   nothing reconciled to a declared response definition.
+ */
+enum EndpointCoverageState: string
+{
+    case AllCovered = 'all-covered';
+    case Partial = 'partial';
+    case Uncovered = 'uncovered';
+    case RequestOnly = 'request-only';
+}

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -334,7 +334,7 @@ trait ValidatesOpenApiSchema
         // tracking semantics as the response-side hook. The tracker is a set,
         // so this does not double-count when response auto-assert also fires.
         if ($result->matchedPath() !== null) {
-            OpenApiCoverageTracker::record(
+            OpenApiCoverageTracker::recordRequest(
                 $specName,
                 $resolvedMethod,
                 $result->matchedPath(),
@@ -477,14 +477,23 @@ trait ValidatesOpenApiSchema
         // Note: under auto_assert, this records coverage for every Laravel HTTP
         // call — including responses with no explicit contract-test intent.
         //
+        // matchedStatusCode falls back to the literal status string when the
+        // validator could not pick a spec key (e.g. "Status code N not defined"
+        // failures) so the recording still pins the actually-exercised status.
+        // Such recordings surface in `unexpectedObservations` rather than
+        // counting toward coverage of declared spec entries.
+        //
         // 204 and non-JSON still count as validated; only skip_response_codes
         // matches (isSkipped() === true) suppress body validation.
         if ($result->matchedPath() !== null) {
-            OpenApiCoverageTracker::record(
+            OpenApiCoverageTracker::recordResponse(
                 $specName,
                 $resolvedMethod,
                 $result->matchedPath(),
+                $result->matchedStatusCode() ?? (string) $response->getStatusCode(),
+                $result->matchedContentType(),
                 schemaValidated: !$result->isSkipped(),
+                skipReason: $result->skipReason(),
             );
         }
 

--- a/src/OpenApiCoverageTracker.php
+++ b/src/OpenApiCoverageTracker.php
@@ -7,64 +7,154 @@ namespace Studio\OpenApiContractTesting;
 use function array_keys;
 use function count;
 use function in_array;
-use function sort;
+use function is_array;
+use function is_string;
+use function preg_match;
+use function strcasecmp;
+use function strcmp;
+use function strpos;
 use function strtoupper;
+use function substr;
+use function usort;
 
 /**
+ * @phpstan-type ResponseCoverageState 'validated'|'skipped'
+ * @phpstan-type ResponseCoverage array{
+ *     state: ResponseCoverageState,
+ *     hits: int,
+ *     skipReason?: ?string,
+ * }
+ * @phpstan-type EndpointCoverage array{
+ *     requestReached: bool,
+ *     responses: array<string, ResponseCoverage>,
+ * }
+ * @phpstan-type ResponseRowState 'validated'|'uncovered'|'skipped'
+ * @phpstan-type ResponseRow array{
+ *     statusKey: string,
+ *     contentTypeKey: string,
+ *     state: ResponseRowState,
+ *     hits: int,
+ *     skipReason: ?string,
+ * }
+ * @phpstan-type EndpointState 'all-covered'|'partial'|'uncovered'|'request-only'
+ * @phpstan-type EndpointSummary array{
+ *     endpoint: string,
+ *     method: string,
+ *     path: string,
+ *     operationId: ?string,
+ *     state: EndpointState,
+ *     requestReached: bool,
+ *     responses: list<ResponseRow>,
+ *     coveredResponseCount: int,
+ *     skippedResponseCount: int,
+ *     totalResponseCount: int,
+ *     unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>,
+ * }
  * @phpstan-type CoverageResult array{
- *     covered: string[],
- *     uncovered: string[],
- *     total: int,
- *     coveredCount: int,
- *     skippedOnly: string[],
- *     skippedOnlyCount: int,
+ *     endpoints: list<EndpointSummary>,
+ *     endpointTotal: int,
+ *     endpointFullyCovered: int,
+ *     endpointPartial: int,
+ *     endpointUncovered: int,
+ *     endpointRequestOnly: int,
+ *     responseTotal: int,
+ *     responseCovered: int,
+ *     responseSkipped: int,
+ *     responseUncovered: int,
  * }
  */
 final class OpenApiCoverageTracker
 {
+    /** Wildcard sentinel for "any / no content-type" — used when a recording predates */
+    /** content-type lookup (skipped responses) and when a spec response has no `content` block. */
+    public const ANY_CONTENT_TYPE = '*';
+
     /**
-     * `validated` is monotonic — once true, a later skipped record does not
-     * demote it — so ordering of observations across a suite does not matter.
+     * Per-(spec, endpoint) coverage state. Endpoint key is `"{METHOD} {path}"`.
      *
-     * @var array<string, array<string, array{validated: bool, skipped: bool}>>
+     * Each (statusKey, contentTypeKey) pair is stored under
+     * `"{statusKey}:{contentTypeKey}"` and tracks monotonic state — validated
+     * > skipped, never demoted — so observation order across a suite does not
+     * matter. `hits` increments on each recording. `skipReason` carries the
+     * pattern that triggered the skip (latest recording wins).
+     *
+     * statusKey is the validator's matchedStatusCode (the literal HTTP status
+     * for skipped, or the spec response key for validated/failed). Matching
+     * against spec range keys (`5XX`, `default`) happens at compute time via
+     * {@see self::statusKeyMatches()}.
+     *
+     * @var array<string, array<string, EndpointCoverage>>
      */
     private static array $covered = [];
 
-    public static function record(
+    /** Static-only utility — no instances. */
+    private function __construct() {}
+
+    /**
+     * Mark an endpoint as request-side reached. Used by request validators
+     * which see a path/method but no response. Idempotent.
+     */
+    public static function recordRequest(
         string $specName,
         string $method,
         string $path,
-        bool $schemaValidated = true,
     ): void {
-        $key = strtoupper($method) . ' ' . $path;
-        $entry = self::$covered[$specName][$key] ?? ['validated' => false, 'skipped' => false];
-
-        if ($schemaValidated) {
-            $entry['validated'] = true;
-        } else {
-            $entry['skipped'] = true;
-        }
-
-        self::$covered[$specName][$key] = $entry;
+        $key = self::endpointKey($method, $path);
+        self::$covered[$specName][$key] ??= ['requestReached' => false, 'responses' => []];
+        self::$covered[$specName][$key]['requestReached'] = true;
     }
 
     /**
-     * Flattens the internal 2-flag entry to `true` to preserve the public
-     * shape. Richer skipped-only data lives on computeCoverage().
+     * Record a response observation. `statusKey` is the spec key when the
+     * validator matched a declared response (e.g. `"200"`), or the literal
+     * HTTP status string when the response was skipped before lookup
+     * (e.g. `"503"` matched the `5\d\d` skip pattern). `contentTypeKey` is
+     * the spec media-type key (with the spec author's original casing) when
+     * a content lookup happened, or null for skipped / 204 / non-JSON-only
+     * responses — stored under {@see self::ANY_CONTENT_TYPE}.
      *
-     * @return array<string, array<string, true>>
+     * `validated` states win over `skipped` for the same (status, content)
+     * pair across multiple recordings; `hits` accumulates.
      */
-    public static function getCovered(): array
-    {
-        $external = [];
+    public static function recordResponse(
+        string $specName,
+        string $method,
+        string $path,
+        string $statusKey,
+        ?string $contentTypeKey,
+        bool $schemaValidated,
+        ?string $skipReason = null,
+    ): void {
+        $endpointKey = self::endpointKey($method, $path);
+        $contentKey = $contentTypeKey ?? self::ANY_CONTENT_TYPE;
+        $responseKey = $statusKey . ':' . $contentKey;
 
-        foreach (self::$covered as $spec => $endpoints) {
-            foreach (array_keys($endpoints) as $endpoint) {
-                $external[$spec][$endpoint] = true;
-            }
+        self::$covered[$specName][$endpointKey] ??= ['requestReached' => false, 'responses' => []];
+        $existing = self::$covered[$specName][$endpointKey]['responses'][$responseKey] ?? null;
+
+        if ($existing === null) {
+            self::$covered[$specName][$endpointKey]['responses'][$responseKey] = [
+                'state' => $schemaValidated ? 'validated' : 'skipped',
+                'hits' => 1,
+                'skipReason' => $schemaValidated ? null : $skipReason,
+            ];
+
+            return;
         }
 
-        return $external;
+        $existing['hits']++;
+        if ($schemaValidated) {
+            // Promote skipped → validated; once validated, stay validated.
+            $existing['state'] = 'validated';
+            $existing['skipReason'] = null;
+        } elseif ($existing['state'] === 'skipped' && $skipReason !== null) {
+            // Latest skipReason wins so the renderer surfaces the most recent
+            // skip pattern (typically all-the-same in practice; but we don't
+            // want to hide a per-test override).
+            $existing['skipReason'] = $skipReason;
+        }
+
+        self::$covered[$specName][$endpointKey]['responses'][$responseKey] = $existing;
     }
 
     public static function reset(): void
@@ -73,49 +163,438 @@ final class OpenApiCoverageTracker
     }
 
     /**
+     * Returns true when any record (request or response) exists for the given
+     * spec. The PHPUnit extension uses this to gate the "no coverage to report"
+     * short-circuit so the report block only renders when at least one test
+     * exercised a spec.
+     */
+    public static function hasAnyCoverage(string $specName): bool
+    {
+        return (self::$covered[$specName] ?? []) !== [];
+    }
+
+    /**
+     * Diagnostic accessor: which `"METHOD path"` keys have any recorded
+     * activity (request reached or any response observation), grouped by spec.
+     * Intended for tests and CLI tooling that only need an "endpoint touched"
+     * predicate; richer shape is available via {@see self::computeCoverage()}.
+     *
+     * @return array<string, array<string, true>>
+     */
+    public static function getCovered(): array
+    {
+        $external = [];
+
+        foreach (self::$covered as $spec => $endpoints) {
+            foreach ($endpoints as $endpointKey => $entry) {
+                if ($entry['requestReached'] === false && $entry['responses'] === []) {
+                    continue;
+                }
+                $external[$spec][$endpointKey] = true;
+            }
+        }
+
+        return $external;
+    }
+
+    /**
      * @return CoverageResult
      */
     public static function computeCoverage(string $specName): array
     {
         $spec = OpenApiSpecLoader::load($specName);
-        $allEndpoints = [];
+        $recordedEndpoints = self::$covered[$specName] ?? [];
+        $endpoints = [];
 
-        /** @var array<string, mixed> $methods */
-        foreach ($spec['paths'] ?? [] as $path => $methods) {
-            foreach (array_keys($methods) as $method) {
-                $upper = strtoupper((string) $method);
-                if (in_array($upper, ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'], true)) {
-                    $allEndpoints[] = "{$upper} {$path}";
+        $endpointFullyCovered = 0;
+        $endpointPartial = 0;
+        $endpointUncovered = 0;
+        $endpointRequestOnly = 0;
+        $responseTotal = 0;
+        $responseCovered = 0;
+        $responseSkipped = 0;
+
+        $declaredEndpoints = self::collectDeclaredEndpoints($spec);
+
+        foreach ($declaredEndpoints as $declared) {
+            $endpointKey = $declared['endpoint'];
+            $recorded = $recordedEndpoints[$endpointKey] ?? null;
+            $rows = self::buildResponseRows($declared['responses'], $recorded['responses'] ?? []);
+            $unexpected = self::collectUnexpectedObservations($declared['responses'], $recorded['responses'] ?? []);
+
+            $coveredCount = 0;
+            $skippedCount = 0;
+            foreach ($rows as $row) {
+                if ($row['state'] === 'validated') {
+                    $coveredCount++;
+                } elseif ($row['state'] === 'skipped') {
+                    $skippedCount++;
                 }
             }
-        }
+            $totalCount = count($rows);
 
-        sort($allEndpoints);
+            $requestReached = $recorded['requestReached'] ?? false;
+            $hasAnyResponseObservation = ($recorded['responses'] ?? []) !== [];
+            $state = self::deriveEndpointState(
+                totalDeclared: $totalCount,
+                covered: $coveredCount,
+                skipped: $skippedCount,
+                requestReached: $requestReached,
+                hasAnyResponseObservation: $hasAnyResponseObservation,
+            );
 
-        $coveredSet = self::$covered[$specName] ?? [];
-        $covered = [];
-        $uncovered = [];
-        $skippedOnly = [];
+            match ($state) {
+                'all-covered' => $endpointFullyCovered++,
+                'partial' => $endpointPartial++,
+                'uncovered' => $endpointUncovered++,
+                'request-only' => $endpointRequestOnly++,
+            };
 
-        foreach ($allEndpoints as $endpoint) {
-            if (isset($coveredSet[$endpoint])) {
-                $covered[] = $endpoint;
-                $entry = $coveredSet[$endpoint];
-                if ($entry['skipped'] && !$entry['validated']) {
-                    $skippedOnly[] = $endpoint;
-                }
-            } else {
-                $uncovered[] = $endpoint;
-            }
+            $responseTotal += $totalCount;
+            $responseCovered += $coveredCount;
+            $responseSkipped += $skippedCount;
+
+            $endpoints[] = [
+                'endpoint' => $endpointKey,
+                'method' => $declared['method'],
+                'path' => $declared['path'],
+                'operationId' => $declared['operationId'],
+                'state' => $state,
+                'requestReached' => $requestReached,
+                'responses' => $rows,
+                'coveredResponseCount' => $coveredCount,
+                'skippedResponseCount' => $skippedCount,
+                'totalResponseCount' => $totalCount,
+                'unexpectedObservations' => $unexpected,
+            ];
         }
 
         return [
-            'covered' => $covered,
-            'uncovered' => $uncovered,
-            'total' => count($allEndpoints),
-            'coveredCount' => count($covered),
-            'skippedOnly' => $skippedOnly,
-            'skippedOnlyCount' => count($skippedOnly),
+            'endpoints' => $endpoints,
+            'endpointTotal' => count($endpoints),
+            'endpointFullyCovered' => $endpointFullyCovered,
+            'endpointPartial' => $endpointPartial,
+            'endpointUncovered' => $endpointUncovered,
+            'endpointRequestOnly' => $endpointRequestOnly,
+            'responseTotal' => $responseTotal,
+            'responseCovered' => $responseCovered,
+            'responseSkipped' => $responseSkipped,
+            'responseUncovered' => $responseTotal - $responseCovered - $responseSkipped,
         ];
+    }
+
+    private static function endpointKey(string $method, string $path): string
+    {
+        return strtoupper($method) . ' ' . $path;
+    }
+
+    /**
+     * Walk the spec's `paths` map and yield one entry per declared
+     * (method, path) operation, listing all (statusKey, contentTypeKey)
+     * pairs declared for it. A response with no `content` block contributes
+     * a single `(statusKey, '*')` pair so 204-style responses appear in
+     * coverage instead of being silently omitted.
+     *
+     * @param array<string, mixed> $spec
+     *
+     * @return list<array{
+     *     endpoint: string,
+     *     method: string,
+     *     path: string,
+     *     operationId: ?string,
+     *     responses: list<array{statusKey: string, contentTypeKey: string}>,
+     * }>
+     */
+    private static function collectDeclaredEndpoints(array $spec): array
+    {
+        /** @var array<string, mixed> $paths */
+        $paths = is_array($spec['paths'] ?? null) ? $spec['paths'] : [];
+        $declared = [];
+
+        foreach ($paths as $path => $methods) {
+            if (!is_array($methods)) {
+                continue;
+            }
+
+            foreach ($methods as $method => $operation) {
+                $upper = strtoupper((string) $method);
+                if (!in_array($upper, ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'], true)) {
+                    continue;
+                }
+                if (!is_array($operation)) {
+                    continue;
+                }
+
+                $operationId = is_string($operation['operationId'] ?? null) ? $operation['operationId'] : null;
+                $responses = is_array($operation['responses'] ?? null) ? $operation['responses'] : [];
+
+                $responsePairs = [];
+                foreach ($responses as $statusKey => $responseSpec) {
+                    $statusKeyStr = (string) $statusKey;
+                    if (!is_array($responseSpec)) {
+                        continue;
+                    }
+                    $content = is_array($responseSpec['content'] ?? null) ? $responseSpec['content'] : null;
+
+                    if ($content === null || $content === []) {
+                        $responsePairs[] = ['statusKey' => $statusKeyStr, 'contentTypeKey' => self::ANY_CONTENT_TYPE];
+
+                        continue;
+                    }
+
+                    foreach (array_keys($content) as $contentTypeKey) {
+                        $responsePairs[] = ['statusKey' => $statusKeyStr, 'contentTypeKey' => (string) $contentTypeKey];
+                    }
+                }
+
+                $declared[] = [
+                    'endpoint' => self::endpointKey($upper, $path),
+                    'method' => $upper,
+                    'path' => $path,
+                    'operationId' => $operationId,
+                    'responses' => $responsePairs,
+                ];
+            }
+        }
+
+        // Stable, predictable order: by endpoint key (method + path) so reports
+        // are diff-friendly across runs.
+        usort($declared, static fn(array $a, array $b): int => strcmp($a['endpoint'], $b['endpoint']));
+
+        return $declared;
+    }
+
+    /**
+     * For each declared (statusKey, contentTypeKey) pair on an endpoint,
+     * compute the resolved state by reconciling against any recordings.
+     * Validated wins over skipped; skipped wins over uncovered.
+     *
+     * Reconciliation pairs each recorded status to declared statuses via
+     * exact match first, then via range matching (`5XX`/`5xx`/`default`).
+     * Recorded `*` content matches any declared content-type; otherwise
+     * matching is case-insensitive on the spec key.
+     *
+     * @param list<array{statusKey: string, contentTypeKey: string}> $declaredResponses
+     * @param array<string, ResponseCoverage> $recordedResponses
+     *
+     * @return list<ResponseRow>
+     */
+    private static function buildResponseRows(array $declaredResponses, array $recordedResponses): array
+    {
+        $rows = [];
+
+        foreach ($declaredResponses as $declared) {
+            $bestState = 'uncovered';
+            $hits = 0;
+            $skipReason = null;
+
+            foreach ($recordedResponses as $recordedKey => $entry) {
+                [$recordedStatus, $recordedContent] = self::splitResponseKey($recordedKey);
+
+                if (!self::statusKeyMatches($declared['statusKey'], $recordedStatus)) {
+                    continue;
+                }
+                if (!self::contentTypeMatches($declared['contentTypeKey'], $recordedContent)) {
+                    continue;
+                }
+
+                if ($entry['state'] === 'validated') {
+                    $bestState = 'validated';
+                    $hits += $entry['hits'];
+                    $skipReason = null;
+
+                    continue;
+                }
+
+                if ($bestState === 'uncovered') {
+                    $bestState = 'skipped';
+                    $hits = $entry['hits'];
+                    $skipReason = $entry['skipReason'] ?? null;
+
+                    continue;
+                }
+                if ($bestState === 'skipped') {
+                    $hits += $entry['hits'];
+                    if (($entry['skipReason'] ?? null) !== null) {
+                        $skipReason = $entry['skipReason'];
+                    }
+                }
+            }
+
+            $rows[] = [
+                'statusKey' => $declared['statusKey'],
+                'contentTypeKey' => $declared['contentTypeKey'],
+                'state' => $bestState,
+                'hits' => $hits,
+                'skipReason' => $skipReason,
+            ];
+        }
+
+        // Sort within an endpoint: statusKey ascending, contentTypeKey ascending,
+        // with `*` last so concrete content-types stay grouped.
+        usort($rows, static function (array $a, array $b): int {
+            $statusCmp = strcmp($a['statusKey'], $b['statusKey']);
+            if ($statusCmp !== 0) {
+                return $statusCmp;
+            }
+            if ($a['contentTypeKey'] === self::ANY_CONTENT_TYPE && $b['contentTypeKey'] !== self::ANY_CONTENT_TYPE) {
+                return 1;
+            }
+            if ($b['contentTypeKey'] === self::ANY_CONTENT_TYPE && $a['contentTypeKey'] !== self::ANY_CONTENT_TYPE) {
+                return -1;
+            }
+
+            return strcasecmp($a['contentTypeKey'], $b['contentTypeKey']);
+        });
+
+        return $rows;
+    }
+
+    /**
+     * Recorded entries that don't reconcile to any spec declaration are
+     * surfaced separately so a test exercising an undocumented response
+     * (e.g. real `503` against a spec with no `5XX` declaration) is visible
+     * without inflating "uncovered" counts.
+     *
+     * @param list<array{statusKey: string, contentTypeKey: string}> $declaredResponses
+     * @param array<string, ResponseCoverage> $recordedResponses
+     *
+     * @return list<array{statusKey: string, contentTypeKey: string}>
+     */
+    private static function collectUnexpectedObservations(array $declaredResponses, array $recordedResponses): array
+    {
+        $unexpected = [];
+
+        foreach ($recordedResponses as $recordedKey => $_entry) {
+            [$recordedStatus, $recordedContent] = self::splitResponseKey($recordedKey);
+
+            $matched = false;
+            foreach ($declaredResponses as $declared) {
+                if (
+                    self::statusKeyMatches($declared['statusKey'], $recordedStatus) &&
+                    self::contentTypeMatches($declared['contentTypeKey'], $recordedContent)
+                ) {
+                    $matched = true;
+
+                    break;
+                }
+            }
+
+            if (!$matched) {
+                $unexpected[] = ['statusKey' => $recordedStatus, 'contentTypeKey' => $recordedContent];
+            }
+        }
+
+        // Stable order for diff-friendly output.
+        usort($unexpected, static function (array $a, array $b): int {
+            $cmp = strcmp($a['statusKey'], $b['statusKey']);
+
+            return $cmp !== 0 ? $cmp : strcasecmp($a['contentTypeKey'], $b['contentTypeKey']);
+        });
+
+        return $unexpected;
+    }
+
+    /**
+     * Determine the endpoint-level state from declared / covered / skipped
+     * counts. `request-only` only when no responses are declared in spec
+     * (or none were observed) and the request side fired — a rare but
+     * legitimate "auto-validate-request without auto-assert" pattern.
+     */
+    /**
+     * @return EndpointState
+     */
+    private static function deriveEndpointState(
+        int $totalDeclared,
+        int $covered,
+        int $skipped,
+        bool $requestReached,
+        bool $hasAnyResponseObservation,
+    ): string {
+        if ($totalDeclared === 0) {
+            // No response definitions in spec — this happens for operations
+            // declared without a `responses` block. Treat as request-only when
+            // the endpoint was reached (request hook fired) so it's not lost.
+            return $requestReached || $hasAnyResponseObservation ? 'request-only' : 'uncovered';
+        }
+
+        if ($covered === 0 && $skipped === 0) {
+            return $requestReached || $hasAnyResponseObservation ? 'request-only' : 'uncovered';
+        }
+
+        if ($covered === $totalDeclared) {
+            return 'all-covered';
+        }
+
+        return 'partial';
+    }
+
+    /**
+     * Spec key matches recorded key when:
+     * - exact case-insensitive match
+     * - `default` matches anything
+     * - `1XX`/`2XX`/`3XX`/`4XX`/`5XX` (case-insensitive) matches a literal
+     *   3-digit status whose first digit equals the leading digit
+     *
+     * Matching is intentionally directional: `$specKey` is what the spec
+     * declares, `$recordedKey` is what the recording stored. So
+     * `statusKeyMatches('5XX', '503')` is true; the reverse is also true
+     * since exact spec key matches happen via the same code path when both
+     * sides are equal.
+     */
+    private static function statusKeyMatches(string $specKey, string $recordedKey): bool
+    {
+        if (strcasecmp($specKey, $recordedKey) === 0) {
+            return true;
+        }
+
+        if (strcasecmp($specKey, 'default') === 0) {
+            return true;
+        }
+
+        // Range key on the spec side: e.g. spec="5XX" recorded="503".
+        if (preg_match('/^([1-5])[xX]{2}$/', $specKey, $matches) === 1 &&
+            preg_match('/^[1-5][0-9]{2}$/', $recordedKey) === 1 &&
+            $recordedKey[0] === $matches[1]
+        ) {
+            return true;
+        }
+
+        // Range key on the recorded side is unusual (validators record literal
+        // statuses) but support symmetry for tests/external callers.
+        if (preg_match('/^([1-5])[xX]{2}$/', $recordedKey, $matches) === 1 &&
+            preg_match('/^[1-5][0-9]{2}$/', $specKey) === 1 &&
+            $specKey[0] === $matches[1]
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * `*` (the wildcard sentinel) on either side matches anything; otherwise
+     * comparison is case-insensitive against the spec author's literal key.
+     */
+    private static function contentTypeMatches(string $specContentType, string $recordedContentType): bool
+    {
+        if ($specContentType === self::ANY_CONTENT_TYPE || $recordedContentType === self::ANY_CONTENT_TYPE) {
+            return true;
+        }
+
+        return strcasecmp($specContentType, $recordedContentType) === 0;
+    }
+
+    /**
+     * @return array{0: string, 1: string}
+     */
+    private static function splitResponseKey(string $key): array
+    {
+        $colonPos = strpos($key, ':');
+        if ($colonPos === false) {
+            return [$key, self::ANY_CONTENT_TYPE];
+        }
+
+        return [substr($key, 0, $colonPos), substr($key, $colonPos + 1)];
     }
 }

--- a/src/OpenApiCoverageTracker.php
+++ b/src/OpenApiCoverageTracker.php
@@ -4,45 +4,47 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting;
 
+use const E_USER_WARNING;
+
 use function array_keys;
 use function count;
+use function get_debug_type;
 use function in_array;
 use function is_array;
 use function is_string;
 use function preg_match;
+use function sprintf;
 use function strcasecmp;
 use function strcmp;
 use function strpos;
 use function strtoupper;
 use function substr;
+use function trigger_error;
 use function usort;
 
 /**
- * @phpstan-type ResponseCoverageState 'validated'|'skipped'
- * @phpstan-type ResponseCoverage array{
+ * @phpstan-type RecordedResponseCoverage array{
  *     state: ResponseCoverageState,
  *     hits: int,
  *     skipReason?: ?string,
  * }
  * @phpstan-type EndpointCoverage array{
  *     requestReached: bool,
- *     responses: array<string, ResponseCoverage>,
+ *     responses: array<string, RecordedResponseCoverage>,
  * }
- * @phpstan-type ResponseRowState 'validated'|'uncovered'|'skipped'
  * @phpstan-type ResponseRow array{
  *     statusKey: string,
  *     contentTypeKey: string,
- *     state: ResponseRowState,
+ *     state: ResponseCoverageState,
  *     hits: int,
  *     skipReason: ?string,
  * }
- * @phpstan-type EndpointState 'all-covered'|'partial'|'uncovered'|'request-only'
  * @phpstan-type EndpointSummary array{
  *     endpoint: string,
  *     method: string,
  *     path: string,
  *     operationId: ?string,
- *     state: EndpointState,
+ *     state: EndpointCoverageState,
  *     requestReached: bool,
  *     responses: list<ResponseRow>,
  *     coveredResponseCount: int,
@@ -65,8 +67,11 @@ use function usort;
  */
 final class OpenApiCoverageTracker
 {
-    /** Wildcard sentinel for "any / no content-type" — used when a recording predates */
-    /** content-type lookup (skipped responses) and when a spec response has no `content` block. */
+    /**
+     * Wildcard sentinel for "any / no content-type" — used when a recording
+     * predates content-type lookup (skipped responses) and when a spec
+     * response has no `content` block.
+     */
     public const ANY_CONTENT_TYPE = '*';
 
     /**
@@ -134,7 +139,7 @@ final class OpenApiCoverageTracker
 
         if ($existing === null) {
             self::$covered[$specName][$endpointKey]['responses'][$responseKey] = [
-                'state' => $schemaValidated ? 'validated' : 'skipped',
+                'state' => $schemaValidated ? ResponseCoverageState::Validated : ResponseCoverageState::Skipped,
                 'hits' => 1,
                 'skipReason' => $schemaValidated ? null : $skipReason,
             ];
@@ -145,9 +150,9 @@ final class OpenApiCoverageTracker
         $existing['hits']++;
         if ($schemaValidated) {
             // Promote skipped → validated; once validated, stay validated.
-            $existing['state'] = 'validated';
+            $existing['state'] = ResponseCoverageState::Validated;
             $existing['skipReason'] = null;
-        } elseif ($existing['state'] === 'skipped' && $skipReason !== null) {
+        } elseif ($existing['state'] === ResponseCoverageState::Skipped && $skipReason !== null) {
             // Latest skipReason wins so the renderer surfaces the most recent
             // skip pattern (typically all-the-same in practice; but we don't
             // want to hide a per-test override).
@@ -214,7 +219,7 @@ final class OpenApiCoverageTracker
         $responseCovered = 0;
         $responseSkipped = 0;
 
-        $declaredEndpoints = self::collectDeclaredEndpoints($spec);
+        $declaredEndpoints = self::collectDeclaredEndpoints($specName, $spec);
 
         foreach ($declaredEndpoints as $declared) {
             $endpointKey = $declared['endpoint'];
@@ -225,9 +230,9 @@ final class OpenApiCoverageTracker
             $coveredCount = 0;
             $skippedCount = 0;
             foreach ($rows as $row) {
-                if ($row['state'] === 'validated') {
+                if ($row['state'] === ResponseCoverageState::Validated) {
                     $coveredCount++;
-                } elseif ($row['state'] === 'skipped') {
+                } elseif ($row['state'] === ResponseCoverageState::Skipped) {
                     $skippedCount++;
                 }
             }
@@ -244,10 +249,10 @@ final class OpenApiCoverageTracker
             );
 
             match ($state) {
-                'all-covered' => $endpointFullyCovered++,
-                'partial' => $endpointPartial++,
-                'uncovered' => $endpointUncovered++,
-                'request-only' => $endpointRequestOnly++,
+                EndpointCoverageState::AllCovered => $endpointFullyCovered++,
+                EndpointCoverageState::Partial => $endpointPartial++,
+                EndpointCoverageState::Uncovered => $endpointUncovered++,
+                EndpointCoverageState::RequestOnly => $endpointRequestOnly++,
             };
 
             $responseTotal += $totalCount;
@@ -289,11 +294,33 @@ final class OpenApiCoverageTracker
     }
 
     /**
+     * Emit a PHPUnit-visible warning when the spec has structurally invalid
+     * branches inside otherwise-valid `paths`. We don't throw — partial
+     * coverage data is still useful — but staying silent would understate
+     * totals without the user noticing.
+     */
+    private static function warnMalformed(string $specName, string $detail): void
+    {
+        trigger_error(
+            sprintf("[OpenAPI Coverage] spec '%s': %s", $specName, $detail),
+            E_USER_WARNING,
+        );
+    }
+
+    /**
      * Walk the spec's `paths` map and yield one entry per declared
      * (method, path) operation, listing all (statusKey, contentTypeKey)
      * pairs declared for it. A response with no `content` block contributes
      * a single `(statusKey, '*')` pair so 204-style responses appear in
      * coverage instead of being silently omitted.
+     *
+     * Malformed spec branches (a path mapped to a non-object, an operation
+     * mapped to a non-object, or a response entry mapped to a non-object)
+     * are skipped AND announced via E_USER_WARNING — silently dropping them
+     * would understate `endpointTotal` / `responseTotal` and let the user
+     * believe their spec was fully read. The eager `OpenApiSpecLoader::load()`
+     * catches structural errors at bootstrap, but it permits the permissive
+     * shapes (`responses: 200` as scalar) that this walker rejects.
      *
      * @param array<string, mixed> $spec
      *
@@ -305,7 +332,7 @@ final class OpenApiCoverageTracker
      *     responses: list<array{statusKey: string, contentTypeKey: string}>,
      * }>
      */
-    private static function collectDeclaredEndpoints(array $spec): array
+    private static function collectDeclaredEndpoints(string $specName, array $spec): array
     {
         /** @var array<string, mixed> $paths */
         $paths = is_array($spec['paths'] ?? null) ? $spec['paths'] : [];
@@ -313,6 +340,8 @@ final class OpenApiCoverageTracker
 
         foreach ($paths as $path => $methods) {
             if (!is_array($methods)) {
+                self::warnMalformed($specName, sprintf('path %s is not an object (got %s); omitted from coverage', (string) $path, get_debug_type($methods)));
+
                 continue;
             }
 
@@ -322,6 +351,8 @@ final class OpenApiCoverageTracker
                     continue;
                 }
                 if (!is_array($operation)) {
+                    self::warnMalformed($specName, sprintf('operation %s %s is not an object (got %s); omitted from coverage', $upper, (string) $path, get_debug_type($operation)));
+
                     continue;
                 }
 
@@ -332,6 +363,8 @@ final class OpenApiCoverageTracker
                 foreach ($responses as $statusKey => $responseSpec) {
                     $statusKeyStr = (string) $statusKey;
                     if (!is_array($responseSpec)) {
+                        self::warnMalformed($specName, sprintf('response %s %s %s is not an object (got %s); omitted from coverage', $upper, (string) $path, $statusKeyStr, get_debug_type($responseSpec)));
+
                         continue;
                     }
                     $content = is_array($responseSpec['content'] ?? null) ? $responseSpec['content'] : null;
@@ -375,7 +408,7 @@ final class OpenApiCoverageTracker
      * matching is case-insensitive on the spec key.
      *
      * @param list<array{statusKey: string, contentTypeKey: string}> $declaredResponses
-     * @param array<string, ResponseCoverage> $recordedResponses
+     * @param array<string, RecordedResponseCoverage> $recordedResponses
      *
      * @return list<ResponseRow>
      */
@@ -384,7 +417,7 @@ final class OpenApiCoverageTracker
         $rows = [];
 
         foreach ($declaredResponses as $declared) {
-            $bestState = 'uncovered';
+            $bestState = ResponseCoverageState::Uncovered;
             $hits = 0;
             $skipReason = null;
 
@@ -398,22 +431,29 @@ final class OpenApiCoverageTracker
                     continue;
                 }
 
-                if ($entry['state'] === 'validated') {
-                    $bestState = 'validated';
-                    $hits += $entry['hits'];
+                if ($entry['state'] === ResponseCoverageState::Validated) {
+                    if ($bestState !== ResponseCoverageState::Validated) {
+                        // Promotion from uncovered/skipped → drop any hits
+                        // accumulated from skipped recordings so the
+                        // displayed `hits` number reflects validations only.
+                        $hits = $entry['hits'];
+                    } else {
+                        $hits += $entry['hits'];
+                    }
+                    $bestState = ResponseCoverageState::Validated;
                     $skipReason = null;
 
                     continue;
                 }
 
-                if ($bestState === 'uncovered') {
-                    $bestState = 'skipped';
+                if ($bestState === ResponseCoverageState::Uncovered) {
+                    $bestState = ResponseCoverageState::Skipped;
                     $hits = $entry['hits'];
                     $skipReason = $entry['skipReason'] ?? null;
 
                     continue;
                 }
-                if ($bestState === 'skipped') {
+                if ($bestState === ResponseCoverageState::Skipped) {
                     $hits += $entry['hits'];
                     if (($entry['skipReason'] ?? null) !== null) {
                         $skipReason = $entry['skipReason'];
@@ -457,7 +497,7 @@ final class OpenApiCoverageTracker
      * without inflating "uncovered" counts.
      *
      * @param list<array{statusKey: string, contentTypeKey: string}> $declaredResponses
-     * @param array<string, ResponseCoverage> $recordedResponses
+     * @param array<string, RecordedResponseCoverage> $recordedResponses
      *
      * @return list<array{statusKey: string, contentTypeKey: string}>
      */
@@ -497,12 +537,12 @@ final class OpenApiCoverageTracker
 
     /**
      * Determine the endpoint-level state from declared / covered / skipped
-     * counts. `request-only` only when no responses are declared in spec
-     * (or none were observed) and the request side fired — a rare but
-     * legitimate "auto-validate-request without auto-assert" pattern.
-     */
-    /**
-     * @return EndpointState
+     * counts. `request-only` covers two situations: (a) no responses are
+     * declared in spec and the request hook fired ("auto-validate-request
+     * without auto-assert"), and (b) responses ARE declared but every
+     * observation reconciled only to `unexpectedObservations` so the
+     * declared coverage is empty — without this carve-out the endpoint
+     * would read `uncovered` despite test traffic.
      */
     private static function deriveEndpointState(
         int $totalDeclared,
@@ -510,37 +550,40 @@ final class OpenApiCoverageTracker
         int $skipped,
         bool $requestReached,
         bool $hasAnyResponseObservation,
-    ): string {
+    ): EndpointCoverageState {
         if ($totalDeclared === 0) {
             // No response definitions in spec — this happens for operations
             // declared without a `responses` block. Treat as request-only when
             // the endpoint was reached (request hook fired) so it's not lost.
-            return $requestReached || $hasAnyResponseObservation ? 'request-only' : 'uncovered';
+            return $requestReached || $hasAnyResponseObservation
+                ? EndpointCoverageState::RequestOnly
+                : EndpointCoverageState::Uncovered;
         }
 
         if ($covered === 0 && $skipped === 0) {
-            return $requestReached || $hasAnyResponseObservation ? 'request-only' : 'uncovered';
+            return $requestReached || $hasAnyResponseObservation
+                ? EndpointCoverageState::RequestOnly
+                : EndpointCoverageState::Uncovered;
         }
 
         if ($covered === $totalDeclared) {
-            return 'all-covered';
+            return EndpointCoverageState::AllCovered;
         }
 
-        return 'partial';
+        return EndpointCoverageState::Partial;
     }
 
     /**
      * Spec key matches recorded key when:
      * - exact case-insensitive match
-     * - `default` matches anything
+     * - `default` matches anything (asymmetric — only when `$specKey === 'default'`,
+     *   never when the recording is `'default'`)
      * - `1XX`/`2XX`/`3XX`/`4XX`/`5XX` (case-insensitive) matches a literal
-     *   3-digit status whose first digit equals the leading digit
-     *
-     * Matching is intentionally directional: `$specKey` is what the spec
-     * declares, `$recordedKey` is what the recording stored. So
-     * `statusKeyMatches('5XX', '503')` is true; the reverse is also true
-     * since exact spec key matches happen via the same code path when both
-     * sides are equal.
+     *   3-digit status whose first digit equals the leading digit. Range
+     *   matching is **symmetric**: spec=`5XX` vs recorded=`503` and the
+     *   reverse both succeed. The validator currently records literal statuses
+     *   so the reverse-direction branch supports tests and framework-agnostic
+     *   external callers that may pass range keys directly to `recordResponse()`.
      */
     private static function statusKeyMatches(string $specKey, string $recordedKey): bool
     {

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Studio\OpenApiContractTesting;
 
 use InvalidArgumentException;
+use RuntimeException;
+use Studio\OpenApiContractTesting\Validation\Response\ResponseBodyValidationResult;
 use Studio\OpenApiContractTesting\Validation\Response\ResponseBodyValidator;
 use Studio\OpenApiContractTesting\Validation\Response\ResponseHeaderValidator;
 use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
@@ -103,9 +105,12 @@ final class OpenApiResponseValidator
         // (path / method not in spec) still fail loudly so typos stay visible.
         $matchingPattern = $this->matchingSkipPattern($statusCodeStr);
         if ($matchingPattern !== null) {
+            // matchedStatusCode here is the literal HTTP status string, not a
+            // spec key — see OpenApiValidationResult::skipped() for why.
             return OpenApiValidationResult::skipped(
                 $matchedPath,
                 sprintf('status %s matched skip pattern %s', $statusCodeStr, $matchingPattern),
+                $statusCodeStr,
             );
         }
 
@@ -117,7 +122,7 @@ final class OpenApiResponseValidator
 
         $responseSpec = $responses[$statusCodeStr];
 
-        $bodyErrors = $this->validateBody(
+        $bodyResult = $this->validateBody(
             $specName,
             $method,
             $matchedPath,
@@ -140,13 +145,22 @@ final class OpenApiResponseValidator
         // Order is body errors first, headers second. Tests that pin
         // specific positions rely on this; reordering would silently
         // change diagnostic flow without breaking behaviour.
-        $errors = array_merge($bodyErrors, $headerErrors);
+        $errors = array_merge($bodyResult->errors, $headerErrors);
 
         if ($errors === []) {
-            return OpenApiValidationResult::success($matchedPath);
+            return OpenApiValidationResult::success(
+                $matchedPath,
+                $statusCodeStr,
+                $bodyResult->matchedContentType,
+            );
         }
 
-        return OpenApiValidationResult::failure($errors, $matchedPath);
+        return OpenApiValidationResult::failure(
+            $errors,
+            $matchedPath,
+            $statusCodeStr,
+            $bodyResult->matchedContentType,
+        );
     }
 
     /**
@@ -191,8 +205,6 @@ final class OpenApiResponseValidator
 
     /**
      * @param array<string, mixed> $responseSpec
-     *
-     * @return string[]
      */
     private function validateBody(
         string $specName,
@@ -203,28 +215,23 @@ final class OpenApiResponseValidator
         mixed $responseBody,
         ?string $responseContentType,
         OpenApiVersion $version,
-    ): array {
+    ): ResponseBodyValidationResult {
         // 204 No Content (and similar) declare no `content` block. Nothing
         // to validate — return empty so the result aggregates cleanly.
         if (!isset($responseSpec['content'])) {
-            return [];
+            return new ResponseBodyValidationResult([], null);
         }
 
         /** @var array<string, array<string, mixed>> $content */
         $content = $responseSpec['content'];
 
-        // ValidatorErrorBoundary::safely() converts a RuntimeException thrown from
-        // body validation (e.g. opis/json-schema SchemaException — InvalidKeywordException,
-        // UnresolvedReferenceException, ...) into an error-string entry rather than
-        // letting it abort the orchestrator. Preserves observability symmetry with
-        // OpenApiRequestValidator. \LogicException and \Error still bubble so
-        // programmer bugs are not masked.
-        return ValidatorErrorBoundary::safely(
-            'response-body',
-            $specName,
-            $method,
-            $matchedPath,
-            fn(): array => $this->bodyValidator->validate(
+        // Inlined try/catch mirrors ValidatorErrorBoundary::safely() for the
+        // body validator: same narrow `RuntimeException` catch, same error
+        // formatting. The boundary returns string[]; the body validator now
+        // returns a richer DTO carrying matchedContentType, so we can't reuse
+        // the helper as-is. \LogicException and \Error still bubble.
+        try {
+            return $this->bodyValidator->validate(
                 $specName,
                 $method,
                 $matchedPath,
@@ -233,8 +240,27 @@ final class OpenApiResponseValidator
                 $responseBody,
                 $responseContentType,
                 $version,
-            ),
-        );
+            );
+        } catch (RuntimeException $e) {
+            $previous = $e->getPrevious();
+            $previousSuffix = $previous !== null
+                ? sprintf(' (caused by %s: %s)', $previous::class, $previous->getMessage())
+                : '';
+
+            return new ResponseBodyValidationResult(
+                [sprintf(
+                    "[%s] %s %s in '%s' spec: %s threw: %s%s",
+                    'response-body',
+                    $method,
+                    $matchedPath,
+                    $specName,
+                    $e::class,
+                    $e->getMessage(),
+                    $previousSuffix,
+                )],
+                null,
+            );
+        }
     }
 
     /**

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -142,6 +142,27 @@ final class OpenApiResponseValidator
             $version,
         );
 
+        // The body validator returns ([], null) for two distinct cases:
+        // (a) 204-style — spec has no `content` block; nothing to validate,
+        //     legitimately Success.
+        // (b) Spec declares only non-JSON content types (e.g. `text/plain`)
+        //     and we have no schema engine for them; the result is "we
+        //     didn't actually check anything". Without this branch the
+        //     orchestrator would mark the response as a clean Success and
+        //     coverage would credit the spec's declared content-type as
+        //     validated even though no validation occurred.
+        // Distinguishing them requires looking at the spec — `content`
+        // present + non-empty + bodyResult.matchedContentType null + body
+        // had no errors → case (b).
+        $hasContentBlock = isset($responseSpec['content']) && is_array($responseSpec['content']) && $responseSpec['content'] !== [];
+        if ($bodyResult->errors === [] && $bodyResult->matchedContentType === null && $hasContentBlock && $headerErrors === []) {
+            return OpenApiValidationResult::skipped(
+                $matchedPath,
+                'spec declares only non-JSON content types and the validator has no schema engine for them',
+                $statusCodeStr,
+            );
+        }
+
         // Order is body errors first, headers second. Tests that pin
         // specific positions rely on this; reordering would silently
         // change diagnostic flow without breaking behaviour.

--- a/src/OpenApiValidationResult.php
+++ b/src/OpenApiValidationResult.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 
 use function implode;
 
-final class OpenApiValidationResult
+final readonly class OpenApiValidationResult
 {
     /**
      * Private so the three factories (success / failure / skipped) are the
@@ -31,12 +31,12 @@ final class OpenApiValidationResult
      * @param string[] $errors
      */
     private function __construct(
-        private readonly OpenApiValidationOutcome $outcome,
-        private readonly array $errors = [],
-        private readonly ?string $matchedPath = null,
-        private readonly ?string $skipReason = null,
-        private readonly ?string $matchedStatusCode = null,
-        private readonly ?string $matchedContentType = null,
+        private OpenApiValidationOutcome $outcome,
+        private array $errors = [],
+        private ?string $matchedPath = null,
+        private ?string $skipReason = null,
+        private ?string $matchedStatusCode = null,
+        private ?string $matchedContentType = null,
     ) {}
 
     public static function success(

--- a/src/OpenApiValidationResult.php
+++ b/src/OpenApiValidationResult.php
@@ -16,6 +16,18 @@ final class OpenApiValidationResult
      * state space to exactly those three cases — errors are only attached
      * to Failure, and skipReason is only attached to Skipped.
      *
+     * `matchedStatusCode` is the spec response key (e.g. `"200"`, `"5XX"`,
+     * `"default"`) that the validator selected, or null when no spec response
+     * was matched (path/method-not-found failures, or skipped responses where
+     * the lookup happens by literal status before any spec key is consulted —
+     * in that case the literal status string is reported instead so coverage
+     * can still pin the actually-exercised status).
+     *
+     * `matchedContentType` is the spec media-type key (with the spec author's
+     * original casing) the body was checked against, or null when no body
+     * lookup occurred (204, non-JSON-only specs, content-type-not-in-spec
+     * failures, skipped responses).
+     *
      * @param string[] $errors
      */
     private function __construct(
@@ -23,11 +35,23 @@ final class OpenApiValidationResult
         private readonly array $errors = [],
         private readonly ?string $matchedPath = null,
         private readonly ?string $skipReason = null,
+        private readonly ?string $matchedStatusCode = null,
+        private readonly ?string $matchedContentType = null,
     ) {}
 
-    public static function success(?string $matchedPath = null): self
-    {
-        return new self(OpenApiValidationOutcome::Success, [], $matchedPath);
+    public static function success(
+        ?string $matchedPath = null,
+        ?string $matchedStatusCode = null,
+        ?string $matchedContentType = null,
+    ): self {
+        return new self(
+            OpenApiValidationOutcome::Success,
+            [],
+            $matchedPath,
+            null,
+            $matchedStatusCode,
+            $matchedContentType,
+        );
     }
 
     /**
@@ -51,8 +75,12 @@ final class OpenApiValidationResult
      *
      * @throws InvalidArgumentException when $errors is empty
      */
-    public static function failure(array $errors, ?string $matchedPath = null): self
-    {
+    public static function failure(
+        array $errors,
+        ?string $matchedPath = null,
+        ?string $matchedStatusCode = null,
+        ?string $matchedContentType = null,
+    ): self {
         // @phpstan-ignore-next-line identical.alwaysFalse — PHPDoc bound is not enforced at runtime; keep guard for consumers without static analysis
         if ($errors === []) {
             throw new InvalidArgumentException(
@@ -60,7 +88,14 @@ final class OpenApiValidationResult
             );
         }
 
-        return new self(OpenApiValidationOutcome::Failure, $errors, $matchedPath);
+        return new self(
+            OpenApiValidationOutcome::Failure,
+            $errors,
+            $matchedPath,
+            null,
+            $matchedStatusCode,
+            $matchedContentType,
+        );
     }
 
     /**
@@ -69,10 +104,26 @@ final class OpenApiValidationResult
      * true so callers that gate on it (e.g. PHPUnit assertions) treat the
      * result as non-failing; isSkipped() / outcome() distinguish it from a
      * genuine successful schema match.
+     *
+     * `matchedStatusCode` for a skipped result is the literal HTTP status
+     * string (e.g. `"503"`), not a spec range key — skipping happens before
+     * the spec response map is consulted. Coverage tracking reconciles the
+     * literal status against any spec range keys (`5XX`/`5xx`/`default`) at
+     * compute time, marking the spec-declared response as `skipped`.
      */
-    public static function skipped(?string $matchedPath = null, ?string $reason = null): self
-    {
-        return new self(OpenApiValidationOutcome::Skipped, [], $matchedPath, $reason);
+    public static function skipped(
+        ?string $matchedPath = null,
+        ?string $reason = null,
+        ?string $matchedStatusCode = null,
+    ): self {
+        return new self(
+            OpenApiValidationOutcome::Skipped,
+            [],
+            $matchedPath,
+            $reason,
+            $matchedStatusCode,
+            null,
+        );
     }
 
     public function outcome(): OpenApiValidationOutcome
@@ -112,5 +163,15 @@ final class OpenApiValidationResult
     public function skipReason(): ?string
     {
         return $this->skipReason;
+    }
+
+    public function matchedStatusCode(): ?string
+    {
+        return $this->matchedStatusCode;
+    }
+
+    public function matchedContentType(): ?string
+    {
+        return $this->matchedContentType;
     }
 }

--- a/src/PHPUnit/ConsoleCoverageRenderer.php
+++ b/src/PHPUnit/ConsoleCoverageRenderer.php
@@ -6,7 +6,9 @@ namespace Studio\OpenApiContractTesting\PHPUnit;
 
 use const STR_PAD_RIGHT;
 
+use Studio\OpenApiContractTesting\EndpointCoverageState;
 use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\ResponseCoverageState;
 
 use function round;
 use function sprintf;
@@ -89,7 +91,7 @@ final class ConsoleCoverageRenderer
             $showSubRows = match ($mode) {
                 ConsoleOutput::DEFAULT => false,
                 ConsoleOutput::ALL => true,
-                ConsoleOutput::UNCOVERED_ONLY => $endpoint['state'] !== 'all-covered',
+                ConsoleOutput::UNCOVERED_ONLY => $endpoint['state'] !== EndpointCoverageState::AllCovered,
             };
 
             $output .= sprintf(
@@ -104,7 +106,7 @@ final class ConsoleCoverageRenderer
             }
 
             foreach ($endpoint['responses'] as $row) {
-                if ($mode === ConsoleOutput::UNCOVERED_ONLY && $row['state'] === 'validated') {
+                if ($mode === ConsoleOutput::UNCOVERED_ONLY && $row['state'] === ResponseCoverageState::Validated) {
                     continue;
                 }
                 $output .= sprintf(
@@ -151,30 +153,30 @@ final class ConsoleCoverageRenderer
     private static function responseTail(array $row): string
     {
         return match ($row['state']) {
-            'validated' => sprintf('[%d]', $row['hits']),
-            'skipped' => $row['skipReason'] !== null
+            ResponseCoverageState::Validated => sprintf('[%d]', $row['hits']),
+            ResponseCoverageState::Skipped => $row['skipReason'] !== null
                 ? sprintf('skipped: %s', $row['skipReason'])
                 : 'skipped',
-            default => 'uncovered',
+            ResponseCoverageState::Uncovered => 'uncovered',
         };
     }
 
-    private static function endpointMarker(string $state): string
+    private static function endpointMarker(EndpointCoverageState $state): string
     {
         return match ($state) {
-            'all-covered' => self::MARKER_ALL_COVERED,
-            'partial' => self::MARKER_PARTIAL,
-            'request-only' => self::MARKER_REQUEST_ONLY,
-            default => self::MARKER_UNCOVERED,
+            EndpointCoverageState::AllCovered => self::MARKER_ALL_COVERED,
+            EndpointCoverageState::Partial => self::MARKER_PARTIAL,
+            EndpointCoverageState::RequestOnly => self::MARKER_REQUEST_ONLY,
+            EndpointCoverageState::Uncovered => self::MARKER_UNCOVERED,
         };
     }
 
-    private static function responseMarker(string $state): string
+    private static function responseMarker(ResponseCoverageState $state): string
     {
         return match ($state) {
-            'validated' => self::MARKER_ALL_COVERED,
-            'skipped' => self::MARKER_SKIPPED,
-            default => self::MARKER_UNCOVERED,
+            ResponseCoverageState::Validated => self::MARKER_ALL_COVERED,
+            ResponseCoverageState::Skipped => self::MARKER_SKIPPED,
+            ResponseCoverageState::Uncovered => self::MARKER_UNCOVERED,
         };
     }
 

--- a/src/PHPUnit/ConsoleCoverageRenderer.php
+++ b/src/PHPUnit/ConsoleCoverageRenderer.php
@@ -4,19 +4,27 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\PHPUnit;
 
+use const STR_PAD_RIGHT;
+
 use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
 
-use function array_flip;
-use function count;
 use function round;
+use function sprintf;
+use function str_pad;
 use function str_repeat;
 
 /**
  * @phpstan-import-type CoverageResult from OpenApiCoverageTracker
+ * @phpstan-import-type EndpointSummary from OpenApiCoverageTracker
+ * @phpstan-import-type ResponseRow from OpenApiCoverageTracker
  */
 final class ConsoleCoverageRenderer
 {
-    private const SKIPPED_ONLY_LEGEND = '  ⚠ = response body validation skipped (e.g. 5xx default skip)';
+    private const MARKER_ALL_COVERED = '✓';
+    private const MARKER_PARTIAL = '◐';
+    private const MARKER_SKIPPED = '⚠';
+    private const MARKER_UNCOVERED = '✗';
+    private const MARKER_REQUEST_ONLY = '·';
 
     /**
      * @param array<string, CoverageResult> $results
@@ -32,16 +40,30 @@ final class ConsoleCoverageRenderer
         $output .= str_repeat('=', 50) . "\n";
 
         foreach ($results as $spec => $result) {
-            $percentage = self::percentage($result['coveredCount'], $result['total']);
-            $skippedTag = $result['skippedOnlyCount'] > 0
-                ? ", {$result['skippedOnlyCount']} skipped-only"
-                : '';
+            $endpointPct = self::percentage($result['endpointFullyCovered'], $result['endpointTotal']);
+            $responsePct = self::percentage($result['responseCovered'], $result['responseTotal']);
 
-            $output .= "\n[{$spec}] {$result['coveredCount']}/{$result['total']} endpoints ({$percentage}%){$skippedTag}\n";
+            $output .= sprintf(
+                "\n[%s] endpoints: %d/%d fully covered (%s%%), %d partial, %d uncovered\n",
+                $spec,
+                $result['endpointFullyCovered'],
+                $result['endpointTotal'],
+                $endpointPct,
+                $result['endpointPartial'],
+                $result['endpointUncovered'],
+            );
+            $output .= sprintf(
+                "        responses: %d/%d covered (%s%%), %d skipped, %d uncovered\n",
+                $result['responseCovered'],
+                $result['responseTotal'],
+                $responsePct,
+                $result['responseSkipped'],
+                $result['responseUncovered'],
+            );
             $output .= str_repeat('-', 50) . "\n";
+            $output .= "Legend: ✓=validated  ⚠=skipped  ✗=uncovered  ◐=partial  ·=request-only  *=any/no content-type\n";
 
-            $output .= self::renderCovered($result, $consoleOutput);
-            $output .= self::renderUncovered($result, $consoleOutput);
+            $output .= self::renderEndpoints($result['endpoints'], $consoleOutput);
         }
 
         $output .= "\n";
@@ -50,56 +72,110 @@ final class ConsoleCoverageRenderer
     }
 
     /**
-     * @param CoverageResult $result
+     * @param list<EndpointSummary> $endpoints
      */
-    private static function renderCovered(array $result, ConsoleOutput $consoleOutput): string
+    private static function renderEndpoints(array $endpoints, ConsoleOutput $mode): string
     {
-        if ($result['covered'] === []) {
+        if ($endpoints === []) {
             return '';
         }
 
-        if ($consoleOutput === ConsoleOutput::UNCOVERED_ONLY) {
-            return "Covered: {$result['coveredCount']} endpoints\n";
-        }
+        $output = '';
+        foreach ($endpoints as $endpoint) {
+            // DEFAULT mode renders one line per endpoint with no sub-rows.
+            // ALL renders sub-rows for every endpoint. UNCOVERED_ONLY only
+            // shows sub-rows when the endpoint isn't all-covered, so a
+            // green run stays compact.
+            $showSubRows = match ($mode) {
+                ConsoleOutput::DEFAULT => false,
+                ConsoleOutput::ALL => true,
+                ConsoleOutput::UNCOVERED_ONLY => $endpoint['state'] !== 'all-covered',
+            };
 
-        $output = "Covered:\n";
+            $output .= sprintf(
+                "  %s %s%s\n",
+                self::endpointMarker($endpoint['state']),
+                $endpoint['endpoint'],
+                self::endpointSummaryTail($endpoint),
+            );
 
-        if ($result['skippedOnlyCount'] > 0) {
-            $output .= self::SKIPPED_ONLY_LEGEND . "\n";
-        }
+            if (!$showSubRows) {
+                continue;
+            }
 
-        $skipSet = array_flip($result['skippedOnly']);
+            foreach ($endpoint['responses'] as $row) {
+                if ($mode === ConsoleOutput::UNCOVERED_ONLY && $row['state'] === 'validated') {
+                    continue;
+                }
+                $output .= sprintf(
+                    "      %s %s  %s%s\n",
+                    self::responseMarker($row['state']),
+                    str_pad($row['statusKey'], 5, ' ', STR_PAD_RIGHT),
+                    str_pad($row['contentTypeKey'], 32, ' ', STR_PAD_RIGHT),
+                    self::responseTail($row),
+                );
+            }
 
-        foreach ($result['covered'] as $endpoint) {
-            $marker = isset($skipSet[$endpoint]) ? '⚠' : '✓';
-            $output .= "  {$marker} {$endpoint}\n";
+            foreach ($endpoint['unexpectedObservations'] as $obs) {
+                $output .= sprintf(
+                    "      ! %s  %s  unexpected (not in spec)\n",
+                    str_pad($obs['statusKey'], 5, ' ', STR_PAD_RIGHT),
+                    str_pad($obs['contentTypeKey'], 32, ' ', STR_PAD_RIGHT),
+                );
+            }
         }
 
         return $output;
     }
 
     /**
-     * @param CoverageResult $result
+     * @param EndpointSummary $endpoint
      */
-    private static function renderUncovered(array $result, ConsoleOutput $consoleOutput): string
+    private static function endpointSummaryTail(array $endpoint): string
     {
-        if ($result['uncovered'] === []) {
-            return '';
+        if ($endpoint['totalResponseCount'] === 0) {
+            return $endpoint['requestReached'] ? '  (request only)' : '';
         }
 
-        $uncoveredCount = count($result['uncovered']);
-
-        if ($consoleOutput === ConsoleOutput::DEFAULT) {
-            return "Uncovered: {$uncoveredCount} endpoints\n";
+        $tail = sprintf('  (%d/%d responses', $endpoint['coveredResponseCount'], $endpoint['totalResponseCount']);
+        if ($endpoint['skippedResponseCount'] > 0) {
+            $tail .= sprintf(', %d skipped', $endpoint['skippedResponseCount']);
         }
 
-        $output = "Uncovered:\n";
+        return $tail . ')';
+    }
 
-        foreach ($result['uncovered'] as $endpoint) {
-            $output .= "  ✗ {$endpoint}\n";
-        }
+    /**
+     * @param ResponseRow $row
+     */
+    private static function responseTail(array $row): string
+    {
+        return match ($row['state']) {
+            'validated' => sprintf('[%d]', $row['hits']),
+            'skipped' => $row['skipReason'] !== null
+                ? sprintf('skipped: %s', $row['skipReason'])
+                : 'skipped',
+            default => 'uncovered',
+        };
+    }
 
-        return $output;
+    private static function endpointMarker(string $state): string
+    {
+        return match ($state) {
+            'all-covered' => self::MARKER_ALL_COVERED,
+            'partial' => self::MARKER_PARTIAL,
+            'request-only' => self::MARKER_REQUEST_ONLY,
+            default => self::MARKER_UNCOVERED,
+        };
+    }
+
+    private static function responseMarker(string $state): string
+    {
+        return match ($state) {
+            'validated' => self::MARKER_ALL_COVERED,
+            'skipped' => self::MARKER_SKIPPED,
+            default => self::MARKER_UNCOVERED,
+        };
     }
 
     private static function percentage(int $covered, int $total): float|int

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -14,6 +14,7 @@ use Studio\OpenApiContractTesting\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\SpecFileNotFoundException;
 
 use function file_put_contents;
+use function is_callable;
 
 /**
  * @phpstan-import-type CoverageResult from OpenApiCoverageTracker
@@ -22,12 +23,16 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
 {
     /**
      * @param string[] $specs
+     * @param null|callable(string): void $stderrWriter Optional sink for warnings (stale/invalid specs,
+     *                                                  failed file_put_contents). Falls back to {@see OpenApiCoverageExtension::writeStderr()} when
+     *                                                  null. Injected for testability — the extension stays the default backstop in production.
      */
     public function __construct(
         private array $specs,
         private ?string $outputFile,
         private ConsoleOutput $consoleOutput,
         private ?string $githubSummaryPath,
+        private mixed $stderrWriter = null,
     ) {}
 
     /** @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter */
@@ -47,6 +52,18 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         if ($this->outputFile !== null || $this->githubSummaryPath !== null) {
             $this->writeMarkdownReport($results);
         }
+    }
+
+    private function writeStderr(string $message): void
+    {
+        $writer = $this->stderrWriter;
+        if (is_callable($writer)) {
+            $writer($message);
+
+            return;
+        }
+
+        OpenApiCoverageExtension::writeStderr($message);
     }
 
     /**
@@ -77,7 +94,7 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
                 // as bootstrap. Unlike bootstrap, the subscriber runs
                 // after tests finished, so continuing lets partial
                 // coverage reports still render.
-                OpenApiCoverageExtension::writeStderr("[OpenAPI Coverage] WARNING: Skipping spec '{$spec}': {$e->getMessage()}\n");
+                $this->writeStderr("[OpenAPI Coverage] WARNING: Skipping spec '{$spec}': {$e->getMessage()}\n");
 
                 continue;
             } catch (InvalidOpenApiSpecException $e) {
@@ -85,7 +102,7 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
                 // was called mid-run and the on-disk spec was edited
                 // between bootstrap and ExecutionFinished. Preserves
                 // the hard-fail contract in that edge case.
-                OpenApiCoverageExtension::writeStderr("[OpenAPI Coverage] FATAL: Invalid OpenAPI spec '{$spec}': {$e->getMessage()}\n");
+                $this->writeStderr("[OpenAPI Coverage] FATAL: Invalid OpenAPI spec '{$spec}': {$e->getMessage()}\n");
 
                 throw $e;
             }
@@ -105,7 +122,7 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
             $written = file_put_contents($this->outputFile, $markdown);
 
             if ($written === false) {
-                OpenApiCoverageExtension::writeStderr("[OpenAPI Coverage] WARNING: Failed to write Markdown report to {$this->outputFile}\n");
+                $this->writeStderr("[OpenAPI Coverage] WARNING: Failed to write Markdown report to {$this->outputFile}\n");
             }
         }
 
@@ -113,7 +130,7 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
             $written = file_put_contents($this->githubSummaryPath, $markdown . "\n", FILE_APPEND);
 
             if ($written === false) {
-                OpenApiCoverageExtension::writeStderr("[OpenAPI Coverage] WARNING: Failed to append Markdown report to GITHUB_STEP_SUMMARY ({$this->githubSummaryPath})\n");
+                $this->writeStderr("[OpenAPI Coverage] WARNING: Failed to append Markdown report to GITHUB_STEP_SUMMARY ({$this->githubSummaryPath})\n");
             }
         }
     }

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\PHPUnit;
+
+use const FILE_APPEND;
+
+use PHPUnit\Event\TestRunner\ExecutionFinished;
+use PHPUnit\Event\TestRunner\ExecutionFinishedSubscriber;
+use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
+use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\SpecFileNotFoundException;
+
+use function file_put_contents;
+
+/**
+ * @phpstan-import-type CoverageResult from OpenApiCoverageTracker
+ */
+final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscriber
+{
+    /**
+     * @param string[] $specs
+     */
+    public function __construct(
+        private array $specs,
+        private ?string $outputFile,
+        private ConsoleOutput $consoleOutput,
+        private ?string $githubSummaryPath,
+    ) {}
+
+    /** @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter */
+    public function notify(ExecutionFinished $event): void
+    {
+        $results = $this->computeAllResults();
+
+        // Free cached spec data now that coverage has been computed
+        OpenApiSpecLoader::clearCache();
+
+        if ($results === []) {
+            return;
+        }
+
+        echo ConsoleCoverageRenderer::render($results, $this->consoleOutput);
+
+        if ($this->outputFile !== null || $this->githubSummaryPath !== null) {
+            $this->writeMarkdownReport($results);
+        }
+    }
+
+    /**
+     * @return array<string, CoverageResult>
+     */
+    private function computeAllResults(): array
+    {
+        $hasCoverage = false;
+        foreach ($this->specs as $spec) {
+            if (OpenApiCoverageTracker::hasAnyCoverage($spec)) {
+                $hasCoverage = true;
+
+                break;
+            }
+        }
+
+        if (!$hasCoverage) {
+            return [];
+        }
+
+        $results = [];
+
+        foreach ($this->specs as $spec) {
+            try {
+                $results[$spec] = OpenApiCoverageTracker::computeCoverage($spec);
+            } catch (SpecFileNotFoundException $e) {
+                // Warn-and-continue for stale specs=, same semantics
+                // as bootstrap. Unlike bootstrap, the subscriber runs
+                // after tests finished, so continuing lets partial
+                // coverage reports still render.
+                OpenApiCoverageExtension::writeStderr("[OpenAPI Coverage] WARNING: Skipping spec '{$spec}': {$e->getMessage()}\n");
+
+                continue;
+            } catch (InvalidOpenApiSpecException $e) {
+                // Defensive: only reachable if OpenApiSpecLoader::evict()
+                // was called mid-run and the on-disk spec was edited
+                // between bootstrap and ExecutionFinished. Preserves
+                // the hard-fail contract in that edge case.
+                OpenApiCoverageExtension::writeStderr("[OpenAPI Coverage] FATAL: Invalid OpenAPI spec '{$spec}': {$e->getMessage()}\n");
+
+                throw $e;
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * @param array<string, CoverageResult> $results
+     */
+    private function writeMarkdownReport(array $results): void
+    {
+        $markdown = MarkdownCoverageRenderer::render($results);
+
+        if ($this->outputFile !== null) {
+            $written = file_put_contents($this->outputFile, $markdown);
+
+            if ($written === false) {
+                OpenApiCoverageExtension::writeStderr("[OpenAPI Coverage] WARNING: Failed to write Markdown report to {$this->outputFile}\n");
+            }
+        }
+
+        if ($this->githubSummaryPath !== null) {
+            $written = file_put_contents($this->githubSummaryPath, $markdown . "\n", FILE_APPEND);
+
+            if ($written === false) {
+                OpenApiCoverageExtension::writeStderr("[OpenAPI Coverage] WARNING: Failed to append Markdown report to GITHUB_STEP_SUMMARY ({$this->githubSummaryPath})\n");
+            }
+        }
+    }
+}

--- a/src/PHPUnit/MarkdownCoverageRenderer.php
+++ b/src/PHPUnit/MarkdownCoverageRenderer.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\PHPUnit;
 
+use Studio\OpenApiContractTesting\EndpointCoverageState;
 use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\ResponseCoverageState;
 
 use function implode;
 use function round;
@@ -158,22 +160,22 @@ final class MarkdownCoverageRenderer
         return $extras === [] ? $line : sprintf('%s (%s)', $line, implode(', ', $extras));
     }
 
-    private static function endpointMarker(string $state): string
+    private static function endpointMarker(EndpointCoverageState $state): string
     {
         return match ($state) {
-            'all-covered' => self::MARKER_ALL_COVERED,
-            'partial' => self::MARKER_PARTIAL,
-            'request-only' => self::MARKER_REQUEST_ONLY,
-            default => self::MARKER_UNCOVERED,
+            EndpointCoverageState::AllCovered => self::MARKER_ALL_COVERED,
+            EndpointCoverageState::Partial => self::MARKER_PARTIAL,
+            EndpointCoverageState::RequestOnly => self::MARKER_REQUEST_ONLY,
+            EndpointCoverageState::Uncovered => self::MARKER_UNCOVERED,
         };
     }
 
-    private static function responseMarker(string $state): string
+    private static function responseMarker(ResponseCoverageState $state): string
     {
         return match ($state) {
-            'validated' => self::MARKER_ALL_COVERED,
-            'skipped' => self::MARKER_SKIPPED,
-            default => self::MARKER_UNCOVERED,
+            ResponseCoverageState::Validated => self::MARKER_ALL_COVERED,
+            ResponseCoverageState::Skipped => self::MARKER_SKIPPED,
+            ResponseCoverageState::Uncovered => self::MARKER_UNCOVERED,
         };
     }
 
@@ -183,11 +185,11 @@ final class MarkdownCoverageRenderer
     private static function responseStateLabel(array $row): string
     {
         return match ($row['state']) {
-            'validated' => sprintf('validated (%d hits)', $row['hits']),
-            'skipped' => $row['skipReason'] !== null
+            ResponseCoverageState::Validated => sprintf('validated (%d hits)', $row['hits']),
+            ResponseCoverageState::Skipped => $row['skipReason'] !== null
                 ? sprintf('skipped (%s)', $row['skipReason'])
                 : 'skipped',
-            default => 'uncovered',
+            ResponseCoverageState::Uncovered => 'uncovered',
         };
     }
 

--- a/src/PHPUnit/MarkdownCoverageRenderer.php
+++ b/src/PHPUnit/MarkdownCoverageRenderer.php
@@ -6,17 +6,22 @@ namespace Studio\OpenApiContractTesting\PHPUnit;
 
 use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
 
-use function array_flip;
-use function count;
 use function implode;
 use function round;
+use function sprintf;
 
 /**
  * @phpstan-import-type CoverageResult from OpenApiCoverageTracker
+ * @phpstan-import-type EndpointSummary from OpenApiCoverageTracker
+ * @phpstan-import-type ResponseRow from OpenApiCoverageTracker
  */
 final class MarkdownCoverageRenderer
 {
-    private const SKIPPED_ONLY_NOTE = '> :warning: response body validation skipped (e.g. 5xx default skip) — endpoint was exercised but its body was never checked against the schema.';
+    private const MARKER_ALL_COVERED = ':white_check_mark:';
+    private const MARKER_PARTIAL = ':large_orange_diamond:';
+    private const MARKER_SKIPPED = ':warning:';
+    private const MARKER_UNCOVERED = ':x:';
+    private const MARKER_REQUEST_ONLY = ':information_source:';
 
     /**
      * @param array<string, CoverageResult> $results
@@ -30,47 +35,169 @@ final class MarkdownCoverageRenderer
         $lines = ['## OpenAPI Contract Test Coverage', ''];
 
         foreach ($results as $specName => $result) {
-            $total = $result['total'];
-            $coveredCount = $result['coveredCount'];
-            $percentage = $total > 0
-                ? round($coveredCount / $total * 100, 1)
-                : 0;
+            $endpointPct = self::percentage($result['endpointFullyCovered'], $result['endpointTotal']);
+            $responsePct = self::percentage($result['responseCovered'], $result['responseTotal']);
 
-            $lines[] = "### {$specName} — {$coveredCount}/{$total} endpoints ({$percentage}%)";
+            $lines[] = sprintf(
+                '### %s — endpoints: %d/%d fully covered (%s%%)',
+                $specName,
+                $result['endpointFullyCovered'],
+                $result['endpointTotal'],
+                self::formatPercent($endpointPct),
+            );
+            $lines[] = sprintf(
+                '_responses: %d/%d covered (%s%%) — %d skipped, %d uncovered, %d partial endpoints, %d uncovered endpoints_',
+                $result['responseCovered'],
+                $result['responseTotal'],
+                self::formatPercent($responsePct),
+                $result['responseSkipped'],
+                $result['responseUncovered'],
+                $result['endpointPartial'],
+                $result['endpointUncovered'],
+            );
             $lines[] = '';
 
-            if ($result['skippedOnlyCount'] > 0) {
-                $lines[] = self::SKIPPED_ONLY_NOTE;
-                $lines[] = '';
+            if ($result['endpoints'] === []) {
+                continue;
             }
 
-            if ($result['covered'] !== []) {
-                $skipSet = array_flip($result['skippedOnly']);
-                $lines[] = '| Status | Endpoint |';
-                $lines[] = '|--------|----------|';
-                foreach ($result['covered'] as $endpoint) {
-                    $marker = isset($skipSet[$endpoint]) ? ':warning:' : ':white_check_mark:';
-                    $lines[] = "| {$marker} | `{$endpoint}` |";
-                }
-                $lines[] = '';
+            $lines[] = '| Status | Endpoint | Responses |';
+            $lines[] = '|--------|----------|-----------|';
+            foreach ($result['endpoints'] as $endpoint) {
+                $lines[] = sprintf(
+                    '| %s | `%s` | %s |',
+                    self::endpointMarker($endpoint['state']),
+                    $endpoint['endpoint'],
+                    self::endpointResponsesSummary($endpoint),
+                );
+            }
+            $lines[] = '';
+
+            $lines[] = '<details>';
+            $lines[] = '<summary>Per-response detail</summary>';
+            $lines[] = '';
+
+            foreach ($result['endpoints'] as $endpoint) {
+                $lines = [...$lines, ...self::renderEndpointDetail($endpoint)];
             }
 
-            $uncoveredCount = count($result['uncovered']);
-            if ($uncoveredCount > 0) {
-                $lines[] = '<details>';
-                $lines[] = "<summary>{$uncoveredCount} uncovered endpoints</summary>";
-                $lines[] = '';
-                $lines[] = '| Endpoint |';
-                $lines[] = '|----------|';
-                foreach ($result['uncovered'] as $endpoint) {
-                    $lines[] = "| `{$endpoint}` |";
-                }
-                $lines[] = '';
-                $lines[] = '</details>';
-                $lines[] = '';
-            }
+            $lines[] = '</details>';
+            $lines[] = '';
         }
 
         return implode("\n", $lines);
+    }
+
+    /**
+     * @param EndpointSummary $endpoint
+     *
+     * @return list<string>
+     */
+    private static function renderEndpointDetail(array $endpoint): array
+    {
+        $heading = $endpoint['operationId'] !== null
+            ? sprintf('#### `%s` (%s)', $endpoint['endpoint'], $endpoint['operationId'])
+            : sprintf('#### `%s`', $endpoint['endpoint']);
+        $lines = [$heading];
+
+        if ($endpoint['responses'] === []) {
+            $lines[] = $endpoint['requestReached']
+                ? '_request reached, no response definitions in spec_'
+                : '_no response definitions in spec_';
+            $lines[] = '';
+
+            return $lines;
+        }
+
+        $lines[] = '| Status | Content-Type | State |';
+        $lines[] = '|--------|--------------|-------|';
+        foreach ($endpoint['responses'] as $row) {
+            $lines[] = sprintf(
+                '| %s %s | %s | %s |',
+                self::responseMarker($row['state']),
+                $row['statusKey'],
+                $row['contentTypeKey'],
+                self::responseStateLabel($row),
+            );
+        }
+
+        if ($endpoint['unexpectedObservations'] !== []) {
+            $lines[] = '';
+            $lines[] = '_Unexpected observations (status / content-type not in spec):_';
+            foreach ($endpoint['unexpectedObservations'] as $obs) {
+                $lines[] = sprintf('- `%s` `%s`', $obs['statusKey'], $obs['contentTypeKey']);
+            }
+        }
+
+        $lines[] = '';
+
+        return $lines;
+    }
+
+    /**
+     * @param EndpointSummary $endpoint
+     */
+    private static function endpointResponsesSummary(array $endpoint): string
+    {
+        if ($endpoint['totalResponseCount'] === 0) {
+            return $endpoint['requestReached'] ? 'request only' : 'no spec entries';
+        }
+
+        $line = sprintf('%d/%d', $endpoint['coveredResponseCount'], $endpoint['totalResponseCount']);
+        $extras = [];
+        if ($endpoint['skippedResponseCount'] > 0) {
+            $extras[] = sprintf('%d skipped', $endpoint['skippedResponseCount']);
+        }
+        $uncovered = $endpoint['totalResponseCount']
+            - $endpoint['coveredResponseCount']
+            - $endpoint['skippedResponseCount'];
+        if ($uncovered > 0) {
+            $extras[] = sprintf('%d uncovered', $uncovered);
+        }
+
+        return $extras === [] ? $line : sprintf('%s (%s)', $line, implode(', ', $extras));
+    }
+
+    private static function endpointMarker(string $state): string
+    {
+        return match ($state) {
+            'all-covered' => self::MARKER_ALL_COVERED,
+            'partial' => self::MARKER_PARTIAL,
+            'request-only' => self::MARKER_REQUEST_ONLY,
+            default => self::MARKER_UNCOVERED,
+        };
+    }
+
+    private static function responseMarker(string $state): string
+    {
+        return match ($state) {
+            'validated' => self::MARKER_ALL_COVERED,
+            'skipped' => self::MARKER_SKIPPED,
+            default => self::MARKER_UNCOVERED,
+        };
+    }
+
+    /**
+     * @param ResponseRow $row
+     */
+    private static function responseStateLabel(array $row): string
+    {
+        return match ($row['state']) {
+            'validated' => sprintf('validated (%d hits)', $row['hits']),
+            'skipped' => $row['skipReason'] !== null
+                ? sprintf('skipped (%s)', $row['skipReason'])
+                : 'skipped',
+            default => 'uncovered',
+        };
+    }
+
+    private static function percentage(int $covered, int $total): float|int
+    {
+        return $total > 0 ? round($covered / $total * 100, 1) : 0;
+    }
+
+    private static function formatPercent(float|int $value): string
+    {
+        return (string) $value;
     }
 }

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -8,14 +8,11 @@ use const FILE_APPEND;
 use const PHP_EOL;
 use const STDERR;
 
-use PHPUnit\Event\TestRunner\ExecutionFinished;
-use PHPUnit\Event\TestRunner\ExecutionFinishedSubscriber;
 use PHPUnit\Runner\Extension\Extension;
 use PHPUnit\Runner\Extension\Facade;
 use PHPUnit\Runner\Extension\ParameterCollection;
 use PHPUnit\TextUI\Configuration\Configuration;
 use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
-use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\SpecFileNotFoundException;
 
@@ -50,7 +47,7 @@ final class OpenApiCoverageExtension implements Extension
     }
 
     /**
-     * @internal exposed so the anonymous subscriber class can reuse the stream override.
+     * @internal exposed so the extension's subscriber can reuse the stream override.
      */
     public static function writeStderr(string $message): void
     {
@@ -149,121 +146,12 @@ final class OpenApiCoverageExtension implements Extension
             return;
         }
 
-        $facade->registerSubscriber(new class ($specs, $outputFile, $consoleOutput, $githubSummaryPath) implements ExecutionFinishedSubscriber {
-            /**
-             * @param string[] $specs
-             */
-            public function __construct(
-                private readonly array $specs,
-                private readonly ?string $outputFile,
-                private readonly ConsoleOutput $consoleOutput,
-                private readonly ?string $githubSummaryPath,
-            ) {}
-
-            /** @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter */
-            public function notify(ExecutionFinished $event): void
-            {
-                $results = $this->computeAllResults();
-
-                // Free cached spec data now that coverage has been computed
-                OpenApiSpecLoader::clearCache();
-
-                if ($results === []) {
-                    return;
-                }
-
-                echo ConsoleCoverageRenderer::render($results, $this->consoleOutput);
-
-                if ($this->outputFile !== null || $this->githubSummaryPath !== null) {
-                    $this->writeMarkdownReport($results);
-                }
-            }
-
-            /**
-             * @return array<string, array{
-             *     covered: string[],
-             *     uncovered: string[],
-             *     total: int,
-             *     coveredCount: int,
-             *     skippedOnly: string[],
-             *     skippedOnlyCount: int,
-             * }>
-             */
-            private function computeAllResults(): array
-            {
-                $covered = OpenApiCoverageTracker::getCovered();
-                $hasCoverage = false;
-
-                foreach ($this->specs as $spec) {
-                    if (isset($covered[$spec]) && $covered[$spec] !== []) {
-                        $hasCoverage = true;
-
-                        break;
-                    }
-                }
-
-                if (!$hasCoverage) {
-                    return [];
-                }
-
-                $results = [];
-
-                foreach ($this->specs as $spec) {
-                    try {
-                        $results[$spec] = OpenApiCoverageTracker::computeCoverage($spec);
-                    } catch (SpecFileNotFoundException $e) {
-                        // Warn-and-continue for stale specs=, same semantics
-                        // as bootstrap. Unlike bootstrap, the subscriber runs
-                        // after tests finished, so continuing lets partial
-                        // coverage reports still render.
-                        OpenApiCoverageExtension::writeStderr("[OpenAPI Coverage] WARNING: Skipping spec '{$spec}': {$e->getMessage()}\n");
-
-                        continue;
-                    } catch (InvalidOpenApiSpecException $e) {
-                        // Defensive: only reachable if OpenApiSpecLoader::evict()
-                        // was called mid-run and the on-disk spec was edited
-                        // between bootstrap and ExecutionFinished. Preserves
-                        // the hard-fail contract in that edge case.
-                        OpenApiCoverageExtension::writeStderr("[OpenAPI Coverage] FATAL: Invalid OpenAPI spec '{$spec}': {$e->getMessage()}\n");
-
-                        throw $e;
-                    }
-                }
-
-                return $results;
-            }
-
-            /**
-             * @param array<string, array{
-             *     covered: string[],
-             *     uncovered: string[],
-             *     total: int,
-             *     coveredCount: int,
-             *     skippedOnly: string[],
-             *     skippedOnlyCount: int,
-             * }> $results
-             */
-            private function writeMarkdownReport(array $results): void
-            {
-                $markdown = MarkdownCoverageRenderer::render($results);
-
-                if ($this->outputFile !== null) {
-                    $written = file_put_contents($this->outputFile, $markdown);
-
-                    if ($written === false) {
-                        OpenApiCoverageExtension::writeStderr("[OpenAPI Coverage] WARNING: Failed to write Markdown report to {$this->outputFile}\n");
-                    }
-                }
-
-                if ($this->githubSummaryPath !== null) {
-                    $written = file_put_contents($this->githubSummaryPath, $markdown . "\n", FILE_APPEND);
-
-                    if ($written === false) {
-                        OpenApiCoverageExtension::writeStderr("[OpenAPI Coverage] WARNING: Failed to append Markdown report to GITHUB_STEP_SUMMARY ({$this->githubSummaryPath})\n");
-                    }
-                }
-            }
-        });
+        $facade->registerSubscriber(new CoverageReportSubscriber(
+            specs: $specs,
+            outputFile: $outputFile,
+            consoleOutput: $consoleOutput,
+            githubSummaryPath: $githubSummaryPath,
+        ));
     }
 
     private static function appendGithubStepSummaryFatalBlock(?string $path, string $spec, string $reason): void

--- a/src/ResponseCoverageState.php
+++ b/src/ResponseCoverageState.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting;
+
+/**
+ * Resolved coverage state for a single declared `(status, content-type)`
+ * pair on an endpoint — exposed on `CoverageResult.endpoints[].responses[].state`.
+ *
+ * - {@see self::Validated}: at least one recording reconciled to this pair
+ *   AND the validator ran (skipped recordings never promote to Validated).
+ * - {@see self::Skipped}: at least one recording reconciled to this pair
+ *   but every reconciled recording was skipped (e.g. the status matched
+ *   a `skip_response_codes` pattern, or the validator had no schema
+ *   engine for the declared content-type).
+ * - {@see self::Uncovered}: no recording reconciled to this pair.
+ */
+enum ResponseCoverageState: string
+{
+    case Validated = 'validated';
+    case Skipped = 'skipped';
+    case Uncovered = 'uncovered';
+}

--- a/src/Validation/Response/ResponseBodyValidationResult.php
+++ b/src/Validation/Response/ResponseBodyValidationResult.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Validation\Response;
+
+/**
+ * Outcome of {@see ResponseBodyValidator::validate()}.
+ *
+ * `errors` carries the same string payload the validator previously returned
+ * (empty list = body acceptable). `matchedContentType` is the spec key (with
+ * the spec author's original casing) that the body validated against, or
+ * `null` when no content-type lookup was performed (204-style responses,
+ * non-JSON specs we don't validate, content-type-not-in-spec failures).
+ *
+ * Coverage tracking uses `matchedContentType` to record per-(status, media-type)
+ * granularity instead of treating the whole endpoint as a single bucket.
+ */
+final readonly class ResponseBodyValidationResult
+{
+    /**
+     * @param string[] $errors
+     */
+    public function __construct(
+        public array $errors,
+        public ?string $matchedContentType,
+    ) {}
+}

--- a/src/Validation/Response/ResponseBodyValidator.php
+++ b/src/Validation/Response/ResponseBodyValidator.php
@@ -24,20 +24,23 @@ final class ResponseBodyValidator
 
     /**
      * Validate the response body against the matched operation's response
-     * entry. Returns an empty list when the body is acceptable (non-JSON
-     * content types that are present in the spec, JSON media types with no
-     * `schema` key, and JSON bodies that pass schema validation). Hard
-     * failures (content-type not defined, empty body against a JSON schema,
-     * schema mismatch) are returned as error strings so the orchestrator can
-     * assemble the final {@see OpenApiValidationResult}.
+     * entry. Returns a {@see ResponseBodyValidationResult} with an empty
+     * `errors` list when the body is acceptable (non-JSON content types that
+     * are present in the spec, JSON media types with no `schema` key, and
+     * JSON bodies that pass schema validation). Hard failures (content-type
+     * not defined, empty body against a JSON schema, schema mismatch) are
+     * returned as error strings so the orchestrator can assemble the final
+     * {@see OpenApiValidationResult}.
+     *
+     * `matchedContentType` is the spec key (with its original casing) the
+     * body was checked against, or `null` when no spec lookup occurred —
+     * used by coverage tracking to record per-(status, media-type) granularity.
      *
      * The 204-style "no content" case is handled upstream in
      * {@see OpenApiResponseValidator::validate()} — when the response spec
      * has no `content` key, this validator is never invoked.
      *
      * @param array<string, array<string, mixed>> $content the `responses[$status].content` map
-     *
-     * @return string[]
      */
     public function validate(
         string $specName,
@@ -48,7 +51,7 @@ final class ResponseBodyValidator
         mixed $responseBody,
         ?string $responseContentType,
         OpenApiVersion $version,
-    ): array {
+    ): ResponseBodyValidationResult {
         // When the actual response Content-Type is provided, handle content negotiation:
         // non-JSON types are checked for spec presence only, while JSON-compatible types
         // fall through to schema validation against the first JSON media type in the spec.
@@ -57,15 +60,19 @@ final class ResponseBodyValidator
 
             if (!ContentTypeMatcher::isJsonContentType($normalizedType)) {
                 // Non-JSON response: check if the content type is defined in the spec.
-                if (ContentTypeMatcher::isContentTypeInSpec($normalizedType, $content)) {
-                    return [];
+                $matchedKey = ContentTypeMatcher::findContentTypeKey($normalizedType, $content);
+                if ($matchedKey !== null) {
+                    return new ResponseBodyValidationResult([], $matchedKey);
                 }
 
                 $defined = implode(', ', array_keys($content));
 
-                return [
-                    "Response Content-Type '{$normalizedType}' is not defined for {$method} {$matchedPath} (status {$statusCode}) in '{$specName}' spec. Defined content types: {$defined}",
-                ];
+                return new ResponseBodyValidationResult(
+                    [
+                        "Response Content-Type '{$normalizedType}' is not defined for {$method} {$matchedPath} (status {$statusCode}) in '{$specName}' spec. Defined content types: {$defined}",
+                    ],
+                    null,
+                );
             }
 
             // JSON-compatible response: continue to JSON schema validation below.
@@ -80,17 +87,20 @@ final class ResponseBodyValidator
         // This validator only handles JSON schemas; non-JSON types (e.g. text/html,
         // application/xml) are outside its scope.
         if ($jsonContentType === null) {
-            return [];
+            return new ResponseBodyValidationResult([], null);
         }
 
         if (!isset($content[$jsonContentType]['schema'])) {
-            return [];
+            return new ResponseBodyValidationResult([], $jsonContentType);
         }
 
         if ($responseBody === null) {
-            return [
-                "Response body is empty but {$method} {$matchedPath} (status {$statusCode}) defines a JSON-compatible response schema in '{$specName}' spec.",
-            ];
+            return new ResponseBodyValidationResult(
+                [
+                    "Response body is empty but {$method} {$matchedPath} (status {$statusCode}) defines a JSON-compatible response schema in '{$specName}' spec.",
+                ],
+                $jsonContentType,
+            );
         }
 
         /** @var array<string, mixed> $schema */
@@ -109,6 +119,6 @@ final class ResponseBodyValidator
             }
         }
 
-        return $errors;
+        return new ResponseBodyValidationResult($errors, $jsonContentType);
     }
 }

--- a/src/Validation/Support/ContentTypeMatcher.php
+++ b/src/Validation/Support/ContentTypeMatcher.php
@@ -56,13 +56,27 @@ final class ContentTypeMatcher
      */
     public static function isContentTypeInSpec(string $normalizedContentType, array $content): bool
     {
+        return self::findContentTypeKey($normalizedContentType, $content) !== null;
+    }
+
+    /**
+     * Return the spec key (with the spec author's original casing) whose
+     * lower-cased form matches the given normalised content type, or null
+     * when no spec key matches. Used by coverage tracking to surface the
+     * spec's literal media-type keys (which may mix casings, e.g. petstore
+     * declares both `Application/Problem+JSON` and `application/problem+json`).
+     *
+     * @param array<string, mixed> $content
+     */
+    public static function findContentTypeKey(string $normalizedContentType, array $content): ?string
+    {
         foreach ($content as $specContentType => $_mediaType) {
             if (strtolower($specContentType) === $normalizedContentType) {
-                return true;
+                return $specContentType;
             }
         }
 
-        return false;
+        return null;
     }
 
     /**

--- a/tests/Integration/ResponseValidationTest.php
+++ b/tests/Integration/ResponseValidationTest.php
@@ -6,11 +6,13 @@ namespace Studio\OpenApiContractTesting\Tests\Integration;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\EndpointCoverageState;
 use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
 use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\OpenApiResponseValidator;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\OpenApiValidationResult;
+use Studio\OpenApiContractTesting\ResponseCoverageState;
 
 class ResponseValidationTest extends TestCase
 {
@@ -61,11 +63,11 @@ class ResponseValidationTest extends TestCase
         $this->assertGreaterThanOrEqual(2, $coverage['endpointFullyCovered'] + $coverage['endpointPartial']);
 
         $endpoints = $this->indexEndpoints($coverage['endpoints']);
-        $this->assertSame('partial', $endpoints['GET /v1/pets']['state']);
+        $this->assertSame(EndpointCoverageState::Partial, $endpoints['GET /v1/pets']['state']);
         // POST /v1/pets has multiple declared responses (201, 409 ×2, 415);
         // recording only 201 leaves the others uncovered → partial state.
-        $this->assertSame('partial', $endpoints['POST /v1/pets']['state']);
-        $this->assertSame('uncovered', $endpoints['GET /v1/health']['state']);
+        $this->assertSame(EndpointCoverageState::Partial, $endpoints['POST /v1/pets']['state']);
+        $this->assertSame(EndpointCoverageState::Uncovered, $endpoints['GET /v1/health']['state']);
     }
 
     #[Test]
@@ -85,12 +87,18 @@ class ResponseValidationTest extends TestCase
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.1');
         $this->assertSame(19, $coverage['endpointTotal']);
         $endpoints = $this->indexEndpoints($coverage['endpoints']);
-        $this->assertContains($endpoints['GET /v1/pets']['state'], ['partial', 'all-covered']);
+        $this->assertContains($endpoints['GET /v1/pets']['state'], [EndpointCoverageState::Partial, EndpointCoverageState::AllCovered]);
     }
 
     #[Test]
-    public function non_json_endpoint_skips_validation_and_records_coverage(): void
+    public function non_json_endpoint_records_skipped_when_no_content_type_supplied(): void
     {
+        // The spec for GET /v1/logout 200 declares only `text/html` — no JSON
+        // schema engine to validate against. Without an explicit response
+        // Content-Type, the validator cannot even check spec presence; it
+        // returns Skipped so coverage reflects that no validation actually
+        // occurred (vs the pre-#111 silent Success that would have inflated
+        // coverage of the `text/html` declaration).
         $result = $this->validator->validate(
             'petstore-3.0',
             'GET',
@@ -99,12 +107,38 @@ class ResponseValidationTest extends TestCase
             '<html><body>Logged out</body></html>',
         );
         $this->assertTrue($result->isValid());
+        $this->assertTrue($result->isSkipped());
 
         $this->recordResult('petstore-3.0', 'GET', $result);
 
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
         $endpoints = $this->indexEndpoints($coverage['endpoints']);
-        $this->assertSame('all-covered', $endpoints['GET /v1/logout']['state']);
+        $this->assertSame(EndpointCoverageState::Partial, $endpoints['GET /v1/logout']['state']);
+        $this->assertSame(1, $endpoints['GET /v1/logout']['skippedResponseCount']);
+    }
+
+    #[Test]
+    public function non_json_endpoint_with_explicit_content_type_marks_validated(): void
+    {
+        // Same endpoint, but the caller supplies the actual response
+        // Content-Type. The body validator can confirm `text/html` is in
+        // the spec's content map and credits the coverage row as validated.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/logout',
+            200,
+            '<html><body>Logged out</body></html>',
+            'text/html',
+        );
+        $this->assertTrue($result->isValid());
+        $this->assertFalse($result->isSkipped());
+
+        $this->recordResult('petstore-3.0', 'GET', $result);
+
+        $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
+        $endpoints = $this->indexEndpoints($coverage['endpoints']);
+        $this->assertSame(EndpointCoverageState::AllCovered, $endpoints['GET /v1/logout']['state']);
     }
 
     #[Test]
@@ -126,7 +160,7 @@ class ResponseValidationTest extends TestCase
         $endpoints = $this->indexEndpoints($coverage['endpoints']);
         // text/html is one of two declared 409 content-types; the other (application/json)
         // remains uncovered, so the endpoint as a whole is partial.
-        $this->assertSame('partial', $endpoints['POST /v1/pets']['state']);
+        $this->assertSame(EndpointCoverageState::Partial, $endpoints['POST /v1/pets']['state']);
     }
 
     #[Test]
@@ -146,13 +180,13 @@ class ResponseValidationTest extends TestCase
 
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
         $endpoints = $this->indexEndpoints($coverage['endpoints']);
-        $this->assertSame('partial', $endpoints['GET /v1/pets']['state']);
+        $this->assertSame(EndpointCoverageState::Partial, $endpoints['GET /v1/pets']['state']);
         // petstore-3.0 declares `500: application/json` literally — recording
         // matches it exactly, so it shows up as `skipped` (not in
         // unexpectedObservations).
         $hadSkipped = false;
         foreach ($endpoints['GET /v1/pets']['responses'] as $row) {
-            if ($row['statusKey'] === '500' && $row['state'] === 'skipped') {
+            if ($row['statusKey'] === '500' && $row['state'] === ResponseCoverageState::Skipped) {
                 $hadSkipped = true;
 
                 break;
@@ -190,8 +224,8 @@ class ResponseValidationTest extends TestCase
         }
 
         // 200:application/json validated independently of 500 skipped.
-        $this->assertSame('validated', $rowsByKey['200:application/json']['state']);
-        $this->assertSame('skipped', $rowsByKey['500:application/json']['state']);
+        $this->assertSame(ResponseCoverageState::Validated, $rowsByKey['200:application/json']['state']);
+        $this->assertSame(ResponseCoverageState::Skipped, $rowsByKey['500:application/json']['state']);
     }
 
     #[Test]
@@ -222,8 +256,8 @@ class ResponseValidationTest extends TestCase
             $rowsByKey[$row['statusKey'] . ':' . $row['contentTypeKey']] = $row;
         }
 
-        $this->assertSame('validated', $rowsByKey['200:application/json']['state']);
-        $this->assertSame('skipped', $rowsByKey['500:application/json']['state']);
+        $this->assertSame(ResponseCoverageState::Validated, $rowsByKey['200:application/json']['state']);
+        $this->assertSame(ResponseCoverageState::Skipped, $rowsByKey['500:application/json']['state']);
     }
 
     #[Test]
@@ -267,9 +301,9 @@ class ResponseValidationTest extends TestCase
     }
 
     /**
-     * @param list<array{endpoint: string, method: string, path: string, operationId: ?string, state: string, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}> $endpoints
+     * @param list<array{endpoint: string, method: string, path: string, operationId: ?string, state: EndpointCoverageState, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}> $endpoints
      *
-     * @return array<string, array{endpoint: string, method: string, path: string, operationId: ?string, state: string, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}>
+     * @return array<string, array{endpoint: string, method: string, path: string, operationId: ?string, state: EndpointCoverageState, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}>
      */
     private function indexEndpoints(array $endpoints): array
     {

--- a/tests/Integration/ResponseValidationTest.php
+++ b/tests/Integration/ResponseValidationTest.php
@@ -6,9 +6,11 @@ namespace Studio\OpenApiContractTesting\Tests\Integration;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
 use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\OpenApiResponseValidator;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\OpenApiValidationResult;
 
 class ResponseValidationTest extends TestCase
 {
@@ -33,7 +35,6 @@ class ResponseValidationTest extends TestCase
     #[Test]
     public function full_pipeline_v30_validate_and_track_coverage(): void
     {
-        // Validate a valid response
         $result = $this->validator->validate(
             'petstore-3.0',
             'GET',
@@ -43,12 +44,8 @@ class ResponseValidationTest extends TestCase
         );
         $this->assertTrue($result->isValid());
 
-        // Track coverage
-        if ($result->matchedPath() !== null) {
-            OpenApiCoverageTracker::record('petstore-3.0', 'GET', $result->matchedPath());
-        }
+        $this->recordResult('petstore-3.0', 'GET', $result);
 
-        // Validate another endpoint
         $result2 = $this->validator->validate(
             'petstore-3.0',
             'POST',
@@ -57,24 +54,18 @@ class ResponseValidationTest extends TestCase
             ['data' => ['id' => 2, 'name' => 'Whiskers', 'tag' => 'cat']],
         );
         $this->assertTrue($result2->isValid());
+        $this->recordResult('petstore-3.0', 'POST', $result2);
 
-        if ($result2->matchedPath() !== null) {
-            OpenApiCoverageTracker::record('petstore-3.0', 'POST', $result2->matchedPath());
-        }
-
-        // Check coverage
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
-        $this->assertSame(23, $coverage['total']);
-        $this->assertSame(2, $coverage['coveredCount']);
-        $this->assertContains('GET /v1/pets', $coverage['covered']);
-        $this->assertContains('POST /v1/pets', $coverage['covered']);
-        $this->assertContains('GET /v1/health', $coverage['uncovered']);
-        $this->assertContains('GET /v1/logout', $coverage['uncovered']);
-        $this->assertContains('GET /v1/pets/search', $coverage['uncovered']);
-        $this->assertContains('DELETE /v1/pets/{petId}', $coverage['uncovered']);
-        $this->assertContains('GET /v1/pets/{petId}', $coverage['uncovered']);
-        $this->assertContains('PATCH /v1/pets/{petId}', $coverage['uncovered']);
-        $this->assertContains('PUT /v1/pets/{petId}', $coverage['uncovered']);
+        $this->assertSame(23, $coverage['endpointTotal']);
+        $this->assertGreaterThanOrEqual(2, $coverage['endpointFullyCovered'] + $coverage['endpointPartial']);
+
+        $endpoints = $this->indexEndpoints($coverage['endpoints']);
+        $this->assertSame('partial', $endpoints['GET /v1/pets']['state']);
+        // POST /v1/pets has multiple declared responses (201, 409 ×2, 415);
+        // recording only 201 leaves the others uncovered → partial state.
+        $this->assertSame('partial', $endpoints['POST /v1/pets']['state']);
+        $this->assertSame('uncovered', $endpoints['GET /v1/health']['state']);
     }
 
     #[Test]
@@ -89,13 +80,12 @@ class ResponseValidationTest extends TestCase
         );
         $this->assertTrue($result->isValid());
 
-        if ($result->matchedPath() !== null) {
-            OpenApiCoverageTracker::record('petstore-3.1', 'GET', $result->matchedPath());
-        }
+        $this->recordResult('petstore-3.1', 'GET', $result);
 
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.1');
-        $this->assertSame(19, $coverage['total']);
-        $this->assertSame(1, $coverage['coveredCount']);
+        $this->assertSame(19, $coverage['endpointTotal']);
+        $endpoints = $this->indexEndpoints($coverage['endpoints']);
+        $this->assertContains($endpoints['GET /v1/pets']['state'], ['partial', 'all-covered']);
     }
 
     #[Test]
@@ -110,13 +100,11 @@ class ResponseValidationTest extends TestCase
         );
         $this->assertTrue($result->isValid());
 
-        if ($result->matchedPath() !== null) {
-            OpenApiCoverageTracker::record('petstore-3.0', 'GET', $result->matchedPath());
-        }
+        $this->recordResult('petstore-3.0', 'GET', $result);
 
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
-        $this->assertSame(1, $coverage['coveredCount']);
-        $this->assertContains('GET /v1/logout', $coverage['covered']);
+        $endpoints = $this->indexEndpoints($coverage['endpoints']);
+        $this->assertSame('all-covered', $endpoints['GET /v1/logout']['state']);
     }
 
     #[Test]
@@ -132,17 +120,17 @@ class ResponseValidationTest extends TestCase
         );
         $this->assertTrue($result->isValid());
 
-        if ($result->matchedPath() !== null) {
-            OpenApiCoverageTracker::record('petstore-3.0', 'POST', $result->matchedPath());
-        }
+        $this->recordResult('petstore-3.0', 'POST', $result);
 
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
-        $this->assertSame(1, $coverage['coveredCount']);
-        $this->assertContains('POST /v1/pets', $coverage['covered']);
+        $endpoints = $this->indexEndpoints($coverage['endpoints']);
+        // text/html is one of two declared 409 content-types; the other (application/json)
+        // remains uncovered, so the endpoint as a whole is partial.
+        $this->assertSame('partial', $endpoints['POST /v1/pets']['state']);
     }
 
     #[Test]
-    public function response_500_records_endpoint_as_skipped_only(): void
+    public function response_500_marks_skipped_response_with_range_reconciliation(): void
     {
         $result = $this->validator->validate(
             'petstore-3.0',
@@ -151,28 +139,30 @@ class ResponseValidationTest extends TestCase
             500,
             ['anything' => 'goes'],
         );
-        // Record before asserting isSkipped() — asserting first lets phpstan
-        // narrow the bool to a constant and flag !isSkipped() as always-false.
-        if ($result->matchedPath() !== null) {
-            OpenApiCoverageTracker::record(
-                'petstore-3.0',
-                'GET',
-                $result->matchedPath(),
-                schemaValidated: !$result->isSkipped(),
-            );
-        }
+        $this->recordResult('petstore-3.0', 'GET', $result);
 
         $this->assertTrue($result->isValid());
         $this->assertTrue($result->isSkipped());
 
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
-        $this->assertContains('GET /v1/pets', $coverage['covered']);
-        $this->assertSame(['GET /v1/pets'], $coverage['skippedOnly']);
-        $this->assertSame(1, $coverage['skippedOnlyCount']);
+        $endpoints = $this->indexEndpoints($coverage['endpoints']);
+        $this->assertSame('partial', $endpoints['GET /v1/pets']['state']);
+        // petstore-3.0 declares `500: application/json` literally — recording
+        // matches it exactly, so it shows up as `skipped` (not in
+        // unexpectedObservations).
+        $hadSkipped = false;
+        foreach ($endpoints['GET /v1/pets']['responses'] as $row) {
+            if ($row['statusKey'] === '500' && $row['state'] === 'skipped') {
+                $hadSkipped = true;
+
+                break;
+            }
+        }
+        $this->assertTrue($hadSkipped, 'Expected a skipped row for status 500');
     }
 
     #[Test]
-    public function response_200_then_500_keeps_endpoint_validated(): void
+    public function response_200_then_500_keeps_pair_validated_independently(): void
     {
         $ok = $this->validator->validate(
             'petstore-3.0',
@@ -181,12 +171,7 @@ class ResponseValidationTest extends TestCase
             200,
             ['data' => [['id' => 1, 'name' => 'Fido', 'tag' => null]]],
         );
-        OpenApiCoverageTracker::record(
-            'petstore-3.0',
-            'GET',
-            $ok->matchedPath() ?? '/v1/pets',
-            schemaValidated: !$ok->isSkipped(),
-        );
+        $this->recordResult('petstore-3.0', 'GET', $ok);
 
         $skip = $this->validator->validate(
             'petstore-3.0',
@@ -195,24 +180,23 @@ class ResponseValidationTest extends TestCase
             500,
             ['anything' => 'goes'],
         );
-        OpenApiCoverageTracker::record(
-            'petstore-3.0',
-            'GET',
-            $skip->matchedPath() ?? '/v1/pets',
-            schemaValidated: !$skip->isSkipped(),
-        );
+        $this->recordResult('petstore-3.0', 'GET', $skip);
 
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
-        $this->assertContains('GET /v1/pets', $coverage['covered']);
-        $this->assertSame([], $coverage['skippedOnly']);
-        $this->assertSame(0, $coverage['skippedOnlyCount']);
+        $endpoints = $this->indexEndpoints($coverage['endpoints']);
+        $rowsByKey = [];
+        foreach ($endpoints['GET /v1/pets']['responses'] as $row) {
+            $rowsByKey[$row['statusKey'] . ':' . $row['contentTypeKey']] = $row;
+        }
+
+        // 200:application/json validated independently of 500 skipped.
+        $this->assertSame('validated', $rowsByKey['200:application/json']['state']);
+        $this->assertSame('skipped', $rowsByKey['500:application/json']['state']);
     }
 
     #[Test]
-    public function response_500_then_200_keeps_endpoint_validated(): void
+    public function response_500_then_200_keeps_pair_validated_independently(): void
     {
-        // Reverse order of the previous test — monotonic `validated` means
-        // ordering does not matter.
         $skip = $this->validator->validate(
             'petstore-3.0',
             'GET',
@@ -220,12 +204,7 @@ class ResponseValidationTest extends TestCase
             500,
             ['anything' => 'goes'],
         );
-        OpenApiCoverageTracker::record(
-            'petstore-3.0',
-            'GET',
-            $skip->matchedPath() ?? '/v1/pets',
-            schemaValidated: !$skip->isSkipped(),
-        );
+        $this->recordResult('petstore-3.0', 'GET', $skip);
 
         $ok = $this->validator->validate(
             'petstore-3.0',
@@ -234,17 +213,17 @@ class ResponseValidationTest extends TestCase
             200,
             ['data' => [['id' => 1, 'name' => 'Fido', 'tag' => null]]],
         );
-        OpenApiCoverageTracker::record(
-            'petstore-3.0',
-            'GET',
-            $ok->matchedPath() ?? '/v1/pets',
-            schemaValidated: !$ok->isSkipped(),
-        );
+        $this->recordResult('petstore-3.0', 'GET', $ok);
 
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
-        $this->assertContains('GET /v1/pets', $coverage['covered']);
-        $this->assertSame([], $coverage['skippedOnly']);
-        $this->assertSame(0, $coverage['skippedOnlyCount']);
+        $endpoints = $this->indexEndpoints($coverage['endpoints']);
+        $rowsByKey = [];
+        foreach ($endpoints['GET /v1/pets']['responses'] as $row) {
+            $rowsByKey[$row['statusKey'] . ':' . $row['contentTypeKey']] = $row;
+        }
+
+        $this->assertSame('validated', $rowsByKey['200:application/json']['state']);
+        $this->assertSame('skipped', $rowsByKey['500:application/json']['state']);
     }
 
     #[Test]
@@ -261,5 +240,44 @@ class ResponseValidationTest extends TestCase
         $this->assertFalse($result->isValid());
         $this->assertNotEmpty($result->errors());
         $this->assertNotEmpty($result->errorMessage());
+    }
+
+    /**
+     * Mirror what {@see ValidatesOpenApiSchema}
+     * does so the integration test exercises the same coverage path.
+     */
+    private function recordResult(
+        string $specName,
+        string $method,
+        OpenApiValidationResult $result,
+    ): void {
+        if ($result->matchedPath() === null) {
+            return;
+        }
+
+        OpenApiCoverageTracker::recordResponse(
+            $specName,
+            $method,
+            $result->matchedPath(),
+            $result->matchedStatusCode() ?? '0',
+            $result->matchedContentType(),
+            schemaValidated: !$result->isSkipped(),
+            skipReason: $result->skipReason(),
+        );
+    }
+
+    /**
+     * @param list<array{endpoint: string, method: string, path: string, operationId: ?string, state: string, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}> $endpoints
+     *
+     * @return array<string, array{endpoint: string, method: string, path: string, operationId: ?string, state: string, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}>
+     */
+    private function indexEndpoints(array $endpoints): array
+    {
+        $indexed = [];
+        foreach ($endpoints as $endpoint) {
+            $indexed[$endpoint['endpoint']] = $endpoint;
+        }
+
+        return $indexed;
     }
 }

--- a/tests/Unit/ConsoleCoverageRendererTest.php
+++ b/tests/Unit/ConsoleCoverageRendererTest.php
@@ -9,8 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\PHPUnit\ConsoleCoverageRenderer;
 use Studio\OpenApiContractTesting\PHPUnit\ConsoleOutput;
 
-use function count;
-use function substr_count;
+use function explode;
 
 class ConsoleCoverageRendererTest extends TestCase
 {
@@ -21,417 +20,266 @@ class ConsoleCoverageRendererTest extends TestCase
     }
 
     #[Test]
-    public function render_default_mode_shows_covered_list_and_uncovered_count(): void
+    public function default_mode_renders_endpoint_summaries_without_sub_rows(): void
     {
         $results = [
-            'front' => self::coverageResult(
-                covered: ['GET /v1/pets', 'POST /v1/pets'],
-                uncovered: ['DELETE /v1/pets/{petId}', 'GET /v1/pets/{petId}'],
-                total: 4,
-            ),
-        ];
-
-        $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::DEFAULT);
-
-        $this->assertStringContainsString('OpenAPI Contract Test Coverage', $output);
-        $this->assertStringContainsString('[front] 2/4 endpoints (50%)', $output);
-        $this->assertStringContainsString('Covered:', $output);
-        $this->assertStringContainsString('  ✓ GET /v1/pets', $output);
-        $this->assertStringContainsString('  ✓ POST /v1/pets', $output);
-        $this->assertStringContainsString('Uncovered: 2 endpoints', $output);
-        $this->assertStringNotContainsString('  ✗', $output);
-        $this->assertStringNotContainsString('skipped-only', $output);
-        $this->assertStringNotContainsString('⚠', $output);
-    }
-
-    #[Test]
-    public function render_all_mode_shows_both_covered_and_uncovered_lists(): void
-    {
-        $results = [
-            'front' => self::coverageResult(
-                covered: ['GET /v1/pets', 'POST /v1/pets'],
-                uncovered: ['DELETE /v1/pets/{petId}', 'GET /v1/pets/{petId}'],
-                total: 4,
-            ),
-        ];
-
-        $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::ALL);
-
-        $this->assertStringContainsString('Covered:', $output);
-        $this->assertStringContainsString('  ✓ GET /v1/pets', $output);
-        $this->assertStringContainsString('  ✓ POST /v1/pets', $output);
-        $this->assertStringContainsString('Uncovered:', $output);
-        $this->assertStringContainsString('  ✗ DELETE /v1/pets/{petId}', $output);
-        $this->assertStringContainsString('  ✗ GET /v1/pets/{petId}', $output);
-        $this->assertStringNotContainsString('Uncovered: 2 endpoints', $output);
-    }
-
-    #[Test]
-    public function render_uncovered_only_mode_shows_uncovered_list_and_covered_count(): void
-    {
-        $results = [
-            'front' => self::coverageResult(
-                covered: ['GET /v1/pets', 'POST /v1/pets'],
-                uncovered: ['DELETE /v1/pets/{petId}', 'GET /v1/pets/{petId}'],
-                total: 4,
-            ),
-        ];
-
-        $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::UNCOVERED_ONLY);
-
-        $this->assertStringContainsString('Covered: 2 endpoints', $output);
-        $this->assertStringNotContainsString('  ✓', $output);
-        $this->assertStringContainsString('Uncovered:', $output);
-        $this->assertStringContainsString('  ✗ DELETE /v1/pets/{petId}', $output);
-        $this->assertStringContainsString('  ✗ GET /v1/pets/{petId}', $output);
-    }
-
-    #[Test]
-    public function render_full_coverage_default_mode_shows_no_uncovered_section(): void
-    {
-        $results = [
-            'front' => self::coverageResult(
-                covered: ['GET /v1/pets', 'POST /v1/pets'],
-                uncovered: [],
-                total: 2,
-            ),
-        ];
-
-        $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::DEFAULT);
-
-        $this->assertStringContainsString('[front] 2/2 endpoints (100%)', $output);
-        $this->assertStringContainsString('  ✓ GET /v1/pets', $output);
-        $this->assertStringNotContainsString('Uncovered', $output);
-    }
-
-    #[Test]
-    public function render_full_coverage_all_mode_shows_no_uncovered_section(): void
-    {
-        $results = [
-            'front' => self::coverageResult(
-                covered: ['GET /v1/pets', 'POST /v1/pets'],
-                uncovered: [],
-                total: 2,
-            ),
-        ];
-
-        $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::ALL);
-
-        $this->assertStringContainsString('  ✓ GET /v1/pets', $output);
-        $this->assertStringNotContainsString('Uncovered', $output);
-    }
-
-    #[Test]
-    public function render_zero_coverage_default_mode_shows_uncovered_count(): void
-    {
-        $results = [
-            'front' => self::coverageResult(
-                covered: [],
-                uncovered: ['GET /v1/pets', 'POST /v1/pets'],
-                total: 2,
-            ),
-        ];
-
-        $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::DEFAULT);
-
-        $this->assertStringContainsString('[front] 0/2 endpoints (0%)', $output);
-        $this->assertStringNotContainsString('Covered:', $output);
-        $this->assertStringContainsString('Uncovered: 2 endpoints', $output);
-    }
-
-    #[Test]
-    public function render_zero_coverage_uncovered_only_mode_shows_uncovered_list(): void
-    {
-        $results = [
-            'front' => self::coverageResult(
-                covered: [],
-                uncovered: ['GET /v1/pets', 'POST /v1/pets'],
-                total: 2,
-            ),
-        ];
-
-        $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::UNCOVERED_ONLY);
-
-        $this->assertStringContainsString('[front] 0/2 endpoints (0%)', $output);
-        $this->assertStringNotContainsString('Covered:', $output);
-        $this->assertStringContainsString('Uncovered:', $output);
-        $this->assertStringContainsString('  ✗ GET /v1/pets', $output);
-        $this->assertStringContainsString('  ✗ POST /v1/pets', $output);
-    }
-
-    #[Test]
-    public function render_multiple_specs(): void
-    {
-        $results = [
-            'front' => self::coverageResult(
-                covered: ['GET /v1/pets'],
-                uncovered: ['POST /v1/pets'],
-                total: 2,
-            ),
-            'admin' => self::coverageResult(
-                covered: ['GET /v1/users'],
-                uncovered: [],
-                total: 1,
-            ),
-        ];
-
-        $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::DEFAULT);
-
-        $this->assertStringContainsString('[front] 1/2 endpoints (50%)', $output);
-        $this->assertStringContainsString('[admin] 1/1 endpoints (100%)', $output);
-    }
-
-    #[Test]
-    public function render_defaults_to_default_mode(): void
-    {
-        $results = [
-            'front' => self::coverageResult(
-                covered: ['GET /v1/pets'],
-                uncovered: ['POST /v1/pets'],
-                total: 2,
-            ),
-        ];
-
-        $withExplicitDefault = ConsoleCoverageRenderer::render($results, ConsoleOutput::DEFAULT);
-        $withImplicitDefault = ConsoleCoverageRenderer::render($results);
-
-        $this->assertSame($withExplicitDefault, $withImplicitDefault);
-    }
-
-    #[Test]
-    public function render_header_and_separators_are_present(): void
-    {
-        $results = [
-            'front' => self::coverageResult(
-                covered: ['GET /v1/pets'],
-                uncovered: [],
-                total: 1,
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v1/pets', 'all-covered', responses: [
+                        self::row('200', 'application/json', 'validated', hits: 3),
+                    ], coveredResponseCount: 1, totalResponseCount: 1),
+                ],
+                endpointTotal: 1,
+                endpointFullyCovered: 1,
+                responseTotal: 1,
+                responseCovered: 1,
             ),
         ];
 
         $output = ConsoleCoverageRenderer::render($results);
 
-        $this->assertStringContainsString('OpenAPI Contract Test Coverage', $output);
-        $this->assertStringContainsString('==================================================', $output);
-        $this->assertStringContainsString('--------------------------------------------------', $output);
+        $this->assertStringContainsString('[front] endpoints: 1/1 fully covered (100%)', $output);
+        $this->assertStringContainsString('responses: 1/1 covered (100%)', $output);
+        $this->assertStringContainsString('✓ GET /v1/pets', $output);
+        // No sub-rows in DEFAULT mode.
+        $this->assertStringNotContainsString('200  application/json', $output);
     }
 
     #[Test]
-    public function render_zero_coverage_all_mode_shows_uncovered_list_only(): void
+    public function all_mode_renders_sub_rows_for_every_endpoint(): void
     {
         $results = [
-            'front' => self::coverageResult(
-                covered: [],
-                uncovered: ['GET /v1/pets', 'POST /v1/pets'],
-                total: 2,
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v1/pets', 'all-covered', responses: [
+                        self::row('200', 'application/json', 'validated', hits: 3),
+                    ], coveredResponseCount: 1, totalResponseCount: 1),
+                ],
+                endpointTotal: 1,
+                endpointFullyCovered: 1,
+                responseTotal: 1,
+                responseCovered: 1,
             ),
         ];
 
         $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::ALL);
 
-        $this->assertStringContainsString('[front] 0/2 endpoints (0%)', $output);
-        $this->assertStringNotContainsString('Covered', $output);
-        $this->assertStringContainsString('Uncovered:', $output);
-        $this->assertStringContainsString('  ✗ GET /v1/pets', $output);
+        $this->assertStringContainsString('200', $output);
+        $this->assertStringContainsString('application/json', $output);
+        $this->assertStringContainsString('[3]', $output);
     }
 
     #[Test]
-    public function render_full_coverage_uncovered_only_mode_shows_covered_count_only(): void
+    public function uncovered_only_mode_omits_sub_rows_for_fully_covered(): void
     {
         $results = [
-            'front' => self::coverageResult(
-                covered: ['GET /v1/pets', 'POST /v1/pets'],
-                uncovered: [],
-                total: 2,
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v1/pets', 'all-covered', responses: [
+                        self::row('200', 'application/json', 'validated', hits: 1),
+                    ], coveredResponseCount: 1, totalResponseCount: 1),
+                    self::endpoint('POST /v1/pets', 'partial', responses: [
+                        self::row('201', 'application/json', 'validated', hits: 1),
+                        self::row('422', 'application/problem+json', 'uncovered'),
+                    ], coveredResponseCount: 1, totalResponseCount: 2),
+                ],
+                endpointTotal: 2,
+                endpointFullyCovered: 1,
+                endpointPartial: 1,
+                responseTotal: 3,
+                responseCovered: 2,
+                responseUncovered: 1,
             ),
         ];
 
         $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::UNCOVERED_ONLY);
 
-        $this->assertStringContainsString('Covered: 2 endpoints', $output);
-        $this->assertStringNotContainsString('  ✓', $output);
-        $this->assertStringNotContainsString('Uncovered', $output);
+        $this->assertStringContainsString('✓ GET /v1/pets', $output);
+        $this->assertStringContainsString('◐ POST /v1/pets', $output);
+        $this->assertStringContainsString('422', $output);
+        $this->assertStringContainsString('uncovered', $output);
     }
 
     #[Test]
-    public function render_percentage_rounds_to_one_decimal_place(): void
+    public function partial_endpoint_uses_orange_diamond_marker(): void
     {
         $results = [
-            'front' => self::coverageResult(
-                covered: ['GET /v1/pets'],
-                uncovered: ['POST /v1/pets', 'DELETE /v1/pets/{petId}'],
-                total: 3,
-            ),
-        ];
-
-        $output = ConsoleCoverageRenderer::render($results);
-
-        $this->assertStringContainsString('[front] 1/3 endpoints (33.3%)', $output);
-    }
-
-    #[Test]
-    public function render_spec_with_zero_endpoints(): void
-    {
-        $results = [
-            'empty' => self::coverageResult(
-                covered: [],
-                uncovered: [],
-                total: 0,
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('POST /v1/pets', 'partial', responses: [
+                        self::row('201', 'application/json', 'validated', hits: 1),
+                        self::row('422', 'application/problem+json', 'uncovered'),
+                    ], coveredResponseCount: 1, totalResponseCount: 2),
+                ],
+                endpointTotal: 1,
+                endpointPartial: 1,
+                responseTotal: 2,
+                responseCovered: 1,
+                responseUncovered: 1,
             ),
         ];
 
         $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::ALL);
 
-        $this->assertStringContainsString('[empty] 0/0 endpoints (0%)', $output);
-        $this->assertStringNotContainsString('Covered', $output);
-        $this->assertStringNotContainsString('Uncovered', $output);
+        $this->assertStringContainsString('◐ POST /v1/pets', $output);
+        $this->assertStringContainsString('1/2 responses', $output);
     }
 
     #[Test]
-    public function header_appends_skipped_only_count_when_nonzero(): void
+    public function skipped_response_uses_warning_marker_with_skip_reason(): void
     {
         $results = [
-            'front' => self::coverageResult(
-                covered: ['GET /v1/pets', 'POST /v1/pets'],
-                uncovered: ['DELETE /v1/pets/{petId}'],
-                total: 3,
-                skippedOnly: ['POST /v1/pets'],
-            ),
-        ];
-
-        $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::DEFAULT);
-
-        $this->assertStringContainsString('[front] 2/3 endpoints (66.7%), 1 skipped-only', $output);
-    }
-
-    #[Test]
-    public function header_omits_skipped_only_when_zero(): void
-    {
-        $results = [
-            'front' => self::coverageResult(
-                covered: ['GET /v1/pets'],
-                uncovered: [],
-                total: 1,
-            ),
-        ];
-
-        $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::DEFAULT);
-
-        $this->assertStringContainsString('[front] 1/1 endpoints (100%)', $output);
-        $this->assertStringNotContainsString('skipped-only', $output);
-    }
-
-    #[Test]
-    public function all_mode_renders_warning_marker_for_skipped_only_rows(): void
-    {
-        $results = [
-            'front' => self::coverageResult(
-                covered: ['GET /v1/pets', 'POST /v1/pets'],
-                uncovered: [],
-                total: 2,
-                skippedOnly: ['POST /v1/pets'],
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('DELETE /v1/pets/{petId}', 'partial', responses: [
+                        self::row('204', '*', 'validated', hits: 2),
+                        self::row('5XX', '*', 'skipped', hits: 1, skipReason: 'status 503 matched skip pattern 5\d\d'),
+                    ], coveredResponseCount: 1, skippedResponseCount: 1, totalResponseCount: 2),
+                ],
+                endpointTotal: 1,
+                endpointPartial: 1,
+                responseTotal: 2,
+                responseCovered: 1,
+                responseSkipped: 1,
             ),
         ];
 
         $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::ALL);
 
-        $this->assertStringContainsString('  ✓ GET /v1/pets', $output);
-        $this->assertStringContainsString('  ⚠ POST /v1/pets', $output);
-        $this->assertStringNotContainsString('  ✓ POST /v1/pets', $output);
+        $this->assertStringContainsString('⚠', $output);
+        $this->assertStringContainsString('5XX', $output);
+        $this->assertStringContainsString('skipped: status 503 matched skip pattern 5\d\d', $output);
+        $this->assertStringContainsString('1/2 responses, 1 skipped', $output);
     }
 
     #[Test]
-    public function default_mode_includes_legend_once_when_any_skipped_only(): void
+    public function uncovered_endpoint_marker(): void
     {
         $results = [
-            'front' => self::coverageResult(
-                covered: ['GET /v1/pets', 'POST /v1/pets'],
-                uncovered: [],
-                total: 2,
-                skippedOnly: ['POST /v1/pets'],
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v1/health', 'uncovered', responses: [
+                        self::row('200', 'application/json', 'uncovered'),
+                    ], totalResponseCount: 1),
+                ],
+                endpointTotal: 1,
+                endpointUncovered: 1,
+                responseTotal: 1,
+                responseUncovered: 1,
             ),
         ];
 
-        $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::DEFAULT);
+        $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::ALL);
 
-        $this->assertStringContainsString('⚠ = response body validation skipped', $output);
-        $this->assertSame(1, substr_count($output, '⚠ = response body validation skipped'));
+        $this->assertStringContainsString('✗ GET /v1/health', $output);
     }
 
     #[Test]
-    public function header_fragment_scales_across_specs_and_counts(): void
+    public function unexpected_observation_appears_with_bang_prefix(): void
     {
-        // Guards against a regression where the fragment were joined across
-        // specs, or where `N > 1` were rendered differently from `N == 1`.
         $results = [
-            'front' => self::coverageResult(
-                covered: ['GET /v1/pets', 'POST /v1/pets'],
-                uncovered: [],
-                total: 2,
-                skippedOnly: ['GET /v1/pets', 'POST /v1/pets'],
-            ),
-            'admin' => self::coverageResult(
-                covered: ['GET /v1/users'],
-                uncovered: [],
-                total: 1,
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v1/pets', 'partial', responses: [
+                        self::row('200', 'application/json', 'validated', hits: 1),
+                    ], coveredResponseCount: 1, totalResponseCount: 1, unexpectedObservations: [
+                        ['statusKey' => '418', 'contentTypeKey' => 'application/json'],
+                    ]),
+                ],
+                endpointTotal: 1,
+                endpointPartial: 1,
+                responseTotal: 1,
+                responseCovered: 1,
             ),
         ];
 
-        $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::DEFAULT);
+        $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::ALL);
 
-        $this->assertStringContainsString('[front] 2/2 endpoints (100%), 2 skipped-only', $output);
-        $this->assertStringContainsString('[admin] 1/1 endpoints (100%)', $output);
-        $this->assertSame(1, substr_count($output, 'skipped-only'));
-    }
-
-    #[Test]
-    public function uncovered_only_mode_omits_legend_and_per_row_markers(): void
-    {
-        $results = [
-            'front' => self::coverageResult(
-                covered: ['GET /v1/pets', 'POST /v1/pets'],
-                uncovered: ['DELETE /v1/pets/{petId}'],
-                total: 3,
-                skippedOnly: ['POST /v1/pets'],
-            ),
-        ];
-
-        $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::UNCOVERED_ONLY);
-
-        $this->assertStringContainsString(', 1 skipped-only', $output);
-        $this->assertStringContainsString('Covered: 2 endpoints', $output);
-        $this->assertStringNotContainsString('⚠', $output);
+        $this->assertStringContainsString('! 418', $output);
+        $this->assertStringContainsString('unexpected (not in spec)', $output);
     }
 
     /**
-     * @param string[] $covered
-     * @param string[] $uncovered
-     * @param null|string[] $skippedOnly
+     * @param list<array{endpoint: string, method: string, path: string, operationId: ?string, state: string, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}> $endpoints
      *
-     * @return array{
-     *     covered: string[],
-     *     uncovered: string[],
-     *     total: int,
-     *     coveredCount: int,
-     *     skippedOnly: string[],
-     *     skippedOnlyCount: int,
-     * }
+     * @return array{endpoints: list<array{endpoint: string, method: string, path: string, operationId: ?string, state: string, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}>, endpointTotal: int, endpointFullyCovered: int, endpointPartial: int, endpointUncovered: int, endpointRequestOnly: int, responseTotal: int, responseCovered: int, responseSkipped: int, responseUncovered: int}
      */
-    private static function coverageResult(
-        array $covered,
-        array $uncovered,
-        int $total,
-        ?array $skippedOnly = null,
+    private static function coverage(
+        array $endpoints,
+        int $endpointTotal = 0,
+        int $endpointFullyCovered = 0,
+        int $endpointPartial = 0,
+        int $endpointUncovered = 0,
+        int $endpointRequestOnly = 0,
+        int $responseTotal = 0,
+        int $responseCovered = 0,
+        int $responseSkipped = 0,
+        int $responseUncovered = 0,
     ): array {
-        $skippedOnly ??= [];
+        return [
+            'endpoints' => $endpoints,
+            'endpointTotal' => $endpointTotal,
+            'endpointFullyCovered' => $endpointFullyCovered,
+            'endpointPartial' => $endpointPartial,
+            'endpointUncovered' => $endpointUncovered,
+            'endpointRequestOnly' => $endpointRequestOnly,
+            'responseTotal' => $responseTotal,
+            'responseCovered' => $responseCovered,
+            'responseSkipped' => $responseSkipped,
+            'responseUncovered' => $responseUncovered,
+        ];
+    }
+
+    /**
+     * @param list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}> $responses
+     * @param list<array{statusKey: string, contentTypeKey: string}> $unexpectedObservations
+     *
+     * @return array{endpoint: string, method: string, path: string, operationId: ?string, state: string, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}
+     */
+    private static function endpoint(
+        string $endpoint,
+        string $state,
+        bool $requestReached = false,
+        ?string $operationId = null,
+        array $responses = [],
+        int $coveredResponseCount = 0,
+        int $skippedResponseCount = 0,
+        int $totalResponseCount = 0,
+        array $unexpectedObservations = [],
+    ): array {
+        [$method, $path] = explode(' ', $endpoint, 2);
 
         return [
-            'covered' => $covered,
-            'uncovered' => $uncovered,
-            'total' => $total,
-            'coveredCount' => count($covered),
-            'skippedOnly' => $skippedOnly,
-            'skippedOnlyCount' => count($skippedOnly),
+            'endpoint' => $endpoint,
+            'method' => $method,
+            'path' => $path,
+            'operationId' => $operationId,
+            'state' => $state,
+            'requestReached' => $requestReached,
+            'responses' => $responses,
+            'coveredResponseCount' => $coveredResponseCount,
+            'skippedResponseCount' => $skippedResponseCount,
+            'totalResponseCount' => $totalResponseCount,
+            'unexpectedObservations' => $unexpectedObservations,
+        ];
+    }
+
+    /**
+     * @return array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}
+     */
+    private static function row(
+        string $statusKey,
+        string $contentTypeKey,
+        string $state,
+        int $hits = 0,
+        ?string $skipReason = null,
+    ): array {
+        return [
+            'statusKey' => $statusKey,
+            'contentTypeKey' => $contentTypeKey,
+            'state' => $state,
+            'hits' => $hits,
+            'skipReason' => $skipReason,
         ];
     }
 }

--- a/tests/Unit/ConsoleCoverageRendererTest.php
+++ b/tests/Unit/ConsoleCoverageRendererTest.php
@@ -6,8 +6,10 @@ namespace Studio\OpenApiContractTesting\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\EndpointCoverageState;
 use Studio\OpenApiContractTesting\PHPUnit\ConsoleCoverageRenderer;
 use Studio\OpenApiContractTesting\PHPUnit\ConsoleOutput;
+use Studio\OpenApiContractTesting\ResponseCoverageState;
 
 use function explode;
 
@@ -98,6 +100,10 @@ class ConsoleCoverageRendererTest extends TestCase
         $this->assertStringContainsString('◐ POST /v1/pets', $output);
         $this->assertStringContainsString('422', $output);
         $this->assertStringContainsString('uncovered', $output);
+        // Pin the per-row validated suppression on the partial endpoint:
+        // POST /v1/pets has a validated 201:application/json sub-row that
+        // must NOT appear in UNCOVERED_ONLY mode (only the uncovered 422 row).
+        $this->assertStringNotContainsString('201    application/json', $output);
     }
 
     #[Test]
@@ -200,9 +206,9 @@ class ConsoleCoverageRendererTest extends TestCase
     }
 
     /**
-     * @param list<array{endpoint: string, method: string, path: string, operationId: ?string, state: string, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}> $endpoints
+     * @param list<array{endpoint: string, method: string, path: string, operationId: ?string, state: EndpointCoverageState, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}> $endpoints
      *
-     * @return array{endpoints: list<array{endpoint: string, method: string, path: string, operationId: ?string, state: string, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}>, endpointTotal: int, endpointFullyCovered: int, endpointPartial: int, endpointUncovered: int, endpointRequestOnly: int, responseTotal: int, responseCovered: int, responseSkipped: int, responseUncovered: int}
+     * @return array{endpoints: list<array{endpoint: string, method: string, path: string, operationId: ?string, state: EndpointCoverageState, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}>, endpointTotal: int, endpointFullyCovered: int, endpointPartial: int, endpointUncovered: int, endpointRequestOnly: int, responseTotal: int, responseCovered: int, responseSkipped: int, responseUncovered: int}
      */
     private static function coverage(
         array $endpoints,
@@ -231,10 +237,10 @@ class ConsoleCoverageRendererTest extends TestCase
     }
 
     /**
-     * @param list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}> $responses
+     * @param list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}> $responses
      * @param list<array{statusKey: string, contentTypeKey: string}> $unexpectedObservations
      *
-     * @return array{endpoint: string, method: string, path: string, operationId: ?string, state: string, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}
+     * @return array{endpoint: string, method: string, path: string, operationId: ?string, state: EndpointCoverageState, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}
      */
     private static function endpoint(
         string $endpoint,
@@ -254,7 +260,7 @@ class ConsoleCoverageRendererTest extends TestCase
             'method' => $method,
             'path' => $path,
             'operationId' => $operationId,
-            'state' => $state,
+            'state' => EndpointCoverageState::from($state),
             'requestReached' => $requestReached,
             'responses' => $responses,
             'coveredResponseCount' => $coveredResponseCount,
@@ -265,7 +271,7 @@ class ConsoleCoverageRendererTest extends TestCase
     }
 
     /**
-     * @return array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}
+     * @return array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}
      */
     private static function row(
         string $statusKey,
@@ -277,7 +283,7 @@ class ConsoleCoverageRendererTest extends TestCase
         return [
             'statusKey' => $statusKey,
             'contentTypeKey' => $contentTypeKey,
-            'state' => $state,
+            'state' => ResponseCoverageState::from($state),
             'hits' => $hits,
             'skipReason' => $skipReason,
         ];

--- a/tests/Unit/MarkdownCoverageRendererTest.php
+++ b/tests/Unit/MarkdownCoverageRendererTest.php
@@ -6,9 +6,12 @@ namespace Studio\OpenApiContractTesting\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\EndpointCoverageState;
 use Studio\OpenApiContractTesting\PHPUnit\MarkdownCoverageRenderer;
+use Studio\OpenApiContractTesting\ResponseCoverageState;
 
 use function explode;
+use function strpos;
 
 class MarkdownCoverageRendererTest extends TestCase
 {
@@ -164,6 +167,93 @@ class MarkdownCoverageRendererTest extends TestCase
     }
 
     #[Test]
+    public function render_endpoint_with_both_skipped_and_uncovered_lists_both_in_summary(): void
+    {
+        // 1 covered + 1 skipped + 1 uncovered → "1/3 (1 skipped, 1 uncovered)"
+        // — the comma-join branch in endpointResponsesSummary needs both segments.
+        $results = [
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v1/mixed', 'partial', responses: [
+                        self::row('200', 'application/json', 'validated', hits: 1),
+                        self::row('5XX', '*', 'skipped', hits: 1, skipReason: 'production 5xx'),
+                        self::row('404', 'application/problem+json', 'uncovered'),
+                    ], coveredResponseCount: 1, skippedResponseCount: 1, totalResponseCount: 3),
+                ],
+                endpointTotal: 1,
+                endpointPartial: 1,
+                responseTotal: 3,
+                responseCovered: 1,
+                responseSkipped: 1,
+                responseUncovered: 1,
+            ),
+        ];
+
+        $output = MarkdownCoverageRenderer::render($results);
+
+        $this->assertStringContainsString('| `GET /v1/mixed` | 1/3 (1 skipped, 1 uncovered) |', $output);
+    }
+
+    #[Test]
+    public function render_unexpected_observations_appear_after_response_table_inside_details(): void
+    {
+        // Pin both presence AND ordering: unexpected observations must come
+        // after the per-endpoint response table and stay inside the
+        // <details> section (so they don't blow up small reports).
+        $results = [
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v1/pets', 'partial', responses: [
+                        self::row('200', 'application/json', 'validated', hits: 1),
+                    ], coveredResponseCount: 1, totalResponseCount: 1, unexpectedObservations: [
+                        ['statusKey' => '418', 'contentTypeKey' => 'application/json'],
+                    ]),
+                ],
+                endpointTotal: 1,
+                endpointPartial: 1,
+                responseTotal: 1,
+                responseCovered: 1,
+            ),
+        ];
+
+        $output = MarkdownCoverageRenderer::render($results);
+
+        $detailsOpen = strpos($output, '<details>');
+        $unexpectedPos = strpos($output, 'Unexpected observations');
+        $detailsClose = strpos($output, '</details>');
+
+        $this->assertNotFalse($detailsOpen);
+        $this->assertNotFalse($unexpectedPos);
+        $this->assertNotFalse($detailsClose);
+        $this->assertGreaterThan($detailsOpen, $unexpectedPos);
+        $this->assertGreaterThan($unexpectedPos, $detailsClose);
+    }
+
+    #[Test]
+    public function render_endpoint_with_null_operation_id_omits_parenthesised_name(): void
+    {
+        // The detail heading branches on operationId !== null.
+        $results = [
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v1/pets', 'all-covered', responses: [
+                        self::row('200', 'application/json', 'validated', hits: 1),
+                    ], coveredResponseCount: 1, totalResponseCount: 1),
+                ],
+                endpointTotal: 1,
+                endpointFullyCovered: 1,
+                responseTotal: 1,
+                responseCovered: 1,
+            ),
+        ];
+
+        $output = MarkdownCoverageRenderer::render($results);
+
+        $this->assertStringContainsString('#### `GET /v1/pets`', $output);
+        $this->assertStringNotContainsString('#### `GET /v1/pets` (', $output);
+    }
+
+    #[Test]
     public function render_includes_operation_id_when_present(): void
     {
         $results = [
@@ -191,9 +281,9 @@ class MarkdownCoverageRendererTest extends TestCase
     }
 
     /**
-     * @param list<array{endpoint: string, method: string, path: string, operationId: ?string, state: string, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}> $endpoints
+     * @param list<array{endpoint: string, method: string, path: string, operationId: ?string, state: EndpointCoverageState, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}> $endpoints
      *
-     * @return array{endpoints: list<array{endpoint: string, method: string, path: string, operationId: ?string, state: string, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}>, endpointTotal: int, endpointFullyCovered: int, endpointPartial: int, endpointUncovered: int, endpointRequestOnly: int, responseTotal: int, responseCovered: int, responseSkipped: int, responseUncovered: int}
+     * @return array{endpoints: list<array{endpoint: string, method: string, path: string, operationId: ?string, state: EndpointCoverageState, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}>, endpointTotal: int, endpointFullyCovered: int, endpointPartial: int, endpointUncovered: int, endpointRequestOnly: int, responseTotal: int, responseCovered: int, responseSkipped: int, responseUncovered: int}
      */
     private static function coverage(
         array $endpoints,
@@ -222,10 +312,10 @@ class MarkdownCoverageRendererTest extends TestCase
     }
 
     /**
-     * @param list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}> $responses
+     * @param list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}> $responses
      * @param list<array{statusKey: string, contentTypeKey: string}> $unexpectedObservations
      *
-     * @return array{endpoint: string, method: string, path: string, operationId: ?string, state: string, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}
+     * @return array{endpoint: string, method: string, path: string, operationId: ?string, state: EndpointCoverageState, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}
      */
     private static function endpoint(
         string $endpoint,
@@ -245,7 +335,7 @@ class MarkdownCoverageRendererTest extends TestCase
             'method' => $method,
             'path' => $path,
             'operationId' => $operationId,
-            'state' => $state,
+            'state' => EndpointCoverageState::from($state),
             'requestReached' => $requestReached,
             'responses' => $responses,
             'coveredResponseCount' => $coveredResponseCount,
@@ -256,7 +346,7 @@ class MarkdownCoverageRendererTest extends TestCase
     }
 
     /**
-     * @return array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}
+     * @return array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}
      */
     private static function row(
         string $statusKey,
@@ -268,7 +358,7 @@ class MarkdownCoverageRendererTest extends TestCase
         return [
             'statusKey' => $statusKey,
             'contentTypeKey' => $contentTypeKey,
-            'state' => $state,
+            'state' => ResponseCoverageState::from($state),
             'hits' => $hits,
             'skipReason' => $skipReason,
         ];

--- a/tests/Unit/MarkdownCoverageRendererTest.php
+++ b/tests/Unit/MarkdownCoverageRendererTest.php
@@ -8,8 +8,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\PHPUnit\MarkdownCoverageRenderer;
 
-use function count;
-use function substr_count;
+use function explode;
 
 class MarkdownCoverageRendererTest extends TestCase
 {
@@ -20,213 +19,258 @@ class MarkdownCoverageRendererTest extends TestCase
     }
 
     #[Test]
-    public function render_full_coverage_has_no_details_block(): void
+    public function render_full_coverage_marks_all_endpoints_with_check(): void
     {
         $results = [
-            'front' => self::coverageResult(
-                covered: ['GET /v1/pets', 'POST /v1/pets'],
-                uncovered: [],
-                total: 2,
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v1/pets', 'all-covered', responses: [
+                        self::row('200', 'application/json', 'validated', hits: 3),
+                    ], coveredResponseCount: 1, totalResponseCount: 1),
+                ],
+                endpointTotal: 1,
+                endpointFullyCovered: 1,
+                responseTotal: 1,
+                responseCovered: 1,
             ),
         ];
 
         $output = MarkdownCoverageRenderer::render($results);
 
-        $this->assertStringContainsString('### front — 2/2 endpoints (100%)', $output);
-        $this->assertStringContainsString('| :white_check_mark: | `GET /v1/pets` |', $output);
-        $this->assertStringContainsString('| :white_check_mark: | `POST /v1/pets` |', $output);
-        $this->assertStringNotContainsString('<details>', $output);
-        $this->assertStringNotContainsString(':warning:', $output);
+        $this->assertStringContainsString('### front — endpoints: 1/1 fully covered (100%)', $output);
+        $this->assertStringContainsString('responses: 1/1 covered (100%)', $output);
+        $this->assertStringContainsString('| :white_check_mark: | `GET /v1/pets` | 1/1 |', $output);
+        $this->assertStringContainsString('| :white_check_mark: 200 | application/json | validated (3 hits) |', $output);
     }
 
     #[Test]
-    public function render_partial_coverage_has_table_and_details(): void
+    public function render_partial_endpoint_uses_orange_diamond_marker(): void
     {
         $results = [
-            'front' => self::coverageResult(
-                covered: ['GET /v1/pets', 'POST /v1/pets'],
-                uncovered: ['DELETE /v1/pets/{petId}', 'GET /v1/pets/{petId}'],
-                total: 4,
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('POST /v1/pets', 'partial', responses: [
+                        self::row('201', 'application/json', 'validated', hits: 1),
+                        self::row('422', 'application/problem+json', 'uncovered'),
+                    ], coveredResponseCount: 1, totalResponseCount: 2),
+                ],
+                endpointTotal: 1,
+                endpointPartial: 1,
+                responseTotal: 2,
+                responseCovered: 1,
+                responseUncovered: 1,
             ),
         ];
 
         $output = MarkdownCoverageRenderer::render($results);
 
-        $this->assertStringContainsString('### front — 2/4 endpoints (50%)', $output);
-        $this->assertStringContainsString('| :white_check_mark: | `GET /v1/pets` |', $output);
-        $this->assertStringContainsString('<details>', $output);
-        $this->assertStringContainsString('<summary>2 uncovered endpoints</summary>', $output);
-        $this->assertStringContainsString('| `DELETE /v1/pets/{petId}` |', $output);
-        $this->assertStringContainsString('| `GET /v1/pets/{petId}` |', $output);
+        $this->assertStringContainsString('| :large_orange_diamond: | `POST /v1/pets` | 1/2 (1 uncovered) |', $output);
+        $this->assertStringContainsString('| :x: 422 | application/problem+json | uncovered |', $output);
     }
 
     #[Test]
-    public function render_zero_coverage_has_only_details(): void
+    public function render_skipped_response_uses_warning_marker_with_reason(): void
     {
         $results = [
-            'front' => self::coverageResult(
-                covered: [],
-                uncovered: ['GET /v1/pets', 'POST /v1/pets'],
-                total: 2,
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('DELETE /v1/pets/{petId}', 'partial', responses: [
+                        self::row('204', '*', 'validated', hits: 2),
+                        self::row('5XX', '*', 'skipped', hits: 1, skipReason: 'status 503 matched skip pattern 5\d\d'),
+                    ], coveredResponseCount: 1, skippedResponseCount: 1, totalResponseCount: 2),
+                ],
+                endpointTotal: 1,
+                endpointPartial: 1,
+                responseTotal: 2,
+                responseCovered: 1,
+                responseSkipped: 1,
             ),
         ];
 
         $output = MarkdownCoverageRenderer::render($results);
 
-        $this->assertStringContainsString('### front — 0/2 endpoints (0%)', $output);
-        $this->assertStringNotContainsString(':white_check_mark:', $output);
-        $this->assertStringContainsString('<details>', $output);
-        $this->assertStringContainsString('<summary>2 uncovered endpoints</summary>', $output);
+        $this->assertStringContainsString('| :warning: 5XX | * | skipped (status 503 matched skip pattern 5\d\d) |', $output);
+        $this->assertStringContainsString('1/2 (1 skipped)', $output);
     }
 
     #[Test]
-    public function render_multiple_specs(): void
+    public function render_uncovered_endpoint_uses_x_marker(): void
     {
         $results = [
-            'front' => self::coverageResult(
-                covered: ['GET /v1/pets'],
-                uncovered: ['POST /v1/pets'],
-                total: 2,
-            ),
-            'admin' => self::coverageResult(
-                covered: ['GET /v1/users'],
-                uncovered: [],
-                total: 1,
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v1/health', 'uncovered', responses: [
+                        self::row('200', 'application/json', 'uncovered'),
+                    ], totalResponseCount: 1),
+                ],
+                endpointTotal: 1,
+                endpointUncovered: 1,
+                responseTotal: 1,
+                responseUncovered: 1,
             ),
         ];
 
         $output = MarkdownCoverageRenderer::render($results);
 
-        $this->assertStringContainsString('### front — 1/2 endpoints (50%)', $output);
-        $this->assertStringContainsString('### admin — 1/1 endpoints (100%)', $output);
+        $this->assertStringContainsString('| :x: | `GET /v1/health` | 0/1 (1 uncovered) |', $output);
     }
 
     #[Test]
-    public function render_spec_with_zero_endpoints(): void
+    public function render_request_only_endpoint_uses_info_marker(): void
     {
         $results = [
-            'empty' => self::coverageResult(
-                covered: [],
-                uncovered: [],
-                total: 0,
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint(
+                        'GET /v1/loose',
+                        'request-only',
+                        requestReached: true,
+                    ),
+                ],
+                endpointTotal: 1,
+                endpointRequestOnly: 1,
             ),
         ];
 
         $output = MarkdownCoverageRenderer::render($results);
 
-        $this->assertStringContainsString('### empty — 0/0 endpoints (0%)', $output);
-        $this->assertStringNotContainsString(':white_check_mark:', $output);
-        $this->assertStringNotContainsString('<details>', $output);
+        $this->assertStringContainsString('| :information_source: | `GET /v1/loose` | request only |', $output);
+        $this->assertStringContainsString('_request reached, no response definitions in spec_', $output);
     }
 
     #[Test]
-    public function covered_table_uses_warning_emoji_for_skipped_only(): void
+    public function render_unexpected_observations_appear_in_detail_section(): void
     {
         $results = [
-            'front' => self::coverageResult(
-                covered: ['GET /v1/pets', 'POST /v1/pets'],
-                uncovered: [],
-                total: 2,
-                skippedOnly: ['POST /v1/pets'],
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v1/pets', 'partial', responses: [
+                        self::row('200', 'application/json', 'validated', hits: 1),
+                    ], coveredResponseCount: 1, totalResponseCount: 1, unexpectedObservations: [
+                        ['statusKey' => '418', 'contentTypeKey' => 'application/json'],
+                    ]),
+                ],
+                endpointTotal: 1,
+                endpointPartial: 1,
+                responseTotal: 1,
+                responseCovered: 1,
             ),
         ];
 
         $output = MarkdownCoverageRenderer::render($results);
 
-        $this->assertStringContainsString('| :white_check_mark: | `GET /v1/pets` |', $output);
-        $this->assertStringContainsString('| :warning: | `POST /v1/pets` |', $output);
-        $this->assertStringNotContainsString('| :white_check_mark: | `POST /v1/pets` |', $output);
+        $this->assertStringContainsString('Unexpected observations', $output);
+        $this->assertStringContainsString('`418` `application/json`', $output);
     }
 
     #[Test]
-    public function renders_skipped_only_note_under_heading_when_present(): void
+    public function render_includes_operation_id_when_present(): void
     {
         $results = [
-            'front' => self::coverageResult(
-                covered: ['GET /v1/pets', 'POST /v1/pets'],
-                uncovered: [],
-                total: 2,
-                skippedOnly: ['POST /v1/pets'],
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint(
+                        'GET /v1/pets',
+                        'all-covered',
+                        operationId: 'listPets',
+                        responses: [self::row('200', 'application/json', 'validated', hits: 1)],
+                        coveredResponseCount: 1,
+                        totalResponseCount: 1,
+                    ),
+                ],
+                endpointTotal: 1,
+                endpointFullyCovered: 1,
+                responseTotal: 1,
+                responseCovered: 1,
             ),
         ];
 
         $output = MarkdownCoverageRenderer::render($results);
 
-        $this->assertStringContainsString('> :warning: response body validation skipped', $output);
-        $this->assertSame(1, substr_count($output, '> :warning:'));
-    }
-
-    #[Test]
-    public function each_spec_with_skipped_only_gets_its_own_note(): void
-    {
-        // Guards against a regression where the note were hoisted outside
-        // the per-spec loop (producing one note for the whole report) or
-        // duplicated (producing two notes for one spec).
-        $results = [
-            'front' => self::coverageResult(
-                covered: ['GET /v1/pets'],
-                uncovered: [],
-                total: 1,
-                skippedOnly: ['GET /v1/pets'],
-            ),
-            'admin' => self::coverageResult(
-                covered: ['GET /v1/users'],
-                uncovered: [],
-                total: 1,
-                skippedOnly: ['GET /v1/users'],
-            ),
-        ];
-
-        $output = MarkdownCoverageRenderer::render($results);
-
-        $this->assertSame(2, substr_count($output, '> :warning:'));
-    }
-
-    #[Test]
-    public function omits_note_when_no_skipped_only(): void
-    {
-        $results = [
-            'front' => self::coverageResult(
-                covered: ['GET /v1/pets'],
-                uncovered: [],
-                total: 1,
-            ),
-        ];
-
-        $output = MarkdownCoverageRenderer::render($results);
-
-        $this->assertStringNotContainsString(':warning:', $output);
+        $this->assertStringContainsString('#### `GET /v1/pets` (listPets)', $output);
     }
 
     /**
-     * @param string[] $covered
-     * @param string[] $uncovered
-     * @param null|string[] $skippedOnly
+     * @param list<array{endpoint: string, method: string, path: string, operationId: ?string, state: string, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}> $endpoints
      *
-     * @return array{
-     *     covered: string[],
-     *     uncovered: string[],
-     *     total: int,
-     *     coveredCount: int,
-     *     skippedOnly: string[],
-     *     skippedOnlyCount: int,
-     * }
+     * @return array{endpoints: list<array{endpoint: string, method: string, path: string, operationId: ?string, state: string, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}>, endpointTotal: int, endpointFullyCovered: int, endpointPartial: int, endpointUncovered: int, endpointRequestOnly: int, responseTotal: int, responseCovered: int, responseSkipped: int, responseUncovered: int}
      */
-    private static function coverageResult(
-        array $covered,
-        array $uncovered,
-        int $total,
-        ?array $skippedOnly = null,
+    private static function coverage(
+        array $endpoints,
+        int $endpointTotal = 0,
+        int $endpointFullyCovered = 0,
+        int $endpointPartial = 0,
+        int $endpointUncovered = 0,
+        int $endpointRequestOnly = 0,
+        int $responseTotal = 0,
+        int $responseCovered = 0,
+        int $responseSkipped = 0,
+        int $responseUncovered = 0,
     ): array {
-        $skippedOnly ??= [];
+        return [
+            'endpoints' => $endpoints,
+            'endpointTotal' => $endpointTotal,
+            'endpointFullyCovered' => $endpointFullyCovered,
+            'endpointPartial' => $endpointPartial,
+            'endpointUncovered' => $endpointUncovered,
+            'endpointRequestOnly' => $endpointRequestOnly,
+            'responseTotal' => $responseTotal,
+            'responseCovered' => $responseCovered,
+            'responseSkipped' => $responseSkipped,
+            'responseUncovered' => $responseUncovered,
+        ];
+    }
+
+    /**
+     * @param list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}> $responses
+     * @param list<array{statusKey: string, contentTypeKey: string}> $unexpectedObservations
+     *
+     * @return array{endpoint: string, method: string, path: string, operationId: ?string, state: string, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}
+     */
+    private static function endpoint(
+        string $endpoint,
+        string $state,
+        bool $requestReached = false,
+        ?string $operationId = null,
+        array $responses = [],
+        int $coveredResponseCount = 0,
+        int $skippedResponseCount = 0,
+        int $totalResponseCount = 0,
+        array $unexpectedObservations = [],
+    ): array {
+        [$method, $path] = explode(' ', $endpoint, 2);
 
         return [
-            'covered' => $covered,
-            'uncovered' => $uncovered,
-            'total' => $total,
-            'coveredCount' => count($covered),
-            'skippedOnly' => $skippedOnly,
-            'skippedOnlyCount' => count($skippedOnly),
+            'endpoint' => $endpoint,
+            'method' => $method,
+            'path' => $path,
+            'operationId' => $operationId,
+            'state' => $state,
+            'requestReached' => $requestReached,
+            'responses' => $responses,
+            'coveredResponseCount' => $coveredResponseCount,
+            'skippedResponseCount' => $skippedResponseCount,
+            'totalResponseCount' => $totalResponseCount,
+            'unexpectedObservations' => $unexpectedObservations,
+        ];
+    }
+
+    /**
+     * @return array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}
+     */
+    private static function row(
+        string $statusKey,
+        string $contentTypeKey,
+        string $state,
+        int $hits = 0,
+        ?string $skipReason = null,
+    ): array {
+        return [
+            'statusKey' => $statusKey,
+            'contentTypeKey' => $contentTypeKey,
+            'state' => $state,
+            'hits' => $hits,
+            'skipReason' => $skipReason,
         ];
     }
 }

--- a/tests/Unit/OpenApiCoverageTrackerTest.php
+++ b/tests/Unit/OpenApiCoverageTrackerTest.php
@@ -9,9 +9,6 @@ use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
 
-use function array_intersect;
-use function array_values;
-
 class OpenApiCoverageTrackerTest extends TestCase
 {
     protected function setUp(): void
@@ -30,164 +27,393 @@ class OpenApiCoverageTrackerTest extends TestCase
     }
 
     #[Test]
-    public function record_stores_covered_endpoint(): void
+    public function record_request_marks_endpoint_request_reached(): void
     {
-        OpenApiCoverageTracker::record('petstore-3.0', 'GET', '/v1/pets');
+        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets');
 
-        $covered = OpenApiCoverageTracker::getCovered();
-
-        $this->assertArrayHasKey('petstore-3.0', $covered);
-        $this->assertArrayHasKey('GET /v1/pets', $covered['petstore-3.0']);
+        $this->assertTrue(OpenApiCoverageTracker::hasAnyCoverage('petstore-3.0'));
     }
 
     #[Test]
-    public function record_uppercases_method(): void
+    public function record_response_uppercases_method(): void
     {
-        OpenApiCoverageTracker::record('petstore-3.0', 'get', '/v1/pets');
+        // /widgets-default has a single declared response (default:application/json)
+        // so we can pin the resulting state without juggling other rows.
+        OpenApiCoverageTracker::recordResponse(
+            'range-keys',
+            'get',
+            '/widgets-default',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
 
-        $covered = OpenApiCoverageTracker::getCovered();
-
-        $this->assertArrayHasKey('GET /v1/pets', $covered['petstore-3.0']);
+        $endpoint = $this->endpointSummary('range-keys', 'GET /widgets-default');
+        $this->assertSame('all-covered', $endpoint['state']);
     }
 
     #[Test]
-    public function record_deduplicates(): void
+    public function record_response_increments_hits_per_pair(): void
     {
-        OpenApiCoverageTracker::record('petstore-3.0', 'GET', '/v1/pets');
-        OpenApiCoverageTracker::record('petstore-3.0', 'GET', '/v1/pets');
+        for ($i = 0; $i < 3; $i++) {
+            OpenApiCoverageTracker::recordResponse(
+                'petstore-3.0',
+                'GET',
+                '/v1/pets',
+                '200',
+                'application/json',
+                schemaValidated: true,
+            );
+        }
 
-        $covered = OpenApiCoverageTracker::getCovered();
-
-        $this->assertCount(1, $covered['petstore-3.0']);
+        $endpoint = $this->endpointSummary('petstore-3.0', 'GET /v1/pets');
+        $row = $this->responseRow($endpoint['responses'], '200', 'application/json');
+        $this->assertSame(3, $row['hits']);
+        $this->assertSame('validated', $row['state']);
     }
 
     #[Test]
-    public function compute_coverage_returns_correct_stats(): void
+    public function validated_promotes_prior_skipped_for_same_pair(): void
     {
-        OpenApiCoverageTracker::record('petstore-3.0', 'GET', '/v1/pets');
-        OpenApiCoverageTracker::record('petstore-3.0', 'POST', '/v1/pets');
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: false,
+            skipReason: 'manually skipped',
+        );
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
 
-        $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
-
-        // See tests/fixtures/specs/petstore-3.0.json for the full endpoint list
-        $this->assertSame(23, $result['total']);
-        $this->assertSame(2, $result['coveredCount']);
-        $this->assertCount(2, $result['covered']);
-        $this->assertCount(21, $result['uncovered']);
+        $endpoint = $this->endpointSummary('petstore-3.0', 'GET /v1/pets');
+        $row = $this->responseRow($endpoint['responses'], '200', 'application/json');
+        $this->assertSame('validated', $row['state']);
+        $this->assertNull($row['skipReason']);
     }
 
     #[Test]
-    public function compute_coverage_with_no_coverage(): void
+    public function skipped_does_not_demote_validated_pair(): void
     {
-        $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: false,
+            skipReason: 'should not win',
+        );
 
-        $this->assertSame(23, $result['total']);
-        $this->assertSame(0, $result['coveredCount']);
-        $this->assertCount(0, $result['covered']);
-        $this->assertCount(23, $result['uncovered']);
+        $endpoint = $this->endpointSummary('petstore-3.0', 'GET /v1/pets');
+        $row = $this->responseRow($endpoint['responses'], '200', 'application/json');
+        $this->assertSame('validated', $row['state']);
+        $this->assertNull($row['skipReason']);
     }
 
     #[Test]
     public function reset_clears_all_coverage(): void
     {
-        OpenApiCoverageTracker::record('petstore-3.0', 'GET', '/v1/pets');
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
 
         OpenApiCoverageTracker::reset();
 
-        $this->assertSame([], OpenApiCoverageTracker::getCovered());
+        $this->assertFalse(OpenApiCoverageTracker::hasAnyCoverage('petstore-3.0'));
     }
 
     #[Test]
-    public function record_defaults_to_schema_validated_true(): void
+    public function endpoint_with_partial_coverage_marks_remaining_as_uncovered(): void
     {
-        OpenApiCoverageTracker::record('petstore-3.0', 'GET', '/v1/pets');
+        // GET /v1/pets declares 4 (status, content-type) pairs in the petstore
+        // fixture: 200, 422, 500, 400. Hitting only 200 → partial.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
 
-        $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
-
-        $this->assertContains('GET /v1/pets', $result['covered']);
-        $this->assertSame([], $result['skippedOnly']);
-        $this->assertSame(0, $result['skippedOnlyCount']);
+        $endpoint = $this->endpointSummary('petstore-3.0', 'GET /v1/pets');
+        $this->assertSame('partial', $endpoint['state']);
+        $this->assertSame(1, $endpoint['coveredResponseCount']);
+        $this->assertSame(0, $endpoint['skippedResponseCount']);
+        $this->assertSame(4, $endpoint['totalResponseCount']);
     }
 
     #[Test]
-    public function record_with_schema_validated_false_marks_skipped_only(): void
+    public function endpoint_with_all_responses_validated_marks_all_covered(): void
     {
-        OpenApiCoverageTracker::record('petstore-3.0', 'GET', '/v1/pets', schemaValidated: false);
+        foreach (
+            [
+                ['200', 'application/json'],
+                ['422', 'Application/Problem+JSON'],
+                ['500', 'application/json'],
+                ['400', 'application/problem+json'],
+            ] as [$status, $contentType]
+        ) {
+            OpenApiCoverageTracker::recordResponse(
+                'petstore-3.0',
+                'GET',
+                '/v1/pets',
+                $status,
+                $contentType,
+                schemaValidated: true,
+            );
+        }
 
-        $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
-
-        $this->assertContains('GET /v1/pets', $result['covered']);
-        $this->assertSame(['GET /v1/pets'], $result['skippedOnly']);
-        $this->assertSame(1, $result['skippedOnlyCount']);
+        $endpoint = $this->endpointSummary('petstore-3.0', 'GET /v1/pets');
+        $this->assertSame('all-covered', $endpoint['state']);
+        $this->assertSame(4, $endpoint['coveredResponseCount']);
     }
 
     #[Test]
-    public function validated_record_overrides_prior_skipped_record(): void
+    public function endpoint_with_no_records_is_uncovered(): void
     {
-        OpenApiCoverageTracker::record('petstore-3.0', 'GET', '/v1/pets', schemaValidated: false);
-        OpenApiCoverageTracker::record('petstore-3.0', 'GET', '/v1/pets', schemaValidated: true);
+        $endpoint = $this->endpointSummary('petstore-3.0', 'GET /v1/pets');
 
-        $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
-
-        $this->assertContains('GET /v1/pets', $result['covered']);
-        $this->assertSame([], $result['skippedOnly']);
-        $this->assertSame(0, $result['skippedOnlyCount']);
+        $this->assertSame('uncovered', $endpoint['state']);
+        foreach ($endpoint['responses'] as $row) {
+            $this->assertSame('uncovered', $row['state']);
+        }
     }
 
     #[Test]
-    public function skipped_record_does_not_demote_validated_endpoint(): void
+    public function request_only_endpoint_has_request_only_state(): void
     {
-        OpenApiCoverageTracker::record('petstore-3.0', 'GET', '/v1/pets', schemaValidated: true);
-        OpenApiCoverageTracker::record('petstore-3.0', 'GET', '/v1/pets', schemaValidated: false);
+        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets');
 
-        $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
-
-        $this->assertContains('GET /v1/pets', $result['covered']);
-        $this->assertSame([], $result['skippedOnly']);
-        $this->assertSame(0, $result['skippedOnlyCount']);
+        $endpoint = $this->endpointSummary('petstore-3.0', 'GET /v1/pets');
+        $this->assertSame('request-only', $endpoint['state']);
+        $this->assertTrue($endpoint['requestReached']);
     }
 
     #[Test]
-    public function compute_coverage_returns_skipped_only_sorted(): void
+    public function content_type_match_is_case_insensitive(): void
     {
-        OpenApiCoverageTracker::record('petstore-3.0', 'POST', '/v1/pets', schemaValidated: false);
-        OpenApiCoverageTracker::record('petstore-3.0', 'GET', '/v1/pets', schemaValidated: false);
-        OpenApiCoverageTracker::record('petstore-3.0', 'GET', '/v1/pets/{petId}', schemaValidated: true);
+        // The 422 response in petstore-3.0 declares `Application/Problem+JSON`
+        // (mixed case). A real response Content-Type is normalised to lower
+        // case (`application/problem+json`). The reconciliation should still
+        // recognise the recorded entry under the spec's casing.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '422',
+            'Application/Problem+JSON',
+            schemaValidated: true,
+        );
 
-        $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
-
-        $this->assertSame(['GET /v1/pets', 'POST /v1/pets'], $result['skippedOnly']);
-        $this->assertSame(2, $result['skippedOnlyCount']);
-        $this->assertSame(3, $result['coveredCount']);
+        $endpoint = $this->endpointSummary('petstore-3.0', 'GET /v1/pets');
+        $row = $this->responseRow($endpoint['responses'], '422', 'Application/Problem+JSON');
+        $this->assertSame('validated', $row['state']);
+        // Spec author casing must be preserved verbatim in the report.
+        $this->assertSame('Application/Problem+JSON', $row['contentTypeKey']);
     }
 
     #[Test]
-    public function skipped_only_preserves_covered_order(): void
+    public function literal_status_skipped_reconciles_to_spec_range_key(): void
     {
-        // Pins the invariant that skippedOnly entries share ordering with
-        // covered (both derive from the same sorted iteration). Without
-        // this, a maintainer could switch covered to insertion order and
-        // accidentally diverge the two lists while the prior sort test
-        // still passed on naturally-sorted inputs.
-        OpenApiCoverageTracker::record('petstore-3.0', 'POST', '/v1/pets', schemaValidated: true);
-        OpenApiCoverageTracker::record('petstore-3.0', 'GET', '/v1/pets', schemaValidated: false);
-        OpenApiCoverageTracker::record('petstore-3.0', 'GET', '/v1/pets/{petId}', schemaValidated: false);
+        // The validator records `503:*` (literal status, content-* sentinel)
+        // for skipped responses. Spec might only declare `5XX` — reconciliation
+        // surfaces the spec-declared range key as `state: skipped`.
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs');
+        $this->recordCoverageForFakeSpec();
 
-        $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
+        $endpoint = $this->endpointSummary('range-keys', 'GET /widgets');
+        $row = $this->responseRow($endpoint['responses'], '5XX', 'application/json');
+        $this->assertSame('skipped', $row['state']);
+        $this->assertSame('status 503 matched skip pattern 5\d\d', $row['skipReason']);
+    }
 
+    #[Test]
+    public function default_spec_key_matches_any_recorded_status(): void
+    {
+        // Spec declares `default` as a catch-all. A literal `418` recording
+        // (validated) should mark it covered.
+        OpenApiCoverageTracker::recordResponse(
+            'range-keys',
+            'GET',
+            '/widgets-default',
+            '418',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        $endpoint = $this->endpointSummary('range-keys', 'GET /widgets-default');
+        $row = $this->responseRow($endpoint['responses'], 'default', 'application/json');
+        $this->assertSame('validated', $row['state']);
+    }
+
+    #[Test]
+    public function unexpected_observations_surface_status_not_in_spec(): void
+    {
+        // petstore-3.0 GET /v1/pets does not declare 418. Recording 418 surfaces
+        // it as an unexpected observation rather than counting toward coverage.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '418',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        $endpoint = $this->endpointSummary('petstore-3.0', 'GET /v1/pets');
         $this->assertSame(
-            array_values(array_intersect($result['covered'], $result['skippedOnly'])),
-            $result['skippedOnly'],
+            [['statusKey' => '418', 'contentTypeKey' => 'application/json']],
+            $endpoint['unexpectedObservations'],
+        );
+        $this->assertSame(0, $endpoint['coveredResponseCount']);
+    }
+
+    #[Test]
+    public function endpoint_summary_includes_operation_id_when_declared(): void
+    {
+        $endpoint = $this->endpointSummary('petstore-3.0', 'GET /v1/pets');
+
+        // petstore-3.0 declares operationId 'listPets' for GET /v1/pets.
+        $this->assertSame('listPets', $endpoint['operationId']);
+    }
+
+    #[Test]
+    public function compute_coverage_aggregates_response_level_counts(): void
+    {
+        // petstore-3.0 declares 30 (status, content-type) pairs across 23
+        // endpoints. Pin the totals so future spec drift is caught.
+        $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
+
+        $this->assertSame(23, $result['endpointTotal']);
+        $this->assertSame(30, $result['responseTotal']);
+        $this->assertSame(0, $result['responseCovered']);
+        $this->assertSame(0, $result['responseSkipped']);
+        $this->assertSame(30, $result['responseUncovered']);
+        $this->assertSame(23, $result['endpointUncovered']);
+    }
+
+    #[Test]
+    public function response_rows_sorted_with_wildcard_content_last(): void
+    {
+        // Trigger a no-content response (skipped 503 → `503:*`) alongside a
+        // concrete content-type response, then verify the sub-row ordering.
+        OpenApiCoverageTracker::recordResponse(
+            'range-keys',
+            'GET',
+            '/widgets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        OpenApiCoverageTracker::recordResponse(
+            'range-keys',
+            'GET',
+            '/widgets',
+            '503',
+            null,
+            schemaValidated: false,
+            skipReason: 'status 503 matched skip pattern 5\d\d',
+        );
+
+        $endpoint = $this->endpointSummary('range-keys', 'GET /widgets');
+
+        $orderedKeys = [];
+        foreach ($endpoint['responses'] as $row) {
+            $orderedKeys[] = $row['statusKey'] . ':' . $row['contentTypeKey'];
+        }
+        $this->assertSame(['200:application/json', '5XX:application/json'], $orderedKeys);
+    }
+
+    #[Test]
+    public function has_any_coverage_returns_true_for_request_only(): void
+    {
+        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets');
+
+        $this->assertTrue(OpenApiCoverageTracker::hasAnyCoverage('petstore-3.0'));
+        $this->assertFalse(OpenApiCoverageTracker::hasAnyCoverage('other-spec'));
+    }
+
+    /**
+     * Record a 503 against the range-keys fixture's GET /widgets so the
+     * range-key reconciliation test has data to assert against. Inlined into
+     * a helper so the test body stays focused on the assertion.
+     */
+    private function recordCoverageForFakeSpec(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'range-keys',
+            'GET',
+            '/widgets',
+            '503',
+            null,
+            schemaValidated: false,
+            skipReason: 'status 503 matched skip pattern 5\d\d',
         );
     }
 
-    #[Test]
-    public function get_covered_preserves_external_shape(): void
+    /**
+     * @return array{
+     *     endpoint: string,
+     *     method: string,
+     *     path: string,
+     *     operationId: ?string,
+     *     state: string,
+     *     requestReached: bool,
+     *     responses: list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}>,
+     *     coveredResponseCount: int,
+     *     skippedResponseCount: int,
+     *     totalResponseCount: int,
+     *     unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>,
+     * }
+     */
+    private function endpointSummary(string $specName, string $endpointKey): array
     {
-        OpenApiCoverageTracker::record('petstore-3.0', 'GET', '/v1/pets', schemaValidated: false);
+        $result = OpenApiCoverageTracker::computeCoverage($specName);
+        foreach ($result['endpoints'] as $summary) {
+            if ($summary['endpoint'] === $endpointKey) {
+                return $summary;
+            }
+        }
 
-        $covered = OpenApiCoverageTracker::getCovered();
+        $this->fail("No endpoint summary for {$endpointKey} in spec {$specName}");
+    }
 
-        $this->assertSame(['petstore-3.0' => ['GET /v1/pets' => true]], $covered);
+    /**
+     * @param list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}> $rows
+     *
+     * @return array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}
+     */
+    private function responseRow(array $rows, string $statusKey, string $contentTypeKey): array
+    {
+        foreach ($rows as $row) {
+            if ($row['statusKey'] === $statusKey && $row['contentTypeKey'] === $contentTypeKey) {
+                return $row;
+            }
+        }
+
+        $this->fail("No response row for {$statusKey}:{$contentTypeKey}");
     }
 }

--- a/tests/Unit/OpenApiCoverageTrackerTest.php
+++ b/tests/Unit/OpenApiCoverageTrackerTest.php
@@ -6,8 +6,14 @@ namespace Studio\OpenApiContractTesting\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\EndpointCoverageState;
 use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\ResponseCoverageState;
+
+use function implode;
+use function restore_error_handler;
+use function set_error_handler;
 
 class OpenApiCoverageTrackerTest extends TestCase
 {
@@ -49,7 +55,7 @@ class OpenApiCoverageTrackerTest extends TestCase
         );
 
         $endpoint = $this->endpointSummary('range-keys', 'GET /widgets-default');
-        $this->assertSame('all-covered', $endpoint['state']);
+        $this->assertSame(EndpointCoverageState::AllCovered, $endpoint['state']);
     }
 
     #[Test]
@@ -69,7 +75,7 @@ class OpenApiCoverageTrackerTest extends TestCase
         $endpoint = $this->endpointSummary('petstore-3.0', 'GET /v1/pets');
         $row = $this->responseRow($endpoint['responses'], '200', 'application/json');
         $this->assertSame(3, $row['hits']);
-        $this->assertSame('validated', $row['state']);
+        $this->assertSame(ResponseCoverageState::Validated, $row['state']);
     }
 
     #[Test]
@@ -95,7 +101,7 @@ class OpenApiCoverageTrackerTest extends TestCase
 
         $endpoint = $this->endpointSummary('petstore-3.0', 'GET /v1/pets');
         $row = $this->responseRow($endpoint['responses'], '200', 'application/json');
-        $this->assertSame('validated', $row['state']);
+        $this->assertSame(ResponseCoverageState::Validated, $row['state']);
         $this->assertNull($row['skipReason']);
     }
 
@@ -122,7 +128,7 @@ class OpenApiCoverageTrackerTest extends TestCase
 
         $endpoint = $this->endpointSummary('petstore-3.0', 'GET /v1/pets');
         $row = $this->responseRow($endpoint['responses'], '200', 'application/json');
-        $this->assertSame('validated', $row['state']);
+        $this->assertSame(ResponseCoverageState::Validated, $row['state']);
         $this->assertNull($row['skipReason']);
     }
 
@@ -158,7 +164,7 @@ class OpenApiCoverageTrackerTest extends TestCase
         );
 
         $endpoint = $this->endpointSummary('petstore-3.0', 'GET /v1/pets');
-        $this->assertSame('partial', $endpoint['state']);
+        $this->assertSame(EndpointCoverageState::Partial, $endpoint['state']);
         $this->assertSame(1, $endpoint['coveredResponseCount']);
         $this->assertSame(0, $endpoint['skippedResponseCount']);
         $this->assertSame(4, $endpoint['totalResponseCount']);
@@ -186,7 +192,7 @@ class OpenApiCoverageTrackerTest extends TestCase
         }
 
         $endpoint = $this->endpointSummary('petstore-3.0', 'GET /v1/pets');
-        $this->assertSame('all-covered', $endpoint['state']);
+        $this->assertSame(EndpointCoverageState::AllCovered, $endpoint['state']);
         $this->assertSame(4, $endpoint['coveredResponseCount']);
     }
 
@@ -195,9 +201,9 @@ class OpenApiCoverageTrackerTest extends TestCase
     {
         $endpoint = $this->endpointSummary('petstore-3.0', 'GET /v1/pets');
 
-        $this->assertSame('uncovered', $endpoint['state']);
+        $this->assertSame(EndpointCoverageState::Uncovered, $endpoint['state']);
         foreach ($endpoint['responses'] as $row) {
-            $this->assertSame('uncovered', $row['state']);
+            $this->assertSame(ResponseCoverageState::Uncovered, $row['state']);
         }
     }
 
@@ -207,7 +213,7 @@ class OpenApiCoverageTrackerTest extends TestCase
         OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets');
 
         $endpoint = $this->endpointSummary('petstore-3.0', 'GET /v1/pets');
-        $this->assertSame('request-only', $endpoint['state']);
+        $this->assertSame(EndpointCoverageState::RequestOnly, $endpoint['state']);
         $this->assertTrue($endpoint['requestReached']);
     }
 
@@ -229,7 +235,7 @@ class OpenApiCoverageTrackerTest extends TestCase
 
         $endpoint = $this->endpointSummary('petstore-3.0', 'GET /v1/pets');
         $row = $this->responseRow($endpoint['responses'], '422', 'Application/Problem+JSON');
-        $this->assertSame('validated', $row['state']);
+        $this->assertSame(ResponseCoverageState::Validated, $row['state']);
         // Spec author casing must be preserved verbatim in the report.
         $this->assertSame('Application/Problem+JSON', $row['contentTypeKey']);
     }
@@ -246,7 +252,7 @@ class OpenApiCoverageTrackerTest extends TestCase
 
         $endpoint = $this->endpointSummary('range-keys', 'GET /widgets');
         $row = $this->responseRow($endpoint['responses'], '5XX', 'application/json');
-        $this->assertSame('skipped', $row['state']);
+        $this->assertSame(ResponseCoverageState::Skipped, $row['state']);
         $this->assertSame('status 503 matched skip pattern 5\d\d', $row['skipReason']);
     }
 
@@ -266,7 +272,7 @@ class OpenApiCoverageTrackerTest extends TestCase
 
         $endpoint = $this->endpointSummary('range-keys', 'GET /widgets-default');
         $row = $this->responseRow($endpoint['responses'], 'default', 'application/json');
-        $this->assertSame('validated', $row['state']);
+        $this->assertSame(ResponseCoverageState::Validated, $row['state']);
     }
 
     #[Test]
@@ -348,6 +354,263 @@ class OpenApiCoverageTrackerTest extends TestCase
     }
 
     #[Test]
+    public function record_response_with_range_key_reconciles_to_literal_spec_status(): void
+    {
+        // Pin the symmetric branch in statusKeyMatches() — recordings normally
+        // carry literal statuses, but external callers (and future skip-pattern
+        // refactors) may pass spec range keys. The reverse direction must
+        // reconcile too.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '5XX',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        $endpoint = $this->endpointSummary('petstore-3.0', 'GET /v1/pets');
+        // petstore-3.0 declares 500:application/json literally; the 5XX recording
+        // should reconcile against it.
+        $row = $this->responseRow($endpoint['responses'], '500', 'application/json');
+        $this->assertSame(ResponseCoverageState::Validated, $row['state']);
+    }
+
+    #[Test]
+    public function default_spec_key_matches_literal_default_recording(): void
+    {
+        // Edge case: caller passes the literal string "default" as statusKey.
+        // statusKeyMatches() should resolve via the case-insensitive exact match
+        // BEFORE falling through to the `default` wildcard branch.
+        OpenApiCoverageTracker::recordResponse(
+            'range-keys',
+            'GET',
+            '/widgets-default',
+            'default',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        $endpoint = $this->endpointSummary('range-keys', 'GET /widgets-default');
+        $row = $this->responseRow($endpoint['responses'], 'default', 'application/json');
+        $this->assertSame(ResponseCoverageState::Validated, $row['state']);
+    }
+
+    #[Test]
+    public function endpoint_with_no_spec_responses_renders_request_only_when_request_fired(): void
+    {
+        // Pin the deriveEndpointState() $totalDeclared === 0 branch.
+        // The fixture's GET /widgets-no-responses operation has no responses
+        // block at all.
+        OpenApiCoverageTracker::recordRequest('range-keys', 'GET', '/widgets-no-responses');
+
+        $endpoint = $this->endpointSummary('range-keys', 'GET /widgets-no-responses');
+        $this->assertSame(EndpointCoverageState::RequestOnly, $endpoint['state']);
+        $this->assertSame(0, $endpoint['totalResponseCount']);
+    }
+
+    #[Test]
+    public function endpoint_with_no_spec_responses_renders_uncovered_when_no_record(): void
+    {
+        $endpoint = $this->endpointSummary('range-keys', 'GET /widgets-no-responses');
+        $this->assertSame(EndpointCoverageState::Uncovered, $endpoint['state']);
+    }
+
+    #[Test]
+    public function endpoint_with_only_unexpected_observation_renders_request_only(): void
+    {
+        // Pin the hasAnyResponseObservation branch in deriveEndpointState():
+        // a recording that doesn't reconcile to any declared spec entry
+        // (lands in unexpectedObservations) but no recordRequest call —
+        // endpoint state must be `request-only`, not `uncovered`.
+        OpenApiCoverageTracker::recordResponse(
+            'range-keys',
+            'GET',
+            '/widgets',
+            '700',
+            'application/xml',
+            schemaValidated: true,
+        );
+
+        $endpoint = $this->endpointSummary('range-keys', 'GET /widgets');
+        $this->assertSame(EndpointCoverageState::RequestOnly, $endpoint['state']);
+        $this->assertCount(1, $endpoint['unexpectedObservations']);
+    }
+
+    #[Test]
+    public function cross_recording_hits_accumulate_into_validated_pair(): void
+    {
+        // Two distinct recordings (`503` and `599`) both reconcile to spec `5XX`
+        // via range matching. The validated row's `hits` should be the sum.
+        OpenApiCoverageTracker::recordResponse(
+            'range-keys',
+            'GET',
+            '/widgets',
+            '503',
+            'application/json',
+            schemaValidated: true,
+        );
+        OpenApiCoverageTracker::recordResponse(
+            'range-keys',
+            'GET',
+            '/widgets',
+            '599',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        $endpoint = $this->endpointSummary('range-keys', 'GET /widgets');
+        $row = $this->responseRow($endpoint['responses'], '5XX', 'application/json');
+        $this->assertSame(ResponseCoverageState::Validated, $row['state']);
+        $this->assertSame(2, $row['hits']);
+    }
+
+    #[Test]
+    public function validated_promotion_drops_skipped_hits_from_count(): void
+    {
+        // Two skipped recordings followed by a validated one should NOT roll
+        // the skipped hit count into the validated total — the displayed
+        // "validated (N hits)" must reflect validations only.
+        OpenApiCoverageTracker::recordResponse(
+            'range-keys',
+            'GET',
+            '/widgets',
+            '503',
+            null,
+            schemaValidated: false,
+            skipReason: 'first skip',
+        );
+        OpenApiCoverageTracker::recordResponse(
+            'range-keys',
+            'GET',
+            '/widgets',
+            '599',
+            null,
+            schemaValidated: false,
+            skipReason: 'second skip',
+        );
+        OpenApiCoverageTracker::recordResponse(
+            'range-keys',
+            'GET',
+            '/widgets',
+            '500',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        $endpoint = $this->endpointSummary('range-keys', 'GET /widgets');
+        $row = $this->responseRow($endpoint['responses'], '5XX', 'application/json');
+        $this->assertSame(ResponseCoverageState::Validated, $row['state']);
+        $this->assertSame(1, $row['hits'], 'hits should only count validated recordings');
+    }
+
+    #[Test]
+    public function latest_skip_reason_wins_for_same_pair_recordings(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'range-keys',
+            'GET',
+            '/widgets',
+            '503',
+            null,
+            schemaValidated: false,
+            skipReason: 'reason A',
+        );
+        OpenApiCoverageTracker::recordResponse(
+            'range-keys',
+            'GET',
+            '/widgets',
+            '503',
+            null,
+            schemaValidated: false,
+            skipReason: 'reason B',
+        );
+
+        $endpoint = $this->endpointSummary('range-keys', 'GET /widgets');
+        $row = $this->responseRow($endpoint['responses'], '5XX', 'application/json');
+        $this->assertSame('reason B', $row['skipReason']);
+    }
+
+    #[Test]
+    public function latest_skip_reason_wins_across_cross_recording_skips(): void
+    {
+        // Two distinct skip recordings (different literal statuses) both
+        // reconcile to the same spec `5XX:application/json` declaration.
+        // Latest skipReason should win in buildResponseRows too.
+        OpenApiCoverageTracker::recordResponse(
+            'range-keys',
+            'GET',
+            '/widgets',
+            '503',
+            null,
+            schemaValidated: false,
+            skipReason: 'reason A',
+        );
+        OpenApiCoverageTracker::recordResponse(
+            'range-keys',
+            'GET',
+            '/widgets',
+            '599',
+            null,
+            schemaValidated: false,
+            skipReason: 'reason B',
+        );
+
+        $endpoint = $this->endpointSummary('range-keys', 'GET /widgets');
+        $row = $this->responseRow($endpoint['responses'], '5XX', 'application/json');
+        $this->assertSame(ResponseCoverageState::Skipped, $row['state']);
+        $this->assertSame('reason B', $row['skipReason']);
+    }
+
+    #[Test]
+    public function default_and_5xx_overlap_double_counts_response_definitions(): void
+    {
+        // Documented overlap behaviour: when a spec declares BOTH `default`
+        // and `5XX` for the same content-type, a single `503` recording marks
+        // both rows validated and contributes to both counts. Spec authors are
+        // unlikely to write both, but this pin documents the arithmetic so a
+        // future refactor doesn't silently change the totals.
+        OpenApiCoverageTracker::recordResponse(
+            'range-keys-overlap',
+            'GET',
+            '/widgets',
+            '503',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        $endpoint = $this->endpointSummary('range-keys-overlap', 'GET /widgets');
+        // Spec declares both 5XX:application/json and default:application/json
+        $this->assertSame(2, $endpoint['totalResponseCount']);
+        $this->assertSame(2, $endpoint['coveredResponseCount']);
+        $this->assertSame(EndpointCoverageState::AllCovered, $endpoint['state']);
+    }
+
+    #[Test]
+    public function malformed_response_entry_emits_warning_and_omits(): void
+    {
+        // Pin the trigger_error path in collectDeclaredEndpoints — silently
+        // dropping a non-array response would understate totals; without
+        // a warning the user wouldn't notice.
+        $captured = [];
+        $previous = set_error_handler(static function (int $errno, string $message) use (&$captured): bool {
+            $captured[] = $message;
+
+            return true;
+        });
+
+        try {
+            OpenApiCoverageTracker::computeCoverage('malformed-response');
+        } finally {
+            restore_error_handler();
+        }
+
+        $joined = implode(' | ', $captured);
+        $this->assertStringContainsString("spec 'malformed-response'", $joined);
+        $this->assertStringContainsString('not an object', $joined);
+    }
+
+    #[Test]
     public function has_any_coverage_returns_true_for_request_only(): void
     {
         OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets');
@@ -380,9 +643,9 @@ class OpenApiCoverageTrackerTest extends TestCase
      *     method: string,
      *     path: string,
      *     operationId: ?string,
-     *     state: string,
+     *     state: EndpointCoverageState,
      *     requestReached: bool,
-     *     responses: list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}>,
+     *     responses: list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}>,
      *     coveredResponseCount: int,
      *     skippedResponseCount: int,
      *     totalResponseCount: int,
@@ -402,9 +665,9 @@ class OpenApiCoverageTrackerTest extends TestCase
     }
 
     /**
-     * @param list<array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}> $rows
+     * @param list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}> $rows
      *
-     * @return array{statusKey: string, contentTypeKey: string, state: string, hits: int, skipReason: ?string}
+     * @return array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}
      */
     private function responseRow(array $rows, string $statusKey, string $contentTypeKey): array
     {

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -1111,8 +1111,8 @@ class OpenApiResponseValidatorTest extends TestCase
         // Response-side symmetry for the request-side regression guard. The
         // fixture's 200 response schema carries the same malformed `pattern`
         // ("[unterminated") that opis rejects with InvalidKeywordException.
-        // Without ValidatorErrorBoundary::safely() this would escape as an
-        // uncaught throw; post-fix it is a structured [response-body] failure.
+        // Without the inlined try/catch this would escape as an uncaught
+        // throw; post-fix it is a structured [response-body] failure.
         $result = $this->validator->validate(
             'body-validator-throws',
             'POST',
@@ -1127,6 +1127,11 @@ class OpenApiResponseValidatorTest extends TestCase
         $joined = implode(' | ', $result->errors());
         $this->assertStringContainsString('[response-body]', $joined);
         $this->assertStringContainsString('InvalidKeywordException', $joined);
+        // Pin the absence of "(caused by ...)" when the thrown exception
+        // has no previous — without this assertion the suffix-formatting
+        // branch could regress to always emitting it (or omitting it
+        // unconditionally) and tests would still pass.
+        $this->assertStringNotContainsString('(caused by', $joined);
     }
 
     // ========================================

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -1405,6 +1405,119 @@ class OpenApiResponseValidatorTest extends TestCase
         $this->assertStringContainsString('must be an object', $joined);
     }
 
+    // ========================================
+    // matchedStatusCode / matchedContentType propagation (#111)
+    // ========================================
+
+    #[Test]
+    public function success_propagates_matched_status_and_content(): void
+    {
+        // Coverage tracking depends on the validator threading the spec
+        // status key + media-type key through the result so it can record
+        // per-(status, content-type) granularity.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            200,
+            ['data' => [['id' => 1, 'name' => 'Fido']]],
+            'application/json',
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertSame('200', $result->matchedStatusCode());
+        $this->assertSame('application/json', $result->matchedContentType());
+    }
+
+    #[Test]
+    public function failure_still_propagates_matched_status_and_content(): void
+    {
+        // Schema mismatches still pick a (status, content-type) — they got far
+        // enough to know which response definition was being validated. Coverage
+        // must record the partial hit even when validation failed.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            200,
+            ['data' => [['id' => 'not-an-int', 'name' => 'Fido']]],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertSame('200', $result->matchedStatusCode());
+        $this->assertSame('application/json', $result->matchedContentType());
+    }
+
+    #[Test]
+    public function no_content_response_propagates_status_but_not_content_type(): void
+    {
+        // 204 responses have no `content` block, so matchedContentType is
+        // null even though matchedStatusCode pins the status.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'DELETE',
+            '/v1/pets/123',
+            204,
+            null,
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertSame('204', $result->matchedStatusCode());
+        $this->assertNull($result->matchedContentType());
+    }
+
+    #[Test]
+    public function skipped_response_propagates_literal_status_not_spec_key(): void
+    {
+        // Skip happens before the spec response map is consulted — coverage
+        // tracking reconciles literal status against any 5XX/default key
+        // declared in the spec at compute time (see OpenApiCoverageTracker).
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            503,
+            null,
+        );
+
+        $this->assertTrue($result->isSkipped());
+        $this->assertSame('503', $result->matchedStatusCode());
+        $this->assertNull($result->matchedContentType());
+    }
+
+    #[Test]
+    public function content_type_not_in_spec_failure_clears_matched_content(): void
+    {
+        // text/plain isn't in the 409 content map — validator returns failure
+        // and matchedContentType is null because no spec key matched.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            409,
+            null,
+            'text/plain',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertSame('409', $result->matchedStatusCode());
+        $this->assertNull($result->matchedContentType());
+    }
+
+    #[Test]
+    public function path_or_method_failure_does_not_set_matched_status(): void
+    {
+        // Failures earlier than status lookup can't pick a status key.
+        $unknownPath = $this->validator->validate('petstore-3.0', 'GET', '/v1/unknown', 200, []);
+        $undefinedMethod = $this->validator->validate('petstore-3.0', 'PATCH', '/v1/pets', 200, []);
+
+        $this->assertNull($unknownPath->matchedStatusCode());
+        $this->assertNull($unknownPath->matchedContentType());
+        $this->assertNull($undefinedMethod->matchedStatusCode());
+        $this->assertNull($undefinedMethod->matchedContentType());
+    }
+
     #[Test]
     public function optional_header_with_no_schema_passes_silently_when_value_present(): void
     {

--- a/tests/Unit/OpenApiValidationResultTest.php
+++ b/tests/Unit/OpenApiValidationResultTest.php
@@ -108,6 +108,53 @@ class OpenApiValidationResultTest extends TestCase
     }
 
     #[Test]
+    public function matched_status_and_content_default_to_null(): void
+    {
+        // Coverage tracking depends on the absence of these being explicit
+        // null rather than missing — pin the defaults across all three factories.
+        $success = OpenApiValidationResult::success();
+        $failure = OpenApiValidationResult::failure(['err']);
+        $skipped = OpenApiValidationResult::skipped();
+
+        foreach ([$success, $failure, $skipped] as $result) {
+            $this->assertNull($result->matchedStatusCode());
+            $this->assertNull($result->matchedContentType());
+        }
+    }
+
+    #[Test]
+    public function success_propagates_matched_status_and_content(): void
+    {
+        $result = OpenApiValidationResult::success('/v1/pets', '200', 'application/json');
+
+        $this->assertSame('200', $result->matchedStatusCode());
+        $this->assertSame('application/json', $result->matchedContentType());
+    }
+
+    #[Test]
+    public function failure_propagates_matched_status_and_content(): void
+    {
+        // Failures still carry matched-status/content when the validator got far
+        // enough to pick them — coverage records the (status, contentType) pair
+        // even on schema mismatches so partial coverage shows up correctly.
+        $result = OpenApiValidationResult::failure(['err'], '/v1/pets', '422', 'application/problem+json');
+
+        $this->assertSame('422', $result->matchedStatusCode());
+        $this->assertSame('application/problem+json', $result->matchedContentType());
+    }
+
+    #[Test]
+    public function skipped_carries_literal_status_and_no_content_type(): void
+    {
+        // Skip happens before content-type lookup — matchedContentType is always null
+        // and matchedStatusCode is the literal HTTP status, not a spec range key.
+        $result = OpenApiValidationResult::skipped('/v1/pets', 'status 503 matched 5\d\d', '503');
+
+        $this->assertSame('503', $result->matchedStatusCode());
+        $this->assertNull($result->matchedContentType());
+    }
+
+    #[Test]
     public function outcome_match_covers_all_three_cases_exhaustively(): void
     {
         $results = [

--- a/tests/Unit/ValidatesOpenApiSchemaAutoValidateRequestTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaAutoValidateRequestTest.php
@@ -9,6 +9,7 @@ use const JSON_THROW_ON_ERROR;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\EndpointCoverageState;
 use Studio\OpenApiContractTesting\HttpMethod;
 use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
 use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
@@ -107,7 +108,7 @@ class ValidatesOpenApiSchemaAutoValidateRequestTest extends TestCase
         }
         $this->assertNotNull($endpoint);
         $this->assertTrue($endpoint['requestReached']);
-        $this->assertSame('request-only', $endpoint['state']);
+        $this->assertSame(EndpointCoverageState::RequestOnly, $endpoint['state']);
         $this->assertSame(0, $endpoint['skippedResponseCount']);
     }
 

--- a/tests/Unit/ValidatesOpenApiSchemaAutoValidateRequestTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaAutoValidateRequestTest.php
@@ -92,10 +92,23 @@ class ValidatesOpenApiSchemaAutoValidateRequestTest extends TestCase
 
         $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/v1/pets');
 
+        // Request-side recording uses recordRequest() so the endpoint is
+        // marked request-only — request validation has no response context to
+        // mark response-level coverage. This is by design (#111): only the
+        // response hook records (status, content-type) granularity.
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
-        $this->assertContains('POST /v1/pets', $coverage['covered']);
-        $this->assertSame([], $coverage['skippedOnly']);
-        $this->assertSame(0, $coverage['skippedOnlyCount']);
+        $endpoint = null;
+        foreach ($coverage['endpoints'] as $summary) {
+            if ($summary['endpoint'] === 'POST /v1/pets') {
+                $endpoint = $summary;
+
+                break;
+            }
+        }
+        $this->assertNotNull($endpoint);
+        $this->assertTrue($endpoint['requestReached']);
+        $this->assertSame('request-only', $endpoint['state']);
+        $this->assertSame(0, $endpoint['skippedResponseCount']);
     }
 
     #[Test]

--- a/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
+++ b/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
@@ -33,7 +33,7 @@ class ResponseBodyValidatorTest extends TestCase
             ],
         ];
 
-        $errors = $this->validator->validate(
+        $result = $this->validator->validate(
             'spec',
             'GET',
             '/pets/{id}',
@@ -44,7 +44,8 @@ class ResponseBodyValidatorTest extends TestCase
             OpenApiVersion::V3_0,
         );
 
-        $this->assertSame([], $errors);
+        $this->assertSame([], $result->errors);
+        $this->assertSame('application/json', $result->matchedContentType);
     }
 
     #[Test]
@@ -54,7 +55,7 @@ class ResponseBodyValidatorTest extends TestCase
             'application/json' => ['schema' => ['type' => 'object']],
         ];
 
-        $errors = $this->validator->validate(
+        $result = $this->validator->validate(
             'spec',
             'GET',
             '/pets',
@@ -65,8 +66,9 @@ class ResponseBodyValidatorTest extends TestCase
             OpenApiVersion::V3_0,
         );
 
-        $this->assertCount(1, $errors);
-        $this->assertStringContainsString('Response body is empty', $errors[0]);
+        $this->assertCount(1, $result->errors);
+        $this->assertStringContainsString('Response body is empty', $result->errors[0]);
+        $this->assertSame('application/json', $result->matchedContentType);
     }
 
     #[Test]
@@ -76,7 +78,7 @@ class ResponseBodyValidatorTest extends TestCase
             'text/plain' => ['schema' => ['type' => 'string']],
         ];
 
-        $errors = $this->validator->validate(
+        $result = $this->validator->validate(
             'spec',
             'GET',
             '/robots.txt',
@@ -87,7 +89,34 @@ class ResponseBodyValidatorTest extends TestCase
             OpenApiVersion::V3_0,
         );
 
-        $this->assertSame([], $errors);
+        $this->assertSame([], $result->errors);
+        $this->assertSame('text/plain', $result->matchedContentType);
+    }
+
+    #[Test]
+    public function validate_preserves_spec_content_type_casing(): void
+    {
+        // The spec author wrote a mixed-case media type — the matched key
+        // should keep that casing so coverage reports show it verbatim.
+        $content = [
+            'Application/Problem+JSON' => [
+                'schema' => ['type' => 'object'],
+            ],
+        ];
+
+        $result = $this->validator->validate(
+            'spec',
+            'GET',
+            '/pets',
+            422,
+            $content,
+            ['detail' => 'oops'],
+            'application/problem+json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertSame([], $result->errors);
+        $this->assertSame('Application/Problem+JSON', $result->matchedContentType);
     }
 
     #[Test]
@@ -97,7 +126,7 @@ class ResponseBodyValidatorTest extends TestCase
             'application/json' => ['schema' => ['type' => 'object']],
         ];
 
-        $errors = $this->validator->validate(
+        $result = $this->validator->validate(
             'spec',
             'GET',
             '/pets',
@@ -108,8 +137,9 @@ class ResponseBodyValidatorTest extends TestCase
             OpenApiVersion::V3_0,
         );
 
-        $this->assertCount(1, $errors);
-        $this->assertStringContainsString("Content-Type 'application/xml' is not defined", $errors[0]);
+        $this->assertCount(1, $result->errors);
+        $this->assertStringContainsString("Content-Type 'application/xml' is not defined", $result->errors[0]);
+        $this->assertNull($result->matchedContentType);
     }
 
     #[Test]
@@ -118,7 +148,7 @@ class ResponseBodyValidatorTest extends TestCase
         // Non-JSON spec entries with no Content-Type header → out-of-scope, pass.
         $content = ['application/xml' => ['schema' => ['type' => 'string']]];
 
-        $errors = $this->validator->validate(
+        $result = $this->validator->validate(
             'spec',
             'GET',
             '/pets',
@@ -129,7 +159,8 @@ class ResponseBodyValidatorTest extends TestCase
             OpenApiVersion::V3_0,
         );
 
-        $this->assertSame([], $errors);
+        $this->assertSame([], $result->errors);
+        $this->assertNull($result->matchedContentType);
     }
 
     #[Test]
@@ -145,7 +176,7 @@ class ResponseBodyValidatorTest extends TestCase
             ],
         ];
 
-        $errors = $this->validator->validate(
+        $result = $this->validator->validate(
             'spec',
             'GET',
             '/pets/{id}',
@@ -156,7 +187,8 @@ class ResponseBodyValidatorTest extends TestCase
             OpenApiVersion::V3_0,
         );
 
-        $this->assertNotEmpty($errors);
-        $this->assertStringContainsString('/id', $errors[0]);
+        $this->assertNotEmpty($result->errors);
+        $this->assertStringContainsString('/id', $result->errors[0]);
+        $this->assertSame('application/json', $result->matchedContentType);
     }
 }

--- a/tests/fixtures/specs/malformed-response.json
+++ b/tests/fixtures/specs/malformed-response.json
@@ -1,0 +1,17 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Malformed Response Fixture",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/things": {
+      "get": {
+        "operationId": "getThings",
+        "responses": {
+          "200": "this should be an object, not a scalar"
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/specs/range-keys-overlap.json
+++ b/tests/fixtures/specs/range-keys-overlap.json
@@ -1,0 +1,32 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Range Keys Overlap Fixture",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/widgets": {
+      "get": {
+        "operationId": "overlap",
+        "responses": {
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {"type": "object"}
+              }
+            }
+          },
+          "default": {
+            "description": "Catch-all",
+            "content": {
+              "application/json": {
+                "schema": {"type": "object"}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/specs/range-keys.json
+++ b/tests/fixtures/specs/range-keys.json
@@ -60,6 +60,12 @@
           }
         }
       }
+    },
+    "/widgets-no-responses": {
+      "get": {
+        "operationId": "noResponses"
+      }
     }
   }
 }
+

--- a/tests/fixtures/specs/range-keys.json
+++ b/tests/fixtures/specs/range-keys.json
@@ -1,0 +1,65 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Range Keys Fixture",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/widgets": {
+      "get": {
+        "operationId": "listWidgets",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {"type": "integer"}
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {"type": "string"}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/widgets-default": {
+      "get": {
+        "operationId": "showWidget",
+        "responses": {
+          "default": {
+            "description": "Anything",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {"type": "integer"}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #111. Expands `OpenApiCoverageTracker` from endpoint-level granularity (`(method, path)`) to **response-definition level** (`(method, path, statusCode, contentType)`). A `GET /pets` test that exercises only `200 application/json` no longer counts as fully covering an endpoint that also declares `404 application/problem+json` — the endpoint shows as `partial` and the missing response definition is surfaced.

This is the final Sprint A item before the v1.0.0 cut. Pre-v1, so breaking changes land directly without a deprecation shim.

### Headline changes
- `record()` → split into `recordRequest()` + `recordResponse(spec, method, path, statusKey, contentTypeKey, schemaValidated, skipReason?)`
- `computeCoverage()` returns a richer shape: per-endpoint sub-rows, endpoint state (`all-covered`/`partial`/`uncovered`/`request-only`), per-response state (`validated`/`skipped`/`uncovered`), totals at both endpoint and response-definition level
- Markdown + Console renderers fully rewritten — collapsible per-endpoint detail sections, partial markers (`◐` / `:large_orange_diamond:`), inline skip reasons
- `OpenApiValidationResult` gains `matchedStatusCode()` + `matchedContentType()` so the tracker records under the spec author's literal keys (e.g. `Application/Problem+JSON` casing preserved)
- `Validation/Response/ResponseBodyValidator::validate()` now returns a `ResponseBodyValidationResult` DTO so the matched content-type can flow up to the orchestrator
- `OpenApiCoverageTracker::statusKeyMatches()` reconciles skipped literal statuses (e.g. `503`) to spec range keys (`5XX`/`5xx`/`default`) at compute time
- `unexpectedObservations` field flags statuses/content-types observed at runtime but not declared in spec — no longer silently inflate coverage
- `CoverageReportSubscriber` extracted from the inline anonymous subscriber inside `OpenApiCoverageExtension` so PHPStan can resolve the imported `CoverageResult` shape end-to-end
- New fixture `tests/fixtures/specs/range-keys.json` exercises the reconciliation logic

### Migration notes
Documented in [CHANGELOG.md](https://github.com/studio-design/openapi-contract-testing/blob/feature/issue-111-coverage-granularity/CHANGELOG.md). `getCovered()` is retained as a diagnostic shim returning `array<spec, array<\"METHOD path\", true>>` so external test code doesn't break — `hasAnyCoverage()` is the recommended replacement, and `computeCoverage()` exposes the full new shape.

### Quality gates
- `vendor/bin/phpunit` — 794 tests / 1603 assertions, all green
- `vendor/bin/phpstan analyse` — level 6, 0 errors
- `vendor/bin/php-cs-fixer fix --dry-run --diff` — 0 violations

## Test plan
- [x] All existing tests pass with the new tracker API
- [x] New tests cover: per-pair `hits`, validated-promotes-skipped, skipped-doesn't-demote-validated, range key reconciliation (`503` → `5XX`), `default` spec key, content-type case-insensitive matching with spec casing preserved, request-only endpoints, unexpected observations, response row sort with `*` last
- [x] Renderer tests cover all four endpoint state markers + skipped reason inline
- [x] Integration tests updated to use `recordResponse()` and assert on the new `EndpointSummary` shape
- [x] Quality gates pass on PHP 8.2/8.3/8.4 (verified locally on 8.4; CI matrix will exercise the others)

Co-Authored-By: claude (opus-4.7)