### PR TITLE
New Feature: path-not-found エラーに stripped path と類似パス候補を表示

### DIFF
--- a/src/OpenApiPathMatcher.php
+++ b/src/OpenApiPathMatcher.php
@@ -83,6 +83,44 @@ final class OpenApiPathMatcher
     }
 
     /**
+     * Apply the matcher's prefix-stripping and trailing-slash policy to a raw
+     * request URI without attempting to match it against the spec. Exposed so
+     * diagnostic code (e.g. "did you mean?" suggestions) can show users the
+     * exact string that the matcher actually compared against, distinct from
+     * the raw URI they passed in.
+     *
+     * `strippedPrefix` is the literal prefix value that was removed (verbatim
+     * from the constructor's `$stripPrefixes`), or null when no configured
+     * prefix matched. Trailing-slash trimming is applied unconditionally
+     * after prefix stripping but does not surface as a separate signal — its
+     * effect on diagnostic messages is judged not worth a second field.
+     *
+     * @return array{path: string, strippedPrefix: ?string}
+     */
+    public function normalizeRequestPath(string $requestPath): array
+    {
+        $normalizedPath = $requestPath;
+        $strippedPrefix = null;
+
+        foreach ($this->stripPrefixes as $prefix) {
+            if (str_starts_with($normalizedPath, $prefix)) {
+                $normalizedPath = substr($normalizedPath, strlen($prefix));
+                $strippedPrefix = $prefix;
+
+                break;
+            }
+        }
+
+        // Keep the root path intact — collapsing `/` to `` would make the
+        // single literal-root entry unreachable.
+        if ($normalizedPath !== '/' && str_ends_with($normalizedPath, '/')) {
+            $normalizedPath = rtrim($normalizedPath, '/');
+        }
+
+        return ['path' => $normalizedPath, 'strippedPrefix' => $strippedPrefix];
+    }
+
+    /**
      * Match a request path and return both the matched spec path template and
      * the raw values captured for each `{placeholder}` segment.
      *
@@ -98,19 +136,7 @@ final class OpenApiPathMatcher
      */
     public function matchWithVariables(string $requestPath): ?array
     {
-        $normalizedPath = $requestPath;
-
-        foreach ($this->stripPrefixes as $prefix) {
-            if (str_starts_with($normalizedPath, $prefix)) {
-                $normalizedPath = substr($normalizedPath, strlen($prefix));
-                break;
-            }
-        }
-
-        // Strip trailing slash (but keep root /)
-        if ($normalizedPath !== '/' && str_ends_with($normalizedPath, '/')) {
-            $normalizedPath = rtrim($normalizedPath, '/');
-        }
+        $normalizedPath = $this->normalizeRequestPath($requestPath)['path'];
 
         foreach ($this->compiledPaths as $compiled) {
             if (preg_match($compiled['pattern'], $normalizedPath, $matches) !== 1) {

--- a/src/OpenApiPathSuggester.php
+++ b/src/OpenApiPathSuggester.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting;
+
+use function abs;
+use function array_map;
+use function array_slice;
+use function count;
+use function explode;
+use function implode;
+use function in_array;
+use function is_array;
+use function levenshtein;
+use function min;
+use function sort;
+use function strtolower;
+use function strtoupper;
+use function trim;
+use function usort;
+
+/**
+ * Diagnostic helper that proposes "did you mean?" suggestions when a request
+ * path fails to match any spec entry. Pure static utility: it inspects the
+ * decoded spec array (already resolved by OpenApiSpecResolver) and never
+ * touches network or filesystem.
+ *
+ * Kept separate from OpenApiPathMatcher so the matcher's hot-path API stays
+ * focused on matching. Suggestion is only invoked from error paths.
+ */
+final class OpenApiPathSuggester
+{
+    /**
+     * The full set of operation keys that OpenAPI 3.x recognises at the
+     * path-item level. Kept local to the suggester (rather than reusing
+     * `HttpMethod`) because the latter models *request* methods that the
+     * library validates, which is a smaller set than what a spec author may
+     * legitimately document. If `HttpMethod` ever expands, this constant can
+     * be revisited.
+     */
+    private const OPENAPI_PATH_ITEM_METHODS = [
+        'get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace',
+    ];
+
+    /**
+     * @param array<string, mixed> $spec the decoded OpenAPI document
+     * @param string $normalizedPath the request path *after* prefix stripping
+     *                               (i.e. what the matcher actually compared
+     *                               against). Suggestions ranked against this
+     *                               value, not the raw request URI.
+     * @param int $limit maximum number of (method, path) entries to return
+     *
+     * @return list<array{method: string, path: string}> top-$limit candidates
+     *                                                   sorted by similarity descending. Empty when the spec has no
+     *                                                   paths at all.
+     */
+    public static function suggest(array $spec, string $normalizedPath, int $limit = 3): array
+    {
+        /** @var array<string, mixed> $paths */
+        $paths = $spec['paths'] ?? [];
+        if ($paths === []) {
+            return [];
+        }
+
+        $requestSegments = self::segments($normalizedPath);
+        $entries = [];
+
+        foreach ($paths as $specPath => $pathItem) {
+            // Defensive: an unresolved $ref or malformed entry would otherwise
+            // tip a TypeError into the diagnostic path. Suggestions are
+            // best-effort — silently skipping malformed entries keeps the
+            // primary error message intact.
+            if (!is_array($pathItem)) {
+                continue;
+            }
+
+            $specSegments = self::segments((string) $specPath);
+            $segmentDiff = abs(count($requestSegments) - count($specSegments));
+            $commonPrefix = self::commonPrefixSegmentCount($requestSegments, $specSegments);
+            $tailDistance = self::levenshteinTail($requestSegments, $specSegments, $commonPrefix);
+
+            foreach ($pathItem as $key => $value) {
+                $lower = strtolower((string) $key);
+                if (!in_array($lower, self::OPENAPI_PATH_ITEM_METHODS, true)) {
+                    continue;
+                }
+                if (!is_array($value)) {
+                    continue;
+                }
+
+                $entries[] = [
+                    'method' => strtoupper($lower),
+                    'path' => (string) $specPath,
+                    'segmentDiff' => $segmentDiff,
+                    'commonPrefix' => $commonPrefix,
+                    'tailDistance' => $tailDistance,
+                ];
+            }
+        }
+
+        usort($entries, static function (array $a, array $b): int {
+            // Tier ordering chosen so that the strongest signals (segment-count
+            // match, then how many leading segments line up exactly) outrank
+            // raw character-level edit distance. Levenshtein on the tail is the
+            // tiebreaker for paths that are otherwise indistinguishable; a full
+            // path Levenshtein would be dominated by the shared prefix and
+            // surface noisy candidates.
+            return $a['segmentDiff'] <=> $b['segmentDiff']
+                ?: $b['commonPrefix'] <=> $a['commonPrefix']
+                ?: $a['tailDistance'] <=> $b['tailDistance']
+                ?: $a['path'] <=> $b['path']
+                ?: $a['method'] <=> $b['method'];
+        });
+
+        $top = array_slice($entries, 0, $limit);
+
+        // Strip scoring fields before returning so the public shape is a clean
+        // {method, path} record.
+        return array_map(
+            static fn(array $e): array => ['method' => $e['method'], 'path' => $e['path']],
+            $top,
+        );
+    }
+
+    /**
+     * Enumerate the operation methods declared under a given path item.
+     * Uppercase, alphabetically sorted, with non-method keys
+     * (`parameters`, `summary`, `$ref`, …) filtered out. Returns `[]` for an
+     * unknown path or a path-item that only declares shared parameters — the
+     * caller distinguishes the two via prior matching.
+     *
+     * @param array<string, mixed> $spec
+     *
+     * @return list<string>
+     */
+    public static function methodsForPath(array $spec, string $matchedPath): array
+    {
+        $pathItem = $spec['paths'][$matchedPath] ?? null;
+        if (!is_array($pathItem)) {
+            return [];
+        }
+
+        $methods = [];
+        foreach ($pathItem as $key => $value) {
+            $lower = strtolower((string) $key);
+            if (!in_array($lower, self::OPENAPI_PATH_ITEM_METHODS, true)) {
+                continue;
+            }
+            if (!is_array($value)) {
+                continue;
+            }
+            $methods[] = strtoupper($lower);
+        }
+
+        sort($methods);
+
+        return $methods;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function segments(string $path): array
+    {
+        $trimmed = trim($path, '/');
+        if ($trimmed === '') {
+            return [];
+        }
+
+        return explode('/', $trimmed);
+    }
+
+    /**
+     * @param list<string> $a
+     * @param list<string> $b
+     */
+    private static function commonPrefixSegmentCount(array $a, array $b): int
+    {
+        $shared = 0;
+        $bound = min(count($a), count($b));
+        for ($i = 0; $i < $bound; $i++) {
+            if ($a[$i] !== $b[$i]) {
+                break;
+            }
+            $shared++;
+        }
+
+        return $shared;
+    }
+
+    /**
+     * Levenshtein distance over the segments *after* the longest common
+     * prefix, joined back into a `/`-delimited string. Ignoring the shared
+     * prefix prevents long identical heads from dwarfing the actual typo
+     * signal in the differing tail.
+     *
+     * @param list<string> $request
+     * @param list<string> $spec
+     */
+    private static function levenshteinTail(array $request, array $spec, int $commonPrefix): int
+    {
+        $requestTail = implode('/', array_slice($request, $commonPrefix));
+        $specTail = implode('/', array_slice($spec, $commonPrefix));
+
+        return levenshtein($requestTail, $specTail);
+    }
+}

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -14,7 +14,9 @@ use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
 use Studio\OpenApiContractTesting\Validation\Support\ValidatorErrorBoundary;
 
 use function array_keys;
+use function implode;
 use function strtolower;
+use function strtoupper;
 
 final class OpenApiRequestValidator
 {
@@ -71,7 +73,7 @@ final class OpenApiRequestValidator
 
         if ($matched === null) {
             return OpenApiValidationResult::failure([
-                "No matching path found in '{$specName}' spec for: {$requestPath}",
+                self::formatPathNotFoundError($specName, $method, $requestPath, $matcher, $spec),
             ]);
         }
 
@@ -84,7 +86,7 @@ final class OpenApiRequestValidator
 
         if (!isset($pathSpec[$lowerMethod])) {
             return OpenApiValidationResult::failure([
-                "Method {$method} not defined for path {$matchedPath} in '{$specName}' spec.",
+                self::formatMethodNotDefinedError($specName, $method, $matchedPath, $spec),
             ], $matchedPath);
         }
 
@@ -122,6 +124,56 @@ final class OpenApiRequestValidator
         }
 
         return OpenApiValidationResult::failure($errors, $matchedPath);
+    }
+
+    /**
+     * Mirrors OpenApiResponseValidator::formatPathNotFoundError. Duplicated
+     * intentionally — both validators need the same diagnostic shape, but
+     * extracting the helper would either add a new public class for two short
+     * call sites or force a circular dependency through a shared trait.
+     *
+     * @param array<string, mixed> $spec
+     */
+    private static function formatPathNotFoundError(
+        string $specName,
+        string $method,
+        string $requestPath,
+        OpenApiPathMatcher $matcher,
+        array $spec,
+    ): string {
+        $upperMethod = strtoupper($method);
+        $normalized = $matcher->normalizeRequestPath($requestPath);
+        $suggestions = OpenApiPathSuggester::suggest($spec, $normalized['path']);
+
+        $lines = ["No matching path found in '{$specName}' spec for {$upperMethod} {$requestPath}"];
+
+        if ($normalized['strippedPrefix'] !== null) {
+            $lines[] = "  searched as: {$normalized['path']} (after stripping prefix '{$normalized['strippedPrefix']}')";
+        }
+
+        if ($suggestions !== []) {
+            $lines[] = '  closest spec paths:';
+            foreach ($suggestions as $s) {
+                $lines[] = "    - {$s['method']} {$s['path']}";
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @param array<string, mixed> $spec
+     */
+    private static function formatMethodNotDefinedError(
+        string $specName,
+        string $method,
+        string $matchedPath,
+        array $spec,
+    ): string {
+        $methods = OpenApiPathSuggester::methodsForPath($spec, $matchedPath);
+        $defined = $methods === [] ? '(none)' : implode(', ', $methods);
+
+        return "Method {$method} not defined for path {$matchedPath} in '{$specName}' spec. Defined methods: {$defined}.";
     }
 
     /**

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -17,11 +17,13 @@ use Studio\OpenApiContractTesting\Validation\Support\ValidatorErrorBoundary;
 use function array_keys;
 use function array_merge;
 use function get_debug_type;
+use function implode;
 use function is_array;
 use function preg_last_error_msg;
 use function preg_match;
 use function sprintf;
 use function strtolower;
+use function strtoupper;
 use function trigger_error;
 
 final class OpenApiResponseValidator
@@ -85,7 +87,7 @@ final class OpenApiResponseValidator
 
         if ($matchedPath === null) {
             return OpenApiValidationResult::failure([
-                "No matching path found in '{$specName}' spec for: {$requestPath}",
+                self::formatPathNotFoundError($specName, $method, $requestPath, $matcher, $spec),
             ]);
         }
 
@@ -94,7 +96,7 @@ final class OpenApiResponseValidator
 
         if (!isset($pathSpec[$lowerMethod])) {
             return OpenApiValidationResult::failure([
-                "Method {$method} not defined for path {$matchedPath} in '{$specName}' spec.",
+                self::formatMethodNotDefinedError($specName, $method, $matchedPath, $spec),
             ], $matchedPath);
         }
 
@@ -204,6 +206,62 @@ final class OpenApiResponseValidator
             $statusCodeStr,
             $bodyResult->matchedContentType,
         );
+    }
+
+    /**
+     * Compose the "no matching path" diagnostic. Multi-line so the structured
+     * pieces (stripped path, suggestions) stay visually separate from the raw
+     * request URI on the lead line.
+     *
+     * @param array<string, mixed> $spec
+     */
+    private static function formatPathNotFoundError(
+        string $specName,
+        string $method,
+        string $requestPath,
+        OpenApiPathMatcher $matcher,
+        array $spec,
+    ): string {
+        $upperMethod = strtoupper($method);
+        $normalized = $matcher->normalizeRequestPath($requestPath);
+        $suggestions = OpenApiPathSuggester::suggest($spec, $normalized['path']);
+
+        $lines = ["No matching path found in '{$specName}' spec for {$upperMethod} {$requestPath}"];
+
+        // Only mention the stripping when it actually changed the path.
+        // Trailing-slash trim alone is not surfaced — it's universal and
+        // adding a line for it dilutes the more useful prefix signal.
+        if ($normalized['strippedPrefix'] !== null) {
+            $lines[] = "  searched as: {$normalized['path']} (after stripping prefix '{$normalized['strippedPrefix']}')";
+        }
+
+        if ($suggestions !== []) {
+            $lines[] = '  closest spec paths:';
+            foreach ($suggestions as $s) {
+                $lines[] = "    - {$s['method']} {$s['path']}";
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @param array<string, mixed> $spec
+     */
+    private static function formatMethodNotDefinedError(
+        string $specName,
+        string $method,
+        string $matchedPath,
+        array $spec,
+    ): string {
+        $methods = OpenApiPathSuggester::methodsForPath($spec, $matchedPath);
+        // The "(none)" branch is theoretically unreachable from this call site
+        // (we got here because a method-keyed entry was missing for one
+        // specific method, not because every method was missing). Surface it
+        // anyway so a malformed spec doesn't render an empty list.
+        $defined = $methods === [] ? '(none)' : implode(', ', $methods);
+
+        return "Method {$method} not defined for path {$matchedPath} in '{$specName}' spec. Defined methods: {$defined}.";
     }
 
     /**

--- a/tests/Unit/OpenApiPathMatcherTest.php
+++ b/tests/Unit/OpenApiPathMatcherTest.php
@@ -208,6 +208,72 @@ class OpenApiPathMatcherTest extends TestCase
     }
 
     #[Test]
+    public function normalize_request_path_strips_configured_prefix(): void
+    {
+        $matcher = new OpenApiPathMatcher(['/v2/account'], ['/api']);
+
+        $this->assertSame(
+            ['path' => '/v2/account', 'strippedPrefix' => '/api'],
+            $matcher->normalizeRequestPath('/api/v2/account'),
+        );
+    }
+
+    #[Test]
+    public function normalize_request_path_returns_null_prefix_when_none_matches(): void
+    {
+        $matcher = new OpenApiPathMatcher(['/v2/account'], ['/api']);
+
+        $this->assertSame(
+            ['path' => '/v2/account', 'strippedPrefix' => null],
+            $matcher->normalizeRequestPath('/v2/account'),
+        );
+    }
+
+    #[Test]
+    public function normalize_request_path_trims_trailing_slash(): void
+    {
+        $matcher = new OpenApiPathMatcher(['/v2/account']);
+
+        $this->assertSame(
+            ['path' => '/v2/account', 'strippedPrefix' => null],
+            $matcher->normalizeRequestPath('/v2/account/'),
+        );
+    }
+
+    #[Test]
+    public function normalize_request_path_preserves_root_slash(): void
+    {
+        $matcher = new OpenApiPathMatcher(['/']);
+
+        // The trailing-slash trim must not collapse the root path itself,
+        // otherwise a request to `/` would normalize to an empty string and
+        // never match the literal root entry.
+        $this->assertSame(
+            ['path' => '/', 'strippedPrefix' => null],
+            $matcher->normalizeRequestPath('/'),
+        );
+    }
+
+    #[Test]
+    public function normalize_request_path_only_strips_first_matching_prefix(): void
+    {
+        // Mirrors the behaviour of matchWithVariables(): once a prefix
+        // strips, subsequent prefixes are not considered. Ensures
+        // `strippedPrefix` reports the actually-applied prefix rather than
+        // the last entry in the array.
+        $matcher = new OpenApiPathMatcher(['/v2/account'], ['/api', '/internal']);
+
+        $this->assertSame(
+            ['path' => '/v2/account', 'strippedPrefix' => '/api'],
+            $matcher->normalizeRequestPath('/api/v2/account'),
+        );
+        $this->assertSame(
+            ['path' => '/v2/account', 'strippedPrefix' => '/internal'],
+            $matcher->normalizeRequestPath('/internal/v2/account'),
+        );
+    }
+
+    #[Test]
     public function constructor_rejects_duplicate_placeholder_names(): void
     {
         // OpenAPI forbids the same placeholder name appearing twice in one template.

--- a/tests/Unit/OpenApiPathSuggesterTest.php
+++ b/tests/Unit/OpenApiPathSuggesterTest.php
@@ -1,0 +1,293 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\OpenApiPathSuggester;
+
+use function array_map;
+use function sort;
+
+class OpenApiPathSuggesterTest extends TestCase
+{
+    #[Test]
+    public function suggest_returns_empty_array_for_spec_without_paths(): void
+    {
+        $this->assertSame([], OpenApiPathSuggester::suggest([], '/v1/pets'));
+        $this->assertSame([], OpenApiPathSuggester::suggest(['paths' => []], '/v1/pets'));
+    }
+
+    #[Test]
+    public function suggest_filters_non_operation_keys_at_path_item_level(): void
+    {
+        // OpenAPI 3.x permits `parameters`, `summary`, `description`, `servers`,
+        // `$ref` at the path-item level alongside operation methods. The
+        // suggester must not surface these as suggestions or it would render
+        // entries like "PARAMETERS /v1/pets" — meaningless and misleading.
+        $spec = [
+            'paths' => [
+                '/v1/pets' => [
+                    'parameters' => [],
+                    'summary' => 'Pets',
+                    'description' => 'pet ops',
+                    'servers' => [],
+                    'get' => ['responses' => []],
+                    'post' => ['responses' => []],
+                ],
+            ],
+        ];
+
+        $result = OpenApiPathSuggester::suggest($spec, '/v1/pets', 10);
+
+        $this->assertSame(
+            [
+                ['method' => 'GET', 'path' => '/v1/pets'],
+                ['method' => 'POST', 'path' => '/v1/pets'],
+            ],
+            $result,
+        );
+    }
+
+    #[Test]
+    public function suggest_recognises_all_eight_openapi_path_item_methods(): void
+    {
+        // OpenAPI 3.x defines exactly these eight operation keys for a path item.
+        // Any future broadening of HttpMethod for request validation must not
+        // silently drop one of these from suggestions.
+        $methods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
+        $pathItem = [];
+        foreach ($methods as $m) {
+            $pathItem[$m] = ['responses' => []];
+        }
+        $spec = ['paths' => ['/v1/op' => $pathItem]];
+
+        $result = OpenApiPathSuggester::suggest($spec, '/v1/op', 10);
+        $resultMethods = array_map(static fn(array $r): string => $r['method'], $result);
+        sort($resultMethods);
+
+        $this->assertSame(
+            ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE'],
+            $resultMethods,
+        );
+    }
+
+    #[Test]
+    public function suggest_prioritises_segment_count_match_over_levenshtein_distance(): void
+    {
+        // /a/b/c/d/e is character-wise close to /a/b/c (small Levenshtein) but
+        // segment-count match should win — `/x/y/z/q/r` shares the segment
+        // count even though no segment text matches.
+        $spec = [
+            'paths' => [
+                '/a/b/c' => ['get' => ['responses' => []]],
+                '/x/y/z/q/r' => ['get' => ['responses' => []]],
+            ],
+        ];
+
+        $result = OpenApiPathSuggester::suggest($spec, '/a/b/c/d/e', 1);
+
+        $this->assertSame(
+            [['method' => 'GET', 'path' => '/x/y/z/q/r']],
+            $result,
+        );
+    }
+
+    #[Test]
+    public function suggest_uses_common_prefix_segments_as_secondary_sort(): void
+    {
+        // All three candidates share segment count (3). Common prefix segment
+        // count breaks the tie — /v2/admin/users shares two segments with the
+        // request, /v2/users/list shares one, /unrelated/x/y shares zero.
+        $spec = [
+            'paths' => [
+                '/unrelated/x/y' => ['get' => ['responses' => []]],
+                '/v2/users/list' => ['get' => ['responses' => []]],
+                '/v2/admin/users' => ['get' => ['responses' => []]],
+            ],
+        ];
+
+        $result = OpenApiPathSuggester::suggest($spec, '/v2/admin/list', 3);
+
+        $this->assertSame(
+            [
+                ['method' => 'GET', 'path' => '/v2/admin/users'],
+                ['method' => 'GET', 'path' => '/v2/users/list'],
+                ['method' => 'GET', 'path' => '/unrelated/x/y'],
+            ],
+            $result,
+        );
+    }
+
+    #[Test]
+    public function suggest_uses_levenshtein_on_tail_after_common_prefix(): void
+    {
+        // Both candidates share segment count (3) and common prefix length (2:
+        // /v2/admin). The differing tail (`users` vs `userrs`) is what
+        // distinguishes them — Levenshtein on the post-prefix substring puts
+        // `userrs` (distance 1 from `usrs`) above `groups` (distance 5).
+        $spec = [
+            'paths' => [
+                '/v2/admin/groups' => ['get' => ['responses' => []]],
+                '/v2/admin/userrs' => ['get' => ['responses' => []]],
+            ],
+        ];
+
+        $result = OpenApiPathSuggester::suggest($spec, '/v2/admin/usrs', 1);
+
+        $this->assertSame(
+            [['method' => 'GET', 'path' => '/v2/admin/userrs']],
+            $result,
+        );
+    }
+
+    #[Test]
+    public function suggest_falls_back_to_alphabetical_when_all_scores_tie(): void
+    {
+        // All three candidates share segment count, common prefix length, and
+        // a single-character differing tail — every numeric scoring tier ties.
+        // Alphabetical fallback keeps the suggestion list stable across PHP
+        // hash randomisation.
+        $spec = [
+            'paths' => [
+                '/v1/c' => ['get' => ['responses' => []]],
+                '/v1/a' => ['get' => ['responses' => []]],
+                '/v1/b' => ['get' => ['responses' => []]],
+            ],
+        ];
+
+        $result = OpenApiPathSuggester::suggest($spec, '/v1/x', 3);
+
+        $this->assertSame(
+            [
+                ['method' => 'GET', 'path' => '/v1/a'],
+                ['method' => 'GET', 'path' => '/v1/b'],
+                ['method' => 'GET', 'path' => '/v1/c'],
+            ],
+            $result,
+        );
+    }
+
+    #[Test]
+    public function suggest_includes_multiple_methods_for_the_same_top_path(): void
+    {
+        // Mirrors the issue's example: when one path scores best and has
+        // multiple operations, both operations should occupy slots in the
+        // top-N output rather than being deduplicated to the path alone.
+        $spec = [
+            'paths' => [
+                '/v2/admin/early_accesses' => [
+                    'get' => ['responses' => []],
+                    'post' => ['responses' => []],
+                ],
+                '/v2/admin/users/{user_id}' => [
+                    'get' => ['responses' => []],
+                ],
+                '/unrelated' => ['get' => ['responses' => []]],
+            ],
+        ];
+
+        $result = OpenApiPathSuggester::suggest($spec, '/v2/admin/early-access', 3);
+
+        $this->assertSame(
+            [
+                ['method' => 'GET', 'path' => '/v2/admin/early_accesses'],
+                ['method' => 'POST', 'path' => '/v2/admin/early_accesses'],
+                ['method' => 'GET', 'path' => '/v2/admin/users/{user_id}'],
+            ],
+            $result,
+        );
+    }
+
+    #[Test]
+    public function suggest_respects_limit_argument(): void
+    {
+        $spec = [
+            'paths' => [
+                '/a' => ['get' => ['responses' => []]],
+                '/b' => ['get' => ['responses' => []]],
+                '/c' => ['get' => ['responses' => []]],
+                '/d' => ['get' => ['responses' => []]],
+            ],
+        ];
+
+        $this->assertCount(2, OpenApiPathSuggester::suggest($spec, '/x', 2));
+        $this->assertCount(4, OpenApiPathSuggester::suggest($spec, '/x', 10));
+    }
+
+    #[Test]
+    public function suggest_ignores_non_array_path_item_entries(): void
+    {
+        // A spec with an unresolved $ref or a malformed entry (e.g. scalar
+        // instead of object) should be skipped silently rather than tripping
+        // a TypeError. Suggestions are diagnostic, not authoritative — they
+        // should never make a failing test fail twice.
+        $spec = [
+            'paths' => [
+                '/v1/broken' => 'oops',
+                '/v1/ok' => ['get' => ['responses' => []]],
+            ],
+        ];
+
+        $this->assertSame(
+            [['method' => 'GET', 'path' => '/v1/ok']],
+            OpenApiPathSuggester::suggest($spec, '/v1/x', 10),
+        );
+    }
+
+    #[Test]
+    public function methods_for_path_returns_uppercase_sorted_methods(): void
+    {
+        $spec = [
+            'paths' => [
+                '/v1/pets' => [
+                    'parameters' => [],
+                    'post' => ['responses' => []],
+                    'get' => ['responses' => []],
+                    'delete' => ['responses' => []],
+                ],
+            ],
+        ];
+
+        $this->assertSame(
+            ['DELETE', 'GET', 'POST'],
+            OpenApiPathSuggester::methodsForPath($spec, '/v1/pets'),
+        );
+    }
+
+    #[Test]
+    public function methods_for_path_returns_empty_when_path_missing(): void
+    {
+        $this->assertSame(
+            [],
+            OpenApiPathSuggester::methodsForPath(['paths' => []], '/v1/missing'),
+        );
+        $this->assertSame(
+            [],
+            OpenApiPathSuggester::methodsForPath([], '/v1/missing'),
+        );
+    }
+
+    #[Test]
+    public function methods_for_path_returns_empty_when_only_non_method_keys_present(): void
+    {
+        // Edge case: a path item with only `parameters` and no operations is
+        // technically valid OpenAPI (e.g. shared parameter definitions). The
+        // helper must distinguish "no methods defined" from "lookup missed".
+        $spec = [
+            'paths' => [
+                '/v1/orphan' => [
+                    'parameters' => [],
+                    'summary' => 'unused',
+                ],
+            ],
+        ];
+
+        $this->assertSame(
+            [],
+            OpenApiPathSuggester::methodsForPath($spec, '/v1/orphan'),
+        );
+    }
+}

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -148,7 +148,32 @@ class OpenApiRequestValidatorTest extends TestCase
         );
 
         $this->assertFalse($result->isValid());
-        $this->assertStringContainsString('No matching path found', $result->errors()[0]);
+        $error = $result->errors()[0];
+        $this->assertStringContainsString("No matching path found in 'petstore-3.0' spec for POST /v1/unknown", $error);
+        $this->assertStringContainsString('closest spec paths:', $error);
+    }
+
+    #[Test]
+    public function unknown_path_error_reveals_stripped_prefix(): void
+    {
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs', ['/api']);
+
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'POST',
+            '/api/v1/unknown',
+            [],
+            [],
+            ['name' => 'Fido'],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "searched as: /v1/unknown (after stripping prefix '/api')",
+            $result->errors()[0],
+        );
     }
 
     #[Test]
@@ -165,7 +190,9 @@ class OpenApiRequestValidatorTest extends TestCase
         );
 
         $this->assertFalse($result->isValid());
-        $this->assertStringContainsString('Method PUT not defined', $result->errors()[0]);
+        $error = $result->errors()[0];
+        $this->assertStringContainsString('Method PUT not defined', $error);
+        $this->assertStringContainsString('Defined methods: GET, POST', $error);
     }
 
     // ========================================

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -154,7 +154,63 @@ class OpenApiResponseValidatorTest extends TestCase
         );
 
         $this->assertFalse($result->isValid());
-        $this->assertStringContainsString('No matching path found', $result->errors()[0]);
+        $error = $result->errors()[0];
+        // Issue #132: the error must surface the request method (so a
+        // method-mismatch is obvious at a glance) and include "did you mean?"
+        // suggestions drawn from the spec's actual paths.
+        $this->assertStringContainsString("No matching path found in 'petstore-3.0' spec for GET /v1/unknown", $error);
+        $this->assertStringContainsString('closest spec paths:', $error);
+        $this->assertStringContainsString('GET /v1/pets', $error);
+    }
+
+    #[Test]
+    public function unknown_path_error_reveals_stripped_prefix(): void
+    {
+        // When the user configured strip_prefixes the matcher silently drops
+        // the prefix before comparing — without this hint, a near-miss
+        // (request `/api/v1/...` vs spec `/v1/...`) is invisible.
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs', ['/api']);
+
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'GET',
+            '/api/v1/unknown',
+            200,
+            [],
+        );
+
+        $this->assertFalse($result->isValid());
+        $error = $result->errors()[0];
+        $this->assertStringContainsString("searched as: /v1/unknown (after stripping prefix '/api')", $error);
+    }
+
+    #[Test]
+    public function path_not_found_error_renders_full_diagnostic_block(): void
+    {
+        // End-to-end pin against the issue #132 suggested-fix wording. Locks
+        // the indentation, line ordering, prefix-stripping callout, and the
+        // (method, path) layout of the suggestion list so future formatting
+        // tweaks surface as visible test diffs rather than silent UX drift.
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs', ['/api']);
+
+        $result = $this->validator->validate(
+            'path-suggester-pin',
+            'GET',
+            '/api/v2/admin/totally-nonexistent-endpoint-xyz',
+            200,
+            [],
+        );
+
+        $this->assertFalse($result->isValid());
+        $expected = "No matching path found in 'path-suggester-pin' spec for GET /api/v2/admin/totally-nonexistent-endpoint-xyz\n"
+            . "  searched as: /v2/admin/totally-nonexistent-endpoint-xyz (after stripping prefix '/api')\n"
+            . "  closest spec paths:\n"
+            . "    - GET /v2/admin/early_accesses\n"
+            . "    - POST /v2/admin/early_accesses\n"
+            . '    - GET /v2/admin/users/{user_id}';
+        $this->assertSame($expected, $result->errors()[0]);
     }
 
     #[Test]
@@ -169,7 +225,12 @@ class OpenApiResponseValidatorTest extends TestCase
         );
 
         $this->assertFalse($result->isValid());
-        $this->assertStringContainsString('Method PATCH not defined', $result->errors()[0]);
+        $error = $result->errors()[0];
+        $this->assertStringContainsString('Method PATCH not defined', $error);
+        // Issue #132: list the methods the spec actually defines for the
+        // matched path so a method-mismatch typo (POST→PATCH, GET→POST)
+        // resolves in one read.
+        $this->assertStringContainsString('Defined methods: GET, POST', $error);
     }
 
     #[Test]

--- a/tests/fixtures/specs/path-suggester-pin.json
+++ b/tests/fixtures/specs/path-suggester-pin.json
@@ -1,0 +1,31 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Path suggester pin fixture",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/v2/admin/early_accesses": {
+      "get": {
+        "operationId": "listEarlyAccess",
+        "responses": {
+          "200": {"description": "OK"}
+        }
+      },
+      "post": {
+        "operationId": "createEarlyAccess",
+        "responses": {
+          "201": {"description": "Created"}
+        }
+      }
+    },
+    "/v2/admin/users/{user_id}": {
+      "get": {
+        "operationId": "getUser",
+        "responses": {
+          "200": {"description": "OK"}
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# 概要

`No matching path found` / `Method not defined` エラーに、stripping された path と「もしかして？」候補を表示してデバッグを 1 リード化する変更です。

## 変更内容

`v0.14.0` までの「path がマッチしない」エラーは単一行で `No matching path found in 'admin' spec for: /v1/foo` のみ。`strip_prefixes` 設定時に matcher が内部的に何を比較したかが見えず、~370 path 規模の spec では typo / method-mismatch を絞り込む手がかりがありませんでした。本 PR で診断を以下のように拡張します。

- 1 行目に HTTP method を含める（method-mismatch が一目で分かる）
- 設定された prefix が剥がれた場合のみ `searched as: ... (after stripping prefix '...')` 行を追加
- spec の path を「segment 数一致 → 共通 prefix segment 数 → tail-only Levenshtein → alphabetical」の 4 段階でスコアリングし、top 3 の `(method, path)` を `closest spec paths:` セクションに列挙
- `Method not defined` 側には `Defined methods: GET, POST.` サフィックスを追加

新規公開 API:
- `OpenApiPathMatcher::normalizeRequestPath(string): array{path, strippedPrefix}` — 既存の inline 正規化を抽出して公開
- `OpenApiPathSuggester` クラス（`suggest()` / `methodsForPath()` の static helper）

テスト/品質確認:
- 新規テスト 23 ケース（Suggester 13、PathMatcher::normalize 5、両 validator のエラー強化 5、issue 例の rendered output を `assertSame` で固定する pin テスト 1）
- PHPUnit: 918 tests, 1908 assertions ─ all green
- PHPStan level 6: clean
- PHP-CS-Fixer: clean

実装後の典型的なエラー出力（pin テストで固定）:

```
No matching path found in 'path-suggester-pin' spec for GET /api/v2/admin/totally-nonexistent-endpoint-xyz
  searched as: /v2/admin/totally-nonexistent-endpoint-xyz (after stripping prefix '/api')
  closest spec paths:
    - GET /v2/admin/early_accesses
    - POST /v2/admin/early_accesses
    - GET /v2/admin/users/{user_id}
```

## 関連情報

- Closes #132