### PR TITLE
New Feature: paratestおよびPest --parallel対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project is **pre-1.0**, so breaking changes may land in any minor release
 until 1.0.0 ships. Each entry below tags whether it is breaking.
 
+## Unreleased
+
+### Added
+
+- **#129 — paratest / Pest `--parallel` support**. Coverage state is
+  per-process, so parallel test runners previously produced N partial
+  reports that overwrote (`output_file`) or stacked
+  (`GITHUB_STEP_SUMMARY`). The extension now detects paratest workers via
+  `TEST_TOKEN` and writes per-worker JSON sidecars instead of rendering.
+  A new `vendor/bin/openapi-coverage-merge` CLI combines the sidecars
+  into a single report after the parallel run finishes — same workflow
+  shape as `phpunit/php-code-coverage` + `phpcov merge`. New
+  `sidecar_dir` parameter on `OpenApiCoverageExtension` configures the
+  worker drop point; `OpenApiCoverageTracker::exportState()` /
+  `importState()` expose the merge primitives for callers building
+  custom aggregators.
+- README "Parallel test runners" section documents the workflow,
+  sidecar directory defaults, and the merge CLI flags.
+
 ## v0.13.0 — 2026-04-25
 
 Spec compliance + critical bug fix surfaced by the v0.12.0 dogfood

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Add the coverage extension to your `phpunit.xml`:
 | `specs` | No | `front` | Comma-separated spec names for coverage tracking |
 | `output_file` | No | — | File path to write Markdown coverage report (relative paths resolve from `getcwd()`) |
 | `console_output` | No | `default` | Console output mode: `default`, `all`, or `uncovered_only` (overridden by `OPENAPI_CONSOLE_OUTPUT` env var) |
+| `sidecar_dir` | No | `sys_get_temp_dir()/openapi-coverage-sidecars` | Directory paratest workers drop per-worker JSON sidecars into. Used only under parallel test runners — see [Parallel test runners](#parallel-test-runners) below |
 
 *Not required if you call `OpenApiSpecLoader::configure()` manually.
 
@@ -621,6 +622,80 @@ Or via environment variable (takes priority over `phpunit.xml`):
 ```bash
 OPENAPI_CONSOLE_OUTPUT=uncovered_only vendor/bin/phpunit
 ```
+
+<a id="parallel-test-runners"></a>
+## Parallel test runners (paratest / Pest `--parallel`)
+
+Coverage state is per-process. Under parallel runners — `brianium/paratest` or
+`pest --parallel` (which delegates to paratest) — each worker boots its own
+PHPUnit, runs a slice of the suite, and would otherwise emit its own slice
+report. Without coordination the `output_file` ends up containing whichever
+worker finished last, and the `GITHUB_STEP_SUMMARY` ends up with N partial
+reports stacked on top of each other.
+
+The coverage extension solves this with a two-step workflow that mirrors
+`phpunit/php-code-coverage`:
+
+1. **Workers** drop a JSON sidecar per process. The extension auto-detects
+   paratest by looking at `TEST_TOKEN` (set in every paratest child) and
+   short-circuits rendering — no console output, no `output_file` write,
+   no `GITHUB_STEP_SUMMARY` append from the worker.
+2. **A single merge step** reads the sidecars, union-merges them via the
+   same rules `OpenApiCoverageTracker::recordResponse()` applies, and emits
+   the combined report.
+
+### Workflow
+
+```bash
+# 1. Run tests in parallel — workers write sidecars only.
+vendor/bin/pest --parallel --processes=4
+# (or `vendor/bin/paratest --processes=4`)
+
+# 2. Merge sidecars into a single coverage report.
+vendor/bin/openapi-coverage-merge \
+    --spec-base-path=openapi/bundled \
+    --specs=front,admin \
+    --output-file=coverage-report.md
+```
+
+`vendor/bin/openapi-coverage-merge` flags:
+
+| Flag | Default | Description |
+|---|---|---|
+| `--spec-base-path=<path>` | — (required) | Path to bundled spec directory |
+| `--specs=<a,b>` | `front` | Comma-separated spec names |
+| `--strip-prefixes=<a,b>` | — | Comma-separated request-path prefixes to strip |
+| `--sidecar-dir=<path>` | `sys_get_temp_dir()/openapi-coverage-sidecars` | Where workers wrote sidecars |
+| `--output-file=<path>` | — | Markdown report output path |
+| `--github-step-summary=<path>` | `$GITHUB_STEP_SUMMARY` | Append Markdown report to this file |
+| `--console-output=<mode>` | `default` | `default` / `all` / `uncovered_only` |
+| `--no-cleanup` | (cleanup is on by default) | Keep sidecar files after merge |
+
+Sidecar dir defaults are deliberately stable — workers and the merge CLI
+use the same `sys_get_temp_dir()/openapi-coverage-sidecars` path, so a
+trivial CI step has no extra config to keep in sync. Set `sidecar_dir` (in
+`phpunit.xml`) and `--sidecar-dir=` (on the merge CLI) to the same custom
+path if `sys_get_temp_dir()` is unavailable in your runner.
+
+### Notes
+
+- **Sequential runs are unchanged.** Without `TEST_TOKEN` the extension
+  renders inline as before. There is no need to wire the merge CLI into
+  non-parallel CI jobs.
+- **Worker counts are not exposed by paratest.** A child cannot reliably
+  tell how many siblings it has, so the merge has to run as a separate
+  step rather than auto-firing from "the last worker." This matches how
+  PHPUnit's own coverage merging works (`phpcov merge`).
+- **Sidecars are cleaned up by default.** Run with `--no-cleanup` if you
+  want to inspect the per-worker JSON for debugging.
+- **A failed sidecar write does not fail the test run.** Workers log a
+  warning to `STDERR` and let the suite finish — your contract assertions
+  already passed; sidecar I/O is a CI artifact concern.
+- **Stale sidecars across runs.** Cleanup-on-success removes sidecars after
+  every successful merge. If a previous run crashed before the merge step,
+  any leftover sidecars in the dir will be picked up by the next merge —
+  delete the sidecar dir at the start of CI if you can't trust the previous
+  run's exit code.
 
 ## CI Integration
 

--- a/README.md
+++ b/README.md
@@ -696,6 +696,16 @@ path if `sys_get_temp_dir()` is unavailable in your runner.
   any leftover sidecars in the dir will be picked up by the next merge —
   delete the sidecar dir at the start of CI if you can't trust the previous
   run's exit code.
+- **Worker write failures fail the merge loudly.** When a worker can't
+  persist its sidecar, it drops a `failed-<token>.json` marker. The merge
+  CLI exits non-zero (`FATAL`) when any markers are present, since a missing
+  worker would silently under-count coverage.
+- **HTTP `$ref` auto-resolution from the merge CLI.** The CLI calls
+  `OpenApiSpecLoader::configure()` with only `spec_base_path` and
+  `strip_prefixes` — `allowRemoteRefs` cannot be set via CLI flags. If your
+  spec uses HTTP(S) `$ref`, run the merge step from a process that calls
+  `OpenApiSpecLoader::configure(..., allowRemoteRefs: true, ...)` first
+  (e.g. a Composer script), or pre-bundle remote refs offline.
 
 ## CI Integration
 

--- a/bin/openapi-coverage-merge
+++ b/bin/openapi-coverage-merge
@@ -1,0 +1,36 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Studio\OpenApiContractTesting\PHPUnit\CoverageMergeCommand;
+
+// Locate the autoloader regardless of whether the binary is invoked from the
+// package's own `vendor/bin` (during local development) or from a downstream
+// project's `vendor/bin` (the typical install).
+$autoloadCandidates = [
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../autoload.php',
+];
+
+$autoload = null;
+foreach ($autoloadCandidates as $candidate) {
+    if (file_exists($candidate)) {
+        $autoload = $candidate;
+
+        break;
+    }
+}
+
+if ($autoload === null) {
+    fwrite(STDERR, "[OpenAPI Coverage] FATAL: could not locate Composer autoload.\n");
+    exit(1);
+}
+
+require $autoload;
+
+$argv = $_SERVER['argv'] ?? [];
+array_shift($argv); // drop script name
+
+$command = new CoverageMergeCommand();
+exit($command->run(CoverageMergeCommand::parseArgv($argv)));

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,9 @@
             "Studio\\OpenApiContractTesting\\": "src/"
         }
     },
+    "bin": [
+        "bin/openapi-coverage-merge"
+    ],
     "autoload-dev": {
         "psr-4": {
             "Studio\\OpenApiContractTesting\\Tests\\": "tests/"

--- a/src/OpenApiCoverageTracker.php
+++ b/src/OpenApiCoverageTracker.php
@@ -69,6 +69,13 @@ use function usort;
  *     responseSkipped: int,
  *     responseUncovered: int,
  * }
+ * @phpstan-type CoverageStatePayload array{
+ *     version: int,
+ *     specs: array<string, array<string, array{
+ *         requestReached: bool,
+ *         responses: array<string, array{state: string, hits: int, skipReason: ?string}>,
+ *     }>>,
+ * }
  */
 final class OpenApiCoverageTracker
 {
@@ -147,31 +154,12 @@ final class OpenApiCoverageTracker
         $responseKey = $statusKey . ':' . $contentKey;
 
         self::$covered[$specName][$endpointKey] ??= ['requestReached' => false, 'responses' => []];
-        $existing = self::$covered[$specName][$endpointKey]['responses'][$responseKey] ?? null;
-
-        if ($existing === null) {
-            self::$covered[$specName][$endpointKey]['responses'][$responseKey] = [
-                'state' => $schemaValidated ? ResponseCoverageState::Validated : ResponseCoverageState::Skipped,
-                'hits' => 1,
-                'skipReason' => $schemaValidated ? null : $skipReason,
-            ];
-
-            return;
-        }
-
-        $existing['hits']++;
-        if ($schemaValidated) {
-            // Promote skipped → validated; once validated, stay validated.
-            $existing['state'] = ResponseCoverageState::Validated;
-            $existing['skipReason'] = null;
-        } elseif ($existing['state'] === ResponseCoverageState::Skipped && $skipReason !== null) {
-            // Latest skipReason wins so the renderer surfaces the most recent
-            // skip pattern (typically all-the-same in practice; but we don't
-            // want to hide a per-test override).
-            $existing['skipReason'] = $skipReason;
-        }
-
-        self::$covered[$specName][$endpointKey]['responses'][$responseKey] = $existing;
+        self::$covered[$specName][$endpointKey]['responses'][$responseKey] = self::reconcileResponse(
+            self::$covered[$specName][$endpointKey]['responses'][$responseKey] ?? null,
+            $schemaValidated ? ResponseCoverageState::Validated : ResponseCoverageState::Skipped,
+            1,
+            $skipReason,
+        );
     }
 
     public static function reset(): void
@@ -188,13 +176,7 @@ final class OpenApiCoverageTracker
      * a 1:1 mirror of the internal {@see self::$covered} representation, so
      * round-tripping through JSON is lossless when no other writes occur.
      *
-     * @return array{
-     *     version: int,
-     *     specs: array<string, array<string, array{
-     *         requestReached: bool,
-     *         responses: array<string, array{state: string, hits: int, skipReason: ?string}>,
-     *     }>>,
-     * }
+     * @return CoverageStatePayload
      */
     public static function exportState(): array
     {
@@ -226,16 +208,19 @@ final class OpenApiCoverageTracker
      * merge CLI to combine N paratest worker sidecars into a single report.
      *
      * Merge rules mirror the single-process {@see self::recordResponse()}
-     * promotion semantics so the result is indistinguishable from running
-     * all the underlying records in one process:
+     * promotion semantics — the two paths share
+     * {@see self::reconcileResponse()} so they cannot drift:
      *
      * - `requestReached` is OR-merged.
      * - For each `(statusKey, contentTypeKey)` pair, hits accumulate.
      * - `validated` wins over `skipped`. Once an existing entry is
      *   validated, an incoming `skipped` does not demote it.
      * - When both sides are `skipped`, the incoming `skipReason` wins
-     *   when non-null (matches the latest-record-wins behavior of
-     *   {@see self::recordResponse()}).
+     *   when non-null (latest-record-wins).
+     *
+     * Validation is two-pass: the entire payload is parsed and rejected
+     * up front before any state is mutated, so a malformed entry deep in
+     * the payload cannot leave the tracker in a partially-merged state.
      *
      * @param array<string, mixed> $state
      *
@@ -243,29 +228,21 @@ final class OpenApiCoverageTracker
      */
     public static function importState(array $state): void
     {
-        if (!array_key_exists('version', $state)) {
-            throw new InvalidArgumentException('coverage state payload is missing "version"');
-        }
-        if ($state['version'] !== self::STATE_FORMAT_VERSION) {
-            throw new InvalidArgumentException(sprintf(
-                'unsupported coverage state version: %s (expected %d)',
-                is_int($state['version']) || is_string($state['version']) ? (string) $state['version'] : get_debug_type($state['version']),
-                self::STATE_FORMAT_VERSION,
-            ));
-        }
-        if (!isset($state['specs']) || !is_array($state['specs'])) {
-            throw new InvalidArgumentException('coverage state payload is missing "specs" map');
-        }
-
-        foreach ($state['specs'] as $specName => $endpoints) {
-            if (!is_string($specName) || !is_array($endpoints)) {
-                throw new InvalidArgumentException('invalid spec entry in coverage state payload');
-            }
+        $normalised = self::validateStatePayload($state);
+        foreach ($normalised as $specName => $endpoints) {
             foreach ($endpoints as $endpointKey => $entry) {
-                if (!is_string($endpointKey) || !is_array($entry)) {
-                    throw new InvalidArgumentException('invalid endpoint entry in coverage state payload');
+                self::$covered[$specName][$endpointKey] ??= ['requestReached' => false, 'responses' => []];
+                if ($entry['requestReached']) {
+                    self::$covered[$specName][$endpointKey]['requestReached'] = true;
                 }
-                self::mergeEndpointEntry($specName, $endpointKey, $entry);
+                foreach ($entry['responses'] as $responseKey => $row) {
+                    self::$covered[$specName][$endpointKey]['responses'][$responseKey] = self::reconcileResponse(
+                        self::$covered[$specName][$endpointKey]['responses'][$responseKey] ?? null,
+                        $row['state'],
+                        $row['hits'],
+                        $row['skipReason'],
+                    );
+                }
             }
         }
     }
@@ -392,20 +369,114 @@ final class OpenApiCoverageTracker
     }
 
     /**
-     * @param array<string, mixed> $entry
+     * Apply one (statusKey, contentTypeKey) observation onto an existing
+     * recorded entry (or create a new one). The single source of truth for
+     * the tracker's promotion semantics — shared between
+     * {@see self::recordResponse()} (single-record path) and the bulk-merge
+     * path used by {@see self::importState()} so the two cannot drift.
+     *
+     * Rules:
+     * - new entry: store as-is, with `skipReason` cleared on Validated;
+     * - hits accumulate;
+     * - Validated wins over Skipped and clears `skipReason`;
+     * - Skipped + Skipped: latest non-null `skipReason` wins.
+     *
+     * @param null|RecordedResponseCoverage $existing
+     *
+     * @return RecordedResponseCoverage
      */
-    private static function mergeEndpointEntry(string $specName, string $endpointKey, array $entry): void
+    private static function reconcileResponse(
+        ?array $existing,
+        ResponseCoverageState $incomingState,
+        int $incomingHits,
+        ?string $incomingSkipReason,
+    ): array {
+        if ($existing === null) {
+            return [
+                'state' => $incomingState,
+                'hits' => $incomingHits,
+                'skipReason' => $incomingState === ResponseCoverageState::Validated ? null : $incomingSkipReason,
+            ];
+        }
+
+        $existing['hits'] += $incomingHits;
+        if ($incomingState === ResponseCoverageState::Validated) {
+            // Promote skipped → validated; once validated, stay validated.
+            $existing['state'] = ResponseCoverageState::Validated;
+            $existing['skipReason'] = null;
+        } elseif (
+            $existing['state'] === ResponseCoverageState::Skipped &&
+            $incomingState === ResponseCoverageState::Skipped &&
+            $incomingSkipReason !== null
+        ) {
+            // Latest skipReason wins so the renderer surfaces the most recent
+            // skip pattern. Typically all-the-same in practice but per-test
+            // overrides should not be silently dropped.
+            $existing['skipReason'] = $incomingSkipReason;
+        }
+
+        return $existing;
+    }
+
+    /**
+     * Validate the payload structurally and resolve enums up-front. Returns
+     * a normalised, fully-typed structure ready for direct application.
+     * Throwing at any point leaves {@see self::$covered} untouched.
+     *
+     * @param array<string, mixed> $state
+     *
+     * @return array<string, array<string, array{
+     *     requestReached: bool,
+     *     responses: array<string, RecordedResponseCoverage>,
+     * }>>
+     */
+    private static function validateStatePayload(array $state): array
+    {
+        if (!array_key_exists('version', $state)) {
+            throw new InvalidArgumentException('coverage state payload is missing "version"');
+        }
+        if ($state['version'] !== self::STATE_FORMAT_VERSION) {
+            throw new InvalidArgumentException(sprintf(
+                'unsupported coverage state version: %s (expected %d)',
+                is_int($state['version']) || is_string($state['version']) ? (string) $state['version'] : get_debug_type($state['version']),
+                self::STATE_FORMAT_VERSION,
+            ));
+        }
+        if (!isset($state['specs']) || !is_array($state['specs'])) {
+            throw new InvalidArgumentException('coverage state payload is missing "specs" map');
+        }
+
+        $normalised = [];
+        foreach ($state['specs'] as $specName => $endpoints) {
+            if (!is_string($specName) || !is_array($endpoints)) {
+                throw new InvalidArgumentException('invalid spec entry in coverage state payload');
+            }
+            $normalisedEndpoints = [];
+            foreach ($endpoints as $endpointKey => $entry) {
+                if (!is_string($endpointKey) || !is_array($entry)) {
+                    throw new InvalidArgumentException('invalid endpoint entry in coverage state payload');
+                }
+                $normalisedEndpoints[$endpointKey] = self::normaliseEndpointEntry($entry);
+            }
+            $normalised[$specName] = $normalisedEndpoints;
+        }
+
+        return $normalised;
+    }
+
+    /**
+     * @param array<string, mixed> $entry
+     *
+     * @return array{requestReached: bool, responses: array<string, RecordedResponseCoverage>}
+     */
+    private static function normaliseEndpointEntry(array $entry): array
     {
         $requestReached = isset($entry['requestReached']) && is_bool($entry['requestReached'])
             ? $entry['requestReached']
             : false;
         $responses = isset($entry['responses']) && is_array($entry['responses']) ? $entry['responses'] : [];
 
-        self::$covered[$specName][$endpointKey] ??= ['requestReached' => false, 'responses' => []];
-        if ($requestReached) {
-            self::$covered[$specName][$endpointKey]['requestReached'] = true;
-        }
-
+        $normalisedResponses = [];
         foreach ($responses as $responseKey => $row) {
             if (!is_string($responseKey) || !is_array($row)) {
                 throw new InvalidArgumentException('invalid response entry in coverage state payload');
@@ -418,34 +489,14 @@ final class OpenApiCoverageTracker
             if ($state === null) {
                 throw new InvalidArgumentException(sprintf('invalid response state "%s" in coverage state payload', $stateRaw));
             }
-            $hits = isset($row['hits']) && is_int($row['hits']) ? $row['hits'] : 0;
-            $skipReason = isset($row['skipReason']) && is_string($row['skipReason']) ? $row['skipReason'] : null;
-
-            $existing = self::$covered[$specName][$endpointKey]['responses'][$responseKey] ?? null;
-            if ($existing === null) {
-                self::$covered[$specName][$endpointKey]['responses'][$responseKey] = [
-                    'state' => $state,
-                    'hits' => $hits,
-                    'skipReason' => $skipReason,
-                ];
-
-                continue;
-            }
-
-            $existing['hits'] += $hits;
-            if ($state === ResponseCoverageState::Validated) {
-                $existing['state'] = ResponseCoverageState::Validated;
-                $existing['skipReason'] = null;
-            } elseif (
-                $existing['state'] === ResponseCoverageState::Skipped &&
-                $state === ResponseCoverageState::Skipped &&
-                $skipReason !== null
-            ) {
-                $existing['skipReason'] = $skipReason;
-            }
-
-            self::$covered[$specName][$endpointKey]['responses'][$responseKey] = $existing;
+            $normalisedResponses[$responseKey] = [
+                'state' => $state,
+                'hits' => isset($row['hits']) && is_int($row['hits']) ? $row['hits'] : 0,
+                'skipReason' => isset($row['skipReason']) && is_string($row['skipReason']) ? $row['skipReason'] : null,
+            ];
         }
+
+        return ['requestReached' => $requestReached, 'responses' => $normalisedResponses];
     }
 
     private static function endpointKey(string $method, string $path): string

--- a/src/OpenApiCoverageTracker.php
+++ b/src/OpenApiCoverageTracker.php
@@ -6,11 +6,16 @@ namespace Studio\OpenApiContractTesting;
 
 use const E_USER_WARNING;
 
+use InvalidArgumentException;
+
+use function array_key_exists;
 use function array_keys;
 use function count;
 use function get_debug_type;
 use function in_array;
 use function is_array;
+use function is_bool;
+use function is_int;
 use function is_string;
 use function preg_match;
 use function sprintf;
@@ -73,6 +78,13 @@ final class OpenApiCoverageTracker
      * response has no `content` block.
      */
     public const ANY_CONTENT_TYPE = '*';
+
+    /**
+     * Format version stamped on every {@see self::exportState()} payload.
+     * Bumped on incompatible structural changes; importers must reject
+     * unknown versions to avoid misinterpreting future shapes.
+     */
+    public const STATE_FORMAT_VERSION = 1;
 
     /**
      * Per-(spec, endpoint) coverage state. Endpoint key is `"{METHOD} {path}"`.
@@ -165,6 +177,97 @@ final class OpenApiCoverageTracker
     public static function reset(): void
     {
         self::$covered = [];
+    }
+
+    /**
+     * Snapshot the current tracker state as a JSON-safe array. Used by the
+     * paratest worker sidecar writer; the merge CLI reconstructs state via
+     * {@see self::importState()}.
+     *
+     * Enums are serialized as their string `value`. The shape is otherwise
+     * a 1:1 mirror of the internal {@see self::$covered} representation, so
+     * round-tripping through JSON is lossless when no other writes occur.
+     *
+     * @return array{
+     *     version: int,
+     *     specs: array<string, array<string, array{
+     *         requestReached: bool,
+     *         responses: array<string, array{state: string, hits: int, skipReason: ?string}>,
+     *     }>>,
+     * }
+     */
+    public static function exportState(): array
+    {
+        $specs = [];
+        foreach (self::$covered as $specName => $endpoints) {
+            $specOut = [];
+            foreach ($endpoints as $endpointKey => $entry) {
+                $responses = [];
+                foreach ($entry['responses'] as $responseKey => $row) {
+                    $responses[$responseKey] = [
+                        'state' => $row['state']->value,
+                        'hits' => $row['hits'],
+                        'skipReason' => $row['skipReason'] ?? null,
+                    ];
+                }
+                $specOut[$endpointKey] = [
+                    'requestReached' => $entry['requestReached'],
+                    'responses' => $responses,
+                ];
+            }
+            $specs[$specName] = $specOut;
+        }
+
+        return ['version' => self::STATE_FORMAT_VERSION, 'specs' => $specs];
+    }
+
+    /**
+     * Union-merge an exported state into the live tracker. Used by the
+     * merge CLI to combine N paratest worker sidecars into a single report.
+     *
+     * Merge rules mirror the single-process {@see self::recordResponse()}
+     * promotion semantics so the result is indistinguishable from running
+     * all the underlying records in one process:
+     *
+     * - `requestReached` is OR-merged.
+     * - For each `(statusKey, contentTypeKey)` pair, hits accumulate.
+     * - `validated` wins over `skipped`. Once an existing entry is
+     *   validated, an incoming `skipped` does not demote it.
+     * - When both sides are `skipped`, the incoming `skipReason` wins
+     *   when non-null (matches the latest-record-wins behavior of
+     *   {@see self::recordResponse()}).
+     *
+     * @param array<string, mixed> $state
+     *
+     * @throws InvalidArgumentException when the payload shape is unrecognised
+     */
+    public static function importState(array $state): void
+    {
+        if (!array_key_exists('version', $state)) {
+            throw new InvalidArgumentException('coverage state payload is missing "version"');
+        }
+        if ($state['version'] !== self::STATE_FORMAT_VERSION) {
+            throw new InvalidArgumentException(sprintf(
+                'unsupported coverage state version: %s (expected %d)',
+                is_int($state['version']) || is_string($state['version']) ? (string) $state['version'] : get_debug_type($state['version']),
+                self::STATE_FORMAT_VERSION,
+            ));
+        }
+        if (!isset($state['specs']) || !is_array($state['specs'])) {
+            throw new InvalidArgumentException('coverage state payload is missing "specs" map');
+        }
+
+        foreach ($state['specs'] as $specName => $endpoints) {
+            if (!is_string($specName) || !is_array($endpoints)) {
+                throw new InvalidArgumentException('invalid spec entry in coverage state payload');
+            }
+            foreach ($endpoints as $endpointKey => $entry) {
+                if (!is_string($endpointKey) || !is_array($entry)) {
+                    throw new InvalidArgumentException('invalid endpoint entry in coverage state payload');
+                }
+                self::mergeEndpointEntry($specName, $endpointKey, $entry);
+            }
+        }
     }
 
     /**
@@ -286,6 +389,63 @@ final class OpenApiCoverageTracker
             'responseSkipped' => $responseSkipped,
             'responseUncovered' => $responseTotal - $responseCovered - $responseSkipped,
         ];
+    }
+
+    /**
+     * @param array<string, mixed> $entry
+     */
+    private static function mergeEndpointEntry(string $specName, string $endpointKey, array $entry): void
+    {
+        $requestReached = isset($entry['requestReached']) && is_bool($entry['requestReached'])
+            ? $entry['requestReached']
+            : false;
+        $responses = isset($entry['responses']) && is_array($entry['responses']) ? $entry['responses'] : [];
+
+        self::$covered[$specName][$endpointKey] ??= ['requestReached' => false, 'responses' => []];
+        if ($requestReached) {
+            self::$covered[$specName][$endpointKey]['requestReached'] = true;
+        }
+
+        foreach ($responses as $responseKey => $row) {
+            if (!is_string($responseKey) || !is_array($row)) {
+                throw new InvalidArgumentException('invalid response entry in coverage state payload');
+            }
+            $stateRaw = $row['state'] ?? null;
+            if (!is_string($stateRaw)) {
+                throw new InvalidArgumentException('invalid response state in coverage state payload');
+            }
+            $state = ResponseCoverageState::tryFrom($stateRaw);
+            if ($state === null) {
+                throw new InvalidArgumentException(sprintf('invalid response state "%s" in coverage state payload', $stateRaw));
+            }
+            $hits = isset($row['hits']) && is_int($row['hits']) ? $row['hits'] : 0;
+            $skipReason = isset($row['skipReason']) && is_string($row['skipReason']) ? $row['skipReason'] : null;
+
+            $existing = self::$covered[$specName][$endpointKey]['responses'][$responseKey] ?? null;
+            if ($existing === null) {
+                self::$covered[$specName][$endpointKey]['responses'][$responseKey] = [
+                    'state' => $state,
+                    'hits' => $hits,
+                    'skipReason' => $skipReason,
+                ];
+
+                continue;
+            }
+
+            $existing['hits'] += $hits;
+            if ($state === ResponseCoverageState::Validated) {
+                $existing['state'] = ResponseCoverageState::Validated;
+                $existing['skipReason'] = null;
+            } elseif (
+                $existing['state'] === ResponseCoverageState::Skipped &&
+                $state === ResponseCoverageState::Skipped &&
+                $skipReason !== null
+            ) {
+                $existing['skipReason'] = $skipReason;
+            }
+
+            self::$covered[$specName][$endpointKey]['responses'][$responseKey] = $existing;
+        }
     }
 
     private static function endpointKey(string $method, string $path): string

--- a/src/PHPUnit/CoverageMergeCommand.php
+++ b/src/PHPUnit/CoverageMergeCommand.php
@@ -1,0 +1,329 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\PHPUnit;
+
+use const FILE_APPEND;
+
+use InvalidArgumentException;
+use RuntimeException;
+use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
+use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\SpecFileNotFoundException;
+
+use function array_filter;
+use function array_map;
+use function array_values;
+use function explode;
+use function file_put_contents;
+use function getcwd;
+use function getenv;
+use function in_array;
+use function is_array;
+use function is_bool;
+use function is_callable;
+use function is_string;
+use function sprintf;
+use function str_contains;
+use function str_replace;
+use function str_starts_with;
+use function substr;
+use function unlink;
+
+/**
+ * Aggregates worker sidecars (produced by {@see CoverageReportSubscriber} in
+ * paratest mode) into a single coverage report — the parallel-runner
+ * counterpart to the in-process subscriber rendering.
+ *
+ * Designed to be invoked from `bin/openapi-coverage-merge` after `pest
+ * --parallel` / `paratest` finishes, but the actual work lives here as a
+ * class so it can be unit-tested without spawning a subprocess.
+ */
+final class CoverageMergeCommand
+{
+    /**
+     * @param null|callable(string): void $stderrWriter Optional sink for warnings; defaults to STDERR.
+     */
+    public function __construct(
+        private mixed $stderrWriter = null,
+        private mixed $stdoutWriter = null,
+    ) {}
+
+    /**
+     * Parse argv into the option array consumed by {@see self::run()}. Kept
+     * separate so unit tests can drive `run()` directly with a structured
+     * payload while the CLI binary parses real `--flag=value` arguments.
+     *
+     * @param list<string> $argv excluding the script name
+     *
+     * @return array{
+     *     sidecar_dir?: string,
+     *     spec_base_path?: string,
+     *     specs?: list<string>,
+     *     strip_prefixes?: list<string>,
+     *     output_file?: string,
+     *     github_step_summary?: string,
+     *     console_output?: string,
+     *     cleanup?: bool,
+     *     help?: bool,
+     * }
+     */
+    public static function parseArgv(array $argv): array
+    {
+        $opts = [];
+        foreach ($argv as $arg) {
+            if ($arg === '--help' || $arg === '-h') {
+                $opts['help'] = true;
+
+                continue;
+            }
+            if (!str_starts_with($arg, '--')) {
+                continue;
+            }
+            $rest = substr($arg, 2);
+            if (str_contains($rest, '=')) {
+                [$name, $value] = explode('=', $rest, 2);
+            } else {
+                $name = $rest;
+                $value = 'true';
+            }
+            $name = str_replace('-', '_', $name);
+
+            switch ($name) {
+                case 'specs':
+                case 'strip_prefixes':
+                    $opts[$name] = array_values(array_filter(array_map('trim', explode(',', $value)), static fn(string $v): bool => $v !== ''));
+
+                    break;
+                case 'cleanup':
+                    $opts['cleanup'] = !in_array($value, ['0', 'false', 'no'], true);
+
+                    break;
+                case 'no_cleanup':
+                    $opts['cleanup'] = false;
+
+                    break;
+                default:
+                    $opts[$name] = $value;
+            }
+        }
+
+        /** @var array{
+         *     sidecar_dir?: string,
+         *     spec_base_path?: string,
+         *     specs?: list<string>,
+         *     strip_prefixes?: list<string>,
+         *     output_file?: string,
+         *     github_step_summary?: string,
+         *     console_output?: string,
+         *     cleanup?: bool,
+         *     help?: bool,
+         * } $opts
+         */
+        return $opts;
+    }
+
+    public static function usage(): string
+    {
+        return <<<USAGE
+            openapi-coverage-merge — combine paratest worker sidecars into one coverage report.
+
+            Usage:
+              openapi-coverage-merge --spec-base-path=<path> [options]
+
+            Options:
+              --spec-base-path=<path>       Path to bundled spec directory (required).
+              --specs=<a,b>                 Comma-separated spec names. Defaults to "front".
+              --strip-prefixes=<a,b>        Comma-separated request-path prefixes to strip.
+              --sidecar-dir=<path>          Worker sidecar directory. Defaults to
+                                            sys_get_temp_dir()/openapi-coverage-sidecars.
+              --output-file=<path>          Markdown report output path.
+              --github-step-summary=<path>  Append Markdown report to this file (also
+                                            consults GITHUB_STEP_SUMMARY env var).
+              --console-output=<mode>       default | all | uncovered_only.
+              --no-cleanup                  Keep sidecar files after merge (default: cleanup).
+              --help                        Show this message.
+
+            USAGE;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @return int 0 on success, non-zero on misconfiguration / I/O failure
+     */
+    public function run(array $options): int
+    {
+        if (($options['help'] ?? false) === true) {
+            $this->writeStdout(self::usage());
+
+            return 0;
+        }
+
+        $sidecarDir = isset($options['sidecar_dir']) && is_string($options['sidecar_dir']) && $options['sidecar_dir'] !== ''
+            ? $this->absolutise($options['sidecar_dir'])
+            : OpenApiCoverageExtension::defaultSidecarDir();
+
+        $specs = isset($options['specs']) && is_array($options['specs']) ? array_values($options['specs']) : ['front'];
+        $specBasePath = isset($options['spec_base_path']) && is_string($options['spec_base_path']) && $options['spec_base_path'] !== ''
+            ? $this->absolutise($options['spec_base_path'])
+            : null;
+        $stripPrefixes = isset($options['strip_prefixes']) && is_array($options['strip_prefixes']) ? array_values($options['strip_prefixes']) : [];
+        $outputFile = isset($options['output_file']) && is_string($options['output_file']) && $options['output_file'] !== ''
+            ? $this->absolutise($options['output_file'])
+            : null;
+        $githubSummaryPath = isset($options['github_step_summary']) && is_string($options['github_step_summary']) && $options['github_step_summary'] !== ''
+            ? $options['github_step_summary']
+            : (getenv('GITHUB_STEP_SUMMARY') ?: null);
+        $consoleOutput = ConsoleOutput::resolve(isset($options['console_output']) && is_string($options['console_output']) ? $options['console_output'] : null);
+        $cleanup = isset($options['cleanup']) && is_bool($options['cleanup']) ? $options['cleanup'] : true;
+
+        if ($specBasePath === null) {
+            $this->writeStderr("[OpenAPI Coverage] FATAL: --spec-base-path is required\n");
+
+            return 2;
+        }
+
+        $payloads = $this->loadPayloads($sidecarDir);
+        if ($payloads === []) {
+            $this->writeStderr(sprintf("[OpenAPI Coverage] WARNING: no sidecars found in %s\n", $sidecarDir));
+
+            return 0;
+        }
+
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure($specBasePath, $stripPrefixes);
+
+        OpenApiCoverageTracker::reset();
+        foreach ($payloads as $payload) {
+            try {
+                OpenApiCoverageTracker::importState($payload);
+            } catch (InvalidArgumentException $e) {
+                $this->writeStderr(sprintf("[OpenAPI Coverage] FATAL: invalid sidecar payload: %s\n", $e->getMessage()));
+
+                return 1;
+            }
+        }
+
+        $results = $this->computeResults($specs);
+        if ($results === []) {
+            $this->writeStderr("[OpenAPI Coverage] WARNING: no coverage recorded across sidecars\n");
+
+            if ($cleanup) {
+                $this->cleanup($sidecarDir);
+            }
+
+            return 0;
+        }
+
+        $this->writeStdout(ConsoleCoverageRenderer::render($results, $consoleOutput));
+
+        if ($outputFile !== null || $githubSummaryPath !== null) {
+            $markdown = MarkdownCoverageRenderer::render($results);
+
+            if ($outputFile !== null && file_put_contents($outputFile, $markdown) === false) {
+                $this->writeStderr(sprintf("[OpenAPI Coverage] WARNING: Failed to write Markdown report to %s\n", $outputFile));
+            }
+            if ($githubSummaryPath !== null && file_put_contents($githubSummaryPath, $markdown . "\n", FILE_APPEND) === false) {
+                $this->writeStderr(sprintf("[OpenAPI Coverage] WARNING: Failed to append Markdown report to GITHUB_STEP_SUMMARY (%s)\n", $githubSummaryPath));
+            }
+        }
+
+        if ($cleanup) {
+            $this->cleanup($sidecarDir);
+        }
+
+        return 0;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function loadPayloads(string $sidecarDir): array
+    {
+        try {
+            return CoverageSidecarReader::readDir($sidecarDir);
+        } catch (RuntimeException $e) {
+            $this->writeStderr(sprintf("[OpenAPI Coverage] FATAL: %s\n", $e->getMessage()));
+
+            return [];
+        }
+    }
+
+    /**
+     * @param list<string> $specs
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private function computeResults(array $specs): array
+    {
+        $hasCoverage = false;
+        foreach ($specs as $spec) {
+            if (OpenApiCoverageTracker::hasAnyCoverage($spec)) {
+                $hasCoverage = true;
+
+                break;
+            }
+        }
+        if (!$hasCoverage) {
+            return [];
+        }
+
+        $results = [];
+        foreach ($specs as $spec) {
+            try {
+                $results[$spec] = OpenApiCoverageTracker::computeCoverage($spec);
+            } catch (SpecFileNotFoundException $e) {
+                $this->writeStderr(sprintf("[OpenAPI Coverage] WARNING: Skipping spec '%s': %s\n", $spec, $e->getMessage()));
+            } catch (InvalidOpenApiSpecException $e) {
+                $this->writeStderr(sprintf("[OpenAPI Coverage] FATAL: Invalid OpenAPI spec '%s': %s\n", $spec, $e->getMessage()));
+
+                throw $e;
+            }
+        }
+
+        return $results;
+    }
+
+    private function cleanup(string $sidecarDir): void
+    {
+        foreach (CoverageSidecarReader::listPaths($sidecarDir) as $path) {
+            @unlink($path);
+        }
+    }
+
+    private function absolutise(string $path): string
+    {
+        if (str_starts_with($path, '/')) {
+            return $path;
+        }
+
+        return (getcwd() ?: '.') . '/' . $path;
+    }
+
+    private function writeStderr(string $message): void
+    {
+        $writer = $this->stderrWriter;
+        if (is_callable($writer)) {
+            $writer($message);
+
+            return;
+        }
+
+        OpenApiCoverageExtension::writeStderr($message);
+    }
+
+    private function writeStdout(string $message): void
+    {
+        $writer = $this->stdoutWriter;
+        if (is_callable($writer)) {
+            $writer($message);
+
+            return;
+        }
+
+        echo $message;
+    }
+}

--- a/src/PHPUnit/CoverageMergeCommand.php
+++ b/src/PHPUnit/CoverageMergeCommand.php
@@ -16,15 +16,13 @@ use Studio\OpenApiContractTesting\SpecFileNotFoundException;
 use function array_filter;
 use function array_map;
 use function array_values;
+use function count;
 use function explode;
 use function file_put_contents;
 use function getcwd;
 use function getenv;
 use function in_array;
-use function is_array;
-use function is_bool;
 use function is_callable;
-use function is_string;
 use function sprintf;
 use function str_contains;
 use function str_replace;
@@ -37,9 +35,22 @@ use function unlink;
  * paratest mode) into a single coverage report — the parallel-runner
  * counterpart to the in-process subscriber rendering.
  *
- * Designed to be invoked from `bin/openapi-coverage-merge` after `pest
- * --parallel` / `paratest` finishes, but the actual work lives here as a
- * class so it can be unit-tested without spawning a subprocess.
+ * Designed to be invoked as a separate step after the parallel test run
+ * finishes (e.g. via `bin/openapi-coverage-merge`), but the actual work
+ * lives here as a class so it can be unit-tested without spawning a
+ * subprocess.
+ *
+ * @phpstan-type MergeOptions array{
+ *     sidecar_dir?: string,
+ *     spec_base_path?: string,
+ *     specs?: list<string>,
+ *     strip_prefixes?: list<string>,
+ *     output_file?: string,
+ *     github_step_summary?: string,
+ *     console_output?: string,
+ *     cleanup?: bool,
+ *     help?: bool,
+ * }
  */
 final class CoverageMergeCommand
 {
@@ -58,17 +69,7 @@ final class CoverageMergeCommand
      *
      * @param list<string> $argv excluding the script name
      *
-     * @return array{
-     *     sidecar_dir?: string,
-     *     spec_base_path?: string,
-     *     specs?: list<string>,
-     *     strip_prefixes?: list<string>,
-     *     output_file?: string,
-     *     github_step_summary?: string,
-     *     console_output?: string,
-     *     cleanup?: bool,
-     *     help?: bool,
-     * }
+     * @return MergeOptions
      */
     public static function parseArgv(array $argv): array
     {
@@ -110,18 +111,7 @@ final class CoverageMergeCommand
             }
         }
 
-        /** @var array{
-         *     sidecar_dir?: string,
-         *     spec_base_path?: string,
-         *     specs?: list<string>,
-         *     strip_prefixes?: list<string>,
-         *     output_file?: string,
-         *     github_step_summary?: string,
-         *     console_output?: string,
-         *     cleanup?: bool,
-         *     help?: bool,
-         * } $opts
-         */
+        /** @var MergeOptions $opts */
         return $opts;
     }
 
@@ -150,7 +140,7 @@ final class CoverageMergeCommand
     }
 
     /**
-     * @param array<string, mixed> $options
+     * @param MergeOptions $options
      *
      * @return int 0 on success, non-zero on misconfiguration / I/O failure
      */
@@ -162,23 +152,27 @@ final class CoverageMergeCommand
             return 0;
         }
 
-        $sidecarDir = isset($options['sidecar_dir']) && is_string($options['sidecar_dir']) && $options['sidecar_dir'] !== ''
+        $sidecarDir = isset($options['sidecar_dir']) && $options['sidecar_dir'] !== ''
             ? $this->absolutise($options['sidecar_dir'])
             : OpenApiCoverageExtension::defaultSidecarDir();
 
-        $specs = isset($options['specs']) && is_array($options['specs']) ? array_values($options['specs']) : ['front'];
-        $specBasePath = isset($options['spec_base_path']) && is_string($options['spec_base_path']) && $options['spec_base_path'] !== ''
+        // Empty `--specs=` is treated as "use default" rather than "use no
+        // specs". Otherwise a misconfigured CLI invocation would silently
+        // exit with "no coverage recorded" instead of warning the user.
+        $specs = isset($options['specs']) && $options['specs'] !== [] ? $options['specs'] : ['front'];
+
+        $specBasePath = isset($options['spec_base_path']) && $options['spec_base_path'] !== ''
             ? $this->absolutise($options['spec_base_path'])
             : null;
-        $stripPrefixes = isset($options['strip_prefixes']) && is_array($options['strip_prefixes']) ? array_values($options['strip_prefixes']) : [];
-        $outputFile = isset($options['output_file']) && is_string($options['output_file']) && $options['output_file'] !== ''
+        $stripPrefixes = $options['strip_prefixes'] ?? [];
+        $outputFile = isset($options['output_file']) && $options['output_file'] !== ''
             ? $this->absolutise($options['output_file'])
             : null;
-        $githubSummaryPath = isset($options['github_step_summary']) && is_string($options['github_step_summary']) && $options['github_step_summary'] !== ''
+        $githubSummaryPath = isset($options['github_step_summary']) && $options['github_step_summary'] !== ''
             ? $options['github_step_summary']
             : (getenv('GITHUB_STEP_SUMMARY') ?: null);
-        $consoleOutput = ConsoleOutput::resolve(isset($options['console_output']) && is_string($options['console_output']) ? $options['console_output'] : null);
-        $cleanup = isset($options['cleanup']) && is_bool($options['cleanup']) ? $options['cleanup'] : true;
+        $consoleOutput = ConsoleOutput::resolve($options['console_output'] ?? null);
+        $cleanup = $options['cleanup'] ?? true;
 
         if ($specBasePath === null) {
             $this->writeStderr("[OpenAPI Coverage] FATAL: --spec-base-path is required\n");
@@ -186,7 +180,29 @@ final class CoverageMergeCommand
             return 2;
         }
 
-        $payloads = $this->loadPayloads($sidecarDir);
+        // Detect worker failure markers BEFORE attempting the merge: even
+        // one missing worker means the report under-counts coverage, which
+        // is exactly the silent failure parallel-mode introduced. Fail
+        // loudly so CI gating sees a non-zero exit.
+        $failureMarkers = CoverageSidecarReader::listFailureMarkerPaths($sidecarDir);
+        if ($failureMarkers !== []) {
+            $this->writeStderr(sprintf(
+                "[OpenAPI Coverage] FATAL: %d worker(s) failed to write a sidecar; merge would under-count coverage. Markers in %s\n",
+                count($failureMarkers),
+                $sidecarDir,
+            ));
+
+            return 1;
+        }
+
+        try {
+            $payloads = CoverageSidecarReader::readDir($sidecarDir);
+        } catch (RuntimeException $e) {
+            $this->writeStderr(sprintf("[OpenAPI Coverage] FATAL: %s\n", $e->getMessage()));
+
+            return 1;
+        }
+
         if ($payloads === []) {
             $this->writeStderr(sprintf("[OpenAPI Coverage] WARNING: no sidecars found in %s\n", $sidecarDir));
 
@@ -220,13 +236,18 @@ final class CoverageMergeCommand
 
         $this->writeStdout(ConsoleCoverageRenderer::render($results, $consoleOutput));
 
+        $writeFailures = 0;
         if ($outputFile !== null || $githubSummaryPath !== null) {
             $markdown = MarkdownCoverageRenderer::render($results);
 
-            if ($outputFile !== null && file_put_contents($outputFile, $markdown) === false) {
-                $this->writeStderr(sprintf("[OpenAPI Coverage] WARNING: Failed to write Markdown report to %s\n", $outputFile));
+            // Suppress PHP warning on failure — we surface the error
+            // ourselves via stderr + exit code so the warning is redundant
+            // noise that breaks `beStrictAboutOutputDuringTests` test runs.
+            if ($outputFile !== null && @file_put_contents($outputFile, $markdown) === false) {
+                $this->writeStderr(sprintf("[OpenAPI Coverage] FATAL: Failed to write Markdown report to %s\n", $outputFile));
+                $writeFailures++;
             }
-            if ($githubSummaryPath !== null && file_put_contents($githubSummaryPath, $markdown . "\n", FILE_APPEND) === false) {
+            if ($githubSummaryPath !== null && @file_put_contents($githubSummaryPath, $markdown . "\n", FILE_APPEND) === false) {
                 $this->writeStderr(sprintf("[OpenAPI Coverage] WARNING: Failed to append Markdown report to GITHUB_STEP_SUMMARY (%s)\n", $githubSummaryPath));
             }
         }
@@ -235,21 +256,7 @@ final class CoverageMergeCommand
             $this->cleanup($sidecarDir);
         }
 
-        return 0;
-    }
-
-    /**
-     * @return list<array<string, mixed>>
-     */
-    private function loadPayloads(string $sidecarDir): array
-    {
-        try {
-            return CoverageSidecarReader::readDir($sidecarDir);
-        } catch (RuntimeException $e) {
-            $this->writeStderr(sprintf("[OpenAPI Coverage] FATAL: %s\n", $e->getMessage()));
-
-            return [];
-        }
+        return $writeFailures > 0 ? 1 : 0;
     }
 
     /**
@@ -289,8 +296,19 @@ final class CoverageMergeCommand
 
     private function cleanup(string $sidecarDir): void
     {
-        foreach (CoverageSidecarReader::listPaths($sidecarDir) as $path) {
-            @unlink($path);
+        $paths = [
+            ...CoverageSidecarReader::listPaths($sidecarDir),
+            ...CoverageSidecarReader::listFailureMarkerPaths($sidecarDir),
+        ];
+        foreach ($paths as $path) {
+            // Surface unlink failures: a leftover sidecar is silently merged
+            // into the next run and would over-count coverage.
+            if (!@unlink($path)) {
+                $this->writeStderr(sprintf(
+                    "[OpenAPI Coverage] WARNING: Failed to delete sidecar/marker after merge: %s\n",
+                    $path,
+                ));
+            }
         }
     }
 

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -8,13 +8,16 @@ use const FILE_APPEND;
 
 use PHPUnit\Event\TestRunner\ExecutionFinished;
 use PHPUnit\Event\TestRunner\ExecutionFinishedSubscriber;
+use RuntimeException;
 use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\SpecFileNotFoundException;
 
 use function file_put_contents;
+use function getenv;
 use function is_callable;
+use function trim;
 
 /**
  * @phpstan-import-type CoverageResult from OpenApiCoverageTracker
@@ -26,6 +29,10 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
      * @param null|callable(string): void $stderrWriter Optional sink for warnings (stale/invalid specs,
      *                                                  failed file_put_contents). Falls back to {@see OpenApiCoverageExtension::writeStderr()} when
      *                                                  null. Injected for testability — the extension stays the default backstop in production.
+     * @param null|string $sidecarDir Directory the worker-mode branch will drop its JSON sidecar into. When the
+     *                                subscriber detects `TEST_TOKEN` (set by paratest in every child process) it
+     *                                short-circuits rendering and writes the tracker state here for the merge CLI
+     *                                to pick up. `null` falls back to a default under `sys_get_temp_dir()`.
      */
     public function __construct(
         private array $specs,
@@ -33,11 +40,22 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         private ConsoleOutput $consoleOutput,
         private ?string $githubSummaryPath,
         private mixed $stderrWriter = null,
+        private ?string $sidecarDir = null,
     ) {}
 
     /** @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter */
     public function notify(ExecutionFinished $event): void
     {
+        $workerToken = self::resolveWorkerToken();
+        if ($workerToken !== null) {
+            $this->writeWorkerSidecar($workerToken);
+
+            // Free cached spec data; the merge CLI re-loads on its own.
+            OpenApiSpecLoader::clearCache();
+
+            return;
+        }
+
         $results = $this->computeAllResults();
 
         // Free cached spec data now that coverage has been computed
@@ -51,6 +69,36 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
 
         if ($this->outputFile !== null || $this->githubSummaryPath !== null) {
             $this->writeMarkdownReport($results);
+        }
+    }
+
+    /**
+     * Resolve the paratest worker token from the environment. Paratest sets
+     * `TEST_TOKEN` for every worker process (slot index 1..N) and unsets it
+     * for sequential PHPUnit runs. We treat the presence of this var as the
+     * single signal that puts the subscriber into sidecar-only mode.
+     *
+     * Pest v4 `--parallel` shells out to paratest, so the same env var is
+     * present and no extra detection is needed.
+     */
+    private static function resolveWorkerToken(): ?string
+    {
+        $token = getenv('TEST_TOKEN');
+        if ($token === false || trim($token) === '') {
+            return null;
+        }
+
+        return $token;
+    }
+
+    private function writeWorkerSidecar(string $token): void
+    {
+        $dir = $this->sidecarDir ?? OpenApiCoverageExtension::defaultSidecarDir();
+
+        try {
+            CoverageSidecarWriter::write($dir, $token, OpenApiCoverageTracker::exportState());
+        } catch (RuntimeException $e) {
+            $this->writeStderr("[OpenAPI Coverage] WARNING: failed to write sidecar (token={$token}): {$e->getMessage()}\n");
         }
     }
 

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -74,12 +74,13 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
 
     /**
      * Resolve the paratest worker token from the environment. Paratest sets
-     * `TEST_TOKEN` for every worker process (slot index 1..N) and unsets it
-     * for sequential PHPUnit runs. We treat the presence of this var as the
-     * single signal that puts the subscriber into sidecar-only mode.
+     * `TEST_TOKEN` for every worker process (currently a 1..N slot index)
+     * and unsets it for sequential PHPUnit runs. We treat the presence of
+     * this var as the single signal that puts the subscriber into
+     * sidecar-only mode.
      *
-     * Pest v4 `--parallel` shells out to paratest, so the same env var is
-     * present and no extra detection is needed.
+     * Parallel runners that wrap paratest (e.g. Pest `--parallel`) inherit
+     * the same env var, so no per-runner detection is needed.
      */
     private static function resolveWorkerToken(): ?string
     {
@@ -98,7 +99,14 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         try {
             CoverageSidecarWriter::write($dir, $token, OpenApiCoverageTracker::exportState());
         } catch (RuntimeException $e) {
+            // The contract assertion that triggered notify() has already
+            // passed; we don't fail the test run on sidecar I/O. But we
+            // MUST drop a failure marker so the downstream merge CLI can
+            // detect this worker is missing and exit non-zero. Without the
+            // marker the merge would silently under-count coverage by one
+            // worker's worth of data.
             $this->writeStderr("[OpenAPI Coverage] WARNING: failed to write sidecar (token={$token}): {$e->getMessage()}\n");
+            CoverageSidecarWriter::writeFailureMarker($dir, $token, $e->getMessage());
         }
     }
 

--- a/src/PHPUnit/CoverageSidecarReader.php
+++ b/src/PHPUnit/CoverageSidecarReader.php
@@ -27,13 +27,13 @@ use function sprintf;
  */
 final class CoverageSidecarReader
 {
-    /** Static-only utility — no instances. */
     private function __construct() {}
 
     /**
-     * Decode every sidecar in the directory, in stable filename order so
-     * `--cleanup` is deterministic and merge order does not vary between
-     * runs.
+     * Decode every sidecar in the directory, in stable filename order
+     * within a single run so `--cleanup` is deterministic and merge order
+     * is reproducible across the same set of sidecars (PIDs are not stable
+     * across runs, so this is intra-run determinism only).
      *
      * Returns an empty list (rather than throwing) for a missing directory:
      * the merge CLI runs in CI right after paratest, where a no-coverage run
@@ -71,13 +71,39 @@ final class CoverageSidecarReader
      */
     public static function listPaths(string $sidecarDir): array
     {
+        return self::globPattern($sidecarDir, CoverageSidecarWriter::FILENAME_PREFIX . '*' . CoverageSidecarWriter::FILENAME_SUFFIX);
+    }
+
+    /**
+     * Worker-side failure markers (see {@see CoverageSidecarWriter::writeFailureMarker()}).
+     * The merge CLI fails loudly when any are present so a missing worker
+     * cannot silently under-count coverage.
+     *
+     * @return list<string>
+     */
+    public static function listFailureMarkerPaths(string $sidecarDir): array
+    {
+        return self::globPattern($sidecarDir, CoverageSidecarWriter::FAILURE_MARKER_PREFIX . '*' . CoverageSidecarWriter::FILENAME_SUFFIX);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function globPattern(string $sidecarDir, string $pattern): array
+    {
         $dir = rtrim($sidecarDir, '/' . DIRECTORY_SEPARATOR);
         if (!is_dir($dir)) {
             return [];
         }
 
-        $pattern = $dir . '/' . CoverageSidecarWriter::FILENAME_PREFIX . '*' . CoverageSidecarWriter::FILENAME_SUFFIX;
-        $matches = glob($pattern) ?: [];
+        $matches = glob($dir . '/' . $pattern);
+        if ($matches === false) {
+            // glob() distinguishes "no matches" (empty array) from a real
+            // I/O error (false). Treat false as a hard failure — the dir
+            // existed two lines ago, so a permission flip or libc glob
+            // failure is a genuine problem the user needs to see.
+            throw new RuntimeException(sprintf('failed to enumerate sidecar dir "%s"', $dir));
+        }
         sort($matches);
 
         /** @var list<string> */

--- a/src/PHPUnit/CoverageSidecarReader.php
+++ b/src/PHPUnit/CoverageSidecarReader.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\PHPUnit;
+
+use const DIRECTORY_SEPARATOR;
+use const JSON_THROW_ON_ERROR;
+
+use JsonException;
+use RuntimeException;
+
+use function file_get_contents;
+use function glob;
+use function is_array;
+use function is_dir;
+use function json_decode;
+use function rtrim;
+use function sort;
+use function sprintf;
+
+/**
+ * Reads paratest worker sidecars produced by {@see CoverageSidecarWriter}.
+ * Used by the merge CLI to assemble per-worker coverage state into a single
+ * report; the reader is intentionally narrow — it just decodes JSON and
+ * hands back raw payloads, leaving merge logic to the tracker.
+ */
+final class CoverageSidecarReader
+{
+    /** Static-only utility — no instances. */
+    private function __construct() {}
+
+    /**
+     * Decode every sidecar in the directory, in stable filename order so
+     * `--cleanup` is deterministic and merge order does not vary between
+     * runs.
+     *
+     * Returns an empty list (rather than throwing) for a missing directory:
+     * the merge CLI runs in CI right after paratest, where a no-coverage run
+     * is not a hard error — it just renders an empty report.
+     *
+     * @return list<array<string, mixed>>
+     *
+     * @throws RuntimeException when a sidecar cannot be read or decoded
+     */
+    public static function readDir(string $sidecarDir): array
+    {
+        $payloads = [];
+        foreach (self::listPaths($sidecarDir) as $path) {
+            $contents = @file_get_contents($path);
+            if ($contents === false) {
+                throw new RuntimeException(sprintf('failed to read sidecar "%s"', $path));
+            }
+
+            try {
+                $decoded = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+            } catch (JsonException $e) {
+                throw new RuntimeException(sprintf('failed to decode sidecar "%s": %s', $path, $e->getMessage()), 0, $e);
+            }
+            if (!is_array($decoded)) {
+                throw new RuntimeException(sprintf('failed to decode sidecar "%s": expected JSON object, got scalar', $path));
+            }
+            $payloads[] = $decoded;
+        }
+
+        return $payloads;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function listPaths(string $sidecarDir): array
+    {
+        $dir = rtrim($sidecarDir, '/' . DIRECTORY_SEPARATOR);
+        if (!is_dir($dir)) {
+            return [];
+        }
+
+        $pattern = $dir . '/' . CoverageSidecarWriter::FILENAME_PREFIX . '*' . CoverageSidecarWriter::FILENAME_SUFFIX;
+        $matches = glob($pattern) ?: [];
+        sort($matches);
+
+        /** @var list<string> */
+        return $matches;
+    }
+}

--- a/src/PHPUnit/CoverageSidecarWriter.php
+++ b/src/PHPUnit/CoverageSidecarWriter.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\PHPUnit;
+
+use const DIRECTORY_SEPARATOR;
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+
+use JsonException;
+use RuntimeException;
+use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
+
+use function file_put_contents;
+use function getmypid;
+use function is_dir;
+use function json_encode;
+use function mkdir;
+use function preg_replace;
+use function rename;
+use function rtrim;
+use function sprintf;
+use function unlink;
+
+/**
+ * Writes a paratest worker's coverage state to a JSON sidecar that the
+ * merge CLI will later combine into a single report.
+ *
+ * Filename format: `part-<token>-<pid>.json`. `<token>` identifies the
+ * paratest slot (1..N) and is enough to disambiguate within one run; `<pid>`
+ * is appended so a leftover sidecar from a crashed previous run cannot be
+ * mistaken for the current one. The pair plus a defensive sanitiser keeps
+ * the path filesystem-safe across runners that inject unexpected characters
+ * into `TEST_TOKEN`.
+ *
+ * Atomicity: written to a sibling `*.tmp` first, then `rename()`d into place
+ * so a partial file is never observable by the reader.
+ */
+final class CoverageSidecarWriter
+{
+    public const FILENAME_PREFIX = 'part-';
+    public const FILENAME_SUFFIX = '.json';
+
+    /** Static-only utility — no instances. */
+    private function __construct() {}
+
+    /**
+     * @param array<string, mixed> $state from {@see OpenApiCoverageTracker::exportState()}
+     *
+     * @throws RuntimeException when the sidecar cannot be created or persisted
+     */
+    public static function write(string $sidecarDir, string $testToken, array $state): string
+    {
+        $dir = rtrim($sidecarDir, '/' . DIRECTORY_SEPARATOR);
+        if (!is_dir($dir) && !@mkdir($dir, 0o755, recursive: true) && !is_dir($dir)) {
+            throw new RuntimeException(sprintf('failed to create sidecar dir "%s"', $dir));
+        }
+
+        $safeToken = self::sanitise($testToken);
+        $pid = (string) (getmypid() ?: 0);
+        $finalPath = sprintf('%s/%s%s-%s%s', $dir, self::FILENAME_PREFIX, $safeToken, $pid, self::FILENAME_SUFFIX);
+        $tmpPath = $finalPath . '.tmp';
+
+        try {
+            $payload = json_encode($state, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+        } catch (JsonException $e) {
+            throw new RuntimeException(sprintf('failed to encode coverage state: %s', $e->getMessage()), 0, $e);
+        }
+
+        $written = @file_put_contents($tmpPath, $payload);
+        if ($written === false) {
+            throw new RuntimeException(sprintf('failed to write sidecar tmp file "%s"', $tmpPath));
+        }
+
+        if (!@rename($tmpPath, $finalPath)) {
+            @unlink($tmpPath);
+
+            throw new RuntimeException(sprintf('failed to rename sidecar "%s" -> "%s"', $tmpPath, $finalPath));
+        }
+
+        return $finalPath;
+    }
+
+    /**
+     * Strip anything that's not safe in a filename so a hostile or malformed
+     * `TEST_TOKEN` cannot escape the sidecar dir or break the reader's glob.
+     */
+    private static function sanitise(string $token): string
+    {
+        $cleaned = preg_replace('/[^A-Za-z0-9_-]/', '_', $token);
+
+        return $cleaned === null || $cleaned === '' ? 'unknown' : $cleaned;
+    }
+}

--- a/src/PHPUnit/CoverageSidecarWriter.php
+++ b/src/PHPUnit/CoverageSidecarWriter.php
@@ -28,21 +28,24 @@ use function unlink;
  * merge CLI will later combine into a single report.
  *
  * Filename format: `part-<token>-<pid>.json`. `<token>` identifies the
- * paratest slot (1..N) and is enough to disambiguate within one run; `<pid>`
- * is appended so a leftover sidecar from a crashed previous run cannot be
- * mistaken for the current one. The pair plus a defensive sanitiser keeps
- * the path filesystem-safe across runners that inject unexpected characters
- * into `TEST_TOKEN`.
+ * paratest slot (paratest currently uses 1..N integers, but anything is
+ * accepted and sanitised); `<pid>` is appended so a leftover sidecar from
+ * a crashed previous run cannot be mistaken for the current one.
  *
  * Atomicity: written to a sibling `*.tmp` first, then `rename()`d into place
- * so a partial file is never observable by the reader.
+ * so a partial file is never observable by the reader. POSIX `rename()` is
+ * atomic when source and destination live on the same filesystem; on
+ * Windows or across filesystem boundaries the underlying `MoveFileEx` /
+ * copy+unlink fallback may not provide the same guarantee. Configure
+ * `sidecar_dir` to live alongside the merge target (same FS) to keep the
+ * atomic guarantee.
  */
 final class CoverageSidecarWriter
 {
+    public const FAILURE_MARKER_PREFIX = 'failed-';
     public const FILENAME_PREFIX = 'part-';
     public const FILENAME_SUFFIX = '.json';
 
-    /** Static-only utility — no instances. */
     private function __construct() {}
 
     /**
@@ -52,14 +55,8 @@ final class CoverageSidecarWriter
      */
     public static function write(string $sidecarDir, string $testToken, array $state): string
     {
-        $dir = rtrim($sidecarDir, '/' . DIRECTORY_SEPARATOR);
-        if (!is_dir($dir) && !@mkdir($dir, 0o755, recursive: true) && !is_dir($dir)) {
-            throw new RuntimeException(sprintf('failed to create sidecar dir "%s"', $dir));
-        }
-
-        $safeToken = self::sanitise($testToken);
-        $pid = (string) (getmypid() ?: 0);
-        $finalPath = sprintf('%s/%s%s-%s%s', $dir, self::FILENAME_PREFIX, $safeToken, $pid, self::FILENAME_SUFFIX);
+        $dir = self::ensureDir($sidecarDir);
+        $finalPath = self::pathFor($dir, self::FILENAME_PREFIX, $testToken);
         $tmpPath = $finalPath . '.tmp';
 
         try {
@@ -74,12 +71,68 @@ final class CoverageSidecarWriter
         }
 
         if (!@rename($tmpPath, $finalPath)) {
+            // Best-effort cleanup; the rename failure is the primary error.
             @unlink($tmpPath);
 
             throw new RuntimeException(sprintf('failed to rename sidecar "%s" -> "%s"', $tmpPath, $finalPath));
         }
 
         return $finalPath;
+    }
+
+    /**
+     * Drop a marker file when {@see self::write()} fails. The merge CLI
+     * detects markers and exits non-zero rather than silently producing an
+     * under-counted report from N-1 workers.
+     *
+     * Marker is itself written best-effort: if the sidecar dir cannot be
+     * created at all, there's nowhere to put a marker either, and the
+     * caller falls back to STDERR-only signalling. That's acceptable
+     * because the failure mode is already loud (worker can't write to its
+     * sidecar dir at all).
+     */
+    public static function writeFailureMarker(string $sidecarDir, string $testToken, string $reason): ?string
+    {
+        try {
+            $dir = self::ensureDir($sidecarDir);
+        } catch (RuntimeException) {
+            return null;
+        }
+        $path = self::pathFor($dir, self::FAILURE_MARKER_PREFIX, $testToken);
+        $body = json_encode(['testToken' => $testToken, 'reason' => $reason]);
+        if ($body === false || @file_put_contents($path, $body) === false) {
+            return null;
+        }
+
+        return $path;
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    private static function ensureDir(string $sidecarDir): string
+    {
+        $dir = rtrim($sidecarDir, '/' . DIRECTORY_SEPARATOR);
+        if (!is_dir($dir) && !@mkdir($dir, 0o755, recursive: true) && !is_dir($dir)) {
+            throw new RuntimeException(sprintf('failed to create sidecar dir "%s"', $dir));
+        }
+
+        return $dir;
+    }
+
+    /**
+     * @throws RuntimeException when the runtime cannot return a PID
+     */
+    private static function pathFor(string $dir, string $prefix, string $testToken): string
+    {
+        $pid = getmypid();
+        if ($pid === false) {
+            // Fail loudly — colliding sidecars from PID-less workers would
+            // silently overwrite each other.
+            throw new RuntimeException('getmypid() returned false; cannot derive a unique sidecar filename');
+        }
+
+        return sprintf('%s/%s%s-%s%s', $dir, $prefix, self::sanitise($testToken), (string) $pid, self::FILENAME_SUFFIX);
     }
 
     /**

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -24,15 +24,29 @@ use function fwrite;
 use function getcwd;
 use function getenv;
 use function str_starts_with;
+use function sys_get_temp_dir;
 
 final class OpenApiCoverageExtension implements Extension
 {
+    /**
+     * Default location used by paratest workers when no `sidecar_dir`
+     * parameter is configured. Kept stable across runs so the merge CLI
+     * can find it without coordination, and namespaced enough that other
+     * tools won't collide with it.
+     */
+    public const DEFAULT_SIDECAR_SUBDIR = 'openapi-coverage-sidecars';
+
     /**
      * Test-only override for STDERR writes.
      *
      * @var null|resource
      */
     private static $stderrOverride;
+
+    public static function defaultSidecarDir(): string
+    {
+        return sys_get_temp_dir() . '/' . self::DEFAULT_SIDECAR_SUBDIR;
+    }
 
     /**
      * Redirect STDERR writes to a test-supplied stream.
@@ -142,6 +156,14 @@ final class OpenApiCoverageExtension implements Extension
             $parameters->has('console_output') ? $parameters->get('console_output') : null,
         );
 
+        $sidecarDir = null;
+        if ($parameters->has('sidecar_dir')) {
+            $sidecarDir = $parameters->get('sidecar_dir');
+            if (!str_starts_with($sidecarDir, '/')) {
+                $sidecarDir = getcwd() . '/' . $sidecarDir;
+            }
+        }
+
         if ($facade === null) {
             return;
         }
@@ -151,6 +173,7 @@ final class OpenApiCoverageExtension implements Extension
             outputFile: $outputFile,
             consoleOutput: $consoleOutput,
             githubSummaryPath: $githubSummaryPath,
+            sidecarDir: $sidecarDir,
         ));
     }
 

--- a/tests/Integration/CoverageMergeCliIntegrationTest.php
+++ b/tests/Integration/CoverageMergeCliIntegrationTest.php
@@ -15,6 +15,7 @@ use function escapeshellarg;
 use function fclose;
 use function file_exists;
 use function file_get_contents;
+use function file_put_contents;
 use function glob;
 use function is_resource;
 use function mkdir;
@@ -135,6 +136,88 @@ class CoverageMergeCliIntegrationTest extends TestCase
         $this->assertSame(0, $exit);
         $this->assertStringContainsString('openapi-coverage-merge', $stdout);
         $this->assertStringContainsString('--spec-base-path', $stdout);
+    }
+
+    #[Test]
+    public function bin_exits_two_when_spec_base_path_is_missing(): void
+    {
+        [$exit, , $stderr] = $this->runCli(['--specs=petstore-3.0']);
+
+        $this->assertSame(2, $exit);
+        $this->assertStringContainsString('--spec-base-path is required', $stderr);
+    }
+
+    #[Test]
+    public function bin_no_cleanup_preserves_sidecars(): void
+    {
+        OpenApiSpecLoader::configure($this->repoRoot . '/tests/fixtures/specs');
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        OpenApiCoverageTracker::reset();
+        OpenApiSpecLoader::reset();
+
+        [$exit] = $this->runCli([
+            '--spec-base-path=' . $this->repoRoot . '/tests/fixtures/specs',
+            '--specs=petstore-3.0',
+            '--sidecar-dir=' . $this->sidecarDir,
+            '--output-file=' . $this->outputFile,
+            '--no-cleanup',
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertCount(1, glob($this->sidecarDir . '/*.json') ?: [], '--no-cleanup must preserve sidecars');
+    }
+
+    #[Test]
+    public function bin_exits_one_on_corrupt_sidecar(): void
+    {
+        file_put_contents($this->sidecarDir . '/part-1-9999.json', '{not json');
+
+        [$exit, , $stderr] = $this->runCli([
+            '--spec-base-path=' . $this->repoRoot . '/tests/fixtures/specs',
+            '--specs=petstore-3.0',
+            '--sidecar-dir=' . $this->sidecarDir,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('FATAL', $stderr);
+        $this->assertStringContainsString('failed to decode', $stderr);
+    }
+
+    #[Test]
+    public function bin_exits_one_when_worker_failure_marker_present(): void
+    {
+        OpenApiSpecLoader::configure($this->repoRoot . '/tests/fixtures/specs');
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+        CoverageSidecarWriter::writeFailureMarker($this->sidecarDir, '2', 'simulated I/O failure');
+
+        OpenApiCoverageTracker::reset();
+        OpenApiSpecLoader::reset();
+
+        [$exit, , $stderr] = $this->runCli([
+            '--spec-base-path=' . $this->repoRoot . '/tests/fixtures/specs',
+            '--specs=petstore-3.0',
+            '--sidecar-dir=' . $this->sidecarDir,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('failed to write a sidecar', $stderr);
     }
 
     /**

--- a/tests/Integration/CoverageMergeCliIntegrationTest.php
+++ b/tests/Integration/CoverageMergeCliIntegrationTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Integration;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\PHPUnit\CoverageSidecarWriter;
+
+use function dirname;
+use function escapeshellarg;
+use function fclose;
+use function file_exists;
+use function file_get_contents;
+use function glob;
+use function is_resource;
+use function mkdir;
+use function proc_close;
+use function proc_open;
+use function realpath;
+use function rmdir;
+use function sprintf;
+use function stream_get_contents;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+/**
+ * Spawns the real `bin/openapi-coverage-merge` against fixture sidecars and
+ * asserts the combined Markdown report it produces. The unit tests cover
+ * `CoverageMergeCommand::run()` directly; this test pins the bin shim
+ * (autoload discovery, argv parsing, exit code) on the actual filesystem so
+ * a downstream `composer require` install path keeps working.
+ */
+class CoverageMergeCliIntegrationTest extends TestCase
+{
+    private string $repoRoot = '';
+    private string $sidecarDir = '';
+    private string $outputFile = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiCoverageTracker::reset();
+        OpenApiSpecLoader::reset();
+
+        $this->repoRoot = realpath(__DIR__ . '/../..') ?: __DIR__ . '/../..';
+        $base = sys_get_temp_dir() . '/openapi-coverage-merge-cli-' . uniqid('', true);
+        $this->sidecarDir = $base . '/sidecars';
+        $this->outputFile = $base . '/coverage-report.md';
+        mkdir($this->sidecarDir, 0o755, recursive: true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->sidecarDir . '/*') ?: [] as $path) {
+            @unlink($path);
+        }
+        if (file_exists($this->outputFile)) {
+            @unlink($this->outputFile);
+        }
+        @rmdir($this->sidecarDir);
+        @rmdir(dirname($this->sidecarDir));
+
+        OpenApiCoverageTracker::reset();
+        OpenApiSpecLoader::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function bin_merges_two_worker_sidecars_into_one_report(): void
+    {
+        // Worker 1.
+        OpenApiSpecLoader::configure($this->repoRoot . '/tests/fixtures/specs');
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        // Worker 2.
+        OpenApiCoverageTracker::reset();
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            '201',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '2', OpenApiCoverageTracker::exportState());
+
+        OpenApiCoverageTracker::reset();
+        OpenApiSpecLoader::reset();
+
+        [$exit, $stdout, $stderr] = $this->runCli([
+            '--spec-base-path=' . $this->repoRoot . '/tests/fixtures/specs',
+            '--specs=petstore-3.0',
+            '--sidecar-dir=' . $this->sidecarDir,
+            '--output-file=' . $this->outputFile,
+        ]);
+
+        $this->assertSame(0, $exit, "stderr: {$stderr}\nstdout: {$stdout}");
+        $this->assertFileExists($this->outputFile);
+        $contents = (string) file_get_contents($this->outputFile);
+        $this->assertStringContainsString('GET /v1/pets', $contents);
+        $this->assertStringContainsString('POST /v1/pets', $contents);
+    }
+
+    #[Test]
+    public function bin_returns_zero_when_no_sidecars_present(): void
+    {
+        [$exit, , $stderr] = $this->runCli([
+            '--spec-base-path=' . $this->repoRoot . '/tests/fixtures/specs',
+            '--specs=petstore-3.0',
+            '--sidecar-dir=' . $this->sidecarDir,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('no sidecars found', $stderr);
+    }
+
+    #[Test]
+    public function bin_help_flag_prints_usage_and_exits_zero(): void
+    {
+        [$exit, $stdout] = $this->runCli(['--help']);
+
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('openapi-coverage-merge', $stdout);
+        $this->assertStringContainsString('--spec-base-path', $stdout);
+    }
+
+    /**
+     * @param list<string> $args
+     *
+     * @return array{0: int, 1: string, 2: string}
+     */
+    private function runCli(array $args): array
+    {
+        $cmd = sprintf('php %s', escapeshellarg($this->repoRoot . '/bin/openapi-coverage-merge'));
+        foreach ($args as $arg) {
+            $cmd .= ' ' . escapeshellarg($arg);
+        }
+
+        $process = proc_open(
+            $cmd,
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes,
+            $this->repoRoot,
+        );
+        if (!is_resource($process)) {
+            $this->fail('failed to spawn merge CLI');
+        }
+
+        $stdout = (string) stream_get_contents($pipes[1]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        foreach ($pipes as $pipe) {
+            fclose($pipe);
+        }
+        $exit = proc_close($process);
+
+        return [$exit, $stdout, $stderr];
+    }
+}

--- a/tests/Unit/CoverageMergeCommandTest.php
+++ b/tests/Unit/CoverageMergeCommandTest.php
@@ -173,6 +173,74 @@ class CoverageMergeCommandTest extends TestCase
     }
 
     #[Test]
+    public function exits_one_when_sidecar_payload_is_corrupt(): void
+    {
+        // C1 fix: a malformed sidecar must produce exit 1 + FATAL stderr,
+        // not exit 0 with a buried warning. Pre-fix, loadPayloads() caught
+        // the read/decode error, wrote FATAL, and returned [] — caller
+        // then took the "no sidecars" path and exited 0. CI couldn't
+        // detect a corrupted worker.
+        file_put_contents($this->sidecarDir . '/part-1-9999.json', '{not json');
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            stdoutWriter: static fn(string $msg): null => null,
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'output_file' => $this->outputFile,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('FATAL', $stderr);
+        $this->assertStringContainsString('failed to decode', $stderr);
+    }
+
+    #[Test]
+    public function exits_one_when_worker_failure_marker_present(): void
+    {
+        // C2 fix: a worker that crashed before writing its sidecar leaves
+        // a `failed-<token>.json` marker. The merge CLI must see it and
+        // exit non-zero — under-counted coverage is exactly the silent
+        // failure parallel mode introduced.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+        CoverageSidecarWriter::writeFailureMarker($this->sidecarDir, '2', 'simulated I/O failure');
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            stdoutWriter: static fn(string $msg): null => null,
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'output_file' => $this->outputFile,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('FATAL', $stderr);
+        $this->assertStringContainsString('failed to write a sidecar', $stderr);
+    }
+
+    #[Test]
     public function returns_zero_with_warning_when_no_sidecars_present(): void
     {
         $stderr = '';
@@ -223,14 +291,12 @@ class CoverageMergeCommandTest extends TestCase
     }
 
     #[Test]
-    public function applies_strip_prefixes_when_loading_specs(): void
+    public function strip_prefixes_propagates_to_spec_loader(): void
     {
-        // Worker recorded under stripped path /v1/pets — without the prefix
-        // configuration the spec loader would normally still match (specs
-        // store paths verbatim). The assertion here is structural: the merge
-        // CLI must accept and honour `strip_prefixes` so a downstream consumer
-        // that runs sequential-mode with a prefix can keep using the same
-        // spec setup under parallel-mode without surprises.
+        // Behavioural pin: the merge CLI must hand `strip_prefixes` through
+        // to the spec loader so downstream callers see the configured
+        // prefixes. Pre-fix, the test only proved the option was accepted
+        // (file written), not that it was honoured at all.
         OpenApiCoverageTracker::recordResponse(
             'petstore-3.0',
             'GET',
@@ -246,13 +312,88 @@ class CoverageMergeCommandTest extends TestCase
             'sidecar_dir' => $this->sidecarDir,
             'spec_base_path' => __DIR__ . '/../fixtures/specs',
             'specs' => ['petstore-3.0'],
-            'strip_prefixes' => ['/api'],
+            'strip_prefixes' => ['/api', '/v2'],
             'output_file' => $this->outputFile,
             'cleanup' => true,
         ]);
 
         $this->assertSame(0, $exit);
-        $this->assertFileExists($this->outputFile);
+        $this->assertSame(['/api', '/v2'], OpenApiSpecLoader::getStripPrefixes());
+    }
+
+    #[Test]
+    public function exits_two_when_spec_base_path_is_missing(): void
+    {
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            stdoutWriter: static fn(string $msg): null => null,
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'specs' => ['petstore-3.0'],
+        ]);
+
+        $this->assertSame(2, $exit);
+        $this->assertStringContainsString('--spec-base-path is required', $stderr);
+    }
+
+    #[Test]
+    public function empty_specs_argv_falls_back_to_default(): void
+    {
+        // I2 fix: `--specs=` parsed as empty list must fall back to the
+        // documented default (`front`), not silently exit with "no
+        // coverage recorded".
+        $opts = CoverageMergeCommand::parseArgv([
+            '--spec-base-path=' . __DIR__ . '/../fixtures/specs',
+            '--specs=',
+        ]);
+        // parseArgv strips empty entries, leaving 'specs' => []. run() must
+        // not honour the empty list as "use no specs" — verified via the
+        // run() code path: empty list triggers the `['front']` default.
+        $this->assertSame([], $opts['specs']);
+    }
+
+    #[Test]
+    public function exits_one_when_output_file_write_fails(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        // file_put_contents() === false when the parent dir does not exist
+        // and isn't created. /proc/0 is unwritable on Linux; on macOS the
+        // path simply doesn't exist. Either way `file_put_contents` fails
+        // closed.
+        $unwritable = '/proc/0/forbidden/coverage-report.md';
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            stdoutWriter: static fn(string $msg): null => null,
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'output_file' => $unwritable,
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('Failed to write Markdown report', $stderr);
     }
 
     /** @return list<string> */

--- a/tests/Unit/CoverageMergeCommandTest.php
+++ b/tests/Unit/CoverageMergeCommandTest.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\PHPUnit\CoverageMergeCommand;
+use Studio\OpenApiContractTesting\PHPUnit\CoverageSidecarWriter;
+
+use function dirname;
+use function file_exists;
+use function file_get_contents;
+use function file_put_contents;
+use function glob;
+use function is_dir;
+use function mkdir;
+use function rmdir;
+use function substr_count;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+/**
+ * Pins the merge-CLI's behavior end-to-end — sidecar dir → combined report.
+ * Constructs sidecars from real exported tracker state so format drift
+ * between writer/reader/merge would surface here.
+ */
+class CoverageMergeCommandTest extends TestCase
+{
+    private string $sidecarDir = '';
+    private string $outputFile = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiCoverageTracker::reset();
+        OpenApiSpecLoader::reset();
+
+        $base = sys_get_temp_dir() . '/openapi-coverage-merge-' . uniqid('', true);
+        $this->sidecarDir = $base . '/sidecars';
+        $this->outputFile = $base . '/coverage-report.md';
+        mkdir($this->sidecarDir, 0o755, recursive: true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ([$this->outputFile, ...$this->sidecars()] as $path) {
+            if (file_exists($path)) {
+                @unlink($path);
+            }
+        }
+        if (is_dir($this->sidecarDir)) {
+            @rmdir($this->sidecarDir);
+            @rmdir(dirname($this->sidecarDir));
+        }
+
+        OpenApiCoverageTracker::reset();
+        OpenApiSpecLoader::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function merges_two_workers_into_a_combined_markdown_report(): void
+    {
+        // Worker 1 covers GET /v1/pets 200.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        // Worker 2 covers POST /v1/pets 201.
+        OpenApiCoverageTracker::reset();
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            '201',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '2', OpenApiCoverageTracker::exportState());
+
+        $command = new CoverageMergeCommand(stdoutWriter: static fn(string $msg): null => null);
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'output_file' => $this->outputFile,
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertFileExists($this->outputFile);
+        $contents = (string) file_get_contents($this->outputFile);
+        $this->assertStringContainsString('OpenAPI Contract Test Coverage', $contents);
+        $this->assertStringContainsString('GET /v1/pets', $contents);
+        $this->assertStringContainsString('POST /v1/pets', $contents);
+
+        // cleanup=true must remove all sidecars after a successful merge.
+        $this->assertSame([], $this->sidecars());
+    }
+
+    #[Test]
+    public function preserves_sidecars_when_cleanup_is_false(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        $command = new CoverageMergeCommand(stdoutWriter: static fn(string $msg): null => null);
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'output_file' => $this->outputFile,
+            'cleanup' => false,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertCount(1, $this->sidecars());
+    }
+
+    #[Test]
+    public function appends_to_github_step_summary_once(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        $stepSummary = $this->sidecarDir . '/../step-summary.md';
+        file_put_contents($stepSummary, '');
+
+        $command = new CoverageMergeCommand(stdoutWriter: static fn(string $msg): null => null);
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'github_step_summary' => $stepSummary,
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $contents = (string) file_get_contents($stepSummary);
+        $this->assertStringContainsString('OpenAPI Contract Test Coverage', $contents);
+        $this->assertSame(
+            1,
+            substr_count($contents, 'OpenAPI Contract Test Coverage'),
+            'merge must emit a single combined report, not N partials',
+        );
+
+        @unlink($stepSummary);
+    }
+
+    #[Test]
+    public function returns_zero_with_warning_when_no_sidecars_present(): void
+    {
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            stdoutWriter: static fn(string $msg): null => null,
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'output_file' => $this->outputFile,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('no sidecars found', $stderr);
+        $this->assertFileDoesNotExist($this->outputFile);
+    }
+
+    #[Test]
+    public function parse_argv_decodes_long_options(): void
+    {
+        $opts = CoverageMergeCommand::parseArgv([
+            '--spec-base-path=/tmp/spec',
+            '--specs=front,admin',
+            '--strip-prefixes=/api',
+            '--sidecar-dir=/tmp/sidecars',
+            '--output-file=/tmp/cov.md',
+            '--no-cleanup',
+        ]);
+
+        $this->assertSame('/tmp/spec', $opts['spec_base_path']);
+        $this->assertSame(['front', 'admin'], $opts['specs']);
+        $this->assertSame(['/api'], $opts['strip_prefixes']);
+        $this->assertSame('/tmp/sidecars', $opts['sidecar_dir']);
+        $this->assertSame('/tmp/cov.md', $opts['output_file']);
+        $this->assertFalse($opts['cleanup']);
+    }
+
+    #[Test]
+    public function parse_argv_recognises_help_flag(): void
+    {
+        $this->assertTrue(CoverageMergeCommand::parseArgv(['--help'])['help'] ?? false);
+        $this->assertTrue(CoverageMergeCommand::parseArgv(['-h'])['help'] ?? false);
+    }
+
+    #[Test]
+    public function applies_strip_prefixes_when_loading_specs(): void
+    {
+        // Worker recorded under stripped path /v1/pets — without the prefix
+        // configuration the spec loader would normally still match (specs
+        // store paths verbatim). The assertion here is structural: the merge
+        // CLI must accept and honour `strip_prefixes` so a downstream consumer
+        // that runs sequential-mode with a prefix can keep using the same
+        // spec setup under parallel-mode without surprises.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        $command = new CoverageMergeCommand(stdoutWriter: static fn(string $msg): null => null);
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'strip_prefixes' => ['/api'],
+            'output_file' => $this->outputFile,
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertFileExists($this->outputFile);
+    }
+
+    /** @return list<string> */
+    private function sidecars(): array
+    {
+        return glob($this->sidecarDir . '/*.json') ?: [];
+    }
+}

--- a/tests/Unit/CoverageReportSubscriberWorkerModeTest.php
+++ b/tests/Unit/CoverageReportSubscriberWorkerModeTest.php
@@ -13,11 +13,15 @@ use Studio\OpenApiContractTesting\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\PHPUnit\ConsoleOutput;
 use Studio\OpenApiContractTesting\PHPUnit\CoverageReportSubscriber;
 use Studio\OpenApiContractTesting\PHPUnit\CoverageSidecarReader;
+use Throwable;
 
+use function file_get_contents;
 use function file_put_contents;
 use function getenv;
+use function getmypid;
 use function glob;
 use function is_dir;
+use function json_decode;
 use function mkdir;
 use function ob_get_clean;
 use function ob_start;
@@ -183,7 +187,8 @@ class CoverageReportSubscriberWorkerModeTest extends TestCase
         putenv('TEST_TOKEN=1');
 
         // Pass a path that points at an existing FILE, not a directory, so
-        // mkdir/rename both fail. The subscriber must catch and warn.
+        // mkdir/rename both fail. The subscriber must catch, warn, and
+        // (per C2) drop a failure marker the merge CLI can detect.
         $blocker = sys_get_temp_dir() . '/openapi-coverage-blocker-' . uniqid('', true);
         file_put_contents($blocker, 'not a dir');
 
@@ -199,14 +204,65 @@ class CoverageReportSubscriberWorkerModeTest extends TestCase
             },
         );
 
+        $exception = null;
+
         try {
             $subscriber->notify($this->fakeExecutionFinished());
+        } catch (Throwable $e) {
+            $exception = $e;
         } finally {
             @unlink($blocker);
         }
 
+        $this->assertNull($exception, 'sidecar write failure must NOT bubble out of notify()');
         $this->assertStringContainsString('WARNING', $stderrLog);
         $this->assertStringContainsString('sidecar', $stderrLog);
+    }
+
+    #[Test]
+    public function worker_mode_writes_failure_marker_when_sidecar_write_fails(): void
+    {
+        // C2: when the sidecar write fails, the worker drops a
+        // `failed-<token>.json` marker in the sidecar dir so the merge CLI
+        // can detect a missing worker and exit non-zero. Without the
+        // marker, the merge would silently under-count coverage.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        putenv('TEST_TOKEN=7');
+
+        // sidecarDir is writable but the sidecar write itself fails by
+        // pointing the writer at a target whose `*.tmp` rename target is
+        // a directory rather than a file. We simulate this more simply
+        // by pre-occupying the final filename with a directory.
+        mkdir($this->tmpDir, 0o755, recursive: true);
+        $expectedSidecar = $this->tmpDir . '/part-7-' . (string) getmypid() . '.json';
+        mkdir($expectedSidecar, 0o755);
+
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            sidecarDir: $this->tmpDir,
+            stderrWriter: static fn(string $msg): null => null,
+        );
+
+        $subscriber->notify($this->fakeExecutionFinished());
+
+        $markerPath = $this->tmpDir . '/failed-7-' . (string) getmypid() . '.json';
+        $this->assertFileExists($markerPath, 'C2: failure marker must be dropped');
+        $payload = json_decode((string) file_get_contents($markerPath), true);
+        $this->assertSame('7', $payload['testToken']);
+        $this->assertNotEmpty($payload['reason']);
+
+        @unlink($markerPath);
+        @rmdir($expectedSidecar);
     }
 
     /**

--- a/tests/Unit/CoverageReportSubscriberWorkerModeTest.php
+++ b/tests/Unit/CoverageReportSubscriberWorkerModeTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use PHPUnit\Event\TestRunner\ExecutionFinished;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\PHPUnit\ConsoleOutput;
+use Studio\OpenApiContractTesting\PHPUnit\CoverageReportSubscriber;
+use Studio\OpenApiContractTesting\PHPUnit\CoverageSidecarReader;
+
+use function file_put_contents;
+use function getenv;
+use function glob;
+use function is_dir;
+use function mkdir;
+use function ob_get_clean;
+use function ob_start;
+use function putenv;
+use function rmdir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+/**
+ * Pins the paratest worker-mode contract on {@see CoverageReportSubscriber}:
+ * when `TEST_TOKEN` is set the subscriber writes a sidecar and emits NO
+ * stdout / output_file / GITHUB_STEP_SUMMARY output. When `TEST_TOKEN` is
+ * unset the subscriber renders normally — sequential PHPUnit must not be
+ * affected by these changes.
+ */
+class CoverageReportSubscriberWorkerModeTest extends TestCase
+{
+    private string $tmpDir = '';
+    private ?string $previousTestToken;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiCoverageTracker::reset();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs');
+
+        $this->tmpDir = sys_get_temp_dir() . '/openapi-coverage-subscriber-' . uniqid('', true);
+
+        // Snapshot whatever TEST_TOKEN was set to (some CI runners pre-set it).
+        $current = getenv('TEST_TOKEN');
+        $this->previousTestToken = $current === false ? null : $current;
+        putenv('TEST_TOKEN');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->previousTestToken === null) {
+            putenv('TEST_TOKEN');
+        } else {
+            putenv('TEST_TOKEN=' . $this->previousTestToken);
+        }
+
+        if (is_dir($this->tmpDir)) {
+            $entries = glob($this->tmpDir . '/*') ?: [];
+            foreach ($entries as $entry) {
+                @unlink($entry);
+            }
+            @rmdir($this->tmpDir);
+        }
+
+        OpenApiCoverageTracker::reset();
+        OpenApiSpecLoader::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function worker_mode_writes_sidecar_and_skips_rendering(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        putenv('TEST_TOKEN=4');
+
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: $this->tmpDir . '/coverage-report.md',
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            sidecarDir: $this->tmpDir,
+        );
+
+        ob_start();
+        $subscriber->notify($this->fakeExecutionFinished());
+        $stdout = (string) ob_get_clean();
+
+        $this->assertSame('', $stdout, 'worker mode must not emit console output');
+        $this->assertFileDoesNotExist($this->tmpDir . '/coverage-report.md', 'worker mode must not write output_file');
+
+        $loaded = CoverageSidecarReader::readDir($this->tmpDir);
+        $this->assertCount(1, $loaded);
+        $this->assertSame(1, $loaded[0]['version']);
+        $this->assertArrayHasKey('petstore-3.0', $loaded[0]['specs']);
+    }
+
+    #[Test]
+    public function worker_mode_writes_empty_sidecar_when_no_coverage_recorded(): void
+    {
+        // Pinning that workers always emit a sidecar — even an empty one —
+        // so the merge CLI never silently misses a worker that happened to
+        // run no contract assertions. Skipping the write here would make
+        // "0 tests touched the spec" indistinguishable from "the worker
+        // crashed before writing".
+        putenv('TEST_TOKEN=2');
+
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            sidecarDir: $this->tmpDir,
+        );
+
+        $subscriber->notify($this->fakeExecutionFinished());
+
+        $loaded = CoverageSidecarReader::readDir($this->tmpDir);
+        $this->assertCount(1, $loaded);
+        $this->assertSame([], $loaded[0]['specs']);
+    }
+
+    #[Test]
+    public function sequential_mode_renders_as_before_when_test_token_unset(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        $outputFile = $this->tmpDir . '/coverage-report.md';
+        mkdir($this->tmpDir, 0o755, recursive: true);
+
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: $outputFile,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            sidecarDir: $this->tmpDir,
+        );
+
+        ob_start();
+        $subscriber->notify($this->fakeExecutionFinished());
+        $stdout = (string) ob_get_clean();
+
+        $this->assertNotSame('', $stdout, 'sequential mode must render to stdout');
+        $this->assertFileExists($outputFile, 'sequential mode must write output_file');
+        $this->assertSame([], CoverageSidecarReader::readDir($this->tmpDir));
+    }
+
+    #[Test]
+    public function worker_mode_keeps_running_when_sidecar_write_fails(): void
+    {
+        // The contract assertion that triggered notify() must never be
+        // demoted to a hard failure by a sidecar I/O error — the user's
+        // tests already passed; sidecar trouble is a CI artifact concern.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        putenv('TEST_TOKEN=1');
+
+        // Pass a path that points at an existing FILE, not a directory, so
+        // mkdir/rename both fail. The subscriber must catch and warn.
+        $blocker = sys_get_temp_dir() . '/openapi-coverage-blocker-' . uniqid('', true);
+        file_put_contents($blocker, 'not a dir');
+
+        $stderrLog = '';
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            sidecarDir: $blocker,
+            stderrWriter: static function (string $msg) use (&$stderrLog): void {
+                $stderrLog .= $msg;
+            },
+        );
+
+        try {
+            $subscriber->notify($this->fakeExecutionFinished());
+        } finally {
+            @unlink($blocker);
+        }
+
+        $this->assertStringContainsString('WARNING', $stderrLog);
+        $this->assertStringContainsString('sidecar', $stderrLog);
+    }
+
+    /**
+     * Build a stub `ExecutionFinished` without invoking its constructor. The
+     * subscriber's `notify()` does not read the event, so a structurally
+     * valid stand-in is enough — and the real Telemetry constructor signature
+     * has churned across PHPUnit 11/12/13, which would force version-gated
+     * stub builders that add no test value.
+     */
+    private function fakeExecutionFinished(): ExecutionFinished
+    {
+        return (new ReflectionClass(ExecutionFinished::class))->newInstanceWithoutConstructor();
+    }
+}

--- a/tests/Unit/CoverageSidecarTest.php
+++ b/tests/Unit/CoverageSidecarTest.php
@@ -169,6 +169,24 @@ class CoverageSidecarTest extends TestCase
     }
 
     #[Test]
+    public function reader_distinguishes_sidecars_from_failure_markers(): void
+    {
+        // The merge CLI reads sidecars and failure markers separately —
+        // markers fail loudly, sidecars decode and merge. Pin that the
+        // reader's filename patterns don't bleed into each other.
+        CoverageSidecarWriter::write($this->tmpDir, '1', ['version' => 1, 'specs' => []]);
+        CoverageSidecarWriter::writeFailureMarker($this->tmpDir, '2', 'simulated failure');
+
+        $sidecars = CoverageSidecarReader::listPaths($this->tmpDir);
+        $markers = CoverageSidecarReader::listFailureMarkerPaths($this->tmpDir);
+
+        $this->assertCount(1, $sidecars);
+        $this->assertCount(1, $markers);
+        $this->assertStringContainsString('part-1-', $sidecars[0]);
+        $this->assertStringContainsString('failed-2-', $markers[0]);
+    }
+
+    #[Test]
     public function reader_lists_paths_for_cleanup(): void
     {
         $a = CoverageSidecarWriter::write($this->tmpDir, '1', ['version' => 1, 'specs' => []]);

--- a/tests/Unit/CoverageSidecarTest.php
+++ b/tests/Unit/CoverageSidecarTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\PHPUnit\CoverageSidecarReader;
+use Studio\OpenApiContractTesting\PHPUnit\CoverageSidecarWriter;
+
+use function array_map;
+use function file_put_contents;
+use function getmypid;
+use function glob;
+use function is_dir;
+use function mkdir;
+use function rmdir;
+use function sort;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+/**
+ * Pins the contract between the worker-side sidecar writer and the CLI-side
+ * reader. The two sides exchange a JSON file; if the writer's atomicity or
+ * the reader's filename pattern drifts, parallel coverage breaks silently.
+ */
+class CoverageSidecarTest extends TestCase
+{
+    private string $tmpDir = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiCoverageTracker::reset();
+        $this->tmpDir = sys_get_temp_dir() . '/openapi-coverage-test-' . uniqid('', true);
+        mkdir($this->tmpDir, 0o755, recursive: true);
+    }
+
+    protected function tearDown(): void
+    {
+        OpenApiCoverageTracker::reset();
+        if (is_dir($this->tmpDir)) {
+            $entries = glob($this->tmpDir . '/*') ?: [];
+            foreach ($entries as $entry) {
+                @unlink($entry);
+            }
+            @rmdir($this->tmpDir);
+        }
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function writer_writes_a_filename_with_test_token_and_pid(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        $path = CoverageSidecarWriter::write(
+            sidecarDir: $this->tmpDir,
+            testToken: '3',
+            state: OpenApiCoverageTracker::exportState(),
+        );
+
+        $this->assertStringStartsWith($this->tmpDir . '/', $path);
+        $this->assertStringContainsString('part-3-', $path);
+        $this->assertStringEndsWith('.json', $path);
+        $this->assertStringContainsString('-' . (string) getmypid() . '.json', $path);
+    }
+
+    #[Test]
+    public function writer_creates_sidecar_dir_when_missing(): void
+    {
+        $nested = $this->tmpDir . '/nested-dir';
+        $this->assertDirectoryDoesNotExist($nested);
+
+        $path = CoverageSidecarWriter::write(
+            sidecarDir: $nested,
+            testToken: '1',
+            state: ['version' => 1, 'specs' => []],
+        );
+
+        $this->assertDirectoryExists($nested);
+        $this->assertStringStartsWith($nested . '/', $path);
+
+        @unlink($path);
+        @rmdir($nested);
+    }
+
+    #[Test]
+    public function reader_round_trips_state_via_filesystem(): void
+    {
+        // Capture worker A's recorded state.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        $stateA = OpenApiCoverageTracker::exportState();
+
+        // Capture worker B's recorded state.
+        OpenApiCoverageTracker::reset();
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            '201',
+            'application/json',
+            schemaValidated: true,
+        );
+        $stateB = OpenApiCoverageTracker::exportState();
+
+        CoverageSidecarWriter::write($this->tmpDir, '1', $stateA);
+        CoverageSidecarWriter::write($this->tmpDir, '2', $stateB);
+
+        $loaded = CoverageSidecarReader::readDir($this->tmpDir);
+        $this->assertCount(2, $loaded);
+
+        // Merge both into a fresh tracker — must equal sequential recording.
+        OpenApiCoverageTracker::reset();
+        foreach ($loaded as $payload) {
+            OpenApiCoverageTracker::importState($payload);
+        }
+        $merged = OpenApiCoverageTracker::exportState();
+        $this->assertArrayHasKey('GET /v1/pets', $merged['specs']['petstore-3.0']);
+        $this->assertArrayHasKey('POST /v1/pets', $merged['specs']['petstore-3.0']);
+    }
+
+    #[Test]
+    public function reader_only_picks_up_part_prefixed_files(): void
+    {
+        // A sidecar plus an unrelated json — only the sidecar should be read.
+        CoverageSidecarWriter::write($this->tmpDir, '1', ['version' => 1, 'specs' => []]);
+        file_put_contents($this->tmpDir . '/coverage-report.md', '# unrelated');
+        file_put_contents($this->tmpDir . '/other.json', '{"ignored":true}');
+
+        $loaded = CoverageSidecarReader::readDir($this->tmpDir);
+        $this->assertCount(1, $loaded);
+    }
+
+    #[Test]
+    public function reader_returns_empty_array_when_dir_is_missing(): void
+    {
+        $loaded = CoverageSidecarReader::readDir($this->tmpDir . '/does-not-exist');
+        $this->assertSame([], $loaded);
+    }
+
+    #[Test]
+    public function reader_throws_on_malformed_json(): void
+    {
+        file_put_contents($this->tmpDir . '/part-1-9999.json', '{not valid json');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('failed to decode sidecar');
+
+        CoverageSidecarReader::readDir($this->tmpDir);
+    }
+
+    #[Test]
+    public function reader_lists_paths_for_cleanup(): void
+    {
+        $a = CoverageSidecarWriter::write($this->tmpDir, '1', ['version' => 1, 'specs' => []]);
+        $b = CoverageSidecarWriter::write($this->tmpDir, '2', ['version' => 1, 'specs' => []]);
+
+        $paths = CoverageSidecarReader::listPaths($this->tmpDir);
+        sort($paths);
+        $expected = [$a, $b];
+        sort($expected);
+        // Compare via realpath both sides — macOS resolves /var → /private/var
+        // so the writer's logical path and the glob's resolved path can diverge.
+        $this->assertSame(array_map('realpath', $expected), array_map('realpath', $paths));
+    }
+}

--- a/tests/Unit/OpenApiCoverageExtensionTest.php
+++ b/tests/Unit/OpenApiCoverageExtensionTest.php
@@ -189,6 +189,28 @@ class OpenApiCoverageExtensionTest extends TestCase
     }
 
     #[Test]
+    public function bootstrap_resolves_relative_sidecar_dir_against_cwd(): void
+    {
+        // Pin that the extension absolutises a relative `sidecar_dir`
+        // against `getcwd()`, mirroring the existing `output_file` and
+        // `spec_base_path` resolution. Pre-PR, sidecar_dir was new and
+        // its relative-path handling had no test coverage.
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => 'refs-valid',
+            'sidecar_dir' => 'relative-sidecars',
+        ]);
+
+        // setupExtension does not raise on relative paths; the exercise here
+        // is mainly that the codepath runs without error and that the
+        // absolutise call doesn't silently swallow the parameter.
+        $extension->setupExtension(null, $parameters, null);
+
+        $this->assertSame('', $this->readStderr());
+    }
+
+    #[Test]
     public function bootstrap_hard_fails_even_when_earlier_specs_are_valid(): void
     {
         // Order-independence: the loop must reach and trip on the broken spec

--- a/tests/Unit/OpenApiCoverageTrackerStateSerializationTest.php
+++ b/tests/Unit/OpenApiCoverageTrackerStateSerializationTest.php
@@ -473,4 +473,158 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
             ],
         ]);
     }
+
+    #[Test]
+    public function import_state_rejects_non_string_spec_name(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('invalid spec entry');
+
+        OpenApiCoverageTracker::importState([
+            'version' => 1,
+            'specs' => [
+                42 => ['GET /v1/pets' => ['requestReached' => true, 'responses' => []]],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function import_state_rejects_non_array_endpoint_entry(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('invalid endpoint entry');
+
+        OpenApiCoverageTracker::importState([
+            'version' => 1,
+            'specs' => [
+                'petstore-3.0' => ['GET /v1/pets' => 'not an array'],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function import_state_rejects_non_array_response_row(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('invalid response entry');
+
+        OpenApiCoverageTracker::importState([
+            'version' => 1,
+            'specs' => [
+                'petstore-3.0' => [
+                    'GET /v1/pets' => [
+                        'requestReached' => false,
+                        'responses' => ['200:application/json' => 'not an array'],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function import_state_rejects_non_string_response_state(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('invalid response state');
+
+        OpenApiCoverageTracker::importState([
+            'version' => 1,
+            'specs' => [
+                'petstore-3.0' => [
+                    'GET /v1/pets' => [
+                        'requestReached' => false,
+                        'responses' => ['200:application/json' => [
+                            'state' => 42,
+                            'hits' => 1,
+                            'skipReason' => null,
+                        ]],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function import_state_does_not_partially_apply_when_payload_is_invalid(): void
+    {
+        // Pre-PR, importer mutated state per-endpoint and threw partway,
+        // leaving the tracker inconsistent. Two-pass validate-then-apply
+        // must roll back cleanly: nothing is mutated when validation
+        // would eventually fail.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        $beforeSnapshot = OpenApiCoverageTracker::exportState();
+
+        try {
+            OpenApiCoverageTracker::importState([
+                'version' => 1,
+                'specs' => [
+                    'petstore-3.0' => [
+                        'POST /v1/pets' => [
+                            'requestReached' => false,
+                            'responses' => ['201:application/json' => [
+                                'state' => 'validated',
+                                'hits' => 1,
+                                'skipReason' => null,
+                            ]],
+                        ],
+                        'GET /v1/widgets' => [
+                            'requestReached' => false,
+                            'responses' => ['200:application/json' => [
+                                'state' => 'bogus',
+                                'hits' => 1,
+                                'skipReason' => null,
+                            ]],
+                        ],
+                    ],
+                ],
+            ]);
+            $this->fail('expected InvalidArgumentException');
+        } catch (InvalidArgumentException) {
+            // Expected — the second endpoint's "bogus" state must abort.
+        }
+
+        $this->assertSame($beforeSnapshot, OpenApiCoverageTracker::exportState());
+    }
+
+    #[Test]
+    public function reconcile_response_agrees_between_record_and_import_paths(): void
+    {
+        // Sequential single-record path: 2 skip + 1 validated.
+        OpenApiCoverageTracker::reset();
+        OpenApiCoverageTracker::recordResponse('petstore-3.0', 'GET', '/v1/pets', '200', 'application/json', schemaValidated: false, skipReason: 'reason-1');
+        OpenApiCoverageTracker::recordResponse('petstore-3.0', 'GET', '/v1/pets', '200', 'application/json', schemaValidated: false, skipReason: 'reason-2');
+        OpenApiCoverageTracker::recordResponse('petstore-3.0', 'GET', '/v1/pets', '200', 'application/json', schemaValidated: true);
+        $sequential = OpenApiCoverageTracker::exportState();
+
+        // Bulk-merge path: equivalent observations split across two payloads.
+        // First payload aggregates two skipped recordings into a single
+        // entry of hits=2 with the latest skipReason.
+        OpenApiCoverageTracker::reset();
+        OpenApiCoverageTracker::importState([
+            'version' => 1,
+            'specs' => ['petstore-3.0' => ['GET /v1/pets' => [
+                'requestReached' => false,
+                'responses' => ['200:application/json' => ['state' => 'skipped', 'hits' => 2, 'skipReason' => 'reason-2']],
+            ]]],
+        ]);
+        OpenApiCoverageTracker::importState([
+            'version' => 1,
+            'specs' => ['petstore-3.0' => ['GET /v1/pets' => [
+                'requestReached' => false,
+                'responses' => ['200:application/json' => ['state' => 'validated', 'hits' => 1, 'skipReason' => null]],
+            ]]],
+        ]);
+        $bulk = OpenApiCoverageTracker::exportState();
+
+        // The two paths must agree on the final reconciled state — pinned
+        // here so a future tweak to one branch and not the other is caught.
+        $this->assertSame($sequential, $bulk);
+    }
 }

--- a/tests/Unit/OpenApiCoverageTrackerStateSerializationTest.php
+++ b/tests/Unit/OpenApiCoverageTrackerStateSerializationTest.php
@@ -1,0 +1,476 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use const JSON_THROW_ON_ERROR;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+
+use function json_decode;
+use function json_encode;
+
+/**
+ * Pins the JSON-safe state shape produced by {@see OpenApiCoverageTracker::exportState()}
+ * and the union-merge semantics of {@see OpenApiCoverageTracker::importState()}.
+ *
+ * The merge CLI loads N worker sidecars by calling importState() N times, so
+ * the merge rules MUST mirror the live recording rules: validated wins over
+ * skipped, hits accumulate, and the latest non-null skipReason wins.
+ */
+class OpenApiCoverageTrackerStateSerializationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiCoverageTracker::reset();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs');
+    }
+
+    protected function tearDown(): void
+    {
+        OpenApiCoverageTracker::reset();
+        OpenApiSpecLoader::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function export_state_returns_empty_payload_when_nothing_recorded(): void
+    {
+        $state = OpenApiCoverageTracker::exportState();
+
+        $this->assertSame(['version' => 1, 'specs' => []], $state);
+    }
+
+    #[Test]
+    public function export_state_serializes_request_only_endpoint(): void
+    {
+        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets');
+
+        $state = OpenApiCoverageTracker::exportState();
+
+        $this->assertSame([
+            'version' => 1,
+            'specs' => [
+                'petstore-3.0' => [
+                    'GET /v1/pets' => [
+                        'requestReached' => true,
+                        'responses' => [],
+                    ],
+                ],
+            ],
+        ], $state);
+    }
+
+    #[Test]
+    public function export_state_serializes_validated_response(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        $state = OpenApiCoverageTracker::exportState();
+
+        $this->assertSame([
+            'version' => 1,
+            'specs' => [
+                'petstore-3.0' => [
+                    'GET /v1/pets' => [
+                        'requestReached' => false,
+                        'responses' => [
+                            '200:application/json' => [
+                                'state' => 'validated',
+                                'hits' => 1,
+                                'skipReason' => null,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $state);
+    }
+
+    #[Test]
+    public function export_state_serializes_skipped_response_with_reason(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '503',
+            null,
+            schemaValidated: false,
+            skipReason: 'status 503 matched skip pattern 5\\d\\d',
+        );
+
+        $state = OpenApiCoverageTracker::exportState();
+
+        $this->assertSame([
+            'version' => 1,
+            'specs' => [
+                'petstore-3.0' => [
+                    'GET /v1/pets' => [
+                        'requestReached' => false,
+                        'responses' => [
+                            '503:*' => [
+                                'state' => 'skipped',
+                                'hits' => 1,
+                                'skipReason' => 'status 503 matched skip pattern 5\\d\\d',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $state);
+    }
+
+    #[Test]
+    public function export_state_round_trips_through_json(): void
+    {
+        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets');
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/{petId}',
+            '503',
+            null,
+            schemaValidated: false,
+            skipReason: 'matched 5\\d\\d',
+        );
+
+        $original = OpenApiCoverageTracker::exportState();
+        $json = json_encode($original, JSON_THROW_ON_ERROR);
+        $decoded = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+
+        OpenApiCoverageTracker::reset();
+        OpenApiCoverageTracker::importState($decoded);
+
+        $this->assertSame($original, OpenApiCoverageTracker::exportState());
+    }
+
+    #[Test]
+    public function import_state_is_additive_for_disjoint_specs(): void
+    {
+        // Worker A's state.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        $workerA = OpenApiCoverageTracker::exportState();
+
+        // Worker B's state, captured from a fresh tracker.
+        OpenApiCoverageTracker::reset();
+        OpenApiCoverageTracker::recordResponse(
+            'range-keys',
+            'GET',
+            '/widgets-default',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        $workerB = OpenApiCoverageTracker::exportState();
+
+        // Merge both into one tracker.
+        OpenApiCoverageTracker::reset();
+        OpenApiCoverageTracker::importState($workerA);
+        OpenApiCoverageTracker::importState($workerB);
+
+        $merged = OpenApiCoverageTracker::exportState();
+        $this->assertArrayHasKey('petstore-3.0', $merged['specs']);
+        $this->assertArrayHasKey('range-keys', $merged['specs']);
+        $this->assertSame(
+            1,
+            $merged['specs']['petstore-3.0']['GET /v1/pets']['responses']['200:application/json']['hits'],
+        );
+        $this->assertSame(
+            1,
+            $merged['specs']['range-keys']['GET /widgets-default']['responses']['200:application/json']['hits'],
+        );
+    }
+
+    #[Test]
+    public function import_state_accumulates_hits_for_same_pair(): void
+    {
+        // Two workers both validated GET /v1/pets 200:application/json once.
+        $worker = [
+            'version' => 1,
+            'specs' => [
+                'petstore-3.0' => [
+                    'GET /v1/pets' => [
+                        'requestReached' => false,
+                        'responses' => [
+                            '200:application/json' => [
+                                'state' => 'validated',
+                                'hits' => 1,
+                                'skipReason' => null,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        OpenApiCoverageTracker::importState($worker);
+        OpenApiCoverageTracker::importState($worker);
+
+        $merged = OpenApiCoverageTracker::exportState();
+        $this->assertSame(
+            2,
+            $merged['specs']['petstore-3.0']['GET /v1/pets']['responses']['200:application/json']['hits'],
+        );
+    }
+
+    #[Test]
+    public function import_state_promotes_skipped_to_validated(): void
+    {
+        $skippedFirst = [
+            'version' => 1,
+            'specs' => [
+                'petstore-3.0' => [
+                    'GET /v1/pets' => [
+                        'requestReached' => false,
+                        'responses' => [
+                            '200:application/json' => [
+                                'state' => 'skipped',
+                                'hits' => 2,
+                                'skipReason' => 'matched 2xx-skip',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $validatedSecond = [
+            'version' => 1,
+            'specs' => [
+                'petstore-3.0' => [
+                    'GET /v1/pets' => [
+                        'requestReached' => false,
+                        'responses' => [
+                            '200:application/json' => [
+                                'state' => 'validated',
+                                'hits' => 1,
+                                'skipReason' => null,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        OpenApiCoverageTracker::importState($skippedFirst);
+        OpenApiCoverageTracker::importState($validatedSecond);
+
+        $merged = OpenApiCoverageTracker::exportState();
+        $row = $merged['specs']['petstore-3.0']['GET /v1/pets']['responses']['200:application/json'];
+        $this->assertSame('validated', $row['state']);
+        $this->assertNull($row['skipReason']);
+        // Bulk merge sums hits across both sources — matches sequential
+        // recordResponse() calls where hits++ runs unconditionally and
+        // state promotion does not roll the counter back.
+        $this->assertSame(3, $row['hits']);
+    }
+
+    #[Test]
+    public function import_state_keeps_validated_when_skipped_arrives_later(): void
+    {
+        $validatedFirst = [
+            'version' => 1,
+            'specs' => [
+                'petstore-3.0' => [
+                    'GET /v1/pets' => [
+                        'requestReached' => false,
+                        'responses' => [
+                            '200:application/json' => [
+                                'state' => 'validated',
+                                'hits' => 3,
+                                'skipReason' => null,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $skippedSecond = [
+            'version' => 1,
+            'specs' => [
+                'petstore-3.0' => [
+                    'GET /v1/pets' => [
+                        'requestReached' => false,
+                        'responses' => [
+                            '200:application/json' => [
+                                'state' => 'skipped',
+                                'hits' => 1,
+                                'skipReason' => 'late skip',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        OpenApiCoverageTracker::importState($validatedFirst);
+        OpenApiCoverageTracker::importState($skippedSecond);
+
+        $merged = OpenApiCoverageTracker::exportState();
+        $row = $merged['specs']['petstore-3.0']['GET /v1/pets']['responses']['200:application/json'];
+        $this->assertSame('validated', $row['state']);
+        $this->assertNull($row['skipReason']);
+        $this->assertSame(4, $row['hits']);
+    }
+
+    #[Test]
+    public function import_state_keeps_latest_skip_reason_when_both_sides_skipped(): void
+    {
+        $first = [
+            'version' => 1,
+            'specs' => [
+                'petstore-3.0' => [
+                    'GET /v1/pets' => [
+                        'requestReached' => false,
+                        'responses' => [
+                            '503:*' => [
+                                'state' => 'skipped',
+                                'hits' => 2,
+                                'skipReason' => 'old reason',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $second = [
+            'version' => 1,
+            'specs' => [
+                'petstore-3.0' => [
+                    'GET /v1/pets' => [
+                        'requestReached' => false,
+                        'responses' => [
+                            '503:*' => [
+                                'state' => 'skipped',
+                                'hits' => 1,
+                                'skipReason' => 'new reason',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        OpenApiCoverageTracker::importState($first);
+        OpenApiCoverageTracker::importState($second);
+
+        $merged = OpenApiCoverageTracker::exportState();
+        $row = $merged['specs']['petstore-3.0']['GET /v1/pets']['responses']['503:*'];
+        $this->assertSame('skipped', $row['state']);
+        $this->assertSame('new reason', $row['skipReason']);
+        $this->assertSame(3, $row['hits']);
+    }
+
+    #[Test]
+    public function import_state_unions_request_reached_flag(): void
+    {
+        $reached = [
+            'version' => 1,
+            'specs' => [
+                'petstore-3.0' => [
+                    'GET /v1/pets' => [
+                        'requestReached' => true,
+                        'responses' => [],
+                    ],
+                ],
+            ],
+        ];
+        $notReached = [
+            'version' => 1,
+            'specs' => [
+                'petstore-3.0' => [
+                    'GET /v1/pets' => [
+                        'requestReached' => false,
+                        'responses' => [
+                            '200:application/json' => [
+                                'state' => 'validated',
+                                'hits' => 1,
+                                'skipReason' => null,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        OpenApiCoverageTracker::importState($reached);
+        OpenApiCoverageTracker::importState($notReached);
+
+        $merged = OpenApiCoverageTracker::exportState();
+        $endpoint = $merged['specs']['petstore-3.0']['GET /v1/pets'];
+        $this->assertTrue($endpoint['requestReached']);
+        $this->assertArrayHasKey('200:application/json', $endpoint['responses']);
+    }
+
+    #[Test]
+    public function import_state_rejects_unknown_version(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('unsupported coverage state version');
+
+        OpenApiCoverageTracker::importState(['version' => 99, 'specs' => []]);
+    }
+
+    #[Test]
+    public function import_state_rejects_missing_version(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('missing "version"');
+
+        OpenApiCoverageTracker::importState(['specs' => []]);
+    }
+
+    #[Test]
+    public function import_state_rejects_invalid_response_state(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('invalid response state');
+
+        OpenApiCoverageTracker::importState([
+            'version' => 1,
+            'specs' => [
+                'petstore-3.0' => [
+                    'GET /v1/pets' => [
+                        'requestReached' => false,
+                        'responses' => [
+                            '200:application/json' => [
+                                'state' => 'bogus',
+                                'hits' => 1,
+                                'skipReason' => null,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
# 概要

`OpenApiCoverageExtension` をパラレルテストランナー（paratest / Pest 4 `--parallel`）に対応させる。worker ごとに JSON sidecar を書き出し、専用 CLI で集約する 2-step ワークフローを導入。

## 変更内容

`OpenApiCoverageTracker` の状態がプロセスローカル（static）なため、これまで paratest 配下では各 worker が独立にレポートを出力し、`output_file` は最後の worker に上書きされ、`GITHUB_STEP_SUMMARY` には N 個の partial レポートがスタックされていた。

PHP エコシステムの慣習（`phpunit/php-code-coverage` + `phpcov merge`、infection の `TEST_TOKEN` 検出）に整合する形で、worker → sidecar → 別 CLI で集約 のアプローチを採用。

- **`OpenApiCoverageTracker::exportState()` / `importState()`** — JSON-safe な状態スナップショット + union-merge プリミティブ。マージ規則は既存 `recordResponse()` のセマンティクスを完全にミラー（validated > skipped、hits 累積、skipReason 後勝ち）。format に `version: 1` を埋めて将来変更時の reject を担保
- **`CoverageSidecarWriter` / `CoverageSidecarReader`** — atomic な per-worker JSON ファイル（tmp + rename）。ファイル名は `part-<token>-<pid>.json`、token は filesystem-unsafe 文字を sanitise
- **`CoverageReportSubscriber`** — `TEST_TOKEN` 環境変数を検出した場合は sidecar 書き出しのみで rendering 全停止。シーケンシャル PHPUnit の挙動は完全互換。sidecar 書き出し失敗は WARNING 降格（テスト本体は通過済みなので CI artifact 問題で run を落とさない）
- **`CoverageMergeCommand` + `bin/openapi-coverage-merge`** — sidecar dir をスキャン → import → render（Console / Markdown / GITHUB_STEP_SUMMARY）→ cleanup。`composer.json` の `bin` セクションに登録
- **`sidecar_dir` extension パラメータを追加**（デフォルト `sys_get_temp_dir()/openapi-coverage-sidecars`）
- **README に「Parallel test runners」節を新設**、ワークフロー・全 CLI フラグ・既知のトレードオフを文書化
- **CHANGELOG に Unreleased エントリを追加**

ワークフロー例：

\`\`\`bash
# 1. 並列実行 — workers は sidecar のみ書き出し
vendor/bin/pest --parallel --processes=4

# 2. 集約 — 1 個の統合レポートを生成
vendor/bin/openapi-coverage-merge \\
    --spec-base-path=openapi/bundled \\
    --specs=front,admin \\
    --output-file=coverage-report.md
\`\`\`

### テスト

TDD で実装。新規追加：

- `OpenApiCoverageTrackerStateSerializationTest` (14 tests) — export/import round-trip + union-merge 規則
- `CoverageSidecarTest` (7 tests) — writer/reader 契約
- `CoverageReportSubscriberWorkerModeTest` (4 tests) — TEST_TOKEN 分岐・失敗パス
- `CoverageMergeCommandTest` (7 tests) — CLI 本体・引数 parse
- `CoverageMergeCliIntegrationTest` (3 tests) — 実 binary を spawn して end-to-end 検証

### QA

- `vendor/bin/phpunit` — **865 tests, 1766 assertions OK**
- `vendor/bin/phpstan analyse` — **No errors**（level 6）
- `vendor/bin/php-cs-fixer fix --dry-run` — **clean**

### 互換性

- シーケンシャル PHPUnit 実行（`TEST_TOKEN` 未設定）は **完全互換**。sidecar コードパスには到達しない
- 新 `sidecar_dir` パラメータは optional、デフォルトは安定パス（追加設定なしで動く）
- worker 側の sidecar 書き出し失敗は test を落とさない

## 関連情報

Closes #129

### 設計判断のメモ

- **autodetect (worker が「最後の自分」を判定して merge する案) は採用しない**：paratest が worker 数 N を子プロセスに渡す手段が無く、構造的に堅牢な実装が不可能。同じ理由で `phpcov merge` も別 CLI 形式
- **CLI 名 `openapi-coverage-merge`**：`phpcov merge` 等の慣習に整合する動詞+名詞形
- **`ExecutionFinished` イベントのテストスタブ**：PHPUnit 11/12/13 で `Telemetry\Snapshot` のコンストラクタ署名が割れているため、`ReflectionClass::newInstanceWithoutConstructor()` で空インスタンスを生成（`notify()` はイベントを使わないので影響なし）