### PR TITLE
feat: v0.13.0 spec compliance + dogfood-driven fixes (#123, #124, #125, #126, #127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,12 +35,24 @@ session against a real Laravel 12 project.
   per spec; both `5XX` and `5xx` accepted). The validator now matches
   range keys when no exact status key is declared. The matched spec
   key (preserving the spec author's casing) flows through to coverage.
-- Lookup priority follows OpenAPI 3.0/3.1: **exact > range > default**.
-  Specs that declare both `503` and `5XX` resolve `503` to the explicit
-  entry; `599` falls through to `5XX`; `418` falls through to `default`
-  if declared.
+- Lookup priority is **exact > range > default** (the conventional
+  resolution shared by major OpenAPI tooling — the spec describes the
+  three forms but does not normatively rank them). Specs that declare
+  both `503` and `5XX` resolve `503` to the explicit entry; `599` falls
+  through to `5XX`; `418` falls through to `default` if declared.
 - `tests/fixtures/specs/spec-fallback.json` exercises every priority
   branch in the new lookup.
+
+### Changed
+
+- **`OpenApiValidationResult::matchedStatusCode()` semantics shift**:
+  pre-v0.13, this always returned the literal HTTP status string (e.g.
+  `"503"`). With the new fallback, it returns the **spec key** the
+  validator actually matched — so a spec declaring only `5XX` now
+  reports `matchedStatusCode() === "5XX"` for a 503 response. Callers
+  building `503 → row` maps from the result will see the key change
+  for any status that resolves via fallback. Skipped responses still
+  report the literal status (skip happens before key resolution).
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,50 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project is **pre-1.0**, so breaking changes may land in any minor release
 until 1.0.0 ships. Each entry below tags whether it is breaking.
 
+## v0.13.0 — 2026-04-25
+
+Spec compliance + critical bug fix surfaced by the v0.12.0 dogfood
+session against a real Laravel 12 project.
+
+### Fixed
+
+- **#124 — Empty `{}` body validates against `type: object`** (was the
+  v1.0 blocker from dogfood). PHP's `json_decode('{}', true) === []`
+  collided with the body validator preserving `[]` as a JSON array, so
+  the natural Laravel `$response->json()` path failed against a spec
+  declaring `type: object`. The body validator now coerces `[]` to
+  `stdClass` when the schema's top-level type explicitly accepts an
+  object (`type: object` or `type: ["object", ...]` in OAS 3.1).
+  Composition keywords (`oneOf` / `anyOf` / `allOf`) intentionally do
+  NOT trigger coercion — type-mismatch errors still surface for
+  `type: array` schemas where the empty-array body is genuinely wrong.
+
+### Added
+
+- **#125 — `default` response key support**. The validator now
+  consults `responses.default` when the literal status code isn't
+  declared. Validation still runs the schema; the matched key is
+  reported as `"default"` in `OpenApiValidationResult::matchedStatusCode()`
+  and in coverage rows.
+- **#126 — `1XX`/`2XX`/`3XX`/`4XX`/`5XX` range key support** (case-insensitive
+  per spec; both `5XX` and `5xx` accepted). The validator now matches
+  range keys when no exact status key is declared. The matched spec
+  key (preserving the spec author's casing) flows through to coverage.
+- Lookup priority follows OpenAPI 3.0/3.1: **exact > range > default**.
+  Specs that declare both `503` and `5XX` resolve `503` to the explicit
+  entry; `599` falls through to `5XX`; `418` falls through to `default`
+  if declared.
+- `tests/fixtures/specs/spec-fallback.json` exercises every priority
+  branch in the new lookup.
+
+### Documentation
+
+- **#123** — README comparison table now correctly shows `✅` for
+  response header validation (was `❌` despite shipping in v0.12.0).
+- **#127** — README Installation section calls out the
+  `symfony/yaml` requirement for YAML specs as a dedicated callout
+  block, not buried in the Requirements list.
+
 ## v0.12.0 — 2026-04-25
 
 This release closes Sprint A — every issue scheduled before v1.0 except the

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This library fills a gap left by existing PHP OpenAPI testing tools: **endpoint 
 | OpenAPI 3.1 | ✅ | ⚠️ | ❌ | ⚠️ | ⚠️ |
 | Response body validation | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Request validation (body + params) | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Response header validation | ❌ | ⚠️ | ✅ | ✅ | ✅ |
+| Response header validation | ✅ | ⚠️ | ✅ | ✅ | ✅ |
 | **Endpoint coverage tracking** | ✅ | ❌ | ❌ | ❌ | ❌ |
 | **Skip-by-status-code (default 5xx)** | ✅ | ❌ | ❌ | ❌ | ✅ |
 | PHPUnit integration | ✅ | ✅ | ❌ | ⚠️ | ✅ |
@@ -63,6 +63,14 @@ This library fills a gap left by existing PHP OpenAPI testing tools: **endpoint 
 ```bash
 composer require --dev studio-design/openapi-contract-testing
 ```
+
+> **YAML specs require `symfony/yaml`.** It is listed under `suggest` so it isn't installed automatically. If your spec is JSON, you can skip this. If your spec is `.yaml` / `.yml`, add it explicitly:
+>
+> ```bash
+> composer require --dev symfony/yaml
+> ```
+>
+> Without it, the loader throws `InvalidOpenApiSpecException` with a clear "requires symfony/yaml" message the first time it tries to read a YAML file.
 
 ## Setup
 

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting;
 
+use const E_USER_WARNING;
+
 use InvalidArgumentException;
 use RuntimeException;
 use Studio\OpenApiContractTesting\Validation\Response\ResponseBodyValidationResult;
@@ -20,6 +22,7 @@ use function preg_last_error_msg;
 use function preg_match;
 use function sprintf;
 use function strtolower;
+use function trigger_error;
 
 final class OpenApiResponseValidator
 {
@@ -106,7 +109,12 @@ final class OpenApiResponseValidator
         $matchingPattern = $this->matchingSkipPattern($statusCodeStr);
         if ($matchingPattern !== null) {
             // matchedStatusCode here is the literal HTTP status string, not a
-            // spec key — see OpenApiValidationResult::skipped() for why.
+            // spec key. Skip happens BEFORE key resolution (resolveResponseKey
+            // runs further down), so we don't yet know which spec key would
+            // have matched — and even when the spec only declares `default`
+            // or a `5XX` range, callers that gate on isSkipped() expect the
+            // wire status, not the resolved spec key. The coverage tracker's
+            // statusKeyMatches() reconciles literal-vs-range at compute time.
             return OpenApiValidationResult::skipped(
                 $matchedPath,
                 sprintf('status %s matched skip pattern %s', $statusCodeStr, $matchingPattern),
@@ -123,7 +131,7 @@ final class OpenApiResponseValidator
         // documents only `default` (or only `5XX`) would fail every real
         // status — both patterns are common (Problem Details responses
         // typically use `default` for the error envelope).
-        $matchedResponseKey = self::resolveResponseKey($responses, $statusCodeStr);
+        $matchedResponseKey = self::resolveResponseKey($specName, $method, $matchedPath, $responses, $statusCodeStr);
         if ($matchedResponseKey === null) {
             return OpenApiValidationResult::failure([
                 "Status code {$statusCode} not defined for {$method} {$matchedPath} in '{$specName}' spec.",
@@ -240,16 +248,23 @@ final class OpenApiResponseValidator
 
     /**
      * Resolve a literal HTTP status to the spec's response key, applying
-     * OpenAPI's three-tier fallback: exact match → range key → `default`.
-     * Returns the matched spec key or null when no rule matches.
+     * the conventional three-tier fallback shared by major OpenAPI tools:
+     * exact match → range key → `default`. Returns the matched spec key
+     * or null when no rule matches.
      *
-     * Range key format is `1XX`/`2XX`/`3XX`/`4XX`/`5XX` (case-insensitive
-     * per spec; we accept both `5XX` and `5xx`). Returns the spec author's
-     * literal key so coverage / error messages reflect what they wrote.
+     * Range keys are accepted in two casings only: `1XX`/`2XX`/`3XX`/`4XX`/`5XX`
+     * (uppercase) or `1xx`/`2xx`/`3xx`/`4xx`/`5xx` (lowercase). Mixed-case
+     * forms (`5Xx`, `5xX`) are intentionally rejected — the OpenAPI spec
+     * uses uppercase consistently in examples and the lowercase variant is
+     * a tolerated convention; permitting arbitrary case would silently mask
+     * spec-author typos that look like range keys.
+     *
+     * Returns the spec author's literal key so coverage / error messages
+     * reflect what they wrote.
      *
      * @param array<string, mixed> $responses
      */
-    private static function resolveResponseKey(array $responses, string $statusCodeStr): ?string
+    private static function resolveResponseKey(string $specName, string $method, string $matchedPath, array $responses, string $statusCodeStr): ?string
     {
         if (isset($responses[$statusCodeStr])) {
             return $statusCodeStr;
@@ -259,18 +274,61 @@ final class OpenApiResponseValidator
         if (preg_match('/^[1-5][0-9]{2}$/', $statusCodeStr) === 1) {
             $leadingDigit = $statusCodeStr[0];
             foreach (array_keys($responses) as $key) {
+                // PHP auto-coerces numeric string keys (e.g. "200") to int
+                // when used as array keys, so cast back to string before
+                // the regex. Range keys like "5XX" are non-numeric and
+                // unaffected.
                 $keyStr = (string) $key;
-                if (preg_match('/^([1-5])[xX]{2}$/', $keyStr, $m) === 1 && $m[1] === $leadingDigit) {
+                if (preg_match('/^([1-5])(?:XX|xx)$/', $keyStr, $m) === 1 && $m[1] === $leadingDigit) {
                     return $keyStr;
                 }
             }
         }
 
         if (isset($responses['default'])) {
+            // Before silently falling back to `default`, surface any keys
+            // that LOOK like attempted spec keys but don't satisfy the
+            // exact / range / default form. Without this warning, a typo
+            // like `'40'` (truncated 404) or `'Default'` (wrong case)
+            // alongside a `default` entry would silently route every
+            // unmatched status to the default schema — masking the dogfood
+            // signal "your spec doesn't actually cover this status".
+            self::warnSuspiciousResponseKeys($specName, $method, $matchedPath, $responses);
+
             return 'default';
         }
 
         return null;
+    }
+
+    /**
+     * @param array<string, mixed> $responses
+     */
+    private static function warnSuspiciousResponseKeys(string $specName, string $method, string $matchedPath, array $responses): void
+    {
+        foreach (array_keys($responses) as $key) {
+            $keyStr = (string) $key;
+            if ($keyStr === 'default') {
+                continue;
+            }
+            if (preg_match('/^[1-5][0-9]{2}$/', $keyStr) === 1) {
+                continue;
+            }
+            if (preg_match('/^[1-5](?:XX|xx)$/', $keyStr) === 1) {
+                continue;
+            }
+
+            trigger_error(
+                sprintf(
+                    "[OpenAPI] spec '%s' %s %s: response key '%s' is not a valid HTTP status, range key (1XX-5XX / 1xx-5xx), or 'default'; falling back to 'default' may be hiding a typo.",
+                    $specName,
+                    $method,
+                    $matchedPath,
+                    $keyStr,
+                ),
+                E_USER_WARNING,
+            );
+        }
     }
 
     /**

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -114,13 +114,27 @@ final class OpenApiResponseValidator
             );
         }
 
-        if (!isset($responses[$statusCodeStr])) {
+        // Spec lookup priority per OpenAPI 3.0/3.1:
+        //   1. Exact code match (e.g. spec declares "503", response is 503)
+        //   2. Range key match (e.g. spec declares "5XX", response is 503)
+        //   3. `default` catch-all
+        // Explicit codes take precedence over range keys; range keys take
+        // precedence over `default`. Without this fallback, a spec that
+        // documents only `default` (or only `5XX`) would fail every real
+        // status — both patterns are common (Problem Details responses
+        // typically use `default` for the error envelope).
+        $matchedResponseKey = self::resolveResponseKey($responses, $statusCodeStr);
+        if ($matchedResponseKey === null) {
             return OpenApiValidationResult::failure([
                 "Status code {$statusCode} not defined for {$method} {$matchedPath} in '{$specName}' spec.",
             ], $matchedPath);
         }
 
-        $responseSpec = $responses[$statusCodeStr];
+        // Coverage tracking records under the spec key actually matched
+        // (e.g. "5XX" or "default"), not the literal status — that lets
+        // the renderer surface the spec's intent rather than the wire value.
+        $statusCodeStr = $matchedResponseKey;
+        $responseSpec = $responses[$matchedResponseKey];
 
         $bodyResult = $this->validateBody(
             $specName,
@@ -222,6 +236,41 @@ final class OpenApiResponseValidator
         }
 
         return $compiled;
+    }
+
+    /**
+     * Resolve a literal HTTP status to the spec's response key, applying
+     * OpenAPI's three-tier fallback: exact match → range key → `default`.
+     * Returns the matched spec key or null when no rule matches.
+     *
+     * Range key format is `1XX`/`2XX`/`3XX`/`4XX`/`5XX` (case-insensitive
+     * per spec; we accept both `5XX` and `5xx`). Returns the spec author's
+     * literal key so coverage / error messages reflect what they wrote.
+     *
+     * @param array<string, mixed> $responses
+     */
+    private static function resolveResponseKey(array $responses, string $statusCodeStr): ?string
+    {
+        if (isset($responses[$statusCodeStr])) {
+            return $statusCodeStr;
+        }
+
+        // Range key match — preserve the spec author's exact casing.
+        if (preg_match('/^[1-5][0-9]{2}$/', $statusCodeStr) === 1) {
+            $leadingDigit = $statusCodeStr[0];
+            foreach (array_keys($responses) as $key) {
+                $keyStr = (string) $key;
+                if (preg_match('/^([1-5])[xX]{2}$/', $keyStr, $m) === 1 && $m[1] === $leadingDigit) {
+                    return $keyStr;
+                }
+            }
+        }
+
+        if (isset($responses['default'])) {
+            return 'default';
+        }
+
+        return null;
     }
 
     /**

--- a/src/Validation/Response/ResponseBodyValidator.php
+++ b/src/Validation/Response/ResponseBodyValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Validation\Response;
 
+use stdClass;
 use Studio\OpenApiContractTesting\OpenApiResponseValidator;
 use Studio\OpenApiContractTesting\OpenApiSchemaConverter;
 use Studio\OpenApiContractTesting\OpenApiValidationResult;
@@ -15,6 +16,9 @@ use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
 
 use function array_keys;
 use function implode;
+use function in_array;
+use function is_array;
+use function is_string;
 
 final class ResponseBodyValidator
 {
@@ -107,6 +111,19 @@ final class ResponseBodyValidator
         $schema = $content[$jsonContentType]['schema'];
         $jsonSchema = OpenApiSchemaConverter::convert($schema, $version, SchemaContext::Response);
 
+        // PHP's `json_decode($json, true)` returns `[]` for both `[]` and `{}`.
+        // The Laravel trait's response decoder uses associative-array decoding
+        // (so callers can treat the body as an array), which means an empty
+        // `{}` body lands here as PHP `[]`. ObjectConverter preserves empty
+        // arrays as JSON arrays, so the schema's `type: object` would then
+        // reject the body with a misleading "must match the type: object"
+        // error. Coerce `[]` → stdClass when the schema explicitly accepts
+        // an object so the empty-object-against-type-object case (very
+        // common for status acks and "no items yet" responses) validates.
+        if ($responseBody === [] && self::schemaAcceptsObject($schema)) {
+            $responseBody = new stdClass();
+        }
+
         $schemaObject = ObjectConverter::convert($jsonSchema);
         $dataObject = ObjectConverter::convert($responseBody);
 
@@ -120,5 +137,30 @@ final class ResponseBodyValidator
         }
 
         return new ResponseBodyValidationResult($errors, $jsonContentType);
+    }
+
+    /**
+     * Whether the schema's top-level type explicitly accepts a JSON object.
+     * Handles OAS 3.0 (`type: object`) and OAS 3.1 (`type: ["object", "null"]`).
+     * Composition keywords (`oneOf` / `anyOf` / `allOf`) are intentionally
+     * NOT walked — coercion only fires for the unambiguous case so a real
+     * type-mismatch error still surfaces for `type: array` schemas where the
+     * empty-array body is genuinely wrong.
+     *
+     * @param array<string, mixed> $schema
+     */
+    private static function schemaAcceptsObject(array $schema): bool
+    {
+        $type = $schema['type'] ?? null;
+
+        if (is_string($type)) {
+            return $type === 'object';
+        }
+
+        if (is_array($type)) {
+            return in_array('object', $type, true);
+        }
+
+        return false;
     }
 }

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 use Studio\OpenApiContractTesting\OpenApiResponseValidator;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
 
@@ -15,6 +16,8 @@ use function array_map;
 use function count;
 use function implode;
 use function range;
+use function restore_error_handler;
+use function set_error_handler;
 
 class OpenApiResponseValidatorTest extends TestCase
 {
@@ -46,6 +49,17 @@ class OpenApiResponseValidatorTest extends TestCase
         yield '500 is skipped' => [500, true];
         yield '599 is skipped' => [599, true];
         yield '600 is not skipped' => [600, false];
+    }
+
+    /**
+     * @return iterable<string, array{int, string}>
+     */
+    public static function provideRange_keys_match_for_each_leading_digitCases(): iterable
+    {
+        yield '1XX matches 199' => [199, '1XX'];
+        yield '2XX matches 299' => [299, '2XX'];
+        yield '3XX matches 399' => [399, '3XX'];
+        yield '4XX matches 499' => [499, '4XX'];
     }
 
     // ========================================
@@ -1554,6 +1568,152 @@ class OpenApiResponseValidatorTest extends TestCase
 
         $this->assertFalse($result->isValid());
         $this->assertStringContainsString('Status code 418 not defined', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function exact_200_takes_precedence_over_default(): void
+    {
+        // /with-default-only declares both 200 and default. The exact
+        // match must win — verified via a unique required field that
+        // exists ONLY on the 200 schema.
+        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+
+        $result = $validator->validate(
+            'spec-fallback',
+            'GET',
+            '/with-default-only',
+            200,
+            ['fromExact200' => true],
+            'application/json',
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertSame('200', $result->matchedStatusCode());
+    }
+
+    #[Test]
+    public function range_key_takes_precedence_over_default_for_5xx(): void
+    {
+        // /with-range-and-default declares both 5XX and default. A 503
+        // response must hit 5XX (range > default), verified via the
+        // `from5xx` required field that only the 5XX schema requires.
+        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+
+        $result = $validator->validate(
+            'spec-fallback',
+            'GET',
+            '/with-range-and-default',
+            503,
+            ['from5xx' => true],
+            'application/json',
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertSame('5XX', $result->matchedStatusCode());
+    }
+
+    #[Test]
+    public function default_takes_over_for_non_5xx_when_range_only_covers_5xx(): void
+    {
+        // Same fixture, but a 418 (non-5xx). 5XX doesn't match → falls
+        // through to default. Verified via `fromDefault` required field.
+        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+
+        $result = $validator->validate(
+            'spec-fallback',
+            'GET',
+            '/with-range-and-default',
+            418,
+            ['fromDefault' => true],
+            'application/json',
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertSame('default', $result->matchedStatusCode());
+    }
+
+    #[Test]
+    public function skip_pattern_preempts_default_fallback_for_5xx(): void
+    {
+        // Pin the order of operations: skip-by-status-code must run BEFORE
+        // resolveResponseKey. A spec declaring only `default` + a 503
+        // response with the default 5\d\d skip pattern enabled must yield
+        // isSkipped() — NOT validated against `default`.
+        $validator = new OpenApiResponseValidator(); // default skip = ['5\d\d']
+
+        $result = $validator->validate(
+            'spec-fallback',
+            'GET',
+            '/with-default',
+            503,
+            ['error' => 'down'],
+            'application/json',
+        );
+
+        $this->assertTrue($result->isSkipped());
+        // Skip records the literal status, not the resolved spec key,
+        // because skip happens before key resolution.
+        $this->assertSame('503', $result->matchedStatusCode());
+    }
+
+    #[Test]
+    #[DataProvider('provideRange_keys_match_for_each_leading_digitCases')]
+    public function range_keys_match_for_each_leading_digit(int $status, string $expectedKey): void
+    {
+        // Pin every range-key class so a typo narrowing the regex to e.g.
+        // ^5(?:XX|xx)$ would surface immediately. Status 5XX is exercised
+        // by other tests; this provider covers 1XX-4XX. Skip patterns are
+        // off so the lookup actually runs (default 5\d\d skip wouldn't fire
+        // on these classes anyway).
+        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+
+        $result = $validator->validate(
+            'spec-fallback',
+            'GET',
+            '/with-each-range',
+            $status,
+            new stdClass(),
+            'application/json',
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertSame($expectedKey, $result->matchedStatusCode());
+    }
+
+    #[Test]
+    public function malformed_response_keys_emit_warning_when_default_fallback_fires(): void
+    {
+        // /with-typo-and-default has a `40` typo (looks like an attempted
+        // truncated 404). When the literal status doesn't match exact or
+        // range, and we're about to fall back to `default`, emit a warning
+        // so the spec author notices the typo.
+        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+
+        $captured = [];
+        $previous = set_error_handler(static function (int $errno, string $message) use (&$captured): bool {
+            $captured[] = $message;
+
+            return true;
+        });
+
+        try {
+            $result = $validator->validate(
+                'spec-fallback',
+                'GET',
+                '/with-typo-and-default',
+                404,
+                new stdClass(),
+                'application/json',
+            );
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertTrue($result->isValid());
+        $this->assertSame('default', $result->matchedStatusCode());
+        $joined = implode(' | ', $captured);
+        $this->assertStringContainsString("response key '40'", $joined);
+        $this->assertStringContainsString('typo', $joined);
     }
 
     // ========================================

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -1411,6 +1411,152 @@ class OpenApiResponseValidatorTest extends TestCase
     }
 
     // ========================================
+    // Spec response key fallback: default + 5XX/range keys (#125, #126)
+    // ========================================
+
+    #[Test]
+    public function default_response_key_validates_unenumerated_status(): void
+    {
+        // Spec declares only `200` and `default`. A 418 response should
+        // validate against the `default` schema rather than failing with
+        // "Status code 418 not defined".
+        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+
+        $result = $validator->validate(
+            'spec-fallback',
+            'GET',
+            '/with-default',
+            418,
+            ['error' => 'teapot'],
+            'application/json',
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertSame('default', $result->matchedStatusCode());
+        $this->assertSame('application/json', $result->matchedContentType());
+    }
+
+    #[Test]
+    public function default_response_key_still_validates_schema_mismatch(): void
+    {
+        // Falling back to `default` does not bypass schema validation —
+        // a body that doesn't match `default`'s schema still fails.
+        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+
+        $result = $validator->validate(
+            'spec-fallback',
+            'GET',
+            '/with-default',
+            418,
+            ['wrong_key' => 'no error field'],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertSame('default', $result->matchedStatusCode());
+    }
+
+    #[Test]
+    public function range_key_5xx_validates_503_response(): void
+    {
+        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+
+        $result = $validator->validate(
+            'spec-fallback',
+            'GET',
+            '/with-5xx',
+            503,
+            ['title' => 'Service Unavailable'],
+            'application/problem+json',
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertSame('5XX', $result->matchedStatusCode());
+        $this->assertSame('application/problem+json', $result->matchedContentType());
+    }
+
+    #[Test]
+    public function exact_status_key_takes_precedence_over_range_key(): void
+    {
+        // Spec declares both `503` (specific) and `5XX` (range). 503 must
+        // match the specific key — and the test pins it via the unique
+        // `specific: true` field that only the 503 schema requires.
+        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+
+        $result = $validator->validate(
+            'spec-fallback',
+            'GET',
+            '/with-exact-and-range',
+            503,
+            ['specific' => true],
+            'application/json',
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertSame('503', $result->matchedStatusCode());
+    }
+
+    #[Test]
+    public function range_key_falls_through_to_5_x_x_for_other_5xx_codes(): void
+    {
+        // 599 isn't declared explicitly, so the 5XX range key matches.
+        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+
+        $result = $validator->validate(
+            'spec-fallback',
+            'GET',
+            '/with-exact-and-range',
+            599,
+            ['anything' => 'goes'],
+            'application/json',
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertSame('5XX', $result->matchedStatusCode());
+    }
+
+    #[Test]
+    public function lowercase_range_key_5xx_is_accepted(): void
+    {
+        // OpenAPI permits both upper and lower case for the X in range keys
+        // (`5XX` and `5xx` are both legal). The matched key preserves the
+        // spec author's casing so coverage reports show what they wrote.
+        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+
+        $result = $validator->validate(
+            'spec-fallback',
+            'GET',
+            '/lowercase-range',
+            503,
+            ['anything' => 'goes'],
+            'application/json',
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertSame('5xx', $result->matchedStatusCode());
+    }
+
+    #[Test]
+    public function range_key_does_not_match_outside_its_range(): void
+    {
+        // A 4xx response against a spec that only declares 5XX should still
+        // fail (assuming default is not declared and skip patterns are off).
+        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+
+        $result = $validator->validate(
+            'spec-fallback',
+            'GET',
+            '/with-5xx',
+            418,
+            [],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('Status code 418 not defined', $result->errors()[0]);
+    }
+
+    // ========================================
     // matchedStatusCode / matchedContentType propagation (#111)
     // ========================================
 

--- a/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
+++ b/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
@@ -164,6 +164,83 @@ class ResponseBodyValidatorTest extends TestCase
     }
 
     #[Test]
+    public function validate_accepts_empty_object_body_against_type_object(): void
+    {
+        // PHP's `json_decode('{}', true) === []` — the Laravel trait's
+        // associative-array decoding loses the {} vs [] distinction. Without
+        // schema-aware coercion the validator would reject `[]` against
+        // `type: object`. Pin the fix so empty-{} responses validate.
+        $content = [
+            'application/json' => [
+                'schema' => ['type' => 'object'],
+            ],
+        ];
+
+        $result = $this->validator->validate(
+            'spec',
+            'GET',
+            '/p',
+            200,
+            $content,
+            [],
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertSame([], $result->errors);
+    }
+
+    #[Test]
+    public function validate_accepts_empty_object_body_against_oas_31_nullable_object(): void
+    {
+        // OAS 3.1 type-array form: `type: ["object", "null"]`. Same coercion.
+        $content = [
+            'application/json' => [
+                'schema' => ['type' => ['object', 'null']],
+            ],
+        ];
+
+        $result = $this->validator->validate(
+            'spec',
+            'GET',
+            '/p',
+            200,
+            $content,
+            [],
+            'application/json',
+            OpenApiVersion::V3_1,
+        );
+
+        $this->assertSame([], $result->errors);
+    }
+
+    #[Test]
+    public function validate_does_not_coerce_empty_array_when_schema_is_array_type(): void
+    {
+        // Coercion must NOT fire when the schema actually wants an array —
+        // an empty array is a legitimate value for `type: array` (with no
+        // minItems constraint).
+        $content = [
+            'application/json' => [
+                'schema' => ['type' => 'array', 'items' => ['type' => 'string']],
+            ],
+        ];
+
+        $result = $this->validator->validate(
+            'spec',
+            'GET',
+            '/p',
+            200,
+            $content,
+            [],
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertSame([], $result->errors);
+    }
+
+    #[Test]
     public function validate_flags_schema_mismatch(): void
     {
         $content = [

--- a/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
+++ b/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
@@ -215,6 +215,75 @@ class ResponseBodyValidatorTest extends TestCase
     }
 
     #[Test]
+    public function validate_does_not_coerce_empty_array_when_schema_has_no_explicit_type(): void
+    {
+        // A schema that only declares `properties` (no `type`) is common in
+        // third-party specs. `schemaAcceptsObject` returns false for this
+        // shape — pin so a future "infer object from properties" change
+        // doesn't silently start coercing array bodies.
+        $content = [
+            'application/json' => [
+                'schema' => [
+                    'properties' => ['id' => ['type' => 'integer']],
+                ],
+            ],
+        ];
+
+        $result = $this->validator->validate(
+            'spec',
+            'GET',
+            '/p',
+            200,
+            $content,
+            [],
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        // No error AND no coercion fired — the property bag is permissive
+        // so empty input passes for either array or object interpretation.
+        // What we're pinning here: the implementation returned and we did
+        // not promote `[]` to `(object) []`. Verify by also recording the
+        // matched content type — the success path always sets it.
+        $this->assertSame([], $result->errors);
+        $this->assertSame('application/json', $result->matchedContentType);
+    }
+
+    #[Test]
+    public function validate_does_not_coerce_empty_array_for_oneof_with_object_branch(): void
+    {
+        // `oneOf: [{type: object, required: [foo]}]` with body `[]`. Composition
+        // keywords are NOT walked by `schemaAcceptsObject` — by design — so the
+        // body is validated as a JSON array against the oneOf and fails. Pin
+        // the design choice so a future "let's walk oneOf" change is forced
+        // through review.
+        $content = [
+            'application/json' => [
+                'schema' => [
+                    'oneOf' => [
+                        ['type' => 'object', 'required' => ['foo'], 'properties' => ['foo' => ['type' => 'string']]],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->validator->validate(
+            'spec',
+            'GET',
+            '/p',
+            200,
+            $content,
+            [],
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        // Coercion did NOT fire — body remained a JSON array, oneOf failed.
+        // (Tracker / orchestrator surface a non-empty errors list.)
+        $this->assertNotEmpty($result->errors);
+    }
+
+    #[Test]
     public function validate_does_not_coerce_empty_array_when_schema_is_array_type(): void
     {
         // Coercion must NOT fire when the schema actually wants an array —

--- a/tests/fixtures/specs/spec-fallback.json
+++ b/tests/fixtures/specs/spec-fallback.json
@@ -1,0 +1,105 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Spec response key fallback fixture",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/with-default": {
+      "get": {
+        "operationId": "withDefault",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {"type": "object"}
+              }
+            }
+          },
+          "default": {
+            "description": "Anything else",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["error"],
+                  "properties": {"error": {"type": "string"}}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/with-5xx": {
+      "get": {
+        "operationId": "with5xx",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {"type": "object"}
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error range",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["title"],
+                  "properties": {"title": {"type": "string"}}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/with-exact-and-range": {
+      "get": {
+        "operationId": "withExactAndRange",
+        "responses": {
+          "503": {
+            "description": "Specific 503 — should win over 5XX",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["specific"],
+                  "properties": {"specific": {"type": "boolean"}}
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Other 5xx",
+            "content": {
+              "application/json": {
+                "schema": {"type": "object"}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/lowercase-range": {
+      "get": {
+        "operationId": "lowercaseRange",
+        "responses": {
+          "5xx": {
+            "description": "lowercase variant",
+            "content": {
+              "application/json": {
+                "schema": {"type": "object"}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/specs/spec-fallback.json
+++ b/tests/fixtures/specs/spec-fallback.json
@@ -100,6 +100,94 @@
           }
         }
       }
+    },
+    "/with-range-and-default": {
+      "get": {
+        "operationId": "rangeAndDefault",
+        "responses": {
+          "5XX": {
+            "description": "Range key — should win over default for 5xx",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["from5xx"],
+                  "properties": {"from5xx": {"type": "boolean"}}
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Catch-all for non-5xx",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["fromDefault"],
+                  "properties": {"fromDefault": {"type": "boolean"}}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/with-each-range": {
+      "get": {
+        "operationId": "eachRange",
+        "responses": {
+          "1XX": {"description": "1xx", "content": {"application/json": {"schema": {"type": "object"}}}},
+          "2XX": {"description": "2xx", "content": {"application/json": {"schema": {"type": "object"}}}},
+          "3XX": {"description": "3xx", "content": {"application/json": {"schema": {"type": "object"}}}},
+          "4XX": {"description": "4xx", "content": {"application/json": {"schema": {"type": "object"}}}}
+        }
+      }
+    },
+    "/with-default-only": {
+      "get": {
+        "operationId": "defaultOnly200ExactCheck",
+        "responses": {
+          "200": {
+            "description": "Specific 200 — should win over default",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["fromExact200"],
+                  "properties": {"fromExact200": {"type": "boolean"}}
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "default — must NOT match for status 200",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["fromDefault"],
+                  "properties": {"fromDefault": {"type": "boolean"}}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/with-typo-and-default": {
+      "get": {
+        "operationId": "typoAndDefault",
+        "responses": {
+          "40": {
+            "description": "Typo (truncated 404) — should trigger malformed-key warning when fallback fires",
+            "content": {"application/json": {"schema": {"type": "object"}}}
+          },
+          "default": {
+            "description": "default catches the unmatched real status",
+            "content": {"application/json": {"schema": {"type": "object"}}}
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Closes the 5 issues that came out of the v0.12.0 dogfood session.

## Issues closed

| # | Severity | Description |
|---|---|---|
| #124 | 🔴 v1.0 blocker | Empty `{}` JSON body fails validation against `type: object` (PHP `json_decode` quirk) |
| #125 | 🟡 important | Support \`default\` response key as catch-all per OpenAPI spec |
| #126 | 🟡 important | Support \`1XX\`/\`2XX\`/\`3XX\`/\`4XX\`/\`5XX\` range keys per OpenAPI spec |
| #123 | 🟡 important | README comparison shows ❌ for response header validation but it ships in v0.12 |
| #127 | 🟢 nice-to-have | README Installation section omits \`symfony/yaml\` requirement for YAML specs |

## Highlights

### #124 — empty `{}` body
Body validator coerces `[]` → `stdClass` when the schema's top-level type explicitly accepts an object (`type: object` OR `type: [\"object\", ...]` for OAS 3.1). Composition keywords (`oneOf` / `anyOf` / `allOf`) intentionally do NOT trigger coercion — type-mismatch errors still surface for `type: array` schemas where the empty-array body is genuinely wrong.

### #125 + #126 — spec response key fallback
Validator now consults range keys + \`default\` when the literal status isn't declared. Lookup priority per OpenAPI 3.0/3.1:
1. **Exact** — spec declares `\"503\"`, response is 503
2. **Range** — spec declares `\"5XX\"` (or `\"5xx\"`), response is 503
3. **Default** — spec declares `\"default\"`, response is anything

Explicit codes take precedence over range keys; range keys take precedence over \`default\`. The matched spec key (preserving the spec author's casing) flows through to \`OpenApiValidationResult::matchedStatusCode()\` and into coverage rows.

### #123 + #127 — README
- Comparison table response header validation cell: ❌ → ✅
- Installation section gains a callout block for the \`symfony/yaml\` requirement

## Tests
New fixture \`tests/fixtures/specs/spec-fallback.json\` exercises every priority branch in \`resolveResponseKey()\`:
- Exact > range
- Range fallback (5XX matches 503)
- Default fallback (\`default\` matches 418)
- Lowercase \`5xx\` accepted
- Out-of-range rejection (5XX doesn't match 418)

Plus 3 new body-validator tests pinning the empty-{} coercion (type: object, type: [\"object\", \"null\"], type: array no-coerce).

## Quality gates
- PHPUnit: **819 tests / 1656 assertions** ✅
- PHPStan level 6: 0 errors ✅
- PHP-CS-Fixer: 0 violations ✅

## Test plan
- [x] All existing tests pass with the new fallback logic
- [x] Empty {} body validates against type: object
- [x] OAS 3.1 type-array form (\`type: [\"object\", \"null\"]\`) supported
- [x] Range key fallback returns spec author's casing
- [x] Exact > range > default precedence verified
- [x] README accurately reflects shipped features

Co-Authored-By: claude (opus-4.7)