### PR TITLE
Refactoring: PR #138 のレビュー対応（path-diagnostics ヘルパー抽出と防御強化）

### DIFF
--- a/src/OpenApiPathMatcher.php
+++ b/src/OpenApiPathMatcher.php
@@ -89,11 +89,21 @@ final class OpenApiPathMatcher
      * exact string that the matcher actually compared against, distinct from
      * the raw URI they passed in.
      *
-     * `strippedPrefix` is the literal prefix value that was removed (verbatim
-     * from the constructor's `$stripPrefixes`), or null when no configured
-     * prefix matched. Trailing-slash trimming is applied unconditionally
-     * after prefix stripping but does not surface as a separate signal — its
-     * effect on diagnostic messages is judged not worth a second field.
+     * Contract specifics callers should know:
+     * - **First match wins.** `$stripPrefixes` is iterated in construction
+     *   order; once one matches, the loop breaks. Subsequent prefixes are not
+     *   considered even if they would also match.
+     * - **Prefix matching is literal `str_starts_with`, not segment-aware.**
+     *   A configured prefix `/api` will also strip a request path of
+     *   `/api2/foo` (yielding `2/foo`). Configure prefixes with explicit
+     *   trailing slashes or include a path separator (`/api/`) if segment
+     *   semantics matter.
+     * - `strippedPrefix` is the literal prefix value that was removed
+     *   (verbatim from the constructor's `$stripPrefixes`), or null when no
+     *   configured prefix matched.
+     * - Trailing-slash trimming is applied unconditionally after prefix
+     *   stripping but does not surface as a separate signal — its effect on
+     *   diagnostic messages is judged not worth a second field.
      *
      * @return array{path: string, strippedPrefix: ?string}
      */

--- a/src/OpenApiPathSuggester.php
+++ b/src/OpenApiPathSuggester.php
@@ -57,12 +57,16 @@ final class OpenApiPathSuggester
      */
     public static function suggest(array $spec, string $normalizedPath, int $limit = 3): array
     {
-        /** @var array<string, mixed> $paths */
+        // A malformed spec where `paths` is null / scalar / list (rather than a
+        // string-keyed map) would otherwise warn on `foreach`. The diagnostic
+        // helper must never compound a primary failure with a secondary
+        // TypeError or warning the user can't act on — bail out quietly.
         $paths = $spec['paths'] ?? [];
-        if ($paths === []) {
+        if (!is_array($paths) || $paths === []) {
             return [];
         }
 
+        /** @var array<string, mixed> $paths */
         $requestSegments = self::segments($normalizedPath);
         $entries = [];
 
@@ -136,7 +140,12 @@ final class OpenApiPathSuggester
      */
     public static function methodsForPath(array $spec, string $matchedPath): array
     {
-        $pathItem = $spec['paths'][$matchedPath] ?? null;
+        $paths = $spec['paths'] ?? null;
+        if (!is_array($paths)) {
+            return [];
+        }
+
+        $pathItem = $paths[$matchedPath] ?? null;
         if (!is_array($pathItem)) {
             return [];
         }

--- a/src/OpenApiPathSuggester.php
+++ b/src/OpenApiPathSuggester.php
@@ -33,11 +33,12 @@ final class OpenApiPathSuggester
 {
     /**
      * The full set of operation keys that OpenAPI 3.x recognises at the
-     * path-item level. Kept local to the suggester (rather than reusing
-     * `HttpMethod`) because the latter models *request* methods that the
-     * library validates, which is a smaller set than what a spec author may
-     * legitimately document. If `HttpMethod` ever expands, this constant can
-     * be revisited.
+     * path-item level. Kept local to the suggester rather than reusing the
+     * library's request-method enum — that enum models *request* methods the
+     * library validates (a smaller set), whereas the suggester needs the
+     * broader spec-vocabulary including HEAD / OPTIONS / TRACE. If the
+     * request-method enum ever expands to cover the same ground, this
+     * constant can be revisited.
      */
     private const OPENAPI_PATH_ITEM_METHODS = [
         'get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace',
@@ -57,6 +58,14 @@ final class OpenApiPathSuggester
      */
     public static function suggest(array $spec, string $normalizedPath, int $limit = 3): array
     {
+        // PHP's array_slice would interpret a negative $limit as "count from
+        // the end", producing a surprising non-empty result for what callers
+        // intend as "no suggestions". Treat zero / negative as the obvious
+        // semantic: nothing requested ⇒ nothing returned.
+        if ($limit < 1) {
+            return [];
+        }
+
         // A malformed spec where `paths` is null / scalar / list (rather than a
         // string-keyed map) would otherwise warn on `foreach`. The diagnostic
         // helper must never compound a primary failure with a secondary

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -10,13 +10,12 @@ use Studio\OpenApiContractTesting\Validation\Request\PathParameterValidator;
 use Studio\OpenApiContractTesting\Validation\Request\QueryParameterValidator;
 use Studio\OpenApiContractTesting\Validation\Request\RequestBodyValidator;
 use Studio\OpenApiContractTesting\Validation\Request\SecurityValidator;
+use Studio\OpenApiContractTesting\Validation\Support\PathDiagnosticsFormatter;
 use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
 use Studio\OpenApiContractTesting\Validation\Support\ValidatorErrorBoundary;
 
 use function array_keys;
-use function implode;
 use function strtolower;
-use function strtoupper;
 
 final class OpenApiRequestValidator
 {
@@ -73,7 +72,7 @@ final class OpenApiRequestValidator
 
         if ($matched === null) {
             return OpenApiValidationResult::failure([
-                self::formatPathNotFoundError($specName, $method, $requestPath, $matcher, $spec),
+                PathDiagnosticsFormatter::pathNotFound($specName, $method, $requestPath, $matcher, $spec),
             ]);
         }
 
@@ -86,7 +85,7 @@ final class OpenApiRequestValidator
 
         if (!isset($pathSpec[$lowerMethod])) {
             return OpenApiValidationResult::failure([
-                self::formatMethodNotDefinedError($specName, $method, $matchedPath, $spec),
+                PathDiagnosticsFormatter::methodNotDefined($specName, $method, $matchedPath, $spec),
             ], $matchedPath);
         }
 
@@ -124,56 +123,6 @@ final class OpenApiRequestValidator
         }
 
         return OpenApiValidationResult::failure($errors, $matchedPath);
-    }
-
-    /**
-     * Mirrors OpenApiResponseValidator::formatPathNotFoundError. Duplicated
-     * intentionally — both validators need the same diagnostic shape, but
-     * extracting the helper would either add a new public class for two short
-     * call sites or force a circular dependency through a shared trait.
-     *
-     * @param array<string, mixed> $spec
-     */
-    private static function formatPathNotFoundError(
-        string $specName,
-        string $method,
-        string $requestPath,
-        OpenApiPathMatcher $matcher,
-        array $spec,
-    ): string {
-        $upperMethod = strtoupper($method);
-        $normalized = $matcher->normalizeRequestPath($requestPath);
-        $suggestions = OpenApiPathSuggester::suggest($spec, $normalized['path']);
-
-        $lines = ["No matching path found in '{$specName}' spec for {$upperMethod} {$requestPath}"];
-
-        if ($normalized['strippedPrefix'] !== null) {
-            $lines[] = "  searched as: {$normalized['path']} (after stripping prefix '{$normalized['strippedPrefix']}')";
-        }
-
-        if ($suggestions !== []) {
-            $lines[] = '  closest spec paths:';
-            foreach ($suggestions as $s) {
-                $lines[] = "    - {$s['method']} {$s['path']}";
-            }
-        }
-
-        return implode("\n", $lines);
-    }
-
-    /**
-     * @param array<string, mixed> $spec
-     */
-    private static function formatMethodNotDefinedError(
-        string $specName,
-        string $method,
-        string $matchedPath,
-        array $spec,
-    ): string {
-        $methods = OpenApiPathSuggester::methodsForPath($spec, $matchedPath);
-        $defined = $methods === [] ? '(none)' : implode(', ', $methods);
-
-        return "Method {$method} not defined for path {$matchedPath} in '{$specName}' spec. Defined methods: {$defined}.";
     }
 
     /**

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -11,19 +11,18 @@ use RuntimeException;
 use Studio\OpenApiContractTesting\Validation\Response\ResponseBodyValidationResult;
 use Studio\OpenApiContractTesting\Validation\Response\ResponseBodyValidator;
 use Studio\OpenApiContractTesting\Validation\Response\ResponseHeaderValidator;
+use Studio\OpenApiContractTesting\Validation\Support\PathDiagnosticsFormatter;
 use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
 use Studio\OpenApiContractTesting\Validation\Support\ValidatorErrorBoundary;
 
 use function array_keys;
 use function array_merge;
 use function get_debug_type;
-use function implode;
 use function is_array;
 use function preg_last_error_msg;
 use function preg_match;
 use function sprintf;
 use function strtolower;
-use function strtoupper;
 use function trigger_error;
 
 final class OpenApiResponseValidator
@@ -87,7 +86,7 @@ final class OpenApiResponseValidator
 
         if ($matchedPath === null) {
             return OpenApiValidationResult::failure([
-                self::formatPathNotFoundError($specName, $method, $requestPath, $matcher, $spec),
+                PathDiagnosticsFormatter::pathNotFound($specName, $method, $requestPath, $matcher, $spec),
             ]);
         }
 
@@ -96,7 +95,7 @@ final class OpenApiResponseValidator
 
         if (!isset($pathSpec[$lowerMethod])) {
             return OpenApiValidationResult::failure([
-                self::formatMethodNotDefinedError($specName, $method, $matchedPath, $spec),
+                PathDiagnosticsFormatter::methodNotDefined($specName, $method, $matchedPath, $spec),
             ], $matchedPath);
         }
 
@@ -206,62 +205,6 @@ final class OpenApiResponseValidator
             $statusCodeStr,
             $bodyResult->matchedContentType,
         );
-    }
-
-    /**
-     * Compose the "no matching path" diagnostic. Multi-line so the structured
-     * pieces (stripped path, suggestions) stay visually separate from the raw
-     * request URI on the lead line.
-     *
-     * @param array<string, mixed> $spec
-     */
-    private static function formatPathNotFoundError(
-        string $specName,
-        string $method,
-        string $requestPath,
-        OpenApiPathMatcher $matcher,
-        array $spec,
-    ): string {
-        $upperMethod = strtoupper($method);
-        $normalized = $matcher->normalizeRequestPath($requestPath);
-        $suggestions = OpenApiPathSuggester::suggest($spec, $normalized['path']);
-
-        $lines = ["No matching path found in '{$specName}' spec for {$upperMethod} {$requestPath}"];
-
-        // Only mention the stripping when it actually changed the path.
-        // Trailing-slash trim alone is not surfaced — it's universal and
-        // adding a line for it dilutes the more useful prefix signal.
-        if ($normalized['strippedPrefix'] !== null) {
-            $lines[] = "  searched as: {$normalized['path']} (after stripping prefix '{$normalized['strippedPrefix']}')";
-        }
-
-        if ($suggestions !== []) {
-            $lines[] = '  closest spec paths:';
-            foreach ($suggestions as $s) {
-                $lines[] = "    - {$s['method']} {$s['path']}";
-            }
-        }
-
-        return implode("\n", $lines);
-    }
-
-    /**
-     * @param array<string, mixed> $spec
-     */
-    private static function formatMethodNotDefinedError(
-        string $specName,
-        string $method,
-        string $matchedPath,
-        array $spec,
-    ): string {
-        $methods = OpenApiPathSuggester::methodsForPath($spec, $matchedPath);
-        // The "(none)" branch is theoretically unreachable from this call site
-        // (we got here because a method-keyed entry was missing for one
-        // specific method, not because every method was missing). Surface it
-        // anyway so a malformed spec doesn't render an empty list.
-        $defined = $methods === [] ? '(none)' : implode(', ', $methods);
-
-        return "Method {$method} not defined for path {$matchedPath} in '{$specName}' spec. Defined methods: {$defined}.";
     }
 
     /**

--- a/src/Validation/Support/PathDiagnosticsFormatter.php
+++ b/src/Validation/Support/PathDiagnosticsFormatter.php
@@ -25,10 +25,12 @@ use function strtoupper;
  * - The "closest spec paths:" section is omitted entirely when the suggester
  *   produces no candidates (empty / malformed spec).
  * - The "Defined methods:" suffix renders `(none)` when a path item declares
- *   only non-operation keys (`parameters`, `summary`, ...). Theoretically
- *   unreachable from the current call sites — the helper is only invoked when
- *   one specific method is missing, not all — but rendering a sentinel keeps
- *   a malformed spec visible instead of silently producing "Defined methods: .".
+ *   only non-operation keys. This is reachable in practice when the spec has
+ *   a path-item with shared `parameters` / `summary` but no operations
+ *   declared yet (a legal OpenAPI 3.x construction) — the validator will
+ *   route to this helper because the requested method is missing AND every
+ *   other method is too. Rendering an explicit `(none)` keeps that case
+ *   visible instead of producing "Defined methods: .".
  */
 final class PathDiagnosticsFormatter
 {

--- a/src/Validation/Support/PathDiagnosticsFormatter.php
+++ b/src/Validation/Support/PathDiagnosticsFormatter.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Validation\Support;
+
+use Studio\OpenApiContractTesting\OpenApiPathMatcher;
+use Studio\OpenApiContractTesting\OpenApiPathSuggester;
+
+use function implode;
+use function strtoupper;
+
+/**
+ * Composes the multi-line "no matching path" / single-line "method not
+ * defined" diagnostics shared by {@see OpenApiResponseValidator} and
+ * {@see OpenApiRequestValidator}. Lives alongside {@see ValidatorErrorBoundary}
+ * because both serve the same purpose: keep cross-validator error wording in
+ * one place so it cannot drift between request- and response-side surfaces.
+ *
+ * Formatting decisions worth knowing for callers:
+ * - The "searched as:" callout fires only when {@see OpenApiPathMatcher::normalizeRequestPath()}
+ *   reports a non-null `strippedPrefix`. Trailing-slash trimming alone is not
+ *   surfaced — it's a universal normalization and adding a line for it would
+ *   dilute the more useful prefix signal.
+ * - The "closest spec paths:" section is omitted entirely when the suggester
+ *   produces no candidates (empty / malformed spec).
+ * - The "Defined methods:" suffix renders `(none)` when a path item declares
+ *   only non-operation keys (`parameters`, `summary`, ...). Theoretically
+ *   unreachable from the current call sites — the helper is only invoked when
+ *   one specific method is missing, not all — but rendering a sentinel keeps
+ *   a malformed spec visible instead of silently producing "Defined methods: .".
+ */
+final class PathDiagnosticsFormatter
+{
+    /**
+     * @param array<string, mixed> $spec the decoded OpenAPI document, used to
+     *                                   draw "did you mean?" candidates from
+     */
+    public static function pathNotFound(
+        string $specName,
+        string $method,
+        string $requestPath,
+        OpenApiPathMatcher $matcher,
+        array $spec,
+    ): string {
+        $upperMethod = strtoupper($method);
+        $normalized = $matcher->normalizeRequestPath($requestPath);
+        $suggestions = OpenApiPathSuggester::suggest($spec, $normalized['path']);
+
+        $lines = ["No matching path found in '{$specName}' spec for {$upperMethod} {$requestPath}"];
+
+        if ($normalized['strippedPrefix'] !== null) {
+            $lines[] = "  searched as: {$normalized['path']} (after stripping prefix '{$normalized['strippedPrefix']}')";
+        }
+
+        if ($suggestions !== []) {
+            $lines[] = '  closest spec paths:';
+            foreach ($suggestions as $s) {
+                $lines[] = "    - {$s['method']} {$s['path']}";
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @param array<string, mixed> $spec
+     */
+    public static function methodNotDefined(
+        string $specName,
+        string $method,
+        string $matchedPath,
+        array $spec,
+    ): string {
+        $methods = OpenApiPathSuggester::methodsForPath($spec, $matchedPath);
+        $defined = $methods === [] ? '(none)' : implode(', ', $methods);
+
+        return "Method {$method} not defined for path {$matchedPath} in '{$specName}' spec. Defined methods: {$defined}.";
+    }
+}

--- a/tests/Unit/OpenApiPathSuggesterTest.php
+++ b/tests/Unit/OpenApiPathSuggesterTest.php
@@ -238,6 +238,54 @@ class OpenApiPathSuggesterTest extends TestCase
     }
 
     #[Test]
+    public function suggest_returns_empty_array_for_non_positive_limit(): void
+    {
+        // PHP's array_slice treats negative offsets as "count from the end",
+        // so passing a negative $limit would produce a surprising non-empty
+        // result rather than the expected "no suggestions". Pin the
+        // documented behaviour: zero or negative limit ⇒ no suggestions.
+        $spec = [
+            'paths' => [
+                '/a' => ['get' => ['responses' => []]],
+                '/b' => ['get' => ['responses' => []]],
+            ],
+        ];
+
+        $this->assertSame([], OpenApiPathSuggester::suggest($spec, '/x', 0));
+        $this->assertSame([], OpenApiPathSuggester::suggest($spec, '/x', -1));
+    }
+
+    #[Test]
+    public function suggest_ignores_non_openapi_method_keys(): void
+    {
+        // OpenAPI 3.x defines exactly 8 path-item operation methods. HTTP
+        // verbs that exist outside that set (`connect`, `link`, `unlink`,
+        // arbitrary spec-author typos like `gett`) must not leak into
+        // suggestion output even when they sit alongside legitimate
+        // operations. Locks the path-item method allowlist against
+        // accidental expansion.
+        $spec = [
+            'paths' => [
+                '/v1/op' => [
+                    'connect' => ['responses' => []],
+                    'link' => ['responses' => []],
+                    'gett' => ['responses' => []],
+                    'get' => ['responses' => []],
+                ],
+            ],
+        ];
+
+        $this->assertSame(
+            [['method' => 'GET', 'path' => '/v1/op']],
+            OpenApiPathSuggester::suggest($spec, '/v1/op', 10),
+        );
+        $this->assertSame(
+            ['GET'],
+            OpenApiPathSuggester::methodsForPath($spec, '/v1/op'),
+        );
+    }
+
+    #[Test]
     public function suggest_ignores_non_array_path_item_entries(): void
     {
         // A spec with an unresolved $ref or a malformed entry (e.g. scalar

--- a/tests/Unit/OpenApiPathSuggesterTest.php
+++ b/tests/Unit/OpenApiPathSuggesterTest.php
@@ -21,6 +21,26 @@ class OpenApiPathSuggesterTest extends TestCase
     }
 
     #[Test]
+    public function suggest_returns_empty_array_for_non_array_paths_value(): void
+    {
+        // A malformed spec where `paths` decoded to a non-mapping (null, scalar)
+        // would TypeError on `foreach` if not guarded. The diagnostic helper
+        // must never compound a primary failure with a TypeError of its own —
+        // the user is already debugging an unmatched path.
+        $this->assertSame([], OpenApiPathSuggester::suggest(['paths' => null], '/v1/x'));
+        $this->assertSame([], OpenApiPathSuggester::suggest(['paths' => 'oops'], '/v1/x'));
+        $this->assertSame([], OpenApiPathSuggester::suggest(['paths' => 42], '/v1/x'));
+    }
+
+    #[Test]
+    public function methods_for_path_returns_empty_array_for_non_array_paths_value(): void
+    {
+        $this->assertSame([], OpenApiPathSuggester::methodsForPath(['paths' => null], '/v1/x'));
+        $this->assertSame([], OpenApiPathSuggester::methodsForPath(['paths' => 'oops'], '/v1/x'));
+        $this->assertSame([], OpenApiPathSuggester::methodsForPath(['paths' => 42], '/v1/x'));
+    }
+
+    #[Test]
     public function suggest_filters_non_operation_keys_at_path_item_level(): void
     {
         // OpenAPI 3.x permits `parameters`, `summary`, `description`, `servers`,

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -155,9 +155,9 @@ class OpenApiResponseValidatorTest extends TestCase
 
         $this->assertFalse($result->isValid());
         $error = $result->errors()[0];
-        // Issue #132: the error must surface the request method (so a
-        // method-mismatch is obvious at a glance) and include "did you mean?"
-        // suggestions drawn from the spec's actual paths.
+        // The error must surface the request method (so a method-mismatch is
+        // obvious at a glance) and include "did you mean?" suggestions drawn
+        // from the spec's actual paths.
         $this->assertStringContainsString("No matching path found in 'petstore-3.0' spec for GET /v1/unknown", $error);
         $this->assertStringContainsString('closest spec paths:', $error);
         $this->assertStringContainsString('GET /v1/pets', $error);
@@ -188,8 +188,8 @@ class OpenApiResponseValidatorTest extends TestCase
     #[Test]
     public function path_not_found_error_renders_full_diagnostic_block(): void
     {
-        // End-to-end pin against the issue #132 suggested-fix wording. Locks
-        // the indentation, line ordering, prefix-stripping callout, and the
+        // End-to-end pin of the path-not-found diagnostic wording. Locks the
+        // indentation, line ordering, prefix-stripping callout, and the
         // (method, path) layout of the suggestion list so future formatting
         // tweaks surface as visible test diffs rather than silent UX drift.
         OpenApiSpecLoader::reset();
@@ -227,9 +227,8 @@ class OpenApiResponseValidatorTest extends TestCase
         $this->assertFalse($result->isValid());
         $error = $result->errors()[0];
         $this->assertStringContainsString('Method PATCH not defined', $error);
-        // Issue #132: list the methods the spec actually defines for the
-        // matched path so a method-mismatch typo (POST→PATCH, GET→POST)
-        // resolves in one read.
+        // List the methods the spec actually defines for the matched path so
+        // a method-mismatch typo (POST→PATCH, GET→POST) resolves in one read.
         $this->assertStringContainsString('Defined methods: GET, POST', $error);
     }
 


### PR DESCRIPTION
# 概要

PR #138（issue #132）merge 後の自動レビューで挙がった項目への follow-up。診断ロジックの重複排除・防御ガード追加・コメント rot 修正を含む内部改善で、ユーザー観測可能な振る舞いに変更はありません。

## 変更内容

PR #138 merge 後にレビューエージェント 5 種で精査した結果、Important 2 件 + Suggestions 6 件が挙がりました。以下にまとめて取り込みます（near-miss prefix 検出のみ scope crepe のため別 issue 推奨で見送り）。

- **path-diagnostics ヘルパーを抽出**（コミット `f7177a8`）
  - `OpenApiResponseValidator` と `OpenApiRequestValidator` で byte-for-byte 重複していた `formatPathNotFoundError` / `formatMethodNotDefinedError` を `Validation\Support\PathDiagnosticsFormatter` に集約。`ValidatorErrorBoundary` と同じ pattern でドリフトリスクを排除。
- **`OpenApiPathSuggester` の防御ガード追加**（コミット `f7177a8`）
  - `\$spec['paths']` が非配列（null / scalar）のとき `foreach` 警告が出ていた箇所を `is_array()` ガードで抑制。`paths => null / 'oops' / 42` のテスト追加。
- **`\$limit < 1` ガード**（コミット `ccd52e3`）
  - `array_slice` の負値挙動の foot-gun を排除。
- **non-OAS method 除外テスト**（コミット `ccd52e3`）
  - `connect` / `link` / `gett` を path-item に入れて `OPENAPI_PATH_ITEM_METHODS` の堅牢性を pin。
- **`OpenApiPathMatcher::normalizeRequestPath()` docblock 拡充**（コミット `ccd52e3`）
  - 「first match wins」「`str_starts_with` による literal prefix match」の契約を docblock に明記。
- **コメント rot 対策**（コミット `ccd52e3`）
  - `HttpMethod` 名前参照の汎用化、「theoretically unreachable」コメントの訂正（実は到達可能だった）、テストの `Issue #132:` prefix 削除。

検証:
- PHPUnit: 922 tests, 1918 assertions — all green（PR #138 merge 時の 920 から +2 ケース）
- PHPStan level 6: clean
- PHP-CS-Fixer: clean

## 関連情報

- PR #138 のレビューフィードバック対応
- Issue #132（既に closed）に関する内部品質改善