### PR TITLE
Bugfix: bundled spec が見つからない場合を boot 時に FATAL 化

### DIFF
--- a/src/InvalidOpenApiSpecException.php
+++ b/src/InvalidOpenApiSpecException.php
@@ -14,9 +14,14 @@ use Throwable;
  * `InvalidOpenApiSpecReason`; consumers should branch on `$reason` rather
  * than pattern-matching `$message`.
  *
- * Separate from `SpecFileNotFoundException` so the PHPUnit coverage
- * extension can hard-fail the run on broken specs while continuing to
- * warn for a missing spec file.
+ * Separate from `SpecFileNotFoundException` because the two have different
+ * downstream contracts: a *missing* spec file may legitimately appear after
+ * boot (e.g. mid-run unlink, stale CLI sidecar) and is tolerated by
+ * `CoverageReportSubscriber` / `CoverageMergeCommand` with a warning, while
+ * a *broken* spec is always a hard contract violation. Both, however, are
+ * treated as fatal at PHPUnit boot — see `OpenApiCoverageExtension` (issue
+ * #134) — so a configuration error never sits silent until an unrelated
+ * test happens to exercise the broken spec.
  */
 final class InvalidOpenApiSpecException extends RuntimeException
 {

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -146,10 +146,11 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
             try {
                 $results[$spec] = OpenApiCoverageTracker::computeCoverage($spec);
             } catch (SpecFileNotFoundException $e) {
-                // Warn-and-continue for stale specs=, same semantics
-                // as bootstrap. Unlike bootstrap, the subscriber runs
-                // after tests finished, so continuing lets partial
-                // coverage reports still render.
+                // Unlike bootstrap (which hard-fails missing files since
+                // issue #134), the subscriber runs after tests finished —
+                // so we tolerate a mid-run unlink and let partial coverage
+                // reports still render rather than discarding the run's
+                // observations.
                 $this->writeStderr("[OpenAPI Coverage] WARNING: Skipping spec '{$spec}': {$e->getMessage()}\n");
 
                 continue;

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -73,7 +73,7 @@ final class OpenApiCoverageExtension implements Extension
     {
         try {
             $this->setupExtension($facade, $parameters, getenv('GITHUB_STEP_SUMMARY') ?: null);
-        } catch (InvalidOpenApiSpecException) {
+        } catch (InvalidOpenApiSpecException | SpecFileNotFoundException) {
             // setupExtension() has already written a FATAL line to stderr and
             // (if GITHUB_STEP_SUMMARY is set) appended a fatal block to it.
             // PHPUnit's ExtensionBootstrapper::bootstrap() wraps this call in
@@ -127,15 +127,22 @@ final class OpenApiCoverageExtension implements Extension
         // Eager-load every registered spec so structural problems surface at
         // PHPUnit bootstrap (hard fail via bootstrap()) rather than being
         // silently swallowed when a test happens not to exercise the broken
-        // spec. Only SpecFileNotFoundException keeps the legacy warn-and-
-        // continue behavior, so a stale entry in `specs=` does not block
-        // unrelated work; everything else — broken `$ref`, malformed
-        // JSON/YAML, non-mapping root, missing `symfony/yaml` — is fatal.
+        // spec. A spec named in `specs=` that doesn't resolve to a file is a
+        // configuration error — not a stale leftover — so it is fatal too
+        // (issue #134). Defensive warn-and-continue for missing files lives
+        // downstream in CoverageReportSubscriber / CoverageMergeCommand,
+        // where a mid-run unlink shouldn't lose the report.
         foreach ($specs as $spec) {
             try {
                 OpenApiSpecLoader::load($spec);
             } catch (SpecFileNotFoundException $e) {
-                self::writeStderr("[OpenAPI Coverage] WARNING: Skipping spec '{$spec}': {$e->getMessage()}\n");
+                self::writeStderr(
+                    "[OpenAPI Coverage] FATAL: spec '{$spec}' configured in `specs=` is not loadable: {$e->getMessage()}\n"
+                    . "  Action: regenerate the bundle (e.g. `cd openapi && npm run bundle`) or remove '{$spec}' from `specs=`.\n",
+                );
+                self::appendGithubStepSummaryFatalBlock($githubSummaryPath, $spec, $e->getMessage());
+
+                throw $e;
             } catch (InvalidOpenApiSpecException $e) {
                 self::writeStderr("[OpenAPI Coverage] FATAL: Invalid OpenAPI spec '{$spec}': {$e->getMessage()}\n");
                 self::appendGithubStepSummaryFatalBlock($githubSummaryPath, $spec, $e->getMessage());

--- a/src/SpecFileNotFoundException.php
+++ b/src/SpecFileNotFoundException.php
@@ -9,8 +9,13 @@ use Throwable;
 
 /**
  * Thrown when a registered spec name has no matching file on disk. Distinct
- * from `InvalidOpenApiSpecException` so the coverage extension can continue
- * past a stale `specs=` entry with a warning instead of aborting the run.
+ * from `InvalidOpenApiSpecException` so downstream `CoverageReportSubscriber`
+ * and `CoverageMergeCommand` can defensively warn-and-continue when a spec
+ * file is unlinked mid-run or a CLI invocation references a sidecar whose
+ * spec is no longer on disk. The PHPUnit boot path (issue #134) treats this
+ * as fatal: a missing bundled spec at startup is a configuration error and
+ * must surface immediately, not as a runtime stack trace inside an unrelated
+ * test much later in the suite.
  */
 final class SpecFileNotFoundException extends RuntimeException
 {

--- a/tests/Integration/OpenApiCoverageExtensionBootstrapTest.php
+++ b/tests/Integration/OpenApiCoverageExtensionBootstrapTest.php
@@ -59,15 +59,16 @@ class OpenApiCoverageExtensionBootstrapTest extends TestCase
     }
 
     #[Test]
-    public function phpunit_exits_zero_when_registered_spec_file_is_missing(): void
+    public function phpunit_exits_non_zero_when_registered_spec_file_is_missing(): void
     {
-        // `OpenApiVersionTest` is a lightweight, always-present target so the
-        // suite has something to pass; the stale `specs=` entry must degrade
-        // to a warning without aborting.
-        [$exit, $stderr] = $this->runPhpunit('does-not-exist', '--filter=OpenApiVersionTest');
+        // Issue #134: stale `specs=` entries used to print a warning and pass
+        // the suite green, only blowing up later in an unrelated test. Pin
+        // the new contract — boot aborts non-zero so the misconfiguration is
+        // unmissable, not surfaced on someone else's PR after a merge.
+        [$exit, $stderr] = $this->runPhpunit('does-not-exist', '--filter=DoesNotMatchAnyTest');
 
-        $this->assertSame(0, $exit, "Expected exit 0; stderr was:\n" . $stderr);
-        $this->assertStringContainsString('WARNING', $stderr);
+        $this->assertNotSame(0, $exit, "Expected non-zero exit; stderr was:\n" . $stderr);
+        $this->assertStringContainsString('FATAL', $stderr);
         $this->assertStringContainsString('does-not-exist', $stderr);
     }
 

--- a/tests/Integration/OpenApiCoverageExtensionBootstrapTest.php
+++ b/tests/Integration/OpenApiCoverageExtensionBootstrapTest.php
@@ -61,15 +61,17 @@ class OpenApiCoverageExtensionBootstrapTest extends TestCase
     #[Test]
     public function phpunit_exits_non_zero_when_registered_spec_file_is_missing(): void
     {
-        // Issue #134: stale `specs=` entries used to print a warning and pass
-        // the suite green, only blowing up later in an unrelated test. Pin
-        // the new contract — boot aborts non-zero so the misconfiguration is
-        // unmissable, not surfaced on someone else's PR after a merge.
+        // issue #134 contract pinned end-to-end: the unit test covers the
+        // throw, this one verifies PHPUnit's bootstrapper actually exits
+        // non-zero rather than demoting to a warning. The `Action:` assert
+        // guarantees the remediation hint survives the subprocess boundary
+        // (where PHP could otherwise truncate stderr on an early exit).
         [$exit, $stderr] = $this->runPhpunit('does-not-exist', '--filter=DoesNotMatchAnyTest');
 
         $this->assertNotSame(0, $exit, "Expected non-zero exit; stderr was:\n" . $stderr);
         $this->assertStringContainsString('FATAL', $stderr);
         $this->assertStringContainsString('does-not-exist', $stderr);
+        $this->assertStringContainsString('Action:', $stderr);
     }
 
     /**

--- a/tests/Unit/OpenApiCoverageExtensionTest.php
+++ b/tests/Unit/OpenApiCoverageExtensionTest.php
@@ -11,6 +11,7 @@ use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\InvalidOpenApiSpecReason;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension;
+use Studio\OpenApiContractTesting\SpecFileNotFoundException;
 
 use function fclose;
 use function file_get_contents;
@@ -71,18 +72,29 @@ class OpenApiCoverageExtensionTest extends TestCase
     }
 
     #[Test]
-    public function bootstrap_writes_warning_but_continues_for_missing_spec_file(): void
+    public function bootstrap_throws_fatal_for_missing_spec_file(): void
     {
+        // Issue #134: stale `specs=` entries used to print a warning and let
+        // the suite continue, only blowing up later in an unrelated test.
+        // Boot must now hard-fail so the configuration error surfaces at the
+        // moment of detection — not on someone else's PR after a merge.
         $extension = new OpenApiCoverageExtension();
         $parameters = ParameterCollection::fromArray([
             'spec_base_path' => __DIR__ . '/../fixtures/specs',
             'specs' => 'does-not-exist',
         ]);
 
-        $extension->setupExtension(null, $parameters, null);
+        try {
+            $extension->setupExtension(null, $parameters, null);
+            $this->fail('expected SpecFileNotFoundException');
+        } catch (SpecFileNotFoundException $e) {
+            $this->assertSame('does-not-exist', $e->specName);
+        }
 
-        $this->assertStringContainsString('WARNING', $this->readStderr());
-        $this->assertStringContainsString('does-not-exist', $this->readStderr());
+        $stderr = $this->readStderr();
+        $this->assertStringContainsString('FATAL', $stderr);
+        $this->assertStringContainsString("spec 'does-not-exist'", $stderr);
+        $this->assertStringContainsString('Action:', $stderr);
     }
 
     #[Test]
@@ -128,6 +140,36 @@ class OpenApiCoverageExtensionTest extends TestCase
     }
 
     #[Test]
+    public function bootstrap_appends_fatal_block_to_github_step_summary_for_missing_spec_file(): void
+    {
+        // Issue #134: missing-file failures must reach the GitHub Step
+        // Summary too, not just stderr. CI logs scroll fast; the Step Summary
+        // is where the misconfiguration becomes unmissable for reviewers.
+        $tmp = tempnam(sys_get_temp_dir(), 'openapi-summary-');
+        if ($tmp === false) {
+            $this->fail('Could not create temp file for GITHUB_STEP_SUMMARY');
+        }
+        $this->githubSummaryTmp = $tmp;
+
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => 'does-not-exist',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, $tmp);
+            $this->fail('expected SpecFileNotFoundException');
+        } catch (SpecFileNotFoundException) {
+            // Expected — the FATAL block must still have been written before re-throw.
+        }
+
+        $contents = (string) file_get_contents($tmp);
+        $this->assertStringContainsString('FATAL OpenAPI spec error', $contents);
+        $this->assertStringContainsString('does-not-exist', $contents);
+    }
+
+    #[Test]
     public function bootstrap_throws_for_malformed_json_spec(): void
     {
         // Pre-PR catch-all demoted malformed JSON to a stderr WARNING, which
@@ -169,23 +211,21 @@ class OpenApiCoverageExtensionTest extends TestCase
     }
 
     #[Test]
-    public function bootstrap_continues_past_missing_spec_to_load_valid_ones(): void
+    public function bootstrap_hard_fails_for_missing_spec_even_when_others_are_valid(): void
     {
-        // A stale entry in `specs=` should not block the rest of the list
-        // from being eager-loaded. Pins the warn-and-continue semantics that
-        // differentiate SpecFileNotFoundException from the fatal paths.
+        // Issue #134: a stale entry in `specs=` is a configuration error and
+        // must abort boot. Order-independence is already covered by the
+        // `refs-valid,refs-unresolvable` test below; here we pin that the
+        // missing-file case shares the fatal contract regardless of position.
         $extension = new OpenApiCoverageExtension();
         $parameters = ParameterCollection::fromArray([
             'spec_base_path' => __DIR__ . '/../fixtures/specs',
             'specs' => 'does-not-exist,refs-valid',
         ]);
 
-        $extension->setupExtension(null, $parameters, null);
+        $this->expectException(SpecFileNotFoundException::class);
 
-        $this->assertStringContainsString("WARNING: Skipping spec 'does-not-exist'", $this->readStderr());
-        // refs-valid must have loaded cleanly — its content is cached.
-        $spec = OpenApiSpecLoader::load('refs-valid');
-        $this->assertSame('Refs valid', $spec['info']['title']);
+        $extension->setupExtension(null, $parameters, null);
     }
 
     #[Test]

--- a/tests/Unit/OpenApiCoverageExtensionTest.php
+++ b/tests/Unit/OpenApiCoverageExtensionTest.php
@@ -74,7 +74,7 @@ class OpenApiCoverageExtensionTest extends TestCase
     #[Test]
     public function bootstrap_throws_fatal_for_missing_spec_file(): void
     {
-        // Issue #134: stale `specs=` entries used to print a warning and let
+        // issue #134: stale `specs=` entries used to print a warning and let
         // the suite continue, only blowing up later in an unrelated test.
         // Boot must now hard-fail so the configuration error surfaces at the
         // moment of detection — not on someone else's PR after a merge.
@@ -142,7 +142,7 @@ class OpenApiCoverageExtensionTest extends TestCase
     #[Test]
     public function bootstrap_appends_fatal_block_to_github_step_summary_for_missing_spec_file(): void
     {
-        // Issue #134: missing-file failures must reach the GitHub Step
+        // issue #134: missing-file failures must reach the GitHub Step
         // Summary too, not just stderr. CI logs scroll fast; the Step Summary
         // is where the misconfiguration becomes unmissable for reviewers.
         $tmp = tempnam(sys_get_temp_dir(), 'openapi-summary-');
@@ -167,6 +167,11 @@ class OpenApiCoverageExtensionTest extends TestCase
         $contents = (string) file_get_contents($tmp);
         $this->assertStringContainsString('FATAL OpenAPI spec error', $contents);
         $this->assertStringContainsString('does-not-exist', $contents);
+        // Symmetric with the `Unresolvable $ref` assertion above: pin the
+        // exception's underlying message so future renames of
+        // SpecFileNotFoundException's wording can't silently empty the
+        // Step Summary block of its actual root cause.
+        $this->assertStringContainsString('OpenAPI bundled spec not found', $contents);
     }
 
     #[Test]
@@ -213,14 +218,16 @@ class OpenApiCoverageExtensionTest extends TestCase
     #[Test]
     public function bootstrap_hard_fails_for_missing_spec_even_when_others_are_valid(): void
     {
-        // Issue #134: a stale entry in `specs=` is a configuration error and
-        // must abort boot. Order-independence is already covered by the
-        // `refs-valid,refs-unresolvable` test below; here we pin that the
-        // missing-file case shares the fatal contract regardless of position.
+        // issue #134: a stale entry in `specs=` is a configuration error and
+        // must abort boot. The valid spec is intentionally listed *first* so
+        // we exercise loop-order independence on the missing-file branch:
+        // a future "stop after first successful load" optimisation would be
+        // caught here. The `refs-valid,refs-unresolvable` test below covers
+        // the same shape for the InvalidOpenApiSpecException branch.
         $extension = new OpenApiCoverageExtension();
         $parameters = ParameterCollection::fromArray([
             'spec_base_path' => __DIR__ . '/../fixtures/specs',
-            'specs' => 'does-not-exist,refs-valid',
+            'specs' => 'refs-valid,does-not-exist',
         ]);
 
         $this->expectException(SpecFileNotFoundException::class);


### PR DESCRIPTION
# 概要

`phpunit.xml` の `<parameter name="specs" value="...">` に列挙された bundled spec ファイルが見つからない場合、これまでは boot 時に WARNING 1 行を STDERR に出して継続していました。これを FATAL & abort（exit 1）に変更し、設定ミスがその場で確実に発覚するようにします。

## 変更内容

Issue #134 の Option A（推奨）を採用しました。`OpenApiSpecLoader` がすでに strict singleton であることと整合し、サイレント失敗の形状を解消します。

- `OpenApiCoverageExtension::setupExtension()` の `SpecFileNotFoundException` ハンドリングを WARNING/継続から FATAL/再 throw に変更。FATAL メッセージは Issue 提案どおり `[OpenAPI Coverage] FATAL: spec '<name>' configured in 'specs=' is not loadable: ...` に Action 行を併記。
- `OpenApiCoverageExtension::bootstrap()` の `catch` を `InvalidOpenApiSpecException | SpecFileNotFoundException` に拡張し、`exit(1)` 経路を共有。
- GITHUB_STEP_SUMMARY への FATAL ブロック追記も `InvalidOpenApiSpecException` 経路と同様に missing-spec ケースで動作することを保証。
- `SpecFileNotFoundException` の docblock を更新し、「boot は fatal、`CoverageReportSubscriber` / `CoverageMergeCommand` は防衛的に warn-continue」という意図を明文化。
- Unit テスト 2 本を「FATAL throw を期待」に書き換え、GITHUB_STEP_SUMMARY 経路の missing-spec 用に 1 本追加。Integration テストの exit code 期待値を 0 → non-zero に反転。

## 関連情報

- Closes #134
- Issue が並べていた Option B（`redocly.yaml` / `package.json#scripts` を参照して bundle コマンド推奨文言を切り替える）は本 PR スコープ外。silent-failure 形状を直す目的には Option A だけで十分で、Option B は別 issue / PR で対応する想定です。
- 既存の `CoverageReportSubscriber` / `CoverageMergeCommand` の warn-and-continue は意図的にそのまま残しています（前者はテスト中に spec ファイルが消えた防衛経路、後者は CLI で sidecar から部分レポートを生成するユースケース）。