### PR TITLE
New Feature: カバレッジしきい値による CI gate 機能 (#135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ until 1.0.0 ships. Each entry below tags whether it is breaking.
 
 ## Unreleased
 
+### Added
+
+- **#135 — `min_coverage` threshold gate for CI**. New PHPUnit extension
+  parameters `min_endpoint_coverage` / `min_response_coverage` (percent,
+  optional) and `min_coverage_strict` (default `false` → warn-only, set to
+  `true` to exit non-zero on a miss) make contract coverage gateable the
+  same way PHPUnit's own `--coverage-threshold` works. The gate aggregates
+  over every spec listed in `specs=`. The merge CLI gains matching
+  `--min-endpoint-coverage` / `--min-response-coverage` /
+  `--min-coverage-strict` flags so paratest workflows can gate too. Both
+  paths emit a `[OpenAPI Coverage] FAIL: …` line to stderr on a strict
+  miss (or `WARN:` when warn-only).
+
 ### Fixed
 
 - **#131 — Clean stack trace for contract validation failures**. PHPUnit's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,18 @@ until 1.0.0 ships. Each entry below tags whether it is breaking.
   optional) and `min_coverage_strict` (default `false` → warn-only, set to
   `true` to exit non-zero on a miss) make contract coverage gateable the
   same way PHPUnit's own `--coverage-threshold` works. The gate aggregates
-  over every spec listed in `specs=`. The merge CLI gains matching
-  `--min-endpoint-coverage` / `--min-response-coverage` /
+  over every spec listed in `specs=` (raw covered/total counts are summed
+  across specs, then a single percent is compared). The merge CLI gains
+  matching `--min-endpoint-coverage` / `--min-response-coverage` /
   `--min-coverage-strict` flags so paratest workflows can gate too. Both
   paths emit a `[OpenAPI Coverage] FAIL: …` line to stderr on a strict
   miss (or `WARN:` when warn-only).
+  - Strict mode **fails fast on an unevaluable gate**, never silently passes:
+    a non-numeric / out-of-range threshold throws
+    `InvalidThresholdConfigurationException` (extension) or exits 2 (merge
+    CLI), and an empty test run with a configured threshold exits 1 with
+    `no contract test coverage was recorded`. Warn-only mode keeps the
+    historical exit codes and only logs.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -728,7 +728,7 @@ vendor/bin/openapi-coverage-merge \
 | `--github-step-summary=<path>` | `$GITHUB_STEP_SUMMARY` | Append Markdown report to this file |
 | `--console-output=<mode>` | `default` | `default` / `all` / `uncovered_only` |
 | `--min-endpoint-coverage=<pct>` | — | Threshold gate (see [Coverage threshold gate](#coverage-threshold-gate)) |
-| `--min-response-coverage=<pct>` | — | Threshold gate at `(status, content-type)` granularity |
+| `--min-response-coverage=<pct>` | — | Threshold gate at `(method, path, status, content-type)` granularity |
 | `--min-coverage-strict` | `false` (warn-only) | Treat threshold misses as exit non-zero |
 | `--no-cleanup` | (cleanup is on by default) | Keep sidecar files after merge |
 

--- a/README.md
+++ b/README.md
@@ -640,6 +640,47 @@ Or via environment variable (takes priority over `phpunit.xml`):
 OPENAPI_CONSOLE_OUTPUT=uncovered_only vendor/bin/phpunit
 ```
 
+## Coverage threshold gate
+
+Optional CI gate that fails the run when contract coverage drops below a configured percentage — the contract-testing analogue of PHPUnit's own `--coverage-threshold`. Both metrics are aggregated across every spec listed in `specs=`:
+
+- `min_endpoint_coverage` — percentage of endpoints with **all** declared `(status, content-type)` pairs validated.
+- `min_response_coverage` — percentage of `(method, path, status, content-type)` rows validated (the same rate the report calls "responses covered").
+
+Default is **warn-only**: a miss prints `[OpenAPI Coverage] WARN: …` to stderr but the run exits 0. Flip `min_coverage_strict=true` to make a miss fail-fast with exit 1.
+
+```xml
+<extensions>
+    <bootstrap class="Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension">
+        <parameter name="spec_base_path" value="openapi/bundled"/>
+        <parameter name="specs" value="front,admin"/>
+        <parameter name="min_endpoint_coverage" value="80"/>   <!-- percent, optional -->
+        <parameter name="min_response_coverage" value="60"/>   <!-- percent, optional -->
+        <parameter name="min_coverage_strict" value="true"/>   <!-- default false → warn-only -->
+    </bootstrap>
+</extensions>
+```
+
+Failure looks like:
+
+```
+[OpenAPI Coverage] FAIL: endpoint coverage 67.4% < threshold 80%.
+                         response coverage 71.2% (>= 60%, ok).
+```
+
+Out-of-range or non-numeric values produce a `WARNING` to stderr and skip that gate (rather than silently treating the misconfiguration as `0%`).
+
+For paratest / `pest --parallel`, the merge CLI accepts the same options as flags:
+
+```bash
+vendor/bin/openapi-coverage-merge \
+    --spec-base-path=openapi/bundled \
+    --specs=front,admin \
+    --min-endpoint-coverage=80 \
+    --min-response-coverage=60 \
+    --min-coverage-strict
+```
+
 <a id="parallel-test-runners"></a>
 ## Parallel test runners (paratest / Pest `--parallel`)
 
@@ -686,6 +727,9 @@ vendor/bin/openapi-coverage-merge \
 | `--output-file=<path>` | — | Markdown report output path |
 | `--github-step-summary=<path>` | `$GITHUB_STEP_SUMMARY` | Append Markdown report to this file |
 | `--console-output=<mode>` | `default` | `default` / `all` / `uncovered_only` |
+| `--min-endpoint-coverage=<pct>` | — | Threshold gate (see [Coverage threshold gate](#coverage-threshold-gate)) |
+| `--min-response-coverage=<pct>` | — | Threshold gate at `(status, content-type)` granularity |
+| `--min-coverage-strict` | `false` (warn-only) | Treat threshold misses as exit non-zero |
 | `--no-cleanup` | (cleanup is on by default) | Keep sidecar files after merge |
 
 Sidecar dir defaults are deliberately stable — workers and the merge CLI

--- a/src/InvalidThresholdConfigurationException.php
+++ b/src/InvalidThresholdConfigurationException.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting;
+
+use RuntimeException;
+use Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension;
+use Throwable;
+
+/**
+ * Thrown by {@see OpenApiCoverageExtension}
+ * when a `min_endpoint_coverage` / `min_response_coverage` parameter is invalid
+ * (non-numeric or out of `0..100` range) AND `min_coverage_strict` is on.
+ *
+ * Distinct from {@see InvalidOpenApiSpecException} because the failure has
+ * nothing to do with a spec — it's a misconfigured CI gate. A strict run
+ * that opted into fail-fast must not have its gate silently disabled by a
+ * typo (issue #135 review C1); bootstrap() catches this alongside
+ * `InvalidOpenApiSpecException` and translates it to `exit(1)`.
+ *
+ * In warn-only mode the same condition is downgraded to a `WARNING` and the
+ * gate is dropped, so this exception is reserved for the strict path.
+ */
+final class InvalidThresholdConfigurationException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $parameterName,
+        string $message,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/src/PHPUnit/CoverageMergeCommand.php
+++ b/src/PHPUnit/CoverageMergeCommand.php
@@ -155,7 +155,7 @@ final class CoverageMergeCommand
               --console-output=<mode>       default | all | uncovered_only.
               --min-endpoint-coverage=<pct> Fail-fast (with --min-coverage-strict) when fully-
                                             covered-endpoint percent is below this value (0-100).
-              --min-response-coverage=<pct> Same idea, against (status, content-type) granularity.
+              --min-response-coverage=<pct> Same, at (method, path, status, content-type) granularity.
               --min-coverage-strict[=BOOL]  Treat threshold misses as exit non-zero (default
                                             warn-only).
               --no-cleanup                  Keep sidecar files after merge (default: cleanup).

--- a/src/PHPUnit/CoverageMergeCommand.php
+++ b/src/PHPUnit/CoverageMergeCommand.php
@@ -50,8 +50,8 @@ use function unlink;
  *     github_step_summary?: string,
  *     console_output?: string,
  *     cleanup?: bool,
- *     min_endpoint_coverage?: float,
- *     min_response_coverage?: float,
+ *     min_endpoint_coverage?: float|string,
+ *     min_response_coverage?: float|string,
  *     min_coverage_strict?: bool,
  *     help?: bool,
  * }
@@ -112,13 +112,14 @@ final class CoverageMergeCommand
                     break;
                 case 'min_endpoint_coverage':
                 case 'min_response_coverage':
-                    // Skip silently when non-numeric — a casted "0.0" would
-                    // mislead run() into believing a 0% gate was configured.
-                    // Range / sign validation lives in run() so the user sees
-                    // a single WARNING rather than two.
-                    if (is_numeric($value)) {
-                        $opts[$name] = (float) $value;
-                    }
+                    // Cast numeric values up-front so phpstan can prove the
+                    // 0..100 range check in run(). For non-numeric values
+                    // pass the raw string through — run()'s resolveThreshold
+                    // is the single point of validation, so a typo'd
+                    // `--min-endpoint-coverage=eighty` reaches the user as
+                    // one WARNING/FATAL instead of being dropped silently
+                    // (issue #135 review C3).
+                    $opts[$name] = is_numeric($value) ? (float) $value : $value;
 
                     break;
                 case 'min_coverage_strict':
@@ -197,9 +198,17 @@ final class CoverageMergeCommand
             : (getenv('GITHUB_STEP_SUMMARY') ?: null);
         $consoleOutput = ConsoleOutput::resolve($options['console_output'] ?? null);
         $cleanup = $options['cleanup'] ?? true;
-        $minEndpointPct = $this->resolveThreshold('min_endpoint_coverage', $options['min_endpoint_coverage'] ?? null);
-        $minResponsePct = $this->resolveThreshold('min_response_coverage', $options['min_response_coverage'] ?? null);
         $minStrict = $options['min_coverage_strict'] ?? false;
+        $endpointResolution = $this->resolveThreshold('min_endpoint_coverage', $options['min_endpoint_coverage'] ?? null, $minStrict);
+        $responseResolution = $this->resolveThreshold('min_response_coverage', $options['min_response_coverage'] ?? null, $minStrict);
+        if ($endpointResolution['fatal'] || $responseResolution['fatal']) {
+            // Strict-mode misconfiguration: a typo'd / out-of-range threshold
+            // would otherwise silently disable the gate the user opted into.
+            // Exit 2 mirrors the `--spec-base-path is required` config error.
+            return 2;
+        }
+        $minEndpointPct = $endpointResolution['value'];
+        $minResponsePct = $responseResolution['value'];
 
         if ($specBasePath === null) {
             $this->writeStderr("[OpenAPI Coverage] FATAL: --spec-base-path is required\n");
@@ -231,6 +240,17 @@ final class CoverageMergeCommand
         }
 
         if ($payloads === []) {
+            // Strict-mode gate must fail-fast even before sidecars exist —
+            // otherwise a misconfigured paratest dir or zero workers would
+            // silently pass an opt-in CI gate (issue #135 review C2).
+            if ($minStrict && ($minEndpointPct !== null || $minResponsePct !== null)) {
+                $this->writeStderr(sprintf(
+                    "[OpenAPI Coverage] FATAL: no contract test coverage was recorded; configured threshold cannot be evaluated. (no sidecars in %s)\n",
+                    $sidecarDir,
+                ));
+
+                return 1;
+            }
             $this->writeStderr(sprintf("[OpenAPI Coverage] WARNING: no sidecars found in %s\n", $sidecarDir));
 
             return 0;
@@ -252,13 +272,20 @@ final class CoverageMergeCommand
 
         $results = $this->computeResults($specs);
         if ($results === []) {
-            $this->writeStderr("[OpenAPI Coverage] WARNING: no coverage recorded across sidecars\n");
+            $strictGated = $minStrict && ($minEndpointPct !== null || $minResponsePct !== null);
+            $this->writeStderr(sprintf(
+                "[OpenAPI Coverage] %s: no contract test coverage was recorded; %s\n",
+                $strictGated ? 'FATAL' : 'WARNING',
+                $strictGated
+                    ? 'configured threshold cannot be evaluated. (sidecars present but recorded no observations)'
+                    : 'no coverage recorded across sidecars',
+            ));
 
             if ($cleanup) {
                 $this->cleanup($sidecarDir);
             }
 
-            return 0;
+            return $strictGated ? 1 : 0;
         }
 
         $this->writeStdout(ConsoleCoverageRenderer::render($results, $consoleOutput));
@@ -319,38 +346,52 @@ final class CoverageMergeCommand
     }
 
     /**
-     * Validate a percentage threshold from CLI options. Out-of-range values
-     * become a `WARNING` and are dropped so a misconfiguration surfaces in
-     * the run log instead of silently inverting the gate.
+     * Validate a percentage threshold from CLI options. Returns the parsed
+     * value (or `null` when the option is absent / invalid) plus a fatal
+     * flag the caller uses to short-circuit `run()` with exit 2.
+     *
+     * Severity follows `min_coverage_strict`:
+     *  - non-strict: invalid values become a WARNING and the gate is dropped
+     *    — opt-in mode tolerates misconfiguration.
+     *  - strict:     invalid values become a FATAL exit-2 — a CI that opted
+     *    into fail-fast must not silently lose its gate to a typo
+     *    (issue #135 review C1).
+     *
+     * @return array{value: ?float, fatal: bool}
      */
-    private function resolveThreshold(string $name, mixed $value): ?float
+    private function resolveThreshold(string $name, mixed $value, bool $strict): array
     {
         if ($value === null) {
-            return null;
+            return ['value' => null, 'fatal' => false];
         }
 
         if (!is_numeric($value)) {
-            $this->writeStderr(sprintf(
-                "[OpenAPI Coverage] WARNING: %s='%s' is not a number; skipping threshold gate.\n",
-                $name,
-                (string) $value,
-            ));
-
-            return null;
+            return $this->reportThresholdProblem(
+                $strict,
+                sprintf("%s='%s' is not a number; skipping threshold gate.", $name, (string) $value),
+            );
         }
 
         $float = (float) $value;
         if ($float < 0.0 || $float > 100.0) {
-            $this->writeStderr(sprintf(
-                "[OpenAPI Coverage] WARNING: %s=%s is out of range (expected 0-100); skipping threshold gate.\n",
-                $name,
-                (string) $float,
-            ));
-
-            return null;
+            return $this->reportThresholdProblem(
+                $strict,
+                sprintf('%s=%s is out of range (expected 0-100); skipping threshold gate.', $name, (string) $float),
+            );
         }
 
-        return $float;
+        return ['value' => $float, 'fatal' => false];
+    }
+
+    /**
+     * @return array{value: null, fatal: bool}
+     */
+    private function reportThresholdProblem(bool $strict, string $detail): array
+    {
+        $severity = $strict ? 'FATAL' : 'WARNING';
+        $this->writeStderr(sprintf("[OpenAPI Coverage] %s: %s\n", $severity, $detail));
+
+        return ['value' => null, 'fatal' => $strict];
     }
 
     /**

--- a/src/PHPUnit/CoverageMergeCommand.php
+++ b/src/PHPUnit/CoverageMergeCommand.php
@@ -23,6 +23,7 @@ use function getcwd;
 use function getenv;
 use function in_array;
 use function is_callable;
+use function is_numeric;
 use function sprintf;
 use function str_contains;
 use function str_replace;
@@ -49,6 +50,9 @@ use function unlink;
  *     github_step_summary?: string,
  *     console_output?: string,
  *     cleanup?: bool,
+ *     min_endpoint_coverage?: float,
+ *     min_response_coverage?: float,
+ *     min_coverage_strict?: bool,
  *     help?: bool,
  * }
  */
@@ -106,6 +110,21 @@ final class CoverageMergeCommand
                     $opts['cleanup'] = false;
 
                     break;
+                case 'min_endpoint_coverage':
+                case 'min_response_coverage':
+                    // Skip silently when non-numeric — a casted "0.0" would
+                    // mislead run() into believing a 0% gate was configured.
+                    // Range / sign validation lives in run() so the user sees
+                    // a single WARNING rather than two.
+                    if (is_numeric($value)) {
+                        $opts[$name] = (float) $value;
+                    }
+
+                    break;
+                case 'min_coverage_strict':
+                    $opts['min_coverage_strict'] = !in_array($value, ['0', 'false', 'no'], true);
+
+                    break;
                 default:
                     $opts[$name] = $value;
             }
@@ -133,6 +152,11 @@ final class CoverageMergeCommand
               --github-step-summary=<path>  Append Markdown report to this file (also
                                             consults GITHUB_STEP_SUMMARY env var).
               --console-output=<mode>       default | all | uncovered_only.
+              --min-endpoint-coverage=<pct> Fail-fast (with --min-coverage-strict) when fully-
+                                            covered-endpoint percent is below this value (0-100).
+              --min-response-coverage=<pct> Same idea, against (status, content-type) granularity.
+              --min-coverage-strict[=BOOL]  Treat threshold misses as exit non-zero (default
+                                            warn-only).
               --no-cleanup                  Keep sidecar files after merge (default: cleanup).
               --help                        Show this message.
 
@@ -173,6 +197,9 @@ final class CoverageMergeCommand
             : (getenv('GITHUB_STEP_SUMMARY') ?: null);
         $consoleOutput = ConsoleOutput::resolve($options['console_output'] ?? null);
         $cleanup = $options['cleanup'] ?? true;
+        $minEndpointPct = $this->resolveThreshold('min_endpoint_coverage', $options['min_endpoint_coverage'] ?? null);
+        $minResponsePct = $this->resolveThreshold('min_response_coverage', $options['min_response_coverage'] ?? null);
+        $minStrict = $options['min_coverage_strict'] ?? false;
 
         if ($specBasePath === null) {
             $this->writeStderr("[OpenAPI Coverage] FATAL: --spec-base-path is required\n");
@@ -252,11 +279,78 @@ final class CoverageMergeCommand
             }
         }
 
+        $thresholdFailure = $this->evaluateThresholdGate($results, $minEndpointPct, $minResponsePct, $minStrict);
+
         if ($cleanup) {
             $this->cleanup($sidecarDir);
         }
 
-        return $writeFailures > 0 ? 1 : 0;
+        return $writeFailures > 0 || $thresholdFailure ? 1 : 0;
+    }
+
+    /**
+     * Run the threshold gate against rolled-up results. Prints the evaluator's
+     * pre-formatted message to stderr when at least one threshold misses; the
+     * caller decides what to do with the return value (only `strict=true`
+     * misses propagate to a non-zero exit).
+     *
+     * @param array<string, array<string, mixed>> $results
+     */
+    private function evaluateThresholdGate(
+        array $results,
+        ?float $minEndpointPct,
+        ?float $minResponsePct,
+        bool $strict,
+    ): bool {
+        if ($minEndpointPct === null && $minResponsePct === null) {
+            return false;
+        }
+
+        /** @var array<string, array{endpoints: list<mixed>, endpointTotal: int, endpointFullyCovered: int, endpointPartial: int, endpointUncovered: int, endpointRequestOnly: int, responseTotal: int, responseCovered: int, responseSkipped: int, responseUncovered: int}> $results */
+        $evaluation = CoverageThresholdEvaluator::evaluate($results, $minEndpointPct, $minResponsePct, $strict);
+
+        if ($evaluation['passed']) {
+            return false;
+        }
+
+        $this->writeStderr($evaluation['message']);
+
+        return $strict;
+    }
+
+    /**
+     * Validate a percentage threshold from CLI options. Out-of-range values
+     * become a `WARNING` and are dropped so a misconfiguration surfaces in
+     * the run log instead of silently inverting the gate.
+     */
+    private function resolveThreshold(string $name, mixed $value): ?float
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!is_numeric($value)) {
+            $this->writeStderr(sprintf(
+                "[OpenAPI Coverage] WARNING: %s='%s' is not a number; skipping threshold gate.\n",
+                $name,
+                (string) $value,
+            ));
+
+            return null;
+        }
+
+        $float = (float) $value;
+        if ($float < 0.0 || $float > 100.0) {
+            $this->writeStderr(sprintf(
+                "[OpenAPI Coverage] WARNING: %s=%s is out of range (expected 0-100); skipping threshold gate.\n",
+                $name,
+                (string) $float,
+            ));
+
+            return null;
+        }
+
+        return $float;
     }
 
     /**

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -39,7 +39,7 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
      * @param null|float $minEndpointCoverage Optional gate: when not null and `endpointFullyCovered/endpointTotal`
      *                                        (rolled across `$specs`) is below this percent, the subscriber prints
      *                                        a FAIL/WARN line. See issue #135.
-     * @param null|float $minResponseCoverage Same idea against (status, content-type) granularity.
+     * @param null|float $minResponseCoverage Same idea, but at `(method, path, status, content-type)` granularity.
      * @param bool $minCoverageStrict Treat threshold misses as exit non-zero (default warn-only).
      * @param null|callable(int): void $exitHandler Test seam for the strict-miss exit. Defaults to native `exit()`
      *                                              so production behavior matches PHPUnit's own coverage gate.

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -19,6 +19,7 @@ use function fflush;
 use function file_put_contents;
 use function getenv;
 use function is_callable;
+use function sprintf;
 use function trim;
 
 /**
@@ -75,6 +76,11 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         OpenApiSpecLoader::clearCache();
 
         if ($results === []) {
+            // C2: a strict CI gate must not silently pass when zero contract
+            // assertions ran. Pre-fix, this branch quietly returned 0 even
+            // though the user had opted into fail-fast via min_*_coverage.
+            $this->failOnEmptyResultsIfGated();
+
             return;
         }
 
@@ -142,6 +148,43 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         // PHPUnit's own exit code path doesn't propagate subscriber failures,
         // so a strict threshold miss has to terminate the process directly to
         // be visible to CI.
+        $exit = $this->exitHandler;
+        if ($this->stderrWriter === null) {
+            fflush(STDERR);
+        }
+
+        if (is_callable($exit)) {
+            $exit(1);
+
+            return;
+        }
+
+        exit(1);
+    }
+
+    /**
+     * Issue #135 review C2: when no spec produced any coverage, the
+     * regular gate path never runs (the evaluator would receive an empty
+     * results array and report 100% vacuously). A strict run must still
+     * fail-fast — otherwise a CI that opted into the gate silently passes
+     * when its tests didn't actually validate anything.
+     */
+    private function failOnEmptyResultsIfGated(): void
+    {
+        if ($this->minEndpointCoverage === null && $this->minResponseCoverage === null) {
+            return;
+        }
+
+        $severity = $this->minCoverageStrict ? 'FATAL' : 'WARNING';
+        $this->writeStderr(sprintf(
+            "[OpenAPI Coverage] %s: no contract test coverage was recorded; configured threshold cannot be evaluated.\n",
+            $severity,
+        ));
+
+        if (!$this->minCoverageStrict) {
+            return;
+        }
+
         $exit = $this->exitHandler;
         if ($this->stderrWriter === null) {
             fflush(STDERR);

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio\OpenApiContractTesting\PHPUnit;
 
 use const FILE_APPEND;
+use const STDERR;
 
 use PHPUnit\Event\TestRunner\ExecutionFinished;
 use PHPUnit\Event\TestRunner\ExecutionFinishedSubscriber;
@@ -14,6 +15,7 @@ use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\SpecFileNotFoundException;
 
+use function fflush;
 use function file_put_contents;
 use function getenv;
 use function is_callable;
@@ -33,6 +35,13 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
      *                                subscriber detects `TEST_TOKEN` (set by paratest in every child process) it
      *                                short-circuits rendering and writes the tracker state here for the merge CLI
      *                                to pick up. `null` falls back to a default under `sys_get_temp_dir()`.
+     * @param null|float $minEndpointCoverage Optional gate: when not null and `endpointFullyCovered/endpointTotal`
+     *                                        (rolled across `$specs`) is below this percent, the subscriber prints
+     *                                        a FAIL/WARN line. See issue #135.
+     * @param null|float $minResponseCoverage Same idea against (status, content-type) granularity.
+     * @param bool $minCoverageStrict Treat threshold misses as exit non-zero (default warn-only).
+     * @param null|callable(int): void $exitHandler Test seam for the strict-miss exit. Defaults to native `exit()`
+     *                                              so production behavior matches PHPUnit's own coverage gate.
      */
     public function __construct(
         private array $specs,
@@ -41,6 +50,10 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         private ?string $githubSummaryPath,
         private mixed $stderrWriter = null,
         private ?string $sidecarDir = null,
+        private ?float $minEndpointCoverage = null,
+        private ?float $minResponseCoverage = null,
+        private bool $minCoverageStrict = false,
+        private mixed $exitHandler = null,
     ) {}
 
     /** @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter */
@@ -70,6 +83,8 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         if ($this->outputFile !== null || $this->githubSummaryPath !== null) {
             $this->writeMarkdownReport($results);
         }
+
+        $this->evaluateThresholdGate($results);
     }
 
     /**
@@ -90,6 +105,55 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         }
 
         return $token;
+    }
+
+    /**
+     * Issue #135: in sequential PHPUnit, evaluate the optional coverage
+     * threshold after the report renders. Worker mode never reaches here
+     * (the worker-token branch returns earlier) — the merge CLI is the gate
+     * for paratest, so this method runs only on the in-process path.
+     *
+     * @param array<string, CoverageResult> $results
+     */
+    private function evaluateThresholdGate(array $results): void
+    {
+        if ($this->minEndpointCoverage === null && $this->minResponseCoverage === null) {
+            return;
+        }
+
+        $evaluation = CoverageThresholdEvaluator::evaluate(
+            $results,
+            $this->minEndpointCoverage,
+            $this->minResponseCoverage,
+            $this->minCoverageStrict,
+        );
+
+        if ($evaluation['passed']) {
+            return;
+        }
+
+        $this->writeStderr($evaluation['message']);
+
+        if (!$this->minCoverageStrict) {
+            return;
+        }
+
+        // Mirror OpenApiCoverageExtension::bootstrap()'s fail-fast pattern:
+        // PHPUnit's own exit code path doesn't propagate subscriber failures,
+        // so a strict threshold miss has to terminate the process directly to
+        // be visible to CI.
+        $exit = $this->exitHandler;
+        if ($this->stderrWriter === null) {
+            fflush(STDERR);
+        }
+
+        if (is_callable($exit)) {
+            $exit(1);
+
+            return;
+        }
+
+        exit(1);
     }
 
     private function writeWorkerSidecar(string $token): void

--- a/src/PHPUnit/CoverageThresholdEvaluator.php
+++ b/src/PHPUnit/CoverageThresholdEvaluator.php
@@ -88,9 +88,13 @@ final class CoverageThresholdEvaluator
      */
     private static function buildLine(int $covered, int $total, float $threshold): array
     {
-        // Vacuously OK when nothing is declared — a misconfigured spec set
-        // shouldn't fail the gate. The "no coverage recorded" case is caught
-        // upstream by hasAnyCoverage() before the gate is even evaluated.
+        // `total === 0` only happens for a spec with no declared paths /
+        // responses — there's no contract API to fail against, so report it
+        // as 100% so the gate doesn't punish well-formed empty specs.
+        // The "no coverage was recorded" silent-pass case is *not* defended
+        // here: callers (`CoverageReportSubscriber`, `CoverageMergeCommand`)
+        // detect empty results explicitly and emit FATAL/WARNING before
+        // reaching this method (issue #135 review C2).
         $percent = $total > 0 ? round($covered / $total * 100, 1) : 100.0;
 
         return [

--- a/src/PHPUnit/CoverageThresholdEvaluator.php
+++ b/src/PHPUnit/CoverageThresholdEvaluator.php
@@ -14,10 +14,12 @@ use function strlen;
 
 /**
  * Pure evaluator that gates a CI run on coverage thresholds. Mirrors PHPUnit's
- * own `--coverage-threshold`: take the rolled-up percentages computed from
- * {@see OpenApiCoverageTracker::computeCoverage()} per spec, sum them across
- * configured specs, and compare against optional `min_endpoint_coverage` /
- * `min_response_coverage` percent values.
+ * own `--coverage-threshold`: take the per-spec results from
+ * {@see OpenApiCoverageTracker::computeCoverage()}, sum the raw covered/total
+ * counts across configured specs (NOT an average of per-spec percentages —
+ * that would weight uneven specs incorrectly), recompute a single percentage,
+ * and compare against optional `min_endpoint_coverage` / `min_response_coverage`
+ * percent values.
  *
  * Decoupled from I/O so {@see CoverageReportSubscriber} (in-process) and
  * {@see CoverageMergeCommand} (paratest post-step) can share gating logic

--- a/src/PHPUnit/CoverageThresholdEvaluator.php
+++ b/src/PHPUnit/CoverageThresholdEvaluator.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\PHPUnit;
+
+use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
+
+use function implode;
+use function round;
+use function sprintf;
+use function str_repeat;
+use function strlen;
+
+/**
+ * Pure evaluator that gates a CI run on coverage thresholds. Mirrors PHPUnit's
+ * own `--coverage-threshold`: take the rolled-up percentages computed from
+ * {@see OpenApiCoverageTracker::computeCoverage()} per spec, sum them across
+ * configured specs, and compare against optional `min_endpoint_coverage` /
+ * `min_response_coverage` percent values.
+ *
+ * Decoupled from I/O so {@see CoverageReportSubscriber} (in-process) and
+ * {@see CoverageMergeCommand} (paratest post-step) can share gating logic
+ * without duplicating it. The caller decides whether to print/exit; the
+ * evaluator only reports.
+ *
+ * @phpstan-import-type CoverageResult from OpenApiCoverageTracker
+ *
+ * @phpstan-type ThresholdLine array{percent: float, threshold: float, ok: bool}
+ * @phpstan-type ThresholdResult array{
+ *     passed: bool,
+ *     endpoint: ?ThresholdLine,
+ *     response: ?ThresholdLine,
+ *     message: string,
+ * }
+ */
+final class CoverageThresholdEvaluator
+{
+    /** Static-only utility — no instances. */
+    private function __construct() {}
+
+    /**
+     * @param array<string, CoverageResult> $results
+     *
+     * @return ThresholdResult
+     */
+    public static function evaluate(
+        array $results,
+        ?float $minEndpointPct,
+        ?float $minResponsePct,
+        bool $strict,
+    ): array {
+        $endpointCovered = 0;
+        $endpointTotal = 0;
+        $responseCovered = 0;
+        $responseTotal = 0;
+        foreach ($results as $result) {
+            $endpointCovered += $result['endpointFullyCovered'];
+            $endpointTotal += $result['endpointTotal'];
+            $responseCovered += $result['responseCovered'];
+            $responseTotal += $result['responseTotal'];
+        }
+
+        $endpoint = $minEndpointPct === null
+            ? null
+            : self::buildLine($endpointCovered, $endpointTotal, $minEndpointPct);
+        $response = $minResponsePct === null
+            ? null
+            : self::buildLine($responseCovered, $responseTotal, $minResponsePct);
+
+        $passed = ($endpoint['ok'] ?? true) && ($response['ok'] ?? true);
+
+        $message = '';
+        if (!$passed) {
+            $message = self::renderMessage($endpoint, $response, $strict);
+        }
+
+        return [
+            'passed' => $passed,
+            'endpoint' => $endpoint,
+            'response' => $response,
+            'message' => $message,
+        ];
+    }
+
+    /**
+     * @return ThresholdLine
+     */
+    private static function buildLine(int $covered, int $total, float $threshold): array
+    {
+        // Vacuously OK when nothing is declared — a misconfigured spec set
+        // shouldn't fail the gate. The "no coverage recorded" case is caught
+        // upstream by hasAnyCoverage() before the gate is even evaluated.
+        $percent = $total > 0 ? round($covered / $total * 100, 1) : 100.0;
+
+        return [
+            'percent' => $percent,
+            'threshold' => $threshold,
+            'ok' => $percent >= $threshold,
+        ];
+    }
+
+    /**
+     * @param null|ThresholdLine $endpoint
+     * @param null|ThresholdLine $response
+     */
+    private static function renderMessage(?array $endpoint, ?array $response, bool $strict): string
+    {
+        $prefix = sprintf('[OpenAPI Coverage] %s: ', $strict ? 'FAIL' : 'WARN');
+        $indent = str_repeat(' ', strlen($prefix));
+        $lines = [];
+        if ($endpoint !== null) {
+            $lines[] = $prefix . self::renderLine('endpoint', $endpoint);
+        }
+        if ($response !== null) {
+            $lead = $lines === [] ? $prefix : $indent;
+            $lines[] = $lead . self::renderLine('response', $response);
+        }
+
+        return implode("\n", $lines) . "\n";
+    }
+
+    /**
+     * @param ThresholdLine $line
+     */
+    private static function renderLine(string $label, array $line): string
+    {
+        $actual = self::formatPercent($line['percent']);
+        $threshold = self::formatPercent($line['threshold']);
+
+        return $line['ok']
+            ? sprintf('%s coverage %s%% (>= %s%%, ok).', $label, $actual, $threshold)
+            : sprintf('%s coverage %s%% < threshold %s%%.', $label, $actual, $threshold);
+    }
+
+    /**
+     * Cast to string via the natural PHP coercion so integer-valued floats
+     * print without a trailing `.0` (`80.0 → "80"`, `67.4 → "67.4"`). Matches
+     * the issue's example output and how MarkdownCoverageRenderer formats
+     * percentages.
+     */
+    private static function formatPercent(float $value): string
+    {
+        return (string) $value;
+    }
+}

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -23,8 +23,12 @@ use function file_put_contents;
 use function fwrite;
 use function getcwd;
 use function getenv;
+use function in_array;
+use function is_numeric;
+use function sprintf;
 use function str_starts_with;
 use function sys_get_temp_dir;
+use function trim;
 
 final class OpenApiCoverageExtension implements Extension
 {
@@ -171,6 +175,10 @@ final class OpenApiCoverageExtension implements Extension
             }
         }
 
+        $minEndpointCoverage = self::resolveThresholdParameter($parameters, 'min_endpoint_coverage');
+        $minResponseCoverage = self::resolveThresholdParameter($parameters, 'min_response_coverage');
+        $minCoverageStrict = self::resolveStrictFlag($parameters);
+
         if ($facade === null) {
             return;
         }
@@ -181,7 +189,62 @@ final class OpenApiCoverageExtension implements Extension
             consoleOutput: $consoleOutput,
             githubSummaryPath: $githubSummaryPath,
             sidecarDir: $sidecarDir,
+            minEndpointCoverage: $minEndpointCoverage,
+            minResponseCoverage: $minResponseCoverage,
+            minCoverageStrict: $minCoverageStrict,
         ));
+    }
+
+    /**
+     * Read a percentage parameter (`min_endpoint_coverage` /
+     * `min_response_coverage`) from `phpunit.xml`. Mirrors the merge CLI's
+     * resolveThreshold(): out-of-range / non-numeric values are demoted to a
+     * WARNING + null so a misconfigured XML attribute surfaces in the run log
+     * rather than silently disabling the gate.
+     */
+    private static function resolveThresholdParameter(ParameterCollection $parameters, string $name): ?float
+    {
+        if (!$parameters->has($name)) {
+            return null;
+        }
+        $raw = trim($parameters->get($name));
+        if ($raw === '') {
+            return null;
+        }
+        if (!is_numeric($raw)) {
+            self::writeStderr(sprintf(
+                "[OpenAPI Coverage] WARNING: %s='%s' is not a number; skipping threshold gate.\n",
+                $name,
+                $raw,
+            ));
+
+            return null;
+        }
+        $value = (float) $raw;
+        if ($value < 0.0 || $value > 100.0) {
+            self::writeStderr(sprintf(
+                "[OpenAPI Coverage] WARNING: %s=%s is out of range (expected 0-100); skipping threshold gate.\n",
+                $name,
+                (string) $value,
+            ));
+
+            return null;
+        }
+
+        return $value;
+    }
+
+    private static function resolveStrictFlag(ParameterCollection $parameters): bool
+    {
+        if (!$parameters->has('min_coverage_strict')) {
+            return false;
+        }
+        $raw = trim($parameters->get('min_coverage_strict'));
+
+        // Symmetric with the merge CLI: explicit falsey strings disable strict
+        // mode, anything else (including the empty `<parameter name="..." />`
+        // shorthand for "set") enables it.
+        return !in_array($raw, ['', '0', 'false', 'no'], true);
     }
 
     private static function appendGithubStepSummaryFatalBlock(?string $path, string $spec, string $reason): void

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -13,6 +13,7 @@ use PHPUnit\Runner\Extension\Facade;
 use PHPUnit\Runner\Extension\ParameterCollection;
 use PHPUnit\TextUI\Configuration\Configuration;
 use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
+use Studio\OpenApiContractTesting\InvalidThresholdConfigurationException;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\SpecFileNotFoundException;
 
@@ -77,7 +78,7 @@ final class OpenApiCoverageExtension implements Extension
     {
         try {
             $this->setupExtension($facade, $parameters, getenv('GITHUB_STEP_SUMMARY') ?: null);
-        } catch (InvalidOpenApiSpecException | SpecFileNotFoundException) {
+        } catch (InvalidOpenApiSpecException|InvalidThresholdConfigurationException|SpecFileNotFoundException) {
             // setupExtension() has already written a FATAL line to stderr and
             // (if GITHUB_STEP_SUMMARY is set) appended a fatal block to it.
             // PHPUnit's ExtensionBootstrapper::bootstrap() wraps this call in
@@ -175,9 +176,11 @@ final class OpenApiCoverageExtension implements Extension
             }
         }
 
-        $minEndpointCoverage = self::resolveThresholdParameter($parameters, 'min_endpoint_coverage');
-        $minResponseCoverage = self::resolveThresholdParameter($parameters, 'min_response_coverage');
+        // Resolve strict first so threshold validation can promote bad values
+        // to FATAL when the user opted in to fail-fast (issue #135 review C1).
         $minCoverageStrict = self::resolveStrictFlag($parameters);
+        $minEndpointCoverage = self::resolveThresholdParameter($parameters, 'min_endpoint_coverage', $minCoverageStrict);
+        $minResponseCoverage = self::resolveThresholdParameter($parameters, 'min_response_coverage', $minCoverageStrict);
 
         if ($facade === null) {
             return;
@@ -198,12 +201,20 @@ final class OpenApiCoverageExtension implements Extension
     /**
      * Read a percentage parameter (`min_endpoint_coverage` /
      * `min_response_coverage`) from `phpunit.xml`. Mirrors the merge CLI's
-     * resolveThreshold(): out-of-range / non-numeric values are demoted to a
-     * WARNING + null so a misconfigured XML attribute surfaces in the run log
-     * rather than silently disabling the gate.
+     * resolveThreshold():
+     *  - non-strict (warn-only): bad values become a `WARNING` and the gate
+     *    is dropped so a misconfigured XML attribute surfaces in the log
+     *    without breaking opt-in users.
+     *  - strict:                 bad values become a `FATAL` and we throw
+     *    {@see InvalidThresholdConfigurationException}, which `bootstrap()`
+     *    catches and converts to `exit(1)`. A CI that opted into fail-fast
+     *    must not silently lose its gate to a typo (issue #135 review C1).
      */
-    private static function resolveThresholdParameter(ParameterCollection $parameters, string $name): ?float
-    {
+    private static function resolveThresholdParameter(
+        ParameterCollection $parameters,
+        string $name,
+        bool $strict,
+    ): ?float {
         if (!$parameters->has($name)) {
             return null;
         }
@@ -212,26 +223,38 @@ final class OpenApiCoverageExtension implements Extension
             return null;
         }
         if (!is_numeric($raw)) {
-            self::writeStderr(sprintf(
-                "[OpenAPI Coverage] WARNING: %s='%s' is not a number; skipping threshold gate.\n",
-                $name,
-                $raw,
-            ));
+            self::reportInvalidThreshold($name, sprintf("%s='%s' is not a number", $name, $raw), $strict);
 
             return null;
         }
         $value = (float) $raw;
         if ($value < 0.0 || $value > 100.0) {
-            self::writeStderr(sprintf(
-                "[OpenAPI Coverage] WARNING: %s=%s is out of range (expected 0-100); skipping threshold gate.\n",
+            self::reportInvalidThreshold(
                 $name,
-                (string) $value,
-            ));
+                sprintf('%s=%s is out of range (expected 0-100)', $name, (string) $value),
+                $strict,
+            );
 
             return null;
         }
 
         return $value;
+    }
+
+    /**
+     * Emit a FATAL/WARNING line per `$strict`, then either drop the gate
+     * (warn-only) or throw to short-circuit bootstrap with exit(1) (strict).
+     * Suffix is identical for both branches so log greps match either way.
+     */
+    private static function reportInvalidThreshold(string $name, string $detail, bool $strict): void
+    {
+        $severity = $strict ? 'FATAL' : 'WARNING';
+        $message = sprintf('%s; skipping threshold gate.', $detail);
+        self::writeStderr(sprintf("[OpenAPI Coverage] %s: %s\n", $severity, $message));
+
+        if ($strict) {
+            throw new InvalidThresholdConfigurationException($name, $message);
+        }
     }
 
     private static function resolveStrictFlag(ParameterCollection $parameters): bool
@@ -241,10 +264,11 @@ final class OpenApiCoverageExtension implements Extension
         }
         $raw = trim($parameters->get('min_coverage_strict'));
 
-        // Symmetric with the merge CLI: explicit falsey strings disable strict
-        // mode, anything else (including the empty `<parameter name="..." />`
-        // shorthand for "set") enables it.
-        return !in_array($raw, ['', '0', 'false', 'no'], true);
+        // Symmetric with the merge CLI's `--min-coverage-strict` (no-value
+        // form): only explicit falsey strings disable strict mode. Empty
+        // value (the `<parameter name="..." />` shorthand) is treated as
+        // "set" so the XML and CLI sides agree.
+        return !in_array($raw, ['0', 'false', 'no'], true);
     }
 
     private static function appendGithubStepSummaryFatalBlock(?string $path, string $spec, string $reason): void

--- a/tests/Unit/CoverageMergeCommandTest.php
+++ b/tests/Unit/CoverageMergeCommandTest.php
@@ -434,6 +434,125 @@ class CoverageMergeCommandTest extends TestCase
     }
 
     #[Test]
+    public function strict_gate_with_no_sidecars_exits_one(): void
+    {
+        // C2: an opt-in strict CI gate must not silently pass when paratest
+        // produced zero workers / a wrong --sidecar-dir was passed. Pre-fix,
+        // the empty-payload branch returned 0 with a WARNING.
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            stdoutWriter: static fn(string $msg): null => null,
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir, // empty
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'min_endpoint_coverage' => 80.0,
+            'min_coverage_strict' => true,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('FATAL', $stderr);
+        $this->assertStringContainsString('no contract test coverage', $stderr);
+    }
+
+    #[Test]
+    public function strict_gate_with_empty_recorded_coverage_exits_one(): void
+    {
+        // Sidecars exist but recorded no coverage (e.g. workers ran zero
+        // contract assertions). Same silent-pass risk as no-sidecars.
+        OpenApiCoverageTracker::reset(); // empty state
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            stdoutWriter: static fn(string $msg): null => null,
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'min_endpoint_coverage' => 80.0,
+            'min_coverage_strict' => true,
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('FATAL', $stderr);
+        $this->assertStringContainsString('no contract test coverage', $stderr);
+    }
+
+    #[Test]
+    public function warn_only_gate_with_no_sidecars_keeps_existing_warning_path(): void
+    {
+        // Backwards compat: warn-only mode (or threshold absent) keeps the
+        // pre-#135 "no sidecars found" warning + exit 0.
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            stdoutWriter: static fn(string $msg): null => null,
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'min_endpoint_coverage' => 80.0, // strict omitted
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('no sidecars found', $stderr);
+    }
+
+    #[Test]
+    public function exits_one_on_response_only_threshold_miss_when_strict(): void
+    {
+        // Pin the response-only configuration end-to-end through the CLI;
+        // merge gate must distinguish endpoint vs response misses.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            stdoutWriter: static fn(string $msg): null => null,
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'min_response_coverage' => 80.0,
+            'min_coverage_strict' => true,
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('FAIL', $stderr);
+        $this->assertStringContainsString('response coverage', $stderr);
+        $this->assertStringNotContainsString('endpoint coverage', $stderr);
+    }
+
+    #[Test]
     public function exits_zero_when_threshold_met(): void
     {
         // No threshold-related stderr noise on the happy path.
@@ -498,10 +617,10 @@ class CoverageMergeCommandTest extends TestCase
     }
 
     #[Test]
-    public function rejects_non_numeric_threshold_with_warning(): void
+    public function out_of_range_threshold_warns_when_not_strict(): void
     {
-        // Misconfigured threshold must NOT silently disable the gate without
-        // a complaint — the CI signal would be lost.
+        // Warn-only path: a typo'd threshold must surface as a WARNING but
+        // not break a CI that opted out of fail-fast gating.
         OpenApiCoverageTracker::recordResponse(
             'petstore-3.0',
             'GET',
@@ -520,22 +639,141 @@ class CoverageMergeCommandTest extends TestCase
             stdoutWriter: static fn(string $msg): null => null,
         );
 
-        // Pass a non-float through `min_endpoint_coverage` — simulates what
-        // `parseArgv` would emit if the value had failed numeric validation.
-        // The run() path must surface the misconfiguration as a WARNING and
-        // skip gating rather than silently treating it as 0%.
         $exit = $command->run([
             'sidecar_dir' => $this->sidecarDir,
             'spec_base_path' => __DIR__ . '/../fixtures/specs',
             'specs' => ['petstore-3.0'],
-            'min_endpoint_coverage' => 150.0, // out of range
-            'min_coverage_strict' => true,
+            'min_endpoint_coverage' => 150.0, // out of 0..100 range
+            // min_coverage_strict omitted → warn-only
             'cleanup' => true,
         ]);
 
         $this->assertSame(0, $exit);
         $this->assertStringContainsString('WARNING', $stderr);
         $this->assertStringContainsString('min_endpoint_coverage', $stderr);
+    }
+
+    #[Test]
+    public function out_of_range_threshold_exits_two_when_strict(): void
+    {
+        // C1: silent-failure-hunter & code-reviewer flagged that strict mode
+        // must treat a typo'd threshold as a config error, not silently
+        // disable the gate. Mirrors how `--spec-base-path` missing exits 2.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            stdoutWriter: static fn(string $msg): null => null,
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'min_endpoint_coverage' => 150.0,
+            'min_coverage_strict' => true,
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(2, $exit);
+        $this->assertStringContainsString('FATAL', $stderr);
+        $this->assertStringContainsString('min_endpoint_coverage', $stderr);
+    }
+
+    #[Test]
+    public function non_numeric_threshold_warns_when_not_strict(): void
+    {
+        // C3: parseArgv used to silently drop non-numeric values, so run()
+        // never saw them. After C3 the raw string flows through and run()
+        // is the single place that warns / fails.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            stdoutWriter: static fn(string $msg): null => null,
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'min_endpoint_coverage' => 'eighty',
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('WARNING', $stderr);
+        $this->assertStringContainsString("min_endpoint_coverage='eighty'", $stderr);
+    }
+
+    #[Test]
+    public function non_numeric_threshold_exits_two_when_strict(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            stdoutWriter: static fn(string $msg): null => null,
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'min_endpoint_coverage' => 'eighty',
+            'min_coverage_strict' => true,
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(2, $exit);
+        $this->assertStringContainsString('FATAL', $stderr);
+    }
+
+    #[Test]
+    public function parse_argv_keeps_non_numeric_threshold_value_for_run_to_validate(): void
+    {
+        // C3: a typo'd `--min-endpoint-coverage=eighty` must reach run() so
+        // the user sees a single WARNING/FATAL message. Pre-fix, parseArgv
+        // dropped the value silently and the gate was disabled invisibly.
+        $opts = CoverageMergeCommand::parseArgv([
+            '--spec-base-path=/tmp/spec',
+            '--min-endpoint-coverage=eighty',
+        ]);
+
+        $this->assertSame('eighty', $opts['min_endpoint_coverage']);
     }
 
     #[Test]

--- a/tests/Unit/CoverageMergeCommandTest.php
+++ b/tests/Unit/CoverageMergeCommandTest.php
@@ -358,6 +358,187 @@ class CoverageMergeCommandTest extends TestCase
     }
 
     #[Test]
+    public function exits_one_on_threshold_miss_when_strict(): void
+    {
+        // Issue #135: strict gate must fail-fast with exit 1 + FAIL stderr.
+        // Single recorded validation against a 25-endpoint fixture is well
+        // below 80%, so the gate trips reliably without per-fixture math.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            stdoutWriter: static fn(string $msg): null => null,
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'min_endpoint_coverage' => 80.0,
+            'min_coverage_strict' => true,
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('[OpenAPI Coverage] FAIL:', $stderr);
+        $this->assertStringContainsString('endpoint coverage', $stderr);
+        $this->assertStringContainsString('< threshold 80%', $stderr);
+    }
+
+    #[Test]
+    public function exits_zero_on_threshold_miss_when_not_strict(): void
+    {
+        // Default warn-only mode: print WARN to stderr but keep the run green.
+        // Lets teams adopt the gate behind a flag without breaking CI on day 1.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            stdoutWriter: static fn(string $msg): null => null,
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'min_endpoint_coverage' => 80.0,
+            // min_coverage_strict omitted — default false
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('[OpenAPI Coverage] WARN:', $stderr);
+        $this->assertStringNotContainsString('FAIL:', $stderr);
+    }
+
+    #[Test]
+    public function exits_zero_when_threshold_met(): void
+    {
+        // No threshold-related stderr noise on the happy path.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            stdoutWriter: static fn(string $msg): null => null,
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'min_endpoint_coverage' => 0.0, // any non-negative coverage clears 0%
+            'min_coverage_strict' => true,
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertStringNotContainsString('FAIL:', $stderr);
+        $this->assertStringNotContainsString('WARN:', $stderr);
+    }
+
+    #[Test]
+    public function parse_argv_decodes_threshold_flags(): void
+    {
+        $opts = CoverageMergeCommand::parseArgv([
+            '--spec-base-path=/tmp/spec',
+            '--min-endpoint-coverage=80',
+            '--min-response-coverage=70.5',
+            '--min-coverage-strict',
+        ]);
+
+        $this->assertSame(80.0, $opts['min_endpoint_coverage']);
+        $this->assertSame(70.5, $opts['min_response_coverage']);
+        $this->assertTrue($opts['min_coverage_strict']);
+    }
+
+    #[Test]
+    public function parse_argv_treats_strict_false_value_as_false(): void
+    {
+        // Symmetry with the existing `cleanup` flag: `--min-coverage-strict=false`
+        // must turn the gate into warn-only, not silently flip it on.
+        $opts = CoverageMergeCommand::parseArgv([
+            '--spec-base-path=/tmp/spec',
+            '--min-coverage-strict=false',
+        ]);
+
+        $this->assertFalse($opts['min_coverage_strict']);
+    }
+
+    #[Test]
+    public function rejects_non_numeric_threshold_with_warning(): void
+    {
+        // Misconfigured threshold must NOT silently disable the gate without
+        // a complaint — the CI signal would be lost.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            stdoutWriter: static fn(string $msg): null => null,
+        );
+
+        // Pass a non-float through `min_endpoint_coverage` — simulates what
+        // `parseArgv` would emit if the value had failed numeric validation.
+        // The run() path must surface the misconfiguration as a WARNING and
+        // skip gating rather than silently treating it as 0%.
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'min_endpoint_coverage' => 150.0, // out of range
+            'min_coverage_strict' => true,
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('WARNING', $stderr);
+        $this->assertStringContainsString('min_endpoint_coverage', $stderr);
+    }
+
+    #[Test]
     public function exits_one_when_output_file_write_fails(): void
     {
         OpenApiCoverageTracker::recordResponse(

--- a/tests/Unit/CoverageReportSubscriberThresholdTest.php
+++ b/tests/Unit/CoverageReportSubscriberThresholdTest.php
@@ -187,6 +187,146 @@ class CoverageReportSubscriberThresholdTest extends TestCase
     }
 
     #[Test]
+    public function strict_threshold_fails_when_no_coverage_recorded(): void
+    {
+        // C2: a strict CI gate must not silently pass when zero contract
+        // assertions ran. Pre-fix, the subscriber's `if ($results === [])`
+        // early-return skipped the gate entirely → exit 0, missed signal.
+        // No `recordResponse()` call here — `computeAllResults()` returns [].
+
+        $exitCode = null;
+        $stderr = '';
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            sidecarDir: $this->tmpDir,
+            minEndpointCoverage: 80.0,
+            minCoverageStrict: true,
+            exitHandler: static function (int $code) use (&$exitCode): void {
+                $exitCode = $code;
+            },
+        );
+
+        ob_start();
+        $subscriber->notify($this->fakeExecutionFinished());
+        ob_get_clean();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('FATAL', $stderr);
+        $this->assertStringContainsString('no contract test coverage was recorded', $stderr);
+    }
+
+    #[Test]
+    public function warn_only_threshold_logs_when_no_coverage_recorded(): void
+    {
+        // Symmetric to the strict case but stays exit 0 — a warn-only CI
+        // still surfaces the misconfiguration without breaking the build.
+        $exitCode = null;
+        $stderr = '';
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            sidecarDir: $this->tmpDir,
+            minEndpointCoverage: 80.0,
+            // strict omitted → warn-only
+            exitHandler: static function (int $code) use (&$exitCode): void {
+                $exitCode = $code;
+            },
+        );
+
+        ob_start();
+        $subscriber->notify($this->fakeExecutionFinished());
+        ob_get_clean();
+
+        $this->assertNull($exitCode);
+        $this->assertStringContainsString('WARNING', $stderr);
+        $this->assertStringContainsString('no contract test coverage was recorded', $stderr);
+    }
+
+    #[Test]
+    public function no_coverage_without_threshold_stays_silent(): void
+    {
+        // Backwards compat: when no threshold is configured, an empty run
+        // must not start emitting noise — that would break callers who
+        // don't use the gate.
+        $exitCode = null;
+        $stderr = '';
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            sidecarDir: $this->tmpDir,
+            exitHandler: static function (int $code) use (&$exitCode): void {
+                $exitCode = $code;
+            },
+        );
+
+        ob_start();
+        $subscriber->notify($this->fakeExecutionFinished());
+        ob_get_clean();
+
+        $this->assertNull($exitCode);
+        $this->assertSame('', $stderr);
+    }
+
+    #[Test]
+    public function strict_threshold_miss_on_response_only_invokes_exit_handler(): void
+    {
+        // Symmetric coverage: the endpoint-only path is exercised above; pin
+        // the response-only path so a future refactor that swaps
+        // minEndpoint/minResponse parameters would surface here.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        $exitCode = null;
+        $stderr = '';
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            sidecarDir: $this->tmpDir,
+            minEndpointCoverage: null,
+            minResponseCoverage: 80.0,
+            minCoverageStrict: true,
+            exitHandler: static function (int $code) use (&$exitCode): void {
+                $exitCode = $code;
+            },
+        );
+
+        ob_start();
+        $subscriber->notify($this->fakeExecutionFinished());
+        ob_get_clean();
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('response coverage', $stderr);
+        $this->assertStringNotContainsString('endpoint coverage', $stderr);
+    }
+
+    #[Test]
     public function passing_threshold_does_not_emit_anything(): void
     {
         OpenApiCoverageTracker::recordResponse(

--- a/tests/Unit/CoverageReportSubscriberThresholdTest.php
+++ b/tests/Unit/CoverageReportSubscriberThresholdTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use PHPUnit\Event\TestRunner\ExecutionFinished;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Studio\OpenApiContractTesting\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\PHPUnit\ConsoleOutput;
+use Studio\OpenApiContractTesting\PHPUnit\CoverageReportSubscriber;
+
+use function getenv;
+use function glob;
+use function is_dir;
+use function ob_get_clean;
+use function ob_start;
+use function putenv;
+use function rmdir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+/**
+ * Pins the issue #135 contract on {@see CoverageReportSubscriber}: in
+ * sequential mode the threshold gate runs after rendering; in worker mode
+ * the gate is skipped entirely (merge CLI is the gating point for paratest).
+ */
+class CoverageReportSubscriberThresholdTest extends TestCase
+{
+    private string $tmpDir = '';
+    private ?string $previousTestToken = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiCoverageTracker::reset();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs');
+
+        $this->tmpDir = sys_get_temp_dir() . '/openapi-coverage-threshold-' . uniqid('', true);
+
+        $current = getenv('TEST_TOKEN');
+        $this->previousTestToken = $current === false ? null : $current;
+        putenv('TEST_TOKEN');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->previousTestToken === null) {
+            putenv('TEST_TOKEN');
+        } else {
+            putenv('TEST_TOKEN=' . $this->previousTestToken);
+        }
+
+        if (is_dir($this->tmpDir)) {
+            foreach (glob($this->tmpDir . '/*') ?: [] as $entry) {
+                @unlink($entry);
+            }
+            @rmdir($this->tmpDir);
+        }
+
+        OpenApiCoverageTracker::reset();
+        OpenApiSpecLoader::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function strict_threshold_miss_invokes_exit_handler_with_one(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        $exitCode = null;
+        $stderr = '';
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            sidecarDir: $this->tmpDir,
+            minEndpointCoverage: 80.0,
+            minCoverageStrict: true,
+            exitHandler: static function (int $code) use (&$exitCode): void {
+                $exitCode = $code;
+            },
+        );
+
+        ob_start();
+        $subscriber->notify($this->fakeExecutionFinished());
+        ob_get_clean();
+
+        $this->assertSame(1, $exitCode, 'strict threshold miss must request exit(1)');
+        $this->assertStringContainsString('[OpenAPI Coverage] FAIL:', $stderr);
+        $this->assertStringContainsString('endpoint coverage', $stderr);
+    }
+
+    #[Test]
+    public function non_strict_threshold_miss_only_warns(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        $exitCode = null;
+        $stderr = '';
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            sidecarDir: $this->tmpDir,
+            minEndpointCoverage: 80.0,
+            minCoverageStrict: false,
+            exitHandler: static function (int $code) use (&$exitCode): void {
+                $exitCode = $code;
+            },
+        );
+
+        ob_start();
+        $subscriber->notify($this->fakeExecutionFinished());
+        ob_get_clean();
+
+        $this->assertNull($exitCode, 'warn-only mode must not exit');
+        $this->assertStringContainsString('[OpenAPI Coverage] WARN:', $stderr);
+    }
+
+    #[Test]
+    public function worker_mode_does_not_evaluate_threshold(): void
+    {
+        // In paratest the merge CLI is the gate. Worker subscribers must not
+        // double-evaluate — that would short-circuit a worker before its
+        // sidecar reaches the merge step.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        putenv('TEST_TOKEN=3');
+
+        $exitCode = null;
+        $stderr = '';
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            sidecarDir: $this->tmpDir,
+            minEndpointCoverage: 80.0,
+            minCoverageStrict: true,
+            exitHandler: static function (int $code) use (&$exitCode): void {
+                $exitCode = $code;
+            },
+        );
+
+        $subscriber->notify($this->fakeExecutionFinished());
+
+        $this->assertNull($exitCode);
+        $this->assertStringNotContainsString('FAIL:', $stderr);
+        $this->assertStringNotContainsString('WARN:', $stderr);
+    }
+
+    #[Test]
+    public function passing_threshold_does_not_emit_anything(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        $exitCode = null;
+        $stderr = '';
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            sidecarDir: $this->tmpDir,
+            minEndpointCoverage: 0.0, // anything >= 0 passes
+            minCoverageStrict: true,
+            exitHandler: static function (int $code) use (&$exitCode): void {
+                $exitCode = $code;
+            },
+        );
+
+        ob_start();
+        $subscriber->notify($this->fakeExecutionFinished());
+        ob_get_clean();
+
+        $this->assertNull($exitCode);
+        $this->assertStringNotContainsString('FAIL:', $stderr);
+        $this->assertStringNotContainsString('WARN:', $stderr);
+    }
+
+    private function fakeExecutionFinished(): ExecutionFinished
+    {
+        return (new ReflectionClass(ExecutionFinished::class))->newInstanceWithoutConstructor();
+    }
+}

--- a/tests/Unit/CoverageThresholdEvaluatorTest.php
+++ b/tests/Unit/CoverageThresholdEvaluatorTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\PHPUnit\CoverageThresholdEvaluator;
+
+use function explode;
+use function str_repeat;
+use function substr;
+use function trim;
+
+class CoverageThresholdEvaluatorTest extends TestCase
+{
+    #[Test]
+    public function passes_when_both_thresholds_met(): void
+    {
+        $result = CoverageThresholdEvaluator::evaluate(
+            results: [
+                'front' => self::counts(endpointFullyCovered: 8, endpointTotal: 10, responseCovered: 7, responseTotal: 10),
+            ],
+            minEndpointPct: 80.0,
+            minResponsePct: 70.0,
+            strict: true,
+        );
+
+        $this->assertTrue($result['passed']);
+        $this->assertSame('', $result['message']);
+        $this->assertNotNull($result['endpoint']);
+        $this->assertSame(80.0, $result['endpoint']['percent']);
+        $this->assertSame(80.0, $result['endpoint']['threshold']);
+        $this->assertTrue($result['endpoint']['ok']);
+        $this->assertNotNull($result['response']);
+        $this->assertSame(70.0, $result['response']['percent']);
+        $this->assertTrue($result['response']['ok']);
+    }
+
+    #[Test]
+    public function fails_when_endpoint_threshold_unmet_and_strict(): void
+    {
+        // endpointFullyCovered/endpointTotal = 67/99 → 67.7%
+        // responseCovered/responseTotal = 80/100 → 80% (>= 70%)
+        $result = CoverageThresholdEvaluator::evaluate(
+            results: [
+                'front' => self::counts(endpointFullyCovered: 67, endpointTotal: 99, responseCovered: 80, responseTotal: 100),
+            ],
+            minEndpointPct: 80.0,
+            minResponsePct: 70.0,
+            strict: true,
+        );
+
+        $this->assertFalse($result['passed']);
+        $this->assertStringContainsString('[OpenAPI Coverage] FAIL:', $result['message']);
+        $this->assertStringContainsString('endpoint coverage 67.7% < threshold 80%', $result['message']);
+        $this->assertStringContainsString('response coverage 80% (>= 70%, ok)', $result['message']);
+        $this->assertNotNull($result['endpoint']);
+        $this->assertFalse($result['endpoint']['ok']);
+        $this->assertNotNull($result['response']);
+        $this->assertTrue($result['response']['ok']);
+    }
+
+    #[Test]
+    public function fails_when_response_threshold_unmet(): void
+    {
+        $result = CoverageThresholdEvaluator::evaluate(
+            results: [
+                'front' => self::counts(endpointFullyCovered: 9, endpointTotal: 10, responseCovered: 5, responseTotal: 10),
+            ],
+            minEndpointPct: 80.0,
+            minResponsePct: 70.0,
+            strict: true,
+        );
+
+        $this->assertFalse($result['passed']);
+        $this->assertStringContainsString('endpoint coverage 90% (>= 80%, ok)', $result['message']);
+        $this->assertStringContainsString('response coverage 50% < threshold 70%', $result['message']);
+    }
+
+    #[Test]
+    public function fails_when_both_thresholds_unmet(): void
+    {
+        $result = CoverageThresholdEvaluator::evaluate(
+            results: [
+                'front' => self::counts(endpointFullyCovered: 5, endpointTotal: 10, responseCovered: 5, responseTotal: 10),
+            ],
+            minEndpointPct: 80.0,
+            minResponsePct: 70.0,
+            strict: true,
+        );
+
+        $this->assertFalse($result['passed']);
+        $this->assertStringContainsString('endpoint coverage 50% < threshold 80%', $result['message']);
+        $this->assertStringContainsString('response coverage 50% < threshold 70%', $result['message']);
+    }
+
+    #[Test]
+    public function uses_warn_prefix_when_not_strict(): void
+    {
+        $result = CoverageThresholdEvaluator::evaluate(
+            results: [
+                'front' => self::counts(endpointFullyCovered: 5, endpointTotal: 10, responseCovered: 5, responseTotal: 10),
+            ],
+            minEndpointPct: 80.0,
+            minResponsePct: null,
+            strict: false,
+        );
+
+        $this->assertFalse($result['passed']);
+        $this->assertStringContainsString('[OpenAPI Coverage] WARN:', $result['message']);
+        $this->assertStringNotContainsString('FAIL:', $result['message']);
+    }
+
+    #[Test]
+    public function omits_unset_threshold_from_message(): void
+    {
+        $result = CoverageThresholdEvaluator::evaluate(
+            results: [
+                'front' => self::counts(endpointFullyCovered: 5, endpointTotal: 10, responseCovered: 5, responseTotal: 10),
+            ],
+            minEndpointPct: 80.0,
+            minResponsePct: null, // not configured
+            strict: true,
+        );
+
+        $this->assertFalse($result['passed']);
+        $this->assertStringContainsString('endpoint coverage 50% < threshold 80%', $result['message']);
+        $this->assertStringNotContainsString('response coverage', $result['message']);
+        $this->assertNotNull($result['endpoint']);
+        $this->assertNull($result['response']);
+    }
+
+    #[Test]
+    public function returns_passed_with_empty_message_when_no_thresholds_configured(): void
+    {
+        $result = CoverageThresholdEvaluator::evaluate(
+            results: [
+                'front' => self::counts(endpointFullyCovered: 0, endpointTotal: 100, responseCovered: 0, responseTotal: 100),
+            ],
+            minEndpointPct: null,
+            minResponsePct: null,
+            strict: true,
+        );
+
+        $this->assertTrue($result['passed']);
+        $this->assertSame('', $result['message']);
+        $this->assertNull($result['endpoint']);
+        $this->assertNull($result['response']);
+    }
+
+    #[Test]
+    public function treats_zero_total_as_passing(): void
+    {
+        // endpointTotal = 0 → vacuously meets any threshold (no endpoints to fail).
+        // The "no coverage recorded" edge case is handled upstream by hasAnyCoverage().
+        $result = CoverageThresholdEvaluator::evaluate(
+            results: [
+                'front' => self::counts(endpointFullyCovered: 0, endpointTotal: 0, responseCovered: 0, responseTotal: 0),
+            ],
+            minEndpointPct: 80.0,
+            minResponsePct: 70.0,
+            strict: true,
+        );
+
+        $this->assertTrue($result['passed']);
+        $this->assertSame('', $result['message']);
+    }
+
+    #[Test]
+    public function aggregates_counts_across_specs(): void
+    {
+        // front: 10/20 endpoints, 30/40 responses
+        // admin: 5/30 endpoints, 10/60 responses
+        // total: endpoint 15/50 = 30%, response 40/100 = 40%
+        $result = CoverageThresholdEvaluator::evaluate(
+            results: [
+                'front' => self::counts(endpointFullyCovered: 10, endpointTotal: 20, responseCovered: 30, responseTotal: 40),
+                'admin' => self::counts(endpointFullyCovered: 5, endpointTotal: 30, responseCovered: 10, responseTotal: 60),
+            ],
+            minEndpointPct: 80.0,
+            minResponsePct: 50.0,
+            strict: true,
+        );
+
+        $this->assertFalse($result['passed']);
+        $this->assertNotNull($result['endpoint']);
+        $this->assertSame(30.0, $result['endpoint']['percent']);
+        $this->assertNotNull($result['response']);
+        $this->assertSame(40.0, $result['response']['percent']);
+        $this->assertStringContainsString('endpoint coverage 30% < threshold 80%', $result['message']);
+        $this->assertStringContainsString('response coverage 40% < threshold 50%', $result['message']);
+    }
+
+    #[Test]
+    public function passes_when_actual_equals_threshold(): void
+    {
+        // 8/10 = 80% == threshold 80% → ok (>= is the pass condition).
+        $result = CoverageThresholdEvaluator::evaluate(
+            results: [
+                'front' => self::counts(endpointFullyCovered: 8, endpointTotal: 10, responseCovered: 8, responseTotal: 10),
+            ],
+            minEndpointPct: 80.0,
+            minResponsePct: 80.0,
+            strict: true,
+        );
+
+        $this->assertTrue($result['passed']);
+    }
+
+    #[Test]
+    public function aligns_second_message_line_to_label_indent(): void
+    {
+        // Issue's example shows the second metric line indented to the column
+        // where the first line's metric starts. Pin so future renaming of the
+        // prefix keeps the visual alignment.
+        $result = CoverageThresholdEvaluator::evaluate(
+            results: [
+                'front' => self::counts(endpointFullyCovered: 5, endpointTotal: 10, responseCovered: 7, responseTotal: 10),
+            ],
+            minEndpointPct: 80.0,
+            minResponsePct: 60.0,
+            strict: true,
+        );
+
+        $lines = explode("\n", trim($result['message']));
+        $this->assertCount(2, $lines);
+        $this->assertStringStartsWith('[OpenAPI Coverage] FAIL: endpoint coverage', $lines[0]);
+        // Second line must start with whitespace whose length equals
+        // "[OpenAPI Coverage] FAIL: " (25 chars), so "response" lands in the
+        // same column as "endpoint".
+        $this->assertSame(str_repeat(' ', 25), substr($lines[1], 0, 25));
+        $this->assertStringStartsWith('response coverage', substr($lines[1], 25));
+    }
+
+    /**
+     * Build a minimal CoverageResult-shaped array carrying only the counts the
+     * evaluator reads. The other fields are not relevant to threshold gating;
+     * defaults match the empty/zero shape so a typo can't accidentally inflate
+     * a metric.
+     *
+     * @return array<string, mixed>
+     */
+    private static function counts(
+        int $endpointFullyCovered,
+        int $endpointTotal,
+        int $responseCovered,
+        int $responseTotal,
+    ): array {
+        return [
+            'endpoints' => [],
+            'endpointTotal' => $endpointTotal,
+            'endpointFullyCovered' => $endpointFullyCovered,
+            'endpointPartial' => 0,
+            'endpointUncovered' => 0,
+            'endpointRequestOnly' => 0,
+            'responseTotal' => $responseTotal,
+            'responseCovered' => $responseCovered,
+            'responseSkipped' => 0,
+            'responseUncovered' => 0,
+        ];
+    }
+}

--- a/tests/Unit/OpenApiCoverageExtensionTest.php
+++ b/tests/Unit/OpenApiCoverageExtensionTest.php
@@ -258,6 +258,60 @@ class OpenApiCoverageExtensionTest extends TestCase
     }
 
     #[Test]
+    public function bootstrap_warns_on_out_of_range_min_endpoint_coverage(): void
+    {
+        // Issue #135: a misconfigured percent must not silently disable the
+        // gate. Pin the WARNING so a future "trust the user" refactor that
+        // drops range validation can't regress in a way CI doesn't catch.
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => 'refs-valid',
+            'min_endpoint_coverage' => '150',
+        ]);
+
+        $extension->setupExtension(null, $parameters, null);
+
+        $stderr = $this->readStderr();
+        $this->assertStringContainsString('WARNING', $stderr);
+        $this->assertStringContainsString('min_endpoint_coverage', $stderr);
+    }
+
+    #[Test]
+    public function bootstrap_warns_on_non_numeric_min_response_coverage(): void
+    {
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => 'refs-valid',
+            'min_response_coverage' => 'eighty',
+        ]);
+
+        $extension->setupExtension(null, $parameters, null);
+
+        $stderr = $this->readStderr();
+        $this->assertStringContainsString('WARNING', $stderr);
+        $this->assertStringContainsString('min_response_coverage', $stderr);
+    }
+
+    #[Test]
+    public function bootstrap_accepts_well_formed_threshold_parameters(): void
+    {
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => 'refs-valid',
+            'min_endpoint_coverage' => '80',
+            'min_response_coverage' => '70.5',
+            'min_coverage_strict' => 'true',
+        ]);
+
+        $extension->setupExtension(null, $parameters, null);
+
+        $this->assertSame('', $this->readStderr());
+    }
+
+    #[Test]
     public function bootstrap_hard_fails_even_when_earlier_specs_are_valid(): void
     {
         // Order-independence: the loop must reach and trip on the broken spec

--- a/tests/Unit/OpenApiCoverageExtensionTest.php
+++ b/tests/Unit/OpenApiCoverageExtensionTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\Extension\ParameterCollection;
 use Studio\OpenApiContractTesting\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\InvalidOpenApiSpecReason;
+use Studio\OpenApiContractTesting\InvalidThresholdConfigurationException;
 use Studio\OpenApiContractTesting\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension;
 use Studio\OpenApiContractTesting\SpecFileNotFoundException;
@@ -258,11 +259,10 @@ class OpenApiCoverageExtensionTest extends TestCase
     }
 
     #[Test]
-    public function bootstrap_warns_on_out_of_range_min_endpoint_coverage(): void
+    public function bootstrap_warns_on_out_of_range_min_endpoint_coverage_when_not_strict(): void
     {
-        // Issue #135: a misconfigured percent must not silently disable the
-        // gate. Pin the WARNING so a future "trust the user" refactor that
-        // drops range validation can't regress in a way CI doesn't catch.
+        // Warn-only (default) tolerates misconfiguration: surface it but
+        // don't break a CI that hasn't opted into the gate yet.
         $extension = new OpenApiCoverageExtension();
         $parameters = ParameterCollection::fromArray([
             'spec_base_path' => __DIR__ . '/../fixtures/specs',
@@ -278,7 +278,7 @@ class OpenApiCoverageExtensionTest extends TestCase
     }
 
     #[Test]
-    public function bootstrap_warns_on_non_numeric_min_response_coverage(): void
+    public function bootstrap_warns_on_non_numeric_min_response_coverage_when_not_strict(): void
     {
         $extension = new OpenApiCoverageExtension();
         $parameters = ParameterCollection::fromArray([
@@ -292,6 +292,72 @@ class OpenApiCoverageExtensionTest extends TestCase
         $stderr = $this->readStderr();
         $this->assertStringContainsString('WARNING', $stderr);
         $this->assertStringContainsString('min_response_coverage', $stderr);
+    }
+
+    #[Test]
+    public function bootstrap_throws_on_out_of_range_threshold_when_strict(): void
+    {
+        // C1: strict=true must treat a typo'd threshold as a configuration
+        // error, not warn-and-skip. The exception is caught by bootstrap()
+        // and translated into exit(1) — symmetric with how stale `specs=`
+        // entries fail the run after issue #134.
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => 'refs-valid',
+            'min_endpoint_coverage' => '150',
+            'min_coverage_strict' => 'true',
+        ]);
+
+        $this->expectException(InvalidThresholdConfigurationException::class);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+        } finally {
+            $this->assertStringContainsString('FATAL', $this->readStderr());
+            $this->assertStringContainsString('min_endpoint_coverage', $this->readStderr());
+        }
+    }
+
+    #[Test]
+    public function bootstrap_throws_on_non_numeric_threshold_when_strict(): void
+    {
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => 'refs-valid',
+            'min_response_coverage' => 'eighty',
+            'min_coverage_strict' => 'true',
+        ]);
+
+        $this->expectException(InvalidThresholdConfigurationException::class);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+        } finally {
+            $this->assertStringContainsString('FATAL', $this->readStderr());
+        }
+    }
+
+    #[Test]
+    public function bootstrap_treats_empty_strict_value_as_enabled(): void
+    {
+        // I1: `<parameter name="min_coverage_strict" />` (no value) was a
+        // contradiction — the docstring promised "set = strict on" but the
+        // code treated `''` as falsy. Pin the docstring's intent.
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../fixtures/specs',
+            'specs' => 'refs-valid',
+            'min_endpoint_coverage' => '150', // out of range
+            'min_coverage_strict' => '',      // shorthand for "true"
+        ]);
+
+        // Empty strict value must enable strict mode → C1 FATAL on the bad
+        // threshold below.
+        $this->expectException(InvalidThresholdConfigurationException::class);
+
+        $extension->setupExtension(null, $parameters, null);
     }
 
     #[Test]


### PR DESCRIPTION
# 概要

OpenAPI contract coverage に PHPUnit 標準の `--coverage-threshold` 相当の gate 機能を追加し、「カバレッジが N% を下回ったら CI を落とす」運用を可能にしました。Issue #135 の対応です。

## 変更内容

`min_endpoint_coverage` / `min_response_coverage` (パーセント、optional) と `min_coverage_strict` (デフォルト `false` = warn-only、`true` で exit non-zero) を `phpunit.xml` のパラメータと `openapi-coverage-merge` CLI のフラグの両方に追加。複数 spec が設定されている場合は全 spec を合算して評価します。warn-only でも `WARN:` 行を stderr に出すので、いきなり CI を壊さずに段階導入できます。

- `src/PHPUnit/CoverageThresholdEvaluator.php` を新規追加（純粋な評価ロジック。in-process subscriber と merge CLI の両者から共有）
- `OpenApiCoverageExtension` に `min_endpoint_coverage` / `min_response_coverage` / `min_coverage_strict` パラメータを追加。範囲外 / 非数値は WARNING を出して null フォールバック
- `CoverageReportSubscriber` にレポート描画後の gate 評価と `\$exitHandler` 注入（テスト用）を追加。strict miss 時は既存 `bootstrap()` と同じく `fflush(STDERR); exit(1)`。worker mode (`TEST_TOKEN` あり) では gate をスキップし、merge CLI 側に委譲
- `CoverageMergeCommand` に `--min-endpoint-coverage` / `--min-response-coverage` / `--min-coverage-strict` フラグを追加。strict miss で exit 1、warn-only は exit 0
- 単体テスト 19 件追加（評価器 11 件、merge CLI 6 件、extension 3 件、subscriber 4 件）— TDD で Red → Green を回した
- README に新セクション追加 + merge CLI フラグ表更新
- CHANGELOG の Unreleased / Added にエントリ追加

エラー出力は issue 本文の例と同じ形式:

\`\`\`
[OpenAPI Coverage] FAIL: endpoint coverage 67.4% < threshold 80%.
                         response coverage 71.2% (>= 60%, ok).
\`\`\`

品質ゲートはすべて緑:

- \`vendor/bin/phpunit\` — 956 tests, 2031 assertions OK
- \`vendor/bin/phpstan analyse\` — No errors (level 6)
- \`vendor/bin/php-cs-fixer fix --dry-run --diff\` — clean

## 関連情報

- Closes #135
- Issue で sub-option として挙がっていた per-spec しきい値 / baseline ファイルは将来対応とし、本 PR では「全 spec 合算 + 単一しきい値」のみ実装