### PR TITLE
fix(laravel): trim vendor frames from contract validation failure traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,11 @@ until 1.0.0 ships. Each entry below tags whether it is breaking.
 - **#131 — Clean stack trace for contract validation failures**. PHPUnit's
   failure block no longer surfaces this library's internal frames or
   Laravel's `MakesHttpRequests` / `TestResponse` testing-concern frames
-  before the user's test line. The trait now intercepts the
-  `AssertionFailedError` raised at every failure site and re-throws with a
-  trimmed trace (issue #131). Behavior change is trace-only — exception
-  type, message, and the user-visible test line are unchanged. No
-  user-side configuration is required.
+  before the user's test line. The trait intercepts the
+  `AssertionFailedError` raised at its own failure sites and re-throws
+  with a trimmed trace. Behavior change is trace-only — exception type,
+  message, and the user-visible test line are unchanged. No user-side
+  configuration is required.
 
 ## v0.14.0 — 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project is **pre-1.0**, so breaking changes may land in any minor release
 until 1.0.0 ships. Each entry below tags whether it is breaking.
 
+## Unreleased
+
+### Fixed
+
+- **#131 — Clean stack trace for contract validation failures**. PHPUnit's
+  failure block no longer surfaces this library's internal frames or
+  Laravel's `MakesHttpRequests` / `TestResponse` testing-concern frames
+  before the user's test line. The trait now intercepts the
+  `AssertionFailedError` raised at every failure site and re-throws with a
+  trimmed trace (issue #131). Behavior change is trace-only — exception
+  type, message, and the user-visible test line are unchanged. No
+  user-side configuration is required.
+
 ## v0.14.0 — 2026-04-28
 
 Parallel-runner support unblocks `pest --parallel` / paratest in

--- a/src/Laravel/Internal/StackTraceFilter.php
+++ b/src/Laravel/Internal/StackTraceFilter.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Laravel\Internal;
 
+use Error;
 use Exception;
 use PHPUnit\Framework\AssertionFailedError;
+use ReflectionException;
 use ReflectionProperty;
 
 use function array_values;
@@ -16,7 +18,7 @@ use function str_replace;
 /**
  * @internal Trims this library's own + Laravel test-concern frames out of an
  *           assertion-failure trace so a contract-test failure points at the
- *           user's test line, not at vendor code (issue #131).
+ *           user's test line, not at vendor code.
  */
 final class StackTraceFilter
 {
@@ -31,8 +33,10 @@ final class StackTraceFilter
      *   between the trait hook and the user test method.
      *
      * PHPUnit's own internal frames (Assert, Constraint, TestCase) are
-     * already filtered by PHPUnit's `ExcludeList` at display time, so they
-     * are not listed here.
+     * filtered by PHPUnit's stack-trace formatter when the default result
+     * printer renders the failure block, so we leave them in the raw trace.
+     * Tools that read `$exception->getTrace()` directly (Sentry, custom
+     * reporters) will still see them.
      *
      * @var list<string>
      */
@@ -50,13 +54,16 @@ final class StackTraceFilter
      * Filter library/framework frames out of an assertion failure's trace
      * and re-throw. If filtering would empty the trace, the original trace
      * is preserved — a clean trace is never worth less debug info than what
-     * we started with.
+     * we started with. If the reflection-based trace rewrite fails for any
+     * reason (future PHP / PHPUnit changes the property contract), the
+     * original exception still propagates with its full trace; we never
+     * mask the contract-test failure with a reflection error.
      *
-     * Only `trace` is rewritten. `getFile()` / `getLine()` are left alone
-     * because the displayed PHPUnit failure block lists frames directly and
-     * does not surface a single "in /file:line" header — rewriting them
-     * would only affect programmatic inspection, where the natural target
-     * (the throw site) is rarely the user's test line anyway.
+     * Only `trace` is rewritten. `getFile()` / `getLine()` keep their
+     * throw-site values because rewriting them would lie about where the
+     * exception was actually constructed — a price programmatic consumers
+     * (Sentry, custom reporters) would pay for the default renderer's
+     * display preference.
      */
     public static function rethrowWithCleanTrace(AssertionFailedError $exception): never
     {
@@ -65,7 +72,13 @@ final class StackTraceFilter
         $filtered = self::filterFrames($original);
 
         if ($filtered !== [] && $filtered !== $original) {
-            self::traceProperty()->setValue($exception, $filtered);
+            try {
+                self::traceProperty()->setValue($exception, $filtered);
+            } catch (Error|ReflectionException) {
+                // Reflection contract changed underneath us — fall through
+                // and re-throw with the original trace rather than mask the
+                // assertion failure with a reflection error.
+            }
         }
 
         throw $exception;

--- a/src/Laravel/Internal/StackTraceFilter.php
+++ b/src/Laravel/Internal/StackTraceFilter.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Laravel\Internal;
+
+use Exception;
+use PHPUnit\Framework\AssertionFailedError;
+use ReflectionProperty;
+
+use function array_values;
+use function is_string;
+use function str_contains;
+use function str_replace;
+
+/**
+ * @internal Trims this library's own + Laravel test-concern frames out of an
+ *           assertion-failure trace so a contract-test failure points at the
+ *           user's test line, not at vendor code (issue #131).
+ */
+final class StackTraceFilter
+{
+    /**
+     * Frame `file` substrings (forward-slash form) that mark frames as
+     * library/framework noise and should be dropped from the trace.
+     *
+     * - `studio-design/openapi-contract-testing/src/` covers the composer-installed location.
+     * - `openapi-contract-testing/src/Laravel/`, `…/src/Internal/`, `…/src/PHPUnit/`
+     *   cover path-repo / monorepo dev installs where the vendor prefix is absent.
+     * - The two Laravel entries cover the testing concerns that always sit
+     *   between the trait hook and the user test method.
+     *
+     * PHPUnit's own internal frames (Assert, Constraint, TestCase) are
+     * already filtered by PHPUnit's `ExcludeList` at display time, so they
+     * are not listed here.
+     *
+     * @var list<string>
+     */
+    private const DROP_PATTERNS = [
+        '/studio-design/openapi-contract-testing/src/',
+        '/openapi-contract-testing/src/Laravel/',
+        '/openapi-contract-testing/src/Internal/',
+        '/openapi-contract-testing/src/PHPUnit/',
+        '/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php',
+        '/Illuminate/Testing/TestResponse.php',
+    ];
+    private static ?ReflectionProperty $traceProperty = null;
+
+    /**
+     * Filter library/framework frames out of an assertion failure's trace
+     * and re-throw. If filtering would empty the trace, the original trace
+     * is preserved — a clean trace is never worth less debug info than what
+     * we started with.
+     *
+     * Only `trace` is rewritten. `getFile()` / `getLine()` are left alone
+     * because the displayed PHPUnit failure block lists frames directly and
+     * does not surface a single "in /file:line" header — rewriting them
+     * would only affect programmatic inspection, where the natural target
+     * (the throw site) is rarely the user's test line anyway.
+     */
+    public static function rethrowWithCleanTrace(AssertionFailedError $exception): never
+    {
+        /** @var list<array<string, mixed>> $original */
+        $original = $exception->getTrace();
+        $filtered = self::filterFrames($original);
+
+        if ($filtered !== [] && $filtered !== $original) {
+            self::traceProperty()->setValue($exception, $filtered);
+        }
+
+        throw $exception;
+    }
+
+    /**
+     * Drop frames whose `file` matches any DROP_PATTERNS entry. Frames without
+     * a `file` key (closures, internal calls) are kept — we cannot tell where
+     * they originate, and dropping them would risk hiding user code.
+     *
+     * @param list<array<string, mixed>> $trace
+     *
+     * @return list<array<string, mixed>>
+     */
+    public static function filterFrames(array $trace): array
+    {
+        $kept = [];
+        foreach ($trace as $frame) {
+            $file = $frame['file'] ?? null;
+            if (!is_string($file)) {
+                $kept[] = $frame;
+
+                continue;
+            }
+
+            $normalized = str_replace('\\', '/', $file);
+            $drop = false;
+            foreach (self::DROP_PATTERNS as $pattern) {
+                if (str_contains($normalized, $pattern)) {
+                    $drop = true;
+
+                    break;
+                }
+            }
+            if (!$drop) {
+                $kept[] = $frame;
+            }
+        }
+
+        return array_values($kept);
+    }
+
+    private static function traceProperty(): ReflectionProperty
+    {
+        return self::$traceProperty ??= new ReflectionProperty(Exception::class, 'trace');
+    }
+}

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -13,8 +13,11 @@ use const STDERR;
 use Illuminate\Testing\TestResponse;
 use InvalidArgumentException;
 use JsonException;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\AssertionFailedError;
 use RuntimeException;
 use Studio\OpenApiContractTesting\HttpMethod;
+use Studio\OpenApiContractTesting\Laravel\Internal\StackTraceFilter;
 use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\OpenApiPathMatcher;
 use Studio\OpenApiContractTesting\OpenApiRequestValidator;
@@ -289,7 +292,7 @@ trait ValidatesOpenApiSchema
 
         $specName = $this->resolveOpenApiSpec();
         if ($specName === '') {
-            $this->fail(
+            $this->failOpenApi(
                 'openApiSpec() must return a non-empty spec name, but an empty string was returned. '
                 . 'Either add #[OpenApiSpec(\'your-spec\')] to your test class or method, '
                 . 'override openApiSpec() in your test class, or set the "default_spec" key '
@@ -341,7 +344,7 @@ trait ValidatesOpenApiSchema
             );
         }
 
-        $this->assertTrue(
+        $this->assertOpenApi(
             $result->isValid(),
             "OpenAPI request validation failed for {$resolvedMethod} {$resolvedPath} (spec: {$specName}):\n"
             . $result->errorMessage(),
@@ -427,7 +430,7 @@ trait ValidatesOpenApiSchema
 
         $specName = $this->resolveOpenApiSpec();
         if ($specName === '') {
-            $this->fail(
+            $this->failOpenApi(
                 'openApiSpec() must return a non-empty spec name, but an empty string was returned. '
                 . 'Either add #[OpenApiSpec(\'your-spec\')] to your test class or method, '
                 . 'override openApiSpec() in your test class, or set the "default_spec" key '
@@ -448,7 +451,7 @@ trait ValidatesOpenApiSchema
 
         $content = $response->getContent();
         if ($content === false) {
-            $this->fail('OpenAPI contract testing requires buffered responses, but getContent() returned false (streamed response?).');
+            $this->failOpenApi('OpenAPI contract testing requires buffered responses, but getContent() returned false (streamed response?).');
         }
 
         $contentType = $response->headers->get('Content-Type', '');
@@ -497,7 +500,7 @@ trait ValidatesOpenApiSchema
             );
         }
 
-        $this->assertTrue(
+        $this->assertOpenApi(
             $result->isValid(),
             "OpenAPI schema validation failed for {$resolvedMethod} {$resolvedPath} (spec: {$specName}):\n"
             . $result->errorMessage(),
@@ -693,7 +696,7 @@ trait ValidatesOpenApiSchema
         $raw = config('openapi-contract-testing.skip_response_codes', OpenApiResponseValidator::DEFAULT_SKIP_RESPONSE_CODES);
 
         if (!is_array($raw)) {
-            $this->fail(sprintf(
+            $this->failOpenApi(sprintf(
                 'openapi-contract-testing.skip_response_codes must be an array of regex patterns, got %s: %s.',
                 get_debug_type($raw),
                 var_export($raw, true),
@@ -703,14 +706,14 @@ trait ValidatesOpenApiSchema
         $patterns = [];
         foreach ($raw as $index => $pattern) {
             if (!is_string($pattern)) {
-                $this->fail(sprintf(
+                $this->failOpenApi(sprintf(
                     'openapi-contract-testing.skip_response_codes[%s] must be a string regex pattern, got %s.',
                     (string) $index,
                     get_debug_type($pattern),
                 ));
             }
             if ($pattern === '') {
-                $this->fail(sprintf(
+                $this->failOpenApi(sprintf(
                     'openapi-contract-testing.skip_response_codes[%s] must not be an empty string.',
                     (string) $index,
                 ));
@@ -767,6 +770,33 @@ trait ValidatesOpenApiSchema
         trigger_error($message, E_USER_DEPRECATED);
     }
 
+    /**
+     * fail() with this library's + Laravel testing-concern frames trimmed off
+     * the resulting trace so the user-relevant test line appears first
+     * (issue #131).
+     */
+    private function failOpenApi(string $message): never
+    {
+        try {
+            Assert::fail($message);
+        } catch (AssertionFailedError $e) {
+            StackTraceFilter::rethrowWithCleanTrace($e);
+        }
+    }
+
+    /**
+     * assertTrue() counterpart to {@see self::failOpenApi()} — re-throws with
+     * a trimmed trace on failure, no-ops on success.
+     */
+    private function assertOpenApi(bool $condition, string $message): void
+    {
+        try {
+            Assert::assertTrue($condition, $message);
+        } catch (AssertionFailedError $e) {
+            StackTraceFilter::rethrowWithCleanTrace($e);
+        }
+    }
+
     private function isAutoAssertEnabled(): bool
     {
         return $this->resolveBoolConfig('auto_assert');
@@ -802,7 +832,7 @@ trait ValidatesOpenApiSchema
 
         $parsed = filter_var($raw, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
         if ($parsed === null) {
-            $this->fail(sprintf(
+            $this->failOpenApi(sprintf(
                 'openapi-contract-testing.%s must be a boolean (or a boolean-compatible value '
                 . 'like "true"/"false"/"1"/"0"), got %s: %s.',
                 $key,
@@ -835,7 +865,7 @@ trait ValidatesOpenApiSchema
             /** @var mixed $decoded */
             $decoded = json_decode($content, true, flags: JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {
-            $this->fail(
+            $this->failOpenApi(
                 'Request body could not be parsed as JSON: ' . $e->getMessage()
                 . ($contentType === '' ? ' (no Content-Type header was present on the request)' : ''),
             );
@@ -860,7 +890,7 @@ trait ValidatesOpenApiSchema
         try {
             return $response->json();
         } catch (JsonException $e) {
-            $this->fail(
+            $this->failOpenApi(
                 'Response body could not be parsed as JSON: ' . $e->getMessage()
                 . ($contentType === '' ? ' (no Content-Type header was present on the response)' : ''),
             );

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -770,11 +770,7 @@ trait ValidatesOpenApiSchema
         trigger_error($message, E_USER_DEPRECATED);
     }
 
-    /**
-     * fail() with this library's + Laravel testing-concern frames trimmed off
-     * the resulting trace so the user-relevant test line appears first
-     * (issue #131).
-     */
+    /** Like Assert::fail() but with vendor frames stripped from the trace. */
     private function failOpenApi(string $message): never
     {
         try {
@@ -784,10 +780,7 @@ trait ValidatesOpenApiSchema
         }
     }
 
-    /**
-     * assertTrue() counterpart to {@see self::failOpenApi()} — re-throws with
-     * a trimmed trace on failure, no-ops on success.
-     */
+    /** Like Assert::assertTrue() but with vendor frames stripped from the trace on failure. */
     private function assertOpenApi(bool $condition, string $message): void
     {
         try {

--- a/tests/Unit/Laravel/Internal/StackTraceFilterTest.php
+++ b/tests/Unit/Laravel/Internal/StackTraceFilterTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Laravel\Internal;
+
+use Exception;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use Studio\OpenApiContractTesting\Laravel\Internal\StackTraceFilter;
+
+use function array_column;
+use function array_keys;
+
+class StackTraceFilterTest extends TestCase
+{
+    #[Test]
+    public function drops_frames_inside_studio_design_library_path(): void
+    {
+        $trace = [
+            ['file' => '/app/vendor/studio-design/openapi-contract-testing/src/Laravel/ValidatesOpenApiSchema.php', 'line' => 500, 'function' => 'assertResponseMatchesOpenApiSchema'],
+            ['file' => '/app/tests/Feature/PetTest.php', 'line' => 47, 'function' => 'test_index'],
+        ];
+
+        $filtered = StackTraceFilter::filterFrames($trace);
+
+        $files = array_column($filtered, 'file');
+        $this->assertSame(['/app/tests/Feature/PetTest.php'], $files);
+    }
+
+    #[Test]
+    public function drops_frames_inside_local_path_repo_install(): void
+    {
+        $trace = [
+            ['file' => '/repos/openapi-contract-testing/src/Laravel/ValidatesOpenApiSchema.php', 'line' => 500],
+            ['file' => '/repos/openapi-contract-testing/src/Internal/SpecDocumentDecoder.php', 'line' => 12],
+            ['file' => '/repos/openapi-contract-testing/src/PHPUnit/Subscriber.php', 'line' => 33],
+            ['file' => '/repos/myapp/tests/Feature/PetTest.php', 'line' => 47],
+        ];
+
+        $filtered = StackTraceFilter::filterFrames($trace);
+
+        $this->assertCount(1, $filtered);
+        $this->assertSame('/repos/myapp/tests/Feature/PetTest.php', $filtered[0]['file']);
+    }
+
+    #[Test]
+    public function drops_makes_http_requests_frames(): void
+    {
+        $trace = [
+            ['file' => '/app/vendor/laravel/framework/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php', 'line' => 617],
+            ['file' => '/app/vendor/laravel/framework/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php', 'line' => 573],
+            ['file' => '/app/tests/Feature/PetTest.php', 'line' => 47],
+        ];
+
+        $filtered = StackTraceFilter::filterFrames($trace);
+
+        $this->assertSame(['/app/tests/Feature/PetTest.php'], array_column($filtered, 'file'));
+    }
+
+    #[Test]
+    public function drops_test_response_frames(): void
+    {
+        $trace = [
+            ['file' => '/app/vendor/laravel/framework/src/Illuminate/Testing/TestResponse.php', 'line' => 100],
+            ['file' => '/app/tests/Feature/PetTest.php', 'line' => 47],
+        ];
+
+        $filtered = StackTraceFilter::filterFrames($trace);
+
+        $this->assertSame(['/app/tests/Feature/PetTest.php'], array_column($filtered, 'file'));
+    }
+
+    #[Test]
+    public function preserves_user_frames(): void
+    {
+        $trace = [
+            ['file' => '/app/tests/Feature/Helpers/MyApiHelper.php', 'line' => 10],
+            ['file' => '/app/tests/Feature/PetTest.php', 'line' => 47],
+        ];
+
+        $filtered = StackTraceFilter::filterFrames($trace);
+
+        $this->assertCount(2, $filtered);
+        $this->assertSame('/app/tests/Feature/Helpers/MyApiHelper.php', $filtered[0]['file']);
+        $this->assertSame('/app/tests/Feature/PetTest.php', $filtered[1]['file']);
+    }
+
+    #[Test]
+    public function preserves_order_of_remaining_frames(): void
+    {
+        $trace = [
+            ['file' => '/app/vendor/studio-design/openapi-contract-testing/src/Laravel/ValidatesOpenApiSchema.php', 'line' => 500],
+            ['file' => '/app/tests/Feature/A.php', 'line' => 1],
+            ['file' => '/app/vendor/laravel/framework/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php', 'line' => 617],
+            ['file' => '/app/tests/Feature/B.php', 'line' => 2],
+        ];
+
+        $filtered = StackTraceFilter::filterFrames($trace);
+
+        $this->assertSame(
+            ['/app/tests/Feature/A.php', '/app/tests/Feature/B.php'],
+            array_column($filtered, 'file'),
+        );
+        $this->assertSame([0, 1], array_keys($filtered));
+    }
+
+    #[Test]
+    public function returns_identical_list_when_nothing_matches(): void
+    {
+        $trace = [
+            ['file' => '/app/tests/Feature/A.php', 'line' => 1],
+            ['file' => '/app/tests/Feature/B.php', 'line' => 2],
+        ];
+
+        $this->assertSame($trace, StackTraceFilter::filterFrames($trace));
+    }
+
+    #[Test]
+    public function preserves_frames_without_a_file_key(): void
+    {
+        $trace = [
+            ['function' => '{closure}'],
+            ['file' => '/app/vendor/studio-design/openapi-contract-testing/src/Laravel/ValidatesOpenApiSchema.php', 'line' => 500],
+            ['file' => '/app/tests/Feature/PetTest.php', 'line' => 47],
+        ];
+
+        $filtered = StackTraceFilter::filterFrames($trace);
+
+        $this->assertCount(2, $filtered);
+        $this->assertSame('{closure}', $filtered[0]['function']);
+        $this->assertSame('/app/tests/Feature/PetTest.php', $filtered[1]['file']);
+    }
+
+    #[Test]
+    public function normalizes_windows_style_backslash_paths(): void
+    {
+        $trace = [
+            ['file' => 'C:\\app\\vendor\\studio-design\\openapi-contract-testing\\src\\Laravel\\ValidatesOpenApiSchema.php', 'line' => 500],
+            ['file' => 'C:\\app\\tests\\Feature\\PetTest.php', 'line' => 47],
+        ];
+
+        $filtered = StackTraceFilter::filterFrames($trace);
+
+        $this->assertCount(1, $filtered);
+        $this->assertSame('C:\\app\\tests\\Feature\\PetTest.php', $filtered[0]['file']);
+    }
+
+    #[Test]
+    public function rethrow_with_clean_trace_drops_library_frames_and_preserves_message(): void
+    {
+        $exception = new AssertionFailedError('boom');
+
+        $traceProp = new ReflectionProperty(Exception::class, 'trace');
+        $traceProp->setValue($exception, [
+            ['file' => '/app/vendor/studio-design/openapi-contract-testing/src/Laravel/ValidatesOpenApiSchema.php', 'line' => 500],
+            ['file' => '/app/tests/Feature/PetTest.php', 'line' => 47],
+        ]);
+
+        try {
+            StackTraceFilter::rethrowWithCleanTrace($exception);
+        } catch (AssertionFailedError $thrown) {
+            $this->assertCount(1, $thrown->getTrace());
+            $this->assertSame('/app/tests/Feature/PetTest.php', $thrown->getTrace()[0]['file']);
+            // Message is unchanged — we only rewrite the trace.
+            $this->assertSame('boom', $thrown->getMessage());
+        }
+    }
+
+    #[Test]
+    public function rethrow_preserves_original_trace_when_filtering_would_empty_it(): void
+    {
+        $exception = new AssertionFailedError('boom');
+
+        $originalTrace = [
+            ['file' => '/app/vendor/studio-design/openapi-contract-testing/src/Laravel/ValidatesOpenApiSchema.php', 'line' => 500],
+            ['file' => '/app/vendor/laravel/framework/src/Illuminate/Foundation/Testing/Concerns/MakesHttpRequests.php', 'line' => 617],
+        ];
+
+        $traceProp = new ReflectionProperty(Exception::class, 'trace');
+        $traceProp->setValue($exception, $originalTrace);
+
+        try {
+            StackTraceFilter::rethrowWithCleanTrace($exception);
+        } catch (AssertionFailedError $thrown) {
+            $this->assertSame($originalTrace, $thrown->getTrace());
+        }
+    }
+}

--- a/tests/Unit/ValidatesOpenApiSchemaStackTraceTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaStackTraceTest.php
@@ -9,15 +9,16 @@ use const JSON_THROW_ON_ERROR;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use Studio\OpenApiContractTesting\HttpMethod;
 use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
 use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\Tests\Helpers\CreatesTestResponse;
 
+use function dirname;
 use function is_string;
 use function json_encode;
-use function str_contains;
 use function str_replace;
 
 // Load namespace-level config() mock before the trait resolves the function call.
@@ -27,6 +28,7 @@ class ValidatesOpenApiSchemaStackTraceTest extends TestCase
 {
     use CreatesTestResponse;
     use ValidatesOpenApiSchema;
+    private string $libraryLaravelDir;
 
     protected function setUp(): void
     {
@@ -37,6 +39,13 @@ class ValidatesOpenApiSchemaStackTraceTest extends TestCase
         $GLOBALS['__openapi_testing_config'] = [
             'openapi-contract-testing.default_spec' => 'petstore-3.0',
         ];
+
+        $traitFile = (new ReflectionClass(ValidatesOpenApiSchema::class))->getFileName();
+        // The trait + the StackTraceFilter helper both sit under src/Laravel/.
+        // Deriving the directory at runtime keeps the assertions robust against
+        // CI checkout paths that don't happen to contain the literal string
+        // "/openapi-contract-testing/src/Laravel/".
+        $this->libraryLaravelDir = str_replace('\\', '/', dirname((string) $traitFile)) . '/';
     }
 
     protected function tearDown(): void
@@ -49,7 +58,7 @@ class ValidatesOpenApiSchemaStackTraceTest extends TestCase
     }
 
     #[Test]
-    public function failure_trace_excludes_validates_open_api_schema_frames(): void
+    public function explicit_assert_path_produces_clean_trace(): void
     {
         $body = (string) json_encode(['wrong_key' => 'value'], JSON_THROW_ON_ERROR);
         $response = $this->makeTestResponse($body, 200);
@@ -62,38 +71,42 @@ class ValidatesOpenApiSchemaStackTraceTest extends TestCase
             );
             $this->fail('Expected AssertionFailedError was not thrown.');
         } catch (AssertionFailedError $e) {
-            // The library frames must not appear in the trace shown to the user.
-            foreach ($e->getTrace() as $index => $frame) {
-                $file = $frame['file'] ?? null;
-                if (!is_string($file)) {
-                    continue;
-                }
-                $normalized = str_replace('\\', '/', $file);
-                $this->assertFalse(
-                    str_contains($normalized, '/openapi-contract-testing/src/Laravel/'),
-                    "Frame #{$index} should not be inside src/Laravel/ but was: {$file}",
-                );
-            }
-
-            // Header line ("in /path:NN") must point at user code, not the trait.
-            $exceptionFile = str_replace('\\', '/', $e->getFile());
-            $this->assertFalse(
-                str_contains($exceptionFile, '/openapi-contract-testing/src/Laravel/'),
-                "Exception getFile() should not point inside the library: {$exceptionFile}",
-            );
-
-            // Message is unchanged — we only rewrite trace metadata.
-            $this->assertStringContainsString(
-                'OpenAPI schema validation failed',
-                $e->getMessage(),
-            );
+            $this->assertNoLibraryFrames($e);
+            $this->assertUserFramePresent($e);
+            $this->assertStringContainsString('OpenAPI schema validation failed', $e->getMessage());
         }
     }
 
     #[Test]
-    public function user_test_frame_survives_filtering(): void
+    public function auto_assert_path_produces_clean_trace(): void
     {
+        // The user-reported scenario in #131: failure originates inside the
+        // auto-assert hook (maybeAutoAssertOpenApiSchema), which Laravel calls
+        // from createTestResponse() during $this->get(...) requests.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_assert'] = true;
+
         $body = (string) json_encode(['wrong_key' => 'value'], JSON_THROW_ON_ERROR);
+        $response = $this->makeTestResponse($body, 200);
+
+        try {
+            $this->maybeAutoAssertOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+            $this->fail('Expected AssertionFailedError was not thrown.');
+        } catch (AssertionFailedError $e) {
+            $this->assertNoLibraryFrames($e);
+            $this->assertUserFramePresent($e);
+        }
+    }
+
+    #[Test]
+    public function fail_path_produces_clean_trace(): void
+    {
+        // Triggers the failOpenApi() route (line ~433 in the trait): an empty
+        // default_spec + no #[OpenApiSpec] attribute resolves to '', which the
+        // trait reports via its own fail-with-message branch — different from
+        // the assertTrue path the explicit-assert test exercises.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.default_spec'] = '';
+
+        $body = (string) json_encode(['data' => []], JSON_THROW_ON_ERROR);
         $response = $this->makeTestResponse($body, 200);
 
         try {
@@ -104,22 +117,36 @@ class ValidatesOpenApiSchemaStackTraceTest extends TestCase
             );
             $this->fail('Expected AssertionFailedError was not thrown.');
         } catch (AssertionFailedError $e) {
-            $hasUserFrame = false;
-            foreach ($e->getTrace() as $frame) {
-                $file = $frame['file'] ?? null;
-                if (!is_string($file)) {
-                    continue;
-                }
-                if (str_contains(str_replace('\\', '/', $file), 'ValidatesOpenApiSchemaStackTraceTest.php')) {
-                    $hasUserFrame = true;
+            $this->assertNoLibraryFrames($e);
+            $this->assertUserFramePresent($e);
+            $this->assertStringContainsString('openApiSpec()', $e->getMessage());
+        }
+    }
 
-                    break;
-                }
+    private function assertNoLibraryFrames(AssertionFailedError $e): void
+    {
+        foreach ($e->getTrace() as $index => $frame) {
+            $file = $frame['file'] ?? null;
+            if (!is_string($file)) {
+                continue;
             }
-            $this->assertTrue(
-                $hasUserFrame,
-                'Expected the user test frame to survive filtering — only library and Laravel testing-concern frames should be dropped.',
+            $normalized = str_replace('\\', '/', $file);
+            $this->assertStringStartsNotWith(
+                $this->libraryLaravelDir, $normalized,
+                "Frame #{$index} should not be inside {$this->libraryLaravelDir} but was: {$file}",
             );
         }
+    }
+
+    private function assertUserFramePresent(AssertionFailedError $e): void
+    {
+        $thisFile = str_replace('\\', '/', __FILE__);
+        foreach ($e->getTrace() as $frame) {
+            $file = $frame['file'] ?? null;
+            if (is_string($file) && str_replace('\\', '/', $file) === $thisFile) {
+                return;
+            }
+        }
+        $this->fail('Expected a frame from this test file to survive filtering — only library and Laravel testing-concern frames should be dropped.');
     }
 }

--- a/tests/Unit/ValidatesOpenApiSchemaStackTraceTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaStackTraceTest.php
@@ -132,7 +132,8 @@ class ValidatesOpenApiSchemaStackTraceTest extends TestCase
             }
             $normalized = str_replace('\\', '/', $file);
             $this->assertStringStartsNotWith(
-                $this->libraryLaravelDir, $normalized,
+                $this->libraryLaravelDir,
+                $normalized,
                 "Frame #{$index} should not be inside {$this->libraryLaravelDir} but was: {$file}",
             );
         }

--- a/tests/Unit/ValidatesOpenApiSchemaStackTraceTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaStackTraceTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use const JSON_THROW_ON_ERROR;
+
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\HttpMethod;
+use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
+use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\Tests\Helpers\CreatesTestResponse;
+
+use function is_string;
+use function json_encode;
+use function str_contains;
+use function str_replace;
+
+// Load namespace-level config() mock before the trait resolves the function call.
+require_once __DIR__ . '/../Helpers/LaravelConfigMock.php';
+
+class ValidatesOpenApiSchemaStackTraceTest extends TestCase
+{
+    use CreatesTestResponse;
+    use ValidatesOpenApiSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs');
+        OpenApiCoverageTracker::reset();
+        $GLOBALS['__openapi_testing_config'] = [
+            'openapi-contract-testing.default_spec' => 'petstore-3.0',
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        self::resetValidatorCache();
+        unset($GLOBALS['__openapi_testing_config']);
+        OpenApiSpecLoader::reset();
+        OpenApiCoverageTracker::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function failure_trace_excludes_validates_open_api_schema_frames(): void
+    {
+        $body = (string) json_encode(['wrong_key' => 'value'], JSON_THROW_ON_ERROR);
+        $response = $this->makeTestResponse($body, 200);
+
+        try {
+            $this->assertResponseMatchesOpenApiSchema(
+                $response,
+                HttpMethod::GET,
+                '/v1/pets',
+            );
+            $this->fail('Expected AssertionFailedError was not thrown.');
+        } catch (AssertionFailedError $e) {
+            // The library frames must not appear in the trace shown to the user.
+            foreach ($e->getTrace() as $index => $frame) {
+                $file = $frame['file'] ?? null;
+                if (!is_string($file)) {
+                    continue;
+                }
+                $normalized = str_replace('\\', '/', $file);
+                $this->assertFalse(
+                    str_contains($normalized, '/openapi-contract-testing/src/Laravel/'),
+                    "Frame #{$index} should not be inside src/Laravel/ but was: {$file}",
+                );
+            }
+
+            // Header line ("in /path:NN") must point at user code, not the trait.
+            $exceptionFile = str_replace('\\', '/', $e->getFile());
+            $this->assertFalse(
+                str_contains($exceptionFile, '/openapi-contract-testing/src/Laravel/'),
+                "Exception getFile() should not point inside the library: {$exceptionFile}",
+            );
+
+            // Message is unchanged — we only rewrite trace metadata.
+            $this->assertStringContainsString(
+                'OpenAPI schema validation failed',
+                $e->getMessage(),
+            );
+        }
+    }
+
+    #[Test]
+    public function user_test_frame_survives_filtering(): void
+    {
+        $body = (string) json_encode(['wrong_key' => 'value'], JSON_THROW_ON_ERROR);
+        $response = $this->makeTestResponse($body, 200);
+
+        try {
+            $this->assertResponseMatchesOpenApiSchema(
+                $response,
+                HttpMethod::GET,
+                '/v1/pets',
+            );
+            $this->fail('Expected AssertionFailedError was not thrown.');
+        } catch (AssertionFailedError $e) {
+            $hasUserFrame = false;
+            foreach ($e->getTrace() as $frame) {
+                $file = $frame['file'] ?? null;
+                if (!is_string($file)) {
+                    continue;
+                }
+                if (str_contains(str_replace('\\', '/', $file), 'ValidatesOpenApiSchemaStackTraceTest.php')) {
+                    $hasUserFrame = true;
+
+                    break;
+                }
+            }
+            $this->assertTrue(
+                $hasUserFrame,
+                'Expected the user test frame to survive filtering — only library and Laravel testing-concern frames should be dropped.',
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Closes #131. Contract-validation failures previously printed five vendor frames (library + Laravel `MakesHttpRequests` / `TestResponse`) before the user's test line, burying the only frame the developer cares about.
- Introduces an internal `StackTraceFilter` (under `src/Laravel/Internal/`) that drops library- and Laravel-test-concern frames from the `AssertionFailedError` trace via `ReflectionProperty(\Exception::class, 'trace')` before re-throwing. Pattern is the one used by Symfony's ErrorHandler / React Socket.
- The trait now routes every `fail()` / `assertTrue()` site (11 in total) through two thin private wrappers — `failOpenApi()` / `assertOpenApi()` — that apply the filter on failure.
- Behavior change is **trace-only**: exception type, message, and the user-visible test line are unchanged. No user-side configuration required.

## Why library-side, not `phpunit.xml` config

The issue author asked for it: every adopter should benefit without per-project config. PHPUnit's `ExcludeList::addDirectory()` was the alternative considered but rejected — it would either miss the `MakesHttpRequests` frame or, if Laravel's testing dir was added, mask user-relevant frames in unrelated Laravel test failures.

## Before / after (issue example)

Before:
```
1) Tests\Feature\EarlyAccess\GetEarlyAccessTest::...
OpenAPI schema validation failed for GET /api/v2/admin/...
Failed asserting that false is true.

vendor/studio-design/openapi-contract-testing/src/Laravel/ValidatesOpenApiSchema.php:500
vendor/studio-design/openapi-contract-testing/src/Laravel/ValidatesOpenApiSchema.php:381
vendor/studio-design/openapi-contract-testing/src/Laravel/ValidatesOpenApiSchema.php:241
vendor/laravel/framework/.../MakesHttpRequests.php:617
vendor/laravel/framework/.../MakesHttpRequests.php:573
tests/Feature/EarlyAccess/GetEarlyAccessTest.php:47
```

After:
```
1) Tests\Feature\EarlyAccess\GetEarlyAccessTest::...
OpenAPI schema validation failed for GET /api/v2/admin/...
Failed asserting that false is true.

tests/Feature/EarlyAccess/GetEarlyAccessTest.php:47
```

## Test plan

- [x] `vendor/bin/phpunit` — full suite green (896 tests / 1846 assertions).
- [x] New unit tests `tests/Unit/Laravel/Internal/StackTraceFilterTest.php` — 11 cases covering frame filtering, order preservation, Windows path normalization, frames without `file`, and the all-frames-dropped guard.
- [x] New integration test `tests/Unit/ValidatesOpenApiSchemaStackTraceTest.php` — triggers a real validation failure and asserts the resulting trace contains no `src/Laravel/` frames and the user's test frame survives.
- [x] `vendor/bin/phpstan analyse` — level 6 clean.
- [x] `vendor/bin/php-cs-fixer fix --dry-run --diff` — formatting clean.