### PR TITLE
feat(coverage): add active_only console output mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Add the coverage extension to your `phpunit.xml`:
 | `strip_prefixes` | No | `[]` | Comma-separated prefixes to strip from request paths (e.g., `/api`) |
 | `specs` | No | `front` | Comma-separated spec names for coverage tracking |
 | `output_file` | No | — | File path to write Markdown coverage report (relative paths resolve from `getcwd()`) |
-| `console_output` | No | `default` | Console output mode: `default`, `all`, or `uncovered_only` (overridden by `OPENAPI_CONSOLE_OUTPUT` env var) |
+| `console_output` | No | `default` | Console output mode: `default`, `all`, `uncovered_only`, or `active_only` (overridden by `OPENAPI_CONSOLE_OUTPUT` env var) |
 | `sidecar_dir` | No | `sys_get_temp_dir()/openapi-coverage-sidecars` | Directory paratest workers drop per-worker JSON sidecars into. Used only under parallel test runners — see [Parallel test runners](#parallel-test-runners) below |
 
 *Not required if you call `OpenApiSpecLoader::configure()` manually.
@@ -609,6 +609,23 @@ Legend: ✓=validated  ⚠=skipped  ✗=uncovered  ◐=partial  ·=request-only 
   ✗ PUT /v1/pets/{petId}  (0/2 responses)
       ✗ 200    application/json                  uncovered
       ✗ 404    application/problem+json          uncovered
+```
+
+### `active_only` mode
+
+Useful for the local TDD loop with a multi-spec setup (e.g. `specs="front,store,admin"`). Specs that no test in this run touched are collapsed to a single line, so a focused single-test run no longer has to scroll past hundreds of `✗ uncovered` rows for unrelated specs. Specs with at least one validated, skipped, or request-only observation render the same one-line-per-endpoint view as `default`:
+
+```
+[front] no test activity (373 endpoints, 894 responses in spec)
+[store] no test activity (148 endpoints, 312 responses in spec)
+
+[admin] endpoints: 1/72 fully covered (1.4%), 0 partial, 71 uncovered
+        responses: 1/172 covered (0.6%), 0 skipped, 171 uncovered
+--------------------------------------------------
+Legend: ✓=validated  ⚠=skipped  ✗=uncovered  ◐=partial  ·=request-only  *=any/no content-type
+  ✓ GET /v2/admin/early_accesses  (1/1 responses)
+  ✗ POST /v2/admin/early_accesses  (0/2 responses)
+  ...
 ```
 
 You can set the mode via `phpunit.xml`:

--- a/src/PHPUnit/ConsoleCoverageRenderer.php
+++ b/src/PHPUnit/ConsoleCoverageRenderer.php
@@ -86,9 +86,16 @@ final class ConsoleCoverageRenderer
 
     /**
      * A spec is "active" when at least one validated/skipped response was
-     * recorded, or any endpoint was reached request-only (request hook fired
-     * without a response assertion). Used by ACTIVE_ONLY mode to collapse
-     * specs that no test in this run touched.
+     * recorded, or any endpoint resolved to the `RequestOnly` bucket — see
+     * {@see OpenApiCoverageTracker::deriveEndpointState()}
+     * for the full definition (request hook fired, or only unexpected
+     * observations recorded). Used by ACTIVE_ONLY mode to collapse specs
+     * that no test in this run touched.
+     *
+     * Counts only declared-endpoint activity. Recordings whose endpoint key
+     * is absent from the live spec (e.g. an orphan in a paratest sidecar
+     * after a mid-run spec edit) are dropped by `computeCoverage` and so do
+     * not flip a spec to active here either.
      *
      * @param CoverageResult $result
      */

--- a/src/PHPUnit/ConsoleCoverageRenderer.php
+++ b/src/PHPUnit/ConsoleCoverageRenderer.php
@@ -42,6 +42,17 @@ final class ConsoleCoverageRenderer
         $output .= str_repeat('=', 50) . "\n";
 
         foreach ($results as $spec => $result) {
+            if ($consoleOutput === ConsoleOutput::ACTIVE_ONLY && !self::specHasActivity($result)) {
+                $output .= sprintf(
+                    "\n[%s] no test activity (%d endpoints, %d responses in spec)\n",
+                    $spec,
+                    $result['endpointTotal'],
+                    $result['responseTotal'],
+                );
+
+                continue;
+            }
+
             $endpointPct = self::percentage($result['endpointFullyCovered'], $result['endpointTotal']);
             $responsePct = self::percentage($result['responseCovered'], $result['responseTotal']);
 
@@ -74,6 +85,21 @@ final class ConsoleCoverageRenderer
     }
 
     /**
+     * A spec is "active" when at least one validated/skipped response was
+     * recorded, or any endpoint was reached request-only (request hook fired
+     * without a response assertion). Used by ACTIVE_ONLY mode to collapse
+     * specs that no test in this run touched.
+     *
+     * @param CoverageResult $result
+     */
+    private static function specHasActivity(array $result): bool
+    {
+        return $result['responseCovered'] > 0 ||
+            $result['responseSkipped'] > 0 ||
+            $result['endpointRequestOnly'] > 0;
+    }
+
+    /**
      * @param list<EndpointSummary> $endpoints
      */
     private static function renderEndpoints(array $endpoints, ConsoleOutput $mode): string
@@ -87,9 +113,11 @@ final class ConsoleCoverageRenderer
             // DEFAULT mode renders one line per endpoint with no sub-rows.
             // ALL renders sub-rows for every endpoint. UNCOVERED_ONLY only
             // shows sub-rows when the endpoint isn't all-covered, so a
-            // green run stays compact.
+            // green run stays compact. ACTIVE_ONLY only reaches this branch
+            // for active specs, and renders the same one-line-per-endpoint
+            // shape as DEFAULT (inactive specs are collapsed upstream).
             $showSubRows = match ($mode) {
-                ConsoleOutput::DEFAULT => false,
+                ConsoleOutput::DEFAULT, ConsoleOutput::ACTIVE_ONLY => false,
                 ConsoleOutput::ALL => true,
                 ConsoleOutput::UNCOVERED_ONLY => $endpoint['state'] !== EndpointCoverageState::AllCovered,
             };

--- a/src/PHPUnit/ConsoleOutput.php
+++ b/src/PHPUnit/ConsoleOutput.php
@@ -16,6 +16,7 @@ enum ConsoleOutput: string
     case DEFAULT = 'default';
     case ALL = 'all';
     case UNCOVERED_ONLY = 'uncovered_only';
+    case ACTIVE_ONLY = 'active_only';
 
     /**
      * Resolve the console output mode from environment variable and/or phpunit.xml parameter.
@@ -30,7 +31,7 @@ enum ConsoleOutput: string
             $resolved = self::tryFrom(mb_strtolower(trim($envValue)));
 
             if ($resolved === null) {
-                fwrite(STDERR, "[OpenAPI Coverage] WARNING: Invalid OPENAPI_CONSOLE_OUTPUT value '{$envValue}'. Valid values: default, all, uncovered_only. Falling back to 'default'.\n");
+                fwrite(STDERR, "[OpenAPI Coverage] WARNING: Invalid OPENAPI_CONSOLE_OUTPUT value '{$envValue}'. Valid values: default, all, uncovered_only, active_only. Falling back to 'default'.\n");
             }
 
             return $resolved ?? self::DEFAULT;
@@ -40,7 +41,7 @@ enum ConsoleOutput: string
             $resolved = self::tryFrom(mb_strtolower(trim($parameterValue)));
 
             if ($resolved === null) {
-                fwrite(STDERR, "[OpenAPI Coverage] WARNING: Invalid console_output parameter '{$parameterValue}'. Valid values: default, all, uncovered_only. Falling back to 'default'.\n");
+                fwrite(STDERR, "[OpenAPI Coverage] WARNING: Invalid console_output parameter '{$parameterValue}'. Valid values: default, all, uncovered_only, active_only. Falling back to 'default'.\n");
             }
 
             return $resolved ?? self::DEFAULT;

--- a/tests/Unit/ConsoleCoverageRendererTest.php
+++ b/tests/Unit/ConsoleCoverageRendererTest.php
@@ -181,6 +181,136 @@ class ConsoleCoverageRendererTest extends TestCase
     }
 
     #[Test]
+    public function active_only_collapses_inactive_spec_to_single_line(): void
+    {
+        $results = [
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v1/pets', 'uncovered', responses: [
+                        self::row('200', 'application/json', 'uncovered'),
+                    ], totalResponseCount: 1),
+                ],
+                endpointTotal: 373,
+                endpointUncovered: 373,
+                responseTotal: 894,
+                responseUncovered: 894,
+            ),
+        ];
+
+        $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::ACTIVE_ONLY);
+
+        $this->assertStringContainsString('[front] no test activity (373 endpoints, 894 responses in spec)', $output);
+        // Inactive specs must not render the per-endpoint summary block.
+        $this->assertStringNotContainsString('endpoints: 0/373 fully covered', $output);
+        $this->assertStringNotContainsString('✗ GET /v1/pets', $output);
+    }
+
+    #[Test]
+    public function active_only_renders_full_block_for_active_spec(): void
+    {
+        $results = [
+            'admin' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v2/admin/early_accesses', 'all-covered', responses: [
+                        self::row('200', 'application/json', 'validated', hits: 1),
+                    ], coveredResponseCount: 1, totalResponseCount: 1),
+                ],
+                endpointTotal: 1,
+                endpointFullyCovered: 1,
+                responseTotal: 1,
+                responseCovered: 1,
+            ),
+        ];
+
+        $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::ACTIVE_ONLY);
+
+        $this->assertStringContainsString('[admin] endpoints: 1/1 fully covered (100%)', $output);
+        $this->assertStringContainsString('✓ GET /v2/admin/early_accesses', $output);
+        $this->assertStringNotContainsString('no test activity', $output);
+    }
+
+    #[Test]
+    public function active_only_treats_request_only_endpoint_as_active(): void
+    {
+        $results = [
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v1/health', 'request-only', requestReached: true, totalResponseCount: 0),
+                ],
+                endpointTotal: 1,
+                endpointRequestOnly: 1,
+            ),
+        ];
+
+        $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::ACTIVE_ONLY);
+
+        $this->assertStringNotContainsString('no test activity', $output);
+        $this->assertStringContainsString('· GET /v1/health', $output);
+    }
+
+    #[Test]
+    public function active_only_treats_skipped_only_spec_as_active(): void
+    {
+        $results = [
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('DELETE /v1/pets/{petId}', 'partial', responses: [
+                        self::row('5XX', '*', 'skipped', hits: 1, skipReason: 'status 503 matched skip pattern 5\d\d'),
+                    ], skippedResponseCount: 1, totalResponseCount: 1),
+                ],
+                endpointTotal: 1,
+                endpointPartial: 1,
+                responseTotal: 1,
+                responseSkipped: 1,
+            ),
+        ];
+
+        $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::ACTIVE_ONLY);
+
+        $this->assertStringNotContainsString('no test activity', $output);
+        $this->assertStringContainsString('[front] endpoints', $output);
+    }
+
+    #[Test]
+    public function active_only_mixes_collapsed_and_full_specs_across_specs(): void
+    {
+        $results = [
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v1/pets', 'uncovered', responses: [
+                        self::row('200', 'application/json', 'uncovered'),
+                    ], totalResponseCount: 1),
+                ],
+                endpointTotal: 373,
+                endpointUncovered: 373,
+                responseTotal: 894,
+                responseUncovered: 894,
+            ),
+            'admin' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v2/admin/early_accesses', 'all-covered', responses: [
+                        self::row('200', 'application/json', 'validated', hits: 1),
+                    ], coveredResponseCount: 1, totalResponseCount: 1),
+                ],
+                endpointTotal: 72,
+                endpointFullyCovered: 1,
+                endpointUncovered: 71,
+                responseTotal: 100,
+                responseCovered: 1,
+                responseUncovered: 99,
+            ),
+        ];
+
+        $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::ACTIVE_ONLY);
+
+        $this->assertStringContainsString('[front] no test activity (373 endpoints, 894 responses in spec)', $output);
+        $this->assertStringContainsString('[admin] endpoints: 1/72 fully covered', $output);
+        $this->assertStringContainsString('✓ GET /v2/admin/early_accesses', $output);
+        // The inactive spec's endpoint rows must not leak into the report.
+        $this->assertStringNotContainsString('GET /v1/pets', $output);
+    }
+
+    #[Test]
     public function unexpected_observation_appears_with_bang_prefix(): void
     {
         $results = [

--- a/tests/Unit/ConsoleCoverageRendererTest.php
+++ b/tests/Unit/ConsoleCoverageRendererTest.php
@@ -269,6 +269,55 @@ class ConsoleCoverageRendererTest extends TestCase
 
         $this->assertStringNotContainsString('no test activity', $output);
         $this->assertStringContainsString('[front] endpoints', $output);
+        // Pin that the endpoint row actually rendered (not just the header).
+        // A regression that emitted the summary block but skipped
+        // renderEndpoints would otherwise pass.
+        $this->assertStringContainsString('DELETE /v1/pets/{petId}', $output);
+    }
+
+    #[Test]
+    public function active_only_collapses_every_spec_when_all_inactive(): void
+    {
+        $results = [
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v1/pets', 'uncovered', responses: [
+                        self::row('200', 'application/json', 'uncovered'),
+                    ], totalResponseCount: 1),
+                ],
+                endpointTotal: 10,
+                endpointUncovered: 10,
+                responseTotal: 20,
+                responseUncovered: 20,
+            ),
+            'admin' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v2/admin/early_accesses', 'uncovered', responses: [
+                        self::row('200', 'application/json', 'uncovered'),
+                    ], totalResponseCount: 1),
+                ],
+                endpointTotal: 5,
+                endpointUncovered: 5,
+                responseTotal: 8,
+                responseUncovered: 8,
+            ),
+        ];
+
+        $output = ConsoleCoverageRenderer::render($results, ConsoleOutput::ACTIVE_ONLY);
+
+        $this->assertStringContainsString('OpenAPI Contract Test Coverage', $output);
+        $this->assertStringContainsString('[front] no test activity (10 endpoints, 20 responses in spec)', $output);
+        $this->assertStringContainsString('[admin] no test activity (5 endpoints, 8 responses in spec)', $output);
+        // No legend or per-endpoint rows when every spec is collapsed.
+        $this->assertStringNotContainsString('Legend:', $output);
+        $this->assertStringNotContainsString('GET /v1/pets', $output);
+        $this->assertStringNotContainsString('GET /v2/admin/early_accesses', $output);
+    }
+
+    #[Test]
+    public function active_only_returns_empty_string_for_empty_results(): void
+    {
+        $this->assertSame('', ConsoleCoverageRenderer::render([], ConsoleOutput::ACTIVE_ONLY));
     }
 
     #[Test]

--- a/tests/Unit/ConsoleOutputTest.php
+++ b/tests/Unit/ConsoleOutputTest.php
@@ -58,6 +58,12 @@ class ConsoleOutputTest extends TestCase
     }
 
     #[Test]
+    public function resolve_returns_active_only_from_parameter(): void
+    {
+        $this->assertSame(ConsoleOutput::ACTIVE_ONLY, ConsoleOutput::resolve('active_only'));
+    }
+
+    #[Test]
     public function resolve_returns_default_from_parameter(): void
     {
         $this->assertSame(ConsoleOutput::DEFAULT, ConsoleOutput::resolve('default'));
@@ -70,6 +76,8 @@ class ConsoleOutputTest extends TestCase
         $this->assertSame(ConsoleOutput::ALL, ConsoleOutput::resolve('All'));
         $this->assertSame(ConsoleOutput::UNCOVERED_ONLY, ConsoleOutput::resolve('UNCOVERED_ONLY'));
         $this->assertSame(ConsoleOutput::UNCOVERED_ONLY, ConsoleOutput::resolve('Uncovered_Only'));
+        $this->assertSame(ConsoleOutput::ACTIVE_ONLY, ConsoleOutput::resolve('ACTIVE_ONLY'));
+        $this->assertSame(ConsoleOutput::ACTIVE_ONLY, ConsoleOutput::resolve('Active_Only'));
     }
 
     #[Test]

--- a/tests/Unit/ConsoleOutputTest.php
+++ b/tests/Unit/ConsoleOutputTest.php
@@ -110,6 +110,14 @@ class ConsoleOutputTest extends TestCase
     }
 
     #[Test]
+    public function resolve_returns_active_only_from_env(): void
+    {
+        putenv('OPENAPI_CONSOLE_OUTPUT=active_only');
+
+        $this->assertSame(ConsoleOutput::ACTIVE_ONLY, ConsoleOutput::resolve(null));
+    }
+
+    #[Test]
     public function resolve_env_trims_whitespace(): void
     {
         putenv('OPENAPI_CONSOLE_OUTPUT=  all  ');


### PR DESCRIPTION
## Summary

- Adds `console_output=active_only`, a fourth mode that collapses specs with no test activity to a single line so a focused single-test run no longer prints the full uncovered table for every unrelated spec.
- "Activity" = at least one validated response, skipped response, or request-only endpoint hit. Specs with activity render the same one-line-per-endpoint shape as `default`; inactive specs collapse to `[spec] no test activity (N endpoints, M responses in spec)`.
- Read by both the `console_output` parameter and the `OPENAPI_CONSOLE_OUTPUT` env var, matching the existing modes.

Closes #133.

## Out of scope (deferred)

The issue also lists two optional refinements that are intentionally not part of this PR:

- Auto-defaulting based on CI env vars (`GITHUB_ACTIONS`, etc.) — silent default flips are a behavior change that deserves its own discussion.
- A `--filter-paths` knob to scope rendered rows further — separate design surface (env var vs phpunit param, regex vs glob).

Happy to spin these out into follow-up issues if you want them.

## Test plan

- [x] `vendor/bin/phpunit` (928 tests pass; new tests cover `active_only` parsing, collapsed inactive spec, full-block active spec, request-only-as-active, skipped-only-as-active, multi-spec mix)
- [x] `vendor/bin/phpstan analyse` (no errors)
- [x] `vendor/bin/php-cs-fixer fix --dry-run` (clean)
- [x] README updated with new mode entry, parameter table, and example output