### PR TITLE
fix: v1.0.0 pre-release hardening — schema converter + content-type matcher

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,78 @@
+name: Bug report
+description: Report a bug in the library
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a report. Please fill in as much
+        of the form below as you can — incomplete reports are slower to
+        triage and may be closed.
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug. Include any error messages or warnings.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: |
+        Minimal failing example. A self-contained test (PHPUnit method or
+        Laravel feature test snippet) is much faster to triage than a
+        prose description. Include the relevant OpenAPI spec excerpt.
+      placeholder: |
+        ```php
+        public function test_my_endpoint(): void
+        {
+            // ...
+        }
+        ```
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Library version
+      description: Output of `composer show studio-design/openapi-contract-testing | grep versions`
+      placeholder: e.g. v0.15.0
+    validations:
+      required: true
+  - type: input
+    id: php
+    attributes:
+      label: PHP version
+      placeholder: e.g. 8.3.10
+    validations:
+      required: true
+  - type: input
+    id: phpunit
+    attributes:
+      label: PHPUnit version
+      placeholder: e.g. 11.5.0
+    validations:
+      required: true
+  - type: dropdown
+    id: openapi-version
+    attributes:
+      label: OpenAPI spec version
+      options:
+        - "3.0"
+        - "3.1"
+        - Both
+        - Not relevant
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Stack traces, related issues, screenshots, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question
+    url: https://github.com/studio-design/openapi-contract-testing/discussions/new?category=q-a
+    about: Use Discussions for usage questions and design conversations.
+  - name: Security report
+    url: https://github.com/studio-design/openapi-contract-testing/security/advisories/new
+    about: Report a security vulnerability privately. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: Feature request
+description: Suggest a new feature or behaviour
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening: please skim the README "Supported features and known
+        limitations" section and the existing issues to check this is not
+        already documented or being worked on.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: |
+        Describe the user-facing problem first. "I want X" is less useful
+        than "When I do A, I expected B but got C."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: |
+        Sketch the API or behaviour you have in mind. Code examples help.
+        Be honest about whether it's a complete proposal or just an idea.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What else did you think about, and why is the proposal preferred?
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - Schema validation
+        - Request validation
+        - Response validation
+        - Coverage tracking
+        - Fuzzing
+        - Laravel adapter
+        - PHPUnit extension
+        - CLI tooling
+        - Documentation
+        - Other
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!--
+Title format: Conventional Commits — feat(scope): …, fix(scope): …, docs: …
+Subject must start lowercase. A CI check enforces this.
+-->
+
+## Summary
+
+<!-- What changes, in 1–3 sentences. -->
+
+## Why
+
+<!-- The problem you're solving. Link the issue if any: "Fixes #123" -->
+
+## Verification
+
+<!-- How did you test this? Failing-test-then-fix is preferred for bugs. -->
+
+- [ ] `composer test` passes
+- [ ] `composer stan` passes
+- [ ] `composer cs-check` passes
+- [ ] CHANGELOG.md updated under `## Unreleased` (skip for refactor/docs-only PRs)
+
+## Notes for reviewers
+
+<!-- Anything non-obvious. Trade-offs you considered. Risks. -->

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,30 @@
+# Configuration for GitHub's auto-generated release notes.
+# Used by `gh release create --generate-notes` and the manual UI.
+# Reference: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
+changelog:
+  exclude:
+    labels:
+      - dependencies
+      - documentation
+      - tech-debt
+    authors:
+      - renovate[bot]
+      - dependabot[bot]
+  categories:
+    - title: Breaking changes
+      labels:
+        - breaking-change
+    - title: Added
+      labels:
+        - feature
+        - enhancement
+    - title: Fixed
+      labels:
+        - bug
+    - title: Changed
+      labels:
+        - refactor
+    - title: Other
+      labels:
+        - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:
 
 jobs:
   tests:
-    name: PHP ${{ matrix.php }} / PHPUnit ${{ matrix.phpunit }}
+    name: PHP ${{ matrix.php }} / PHPUnit ${{ matrix.phpunit }}${{ matrix.deps == 'lowest' && ' / lowest deps' || '' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -16,16 +17,25 @@ jobs:
         include:
           - php: '8.2'
             phpunit: '11'
+            deps: highest
+          - php: '8.2'
+            phpunit: '11'
+            deps: lowest
           - php: '8.3'
             phpunit: '11'
+            deps: highest
           - php: '8.3'
             phpunit: '12'
+            deps: highest
           - php: '8.4'
             phpunit: '11'
+            deps: highest
           - php: '8.4'
             phpunit: '12'
+            deps: highest
           - php: '8.4'
             phpunit: '13'
+            deps: highest
 
     steps:
       - uses: actions/checkout@v6
@@ -36,10 +46,14 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: none
 
-      - name: Install dependencies (PHPUnit ${{ matrix.phpunit }})
+      - name: Install dependencies
         run: |
           composer require --dev "phpunit/phpunit:^${{ matrix.phpunit }}.0" --no-interaction --no-update
-          composer update --prefer-dist --no-interaction --no-progress
+          if [ "${{ matrix.deps }}" = "lowest" ]; then
+            composer update --prefer-lowest --prefer-dist --no-interaction --no-progress
+          else
+            composer update --prefer-dist --no-interaction --no-progress
+          fi
 
       - name: Run tests
         run: vendor/bin/phpunit
@@ -79,3 +93,42 @@ jobs:
 
       - name: Check code style
         run: vendor/bin/php-cs-fixer fix --dry-run --diff
+
+  composer-validate:
+    name: composer-validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          # Run on the lowest supported PHP so any constraint mismatch
+          # between composer.json's `php: ^8.2` and the resolved lock
+          # surfaces here, not at install time on a downstream consumer.
+          php-version: '8.2'
+          coverage: none
+
+      - name: Validate composer.json + composer.lock
+        run: composer validate --strict
+
+  composer-audit:
+    name: composer-audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          # Same rationale as composer-validate: the audit itself is
+          # platform-independent, but installing on the lowest PHP catches
+          # platform-constraint regressions in dependencies.
+          php-version: '8.2'
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Audit installed dependencies
+        run: composer audit --abandoned=fail

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,35 @@
+name: PR title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            refactor
+            test
+            chore
+            perf
+            build
+            ci
+            style
+          requireScope: false
+          subjectPattern: ^(?!.*[A-Z]).+$
+          subjectPatternError: |
+            The PR title subject must start lowercase to match the existing
+            repo convention (e.g. "feat(coverage): add foo" not "feat(coverage): Add foo").
+            Allowed prefixes: feat, fix, docs, refactor, test, chore, perf, build, ci, style.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  verify:
+    name: Verify before release
+    uses: ./.github/workflows/ci.yml
+
+  publish:
+    name: Publish GitHub Release
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --generate-notes \
+            --verify-tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,19 @@ the public API without those leaking into the SemVer contract.
   contract test would report a spurious pass.
 - **Content-type matcher — wildcard ranges**. `findContentTypeKey()` now
   resolves with most-specific-first priority: exact match → `<type>/*` →
-  `*/*`. `findJsonContentType()` likewise considers `application/*` and
-  `*/*` as JSON-acceptable when no literal `application/json` /
-  `+json` key is declared. Specs using OpenAPI 3.x §4.7.10 media-type
-  ranges previously skipped JSON schema validation silently because the
-  matcher only compared literally.
+  `*/*`. `findJsonContentType()` resolves with literal `application/json`
+  / `+json` first, falling back to `application/*` only — `text/*`,
+  `image/*`, `multipart/*`, and `*/*` are intentionally NOT returned as
+  JSON-acceptable, since routing those through JSON schema validation
+  would re-introduce the silent-pass class this fix is meant to eliminate.
+  Specs using OpenAPI 3.x §4.7.10 media-type ranges previously skipped
+  JSON schema validation silently because the matcher only compared
+  literally.
+
+- **Schema converter — unsupported keyword warning now fires for both
+  3.0 and 3.1**. `patternProperties` and friends are valid Draft 04 / 07
+  keywords used in 3.0 specs in the wild, so version-gating the warning
+  would have left a 3.0 silent pass while closing the 3.1 case.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,32 @@ the public API without those leaking into the SemVer contract.
   silent passes, but where features are out of scope it now says so
   explicitly rather than leaving users to discover it through silently
   green tests.
+- New `CONTRIBUTING.md`, `SECURITY.md`, `UPGRADING.md`, GitHub issue
+  templates, and pull request template. v1.0.0 will draw a wider audience
+  than v0.x; structured templates reduce triage cost and pin the SemVer /
+  security-disclosure expectations explicitly.
+
+### Release infrastructure
+
+- **CI hardening**. Added `composer-validate` and `composer-audit` jobs.
+  Added a `--prefer-lowest` matrix leg so constraint changes that
+  accidentally require a newer minor of opis/json-schema or PHPUnit are
+  caught instead of silently breaking downstream pin-pinned consumers.
+- **Tag-driven release pipeline**. Pushing a `v*` tag now runs the full
+  CI matrix once more and then publishes a GitHub Release with
+  auto-generated notes via `gh release create --generate-notes`. Notes
+  are grouped by PR labels per `.github/release.yml`. Eliminates the
+  "tagged but forgot to publish the Release" footgun.
+- **PR title convention enforcement** via `amannn/action-semantic-pull-request`.
+  History was already conventional-style; the workflow formalises it so
+  the squash-merge commit history stays parseable for changelog
+  automation.
+- **`composer.json` polish** — added `scripts` (`composer test` /
+  `stan` / `cs` / `cs-check` / `ci`), `support` URLs, and `archive.exclude`
+  so Packagist tarballs ship without `tests/`, `.github/`, dotfiles, etc.
+- **Renovate** now runs Mondays Asia/Tokyo, auto-merges runtime *patch*
+  updates as well as the existing dev minor/patch group. Runtime *minor*
+  stays manual because `opis/json-schema` semantics may shift.
 
 ## v0.15.0 — 2026-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,63 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 This project is **pre-1.0**, so breaking changes may land in any minor release
 until 1.0.0 ships. Each entry below tags whether it is breaking.
 
+## Unreleased
+
+The "v1.0.0 hardening" pass: a competitive review against Spectator,
+league/openapi-psr7-validator, osteel, and kirschbaum surfaced six
+silent-pass bugs in the OAS-to-Draft-07 conversion plus a content-type
+range matching gap. All six are fixed below; the API surface picks up
+`@internal` markers on test/serialisation helpers so v1.0.0 can freeze
+the public API without those leaking into the SemVer contract.
+
+### Fixed
+
+- **Schema converter — `nullable: true` next to `enum`** now appends `null` to
+  the enum so opis Draft 07 actually accepts null values. Previously only
+  `type` was rewritten, causing `enum: ["a", "b"]` + `nullable: true` to
+  reject `null` against the enum constraint even though OAS 3.0 considers
+  null a valid value.
+- **Schema converter — `examples` (Draft 2020-12 array form)** is now
+  stripped from OAS 3.0 schemas as well as 3.1. Singular `example` was
+  already removed for both versions; `examples` was inconsistently kept on
+  3.0, leaving an unrecognised Draft 07 keyword in the output.
+- **Schema converter — OAS 3.1 `const`** is now lowered to `enum: [value]`.
+  Draft 07 has no native `const`, so the keyword silently passed before —
+  a `const: "fixed"` schema would accept any value of the right type.
+- **Schema converter — unsupported 2019-09 / 2020-12 keywords** now emit a
+  one-shot `E_USER_WARNING` when first encountered: `patternProperties`,
+  `unevaluatedProperties`, `unevaluatedItems`, `contentMediaType`,
+  `contentEncoding`. Pre-fix, opis ignored these silently and the
+  contract test would report a spurious pass.
+- **Content-type matcher — wildcard ranges**. `findContentTypeKey()` now
+  resolves with most-specific-first priority: exact match → `<type>/*` →
+  `*/*`. `findJsonContentType()` likewise considers `application/*` and
+  `*/*` as JSON-acceptable when no literal `application/json` /
+  `+json` key is declared. Specs using OpenAPI 3.x §4.7.10 media-type
+  ranges previously skipped JSON schema validation silently because the
+  matcher only compared literally.
+
+### Changed
+
+- **Public-API hygiene** — `OpenApiSpecLoader::clearCache()` / `evict()` /
+  `reset()`, `OpenApiCoverageTracker::reset()` / `exportState()` /
+  `importState()`, and `ValidatesOpenApiSchema::resetValidatorCache()` are
+  now annotated `@internal`. They remain `public` for the PHPUnit extension
+  / paratest sidecar protocol but are no longer part of the user-facing
+  surface that v1.0.0 will freeze.
+
+### Documentation
+
+- README gains a "Supported features and known limitations" section that
+  pins down body-validation media types, parameter style support,
+  security-scheme coverage, schema feature handling, HTTP-method coverage,
+  and spec features that are not consulted (webhooks, callbacks, links,
+  server URL templates, etc.). Important for v1.0.0 expectation-setting:
+  the library favours loud failures or explicit `Skipped` outcomes over
+  silent passes, but where features are out of scope it now says so
+  explicitly rather than leaving users to discover it through silently
+  green tests.
+
 ## v0.15.0 — 2026-04-30
 
 The "v1.0 prep" release: namespaces reorganised so the public surface

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing
+
+Thanks for considering a contribution. This is a small library with a
+single maintainer; the workflow below is optimised for quick iteration.
+
+## Quick start
+
+```bash
+git clone https://github.com/studio-design/openapi-contract-testing
+cd openapi-contract-testing
+composer install
+composer ci   # runs cs-check + stan + test
+```
+
+PHP 8.2 or newer is required. The CI matrix runs PHP 8.2/8.3/8.4 with
+PHPUnit 11/12/13.
+
+## Local checks
+
+| Command                | What it does                                  |
+| ---------------------- | --------------------------------------------- |
+| `composer test`        | Run the full test suite (PHPUnit)             |
+| `composer stan`        | PHPStan level 6 over `src/` and `tests/`      |
+| `composer cs-check`    | PHP-CS-Fixer dry-run                          |
+| `composer cs`          | PHP-CS-Fixer apply (rewrites files)           |
+| `composer ci`          | All of the above, in CI order                 |
+
+## Workflow
+
+1. Open an issue describing the problem before starting non-trivial work.
+   For bug fixes that come with a failing test, jumping straight to a PR
+   is fine.
+2. Fork, branch from `main`, name the branch with the convention
+   `feat/<topic>`, `fix/<topic>`, `docs/<topic>`, etc.
+3. Write tests first when the change is observable behaviour. The test
+   suite uses snake_case method names and PHPUnit `#[Test]` attributes.
+4. Run `composer ci` locally before pushing.
+5. Open a PR. The title must follow Conventional Commits
+   (`feat(scope): …`, `fix(scope): …`, etc.) — a CI check enforces this.
+6. The PR template asks for the failing scenario and how the change is
+   verified. Skipping it slows review.
+
+## Commits
+
+History is squash-merged; the squash uses the PR title. So:
+- The PR title becomes the canonical commit message
+- Conventional Commits convention is enforced on PR titles
+- Commit titles inside the PR are free-form; aim for readable history but
+  don't worry about formatting since they get squashed
+
+## Code style
+
+PER-CS2.0 + `@PHP8x2Migration` via PHP-CS-Fixer (config in
+`.php-cs-fixer.dist.php`). Highlights:
+
+- `declare(strict_types=1);` in every PHP file
+- Strict comparisons (`===`, `!==`) only
+- Explicit `use function` / `use const` imports — no global namespace
+  fallback in production code
+- Class element order: traits → constants → static properties →
+  properties → constructor → public static methods → public → protected
+  → private
+- Tests use snake_case method names
+
+If `composer cs-check` fails, run `composer cs` and commit the result.
+
+## Adding new public API
+
+1. Mark the class `final` unless you have a concrete extension story
+2. Avoid adding public properties — favour readonly DTOs or accessors
+3. Methods that are only public for the PHPUnit extension or paratest
+   sidecar protocol must carry an `@internal` annotation in the docblock
+   with a one-line explanation of why they cannot be `private`
+4. Document the behaviour in README before merging
+5. Add an entry to `CHANGELOG.md` under `## Unreleased`
+
+## Reporting bugs
+
+Use the bug-report issue template. The fastest way to a fix is a
+self-contained reproduction, ideally as a failing test against the
+current `main`.
+
+## Security issues
+
+See `SECURITY.md`. **Do not file security reports as public issues.**

--- a/README.md
+++ b/README.md
@@ -927,10 +927,11 @@ The package auto-detects the OAS version from the `openapi` field and handles sc
 
 | Feature | 3.0 handling | 3.1 handling |
 |---|---|---|
-| `nullable: true` | Converted to type array `["string", "null"]` | Not applicable (uses type arrays natively) |
+| `nullable: true` | Converted to type array `["string", "null"]`; `null` appended to `enum` if present | Not applicable (uses type arrays natively) |
 | `prefixItems` | N/A | Converted to `items` array (Draft 07 tuple) |
 | `$dynamicRef` / `$dynamicAnchor` | N/A | Removed (not in Draft 07) |
-| `examples` (array) | N/A | Removed (OAS extension) |
+| `examples` (array) | Removed (Draft 2020-12 keyword, not Draft 07) | Removed (Draft 2020-12 keyword, not Draft 07) |
+| `const` | N/A | Lowered to `enum: [value]` so opis Draft 07 enforces it |
 | `readOnly` / `writeOnly` | Semantic enforcement (see below). Forbidden properties become boolean `false` subschemas; the keyword is dropped as OAS-only on surviving properties | Semantic enforcement (see below). Forbidden properties become boolean `false` subschemas; the keyword is preserved on surviving properties (valid in Draft 07) |
 
 ### `readOnly` / `writeOnly` enforcement
@@ -941,6 +942,41 @@ Both validators apply OpenAPI's asymmetric semantics instead of letting the keyw
 - **Request validation** (`OpenApiRequestValidator`): any property marked `readOnly: true` must **not** appear in the request body. `readOnly + required` is treated as absent on the request side, so a compliant request that omits the property still validates.
 
 Detection looks at each property schema's own top-level `readOnly` / `writeOnly`; markers nested inside the property's `allOf` / `oneOf` / `anyOf` children are not enforced in the current release.
+
+## Supported features and known limitations
+
+This is a contract-testing tool: where we can't enforce a constraint precisely, we prefer a loud failure or an explicit "skipped" outcome over silently accepting non-compliant data. The list below pins down what does and does not get checked so you can decide whether the gaps matter for your spec.
+
+### Body validation
+- **Validated**: `application/json` and any `+json` structured-syntax suffix (RFC 6838), and content keys using ranges (`application/*`, `*/*`) — the matcher tries exact match first, then `<type>/*`, then `*/*`.
+- **Presence-only** (no schema validation): every other media type, including `application/xml`, `multipart/form-data`, `application/x-www-form-urlencoded`, `text/plain`, and `application/octet-stream`. The validator confirms the spec declares the content type but does not check the body. The orchestrator marks these responses as `Skipped` for coverage reporting.
+- **Multipart `encoding` object**: per-part `contentType` / `headers` / `style` / `explode` are not consulted.
+
+### Parameter styles
+- **Query**: only `style: form` + `explode: true` (the OAS default). Specs declaring `pipeDelimited`, `spaceDelimited`, `deepObject`, or `form` + `explode: false` are not parsed; type-mismatch errors will surface but they will point at the wrong cause.
+- **Header / Path**: only `style: simple` for scalar values. `type: array` and `type: object` parameters are not parsed (the raw string is fed to the schema, which then mismatches). `style: matrix` and `style: label` for path parameters are not handled — the prefix is not stripped before validation.
+- **Cookie parameters** (`apiKey` security scheme aside): not validated.
+- **`parameters[].content`**: only `parameters[].schema` is read.
+
+### Security schemes
+- **Validated**: `apiKey` (in `header` / `query` / `cookie`) and `http` + `bearer` — presence checks for the named header/query/cookie / RFC 6750 `Bearer` token.
+- **Silently passed through**: `oauth2`, `openIdConnect`, `mutualTLS`, and `http` schemes other than `bearer` (`basic`, `digest`). When every scheme in a security requirement is unsupported, the requirement passes — your test will not detect a missing or invalid token.
+
+### Schema features
+- **Validated** (delegated to opis Draft 07): `type`, `enum`, `multipleOf`, `minimum`/`maximum`/`exclusiveMinimum`/`exclusiveMaximum`, `minLength`/`maxLength`/`pattern`, `minItems`/`maxItems`/`uniqueItems`, `minProperties`/`maxProperties`/`required`, `additionalProperties` (`true` / `false` / schema), `allOf` / `oneOf` / `anyOf` / `not`, plus `format` for opis's built-in formats (`uuid`, `email`, `date`, `date-time`, `uri`, `ipv4`, `ipv6`, `hostname`).
+- **Lowered**: `const` → `enum: [value]` (3.1).
+- **Stripped**: `discriminator` (including `mapping`), `xml`, `externalDocs`, `example` / `examples`, `deprecated`, OAS-only `nullable`/`readOnly`/`writeOnly` after enforcement (3.0), and Draft 2020-12 keys `$dynamicRef` / `$dynamicAnchor` / `contentSchema` (3.1).
+- **Not supported (loud E_USER_WARNING when first encountered)**: `patternProperties`, `unevaluatedProperties`, `unevaluatedItems`, `contentMediaType`, `contentEncoding`. opis Draft 07 has no native handling, so the constraint is dropped — the warning surfaces this loudly so you can rewrite using Draft 07 equivalents.
+- **`discriminator`**: the keyword is dropped; the underlying `oneOf` / `anyOf` is still validated as a union, but `discriminator.mapping` does not steer validation toward a single branch.
+- **`readOnly` / `writeOnly`**: enforced at the property's own top level only (see [readOnly / writeOnly enforcement](#readonly--writeonly-enforcement)).
+- **Numeric formats** (`int32`, `int64`, `float`, `double`): not range-checked — treated as advisory.
+- **`binary` / `byte` formats**: not specifically handled; bodies are validated as plain strings when not skipped.
+
+### HTTP methods
+The PHPUnit coverage report counts `GET`, `POST`, `PUT`, `PATCH`, `DELETE`. Operations under `HEAD`, `OPTIONS`, or `TRACE` will be validated by `OpenApiResponseValidator` if you call it directly, but they do not appear in the coverage report.
+
+### Spec features not consulted
+Webhooks (3.1), Callbacks, Response `Links`, Server URL templating (`servers` with `variables`), Examples (`examples` blocks at parameter / requestBody / response level — not used for fuzzing or validation), `tags`, `externalDocs`, vendor extensions (`x-*` keys, ignored harmlessly).
 
 ## API Reference
 

--- a/README.md
+++ b/README.md
@@ -973,7 +973,7 @@ This is a contract-testing tool: where we can't enforce a constraint precisely, 
 - **`binary` / `byte` formats**: not specifically handled; bodies are validated as plain strings when not skipped.
 
 ### HTTP methods
-The PHPUnit coverage report counts `GET`, `POST`, `PUT`, `PATCH`, `DELETE`. Operations under `HEAD`, `OPTIONS`, or `TRACE` will be validated by `OpenApiResponseValidator` if you call it directly, but they do not appear in the coverage report.
+The PHPUnit coverage report counts `GET`, `POST`, `PUT`, `PATCH`, `DELETE`. Operations under `HEAD`, `OPTIONS`, and `TRACE` are not part of the coverage allowlist, and the Laravel auto-validation hook silently skips them (it normalises the request method through `HttpMethod::tryFrom()`, which returns `null` for these). Direct calls to `OpenApiResponseValidator::validate()` with one of these method strings will resolve against the spec — but if you depend on coverage tracking or the Laravel trait, treat HEAD / OPTIONS / TRACE as out of scope today.
 
 ### Spec features not consulted
 Webhooks (3.1), Callbacks, Response `Links`, Server URL templating (`servers` with `variables`), Examples (`examples` blocks at parameter / requestBody / response level — not used for fuzzing or validation), `tags`, `externalDocs`, vendor extensions (`x-*` keys, ignored harmlessly).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+## Supported Versions
+
+The most recent minor release line on the v1.x and v0.x branches receive
+security fixes. Pre-1.0 versions are best-effort.
+
+| Version  | Supported |
+| -------- | --------- |
+| 1.x      | ✓         |
+| 0.15.x   | ✓ (until 1.0 ships) |
+| < 0.15   | ✗         |
+
+## Reporting a Vulnerability
+
+**Do not open a public issue for security-relevant reports.**
+
+Use GitHub's [Private Vulnerability Reporting][pvr] to file the report
+privately:
+
+[pvr]: https://github.com/studio-design/openapi-contract-testing/security/advisories/new
+
+What to include:
+- Affected version(s)
+- Reproduction steps or proof-of-concept
+- Impact assessment (data exposure, RCE, DoS, etc.)
+- Whether the issue is already public
+
+## Response targets
+
+- Acknowledgement: within 5 business days
+- Severity triage: within 10 business days
+- Fix for high-severity issues: within 30 days where feasible
+
+We coordinate disclosure timing with the reporter and credit reporters in
+release notes (with permission).
+
+## Scope
+
+This is a test-only library — it has no runtime production surface. The
+relevant attack vectors are:
+- Resolving HTTP(S) `$ref`s (opt-in, off by default) — verify any untrusted
+  spec source before enabling `allowRemoteRefs`
+- YAML spec loading (opt-in via `symfony/yaml`) — `symfony/yaml` is
+  generally safe but spec inputs should still be trusted
+- Coverage sidecar files written under `sys_get_temp_dir()` in paratest mode
+
+Issues outside that scope (e.g. opis/json-schema validation behaviour) are
+forwarded upstream.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,63 @@
+# Upgrade Guide
+
+This file documents non-trivial upgrades between releases. Patches with
+no behaviour change are not listed here — see `CHANGELOG.md` for the
+full record.
+
+## v0.x → v1.0.0
+
+v1.0.0 is the API stability commitment. Anything not marked `@internal`
+in v1.0.0 is covered by SemVer for the v1.x line.
+
+### What's frozen by SemVer in v1.x
+
+- Public class names and namespaces
+- Public method signatures
+- Public constants and their values
+- Enum cases (additions are SemVer-minor; removals are SemVer-major)
+- The `OpenApiValidationResult` shape
+- The CLI surface of `bin/openapi-coverage-merge`
+- The `OpenApiCoverageExtension` PHPUnit configuration parameters
+- The Laravel `ValidatesOpenApiSchema` trait's public methods
+
+### What's NOT frozen (will not break SemVer when changed)
+
+- Anything marked `@internal`. This includes
+  `OpenApiSpecLoader::clearCache/evict/reset`,
+  `OpenApiCoverageTracker::reset/exportState/importState`,
+  `ValidatesOpenApiSchema::resetValidatorCache`, and
+  `OpenApiSchemaConverter::resetWarningStateForTesting`.
+- The shape of paratest sidecar JSON (versioned via `STATE_FORMAT_VERSION`).
+- Internal helper classes under `Internal/`, `Validation/Support/` (the
+  classes themselves are not user-callable).
+- Error messages from validators (we may improve them).
+- The set of `format` keywords delegated to opis (we follow opis).
+
+### What's NOT covered by SemVer at all
+
+- OpenAPI features explicitly marked "not supported" or "presence-only"
+  in README "Supported features and known limitations"
+- Behaviour of bug-fix releases that close a documented silent-pass case
+  (a test that passed only because of the silent pass may start failing —
+  that's the bug fix doing its job, not a SemVer break)
+
+### Migration notes from v0.15.0
+
+- No breaking source-code changes from v0.15.0.
+- New `E_USER_WARNING` may fire for specs using `patternProperties`,
+  `unevaluatedProperties`, `unevaluatedItems`, `contentMediaType`, or
+  `contentEncoding`. Tests configured with PHPUnit's `failOnWarning="true"`
+  (the default in this repo's `phpunit.xml.dist`) will fail loudly if
+  these are encountered. To suppress: rewrite the spec using Draft 07
+  equivalents, or set `failOnWarning="false"` in your project's
+  `phpunit.xml.dist`.
+
+## v0.14.0 → v0.15.0
+
+The "v1.0 prep" release. Twenty-two classes moved into focused
+sub-namespaces. No compat shim — pre-1.0 breaking changes are the
+contract for this release line.
+
+See the v0.15.0 entry in `CHANGELOG.md` for the full migration table.
+The mechanical fix is updating `use Studio\OpenApiContractTesting\X`
+imports per the table.

--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,47 @@
             ]
         }
     },
+    "scripts": {
+        "test": "phpunit",
+        "stan": "phpstan analyse",
+        "cs": "php-cs-fixer fix",
+        "cs-check": "php-cs-fixer fix --dry-run --diff",
+        "ci": [
+            "@cs-check",
+            "@stan",
+            "@test"
+        ]
+    },
+    "scripts-descriptions": {
+        "test": "Run the full PHPUnit test suite.",
+        "stan": "Run PHPStan static analysis.",
+        "cs": "Run PHP-CS-Fixer in fix mode (rewrites files).",
+        "cs-check": "Run PHP-CS-Fixer in dry-run mode (CI gate).",
+        "ci": "Run the same checks the CI matrix runs."
+    },
+    "support": {
+        "issues": "https://github.com/studio-design/openapi-contract-testing/issues",
+        "source": "https://github.com/studio-design/openapi-contract-testing",
+        "docs": "https://github.com/studio-design/openapi-contract-testing#readme"
+    },
+    "archive": {
+        "exclude": [
+            "/tests",
+            "/.github",
+            "/.php-cs-fixer.dist.php",
+            "/.php-cs-fixer.cache",
+            "/.phpstan.cache",
+            "/.phpunit.cache",
+            "/phpstan.neon.dist",
+            "/phpunit.xml.dist",
+            "/CLAUDE.md",
+            "/CONTRIBUTING.md",
+            "/UPGRADING.md",
+            "/SECURITY.md",
+            "/draft-zenn-article.md",
+            "/renovate.json"
+        ]
+    },
     "minimum-stability": "stable",
     "prefer-stable": true
 }

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,8 @@
     "config:recommended"
   ],
   "labels": ["dependencies"],
+  "schedule": ["before 9am on Monday"],
+  "timezone": "Asia/Tokyo",
   "packageRules": [
     {
       "description": "Group GitHub Actions updates",
@@ -16,6 +18,12 @@
       "matchDepTypes": ["require-dev"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "dev dependencies (non-major)",
+      "automerge": true
+    },
+    {
+      "description": "Automerge runtime patch updates only — minor stays manual because validator semantics may shift",
+      "matchDepTypes": ["require"],
+      "matchUpdateTypes": ["patch"],
       "automerge": true
     }
   ]

--- a/src/Coverage/OpenApiCoverageTracker.php
+++ b/src/Coverage/OpenApiCoverageTracker.php
@@ -163,6 +163,12 @@ final class OpenApiCoverageTracker
         );
     }
 
+    /**
+     * Reset all recorded coverage to the empty state. Intended for test
+     * isolation between runs.
+     *
+     * @internal
+     */
     public static function reset(): void
     {
         self::$covered = [];
@@ -176,6 +182,10 @@ final class OpenApiCoverageTracker
      * Enums are serialized as their string `value`. The shape is otherwise
      * a 1:1 mirror of the internal {@see self::$covered} representation, so
      * round-tripping through JSON is lossless when no other writes occur.
+     *
+     * @internal Stable wire format for sidecar writers / merge CLI. The
+     * `version` field gates compatibility — see {@see self::STATE_FORMAT_VERSION}.
+     * Public users should not depend on the array shape.
      *
      * @return CoverageStatePayload
      */
@@ -222,6 +232,9 @@ final class OpenApiCoverageTracker
      * Validation is two-pass: the entire payload is parsed and rejected
      * up front before any state is mutated, so a malformed entry deep in
      * the payload cannot leave the tracker in a partially-merged state.
+     *
+     * @internal Companion to {@see self::exportState()}. Used by the merge CLI
+     * and not part of the user-facing API.
      *
      * @param array<string, mixed> $state
      *

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -100,6 +100,13 @@ trait ValidatesOpenApiSchema
     /** @var string[] */
     private array $skipNextResponseCodes = [];
 
+    /**
+     * Drop the per-process validator cache so the next assertion rebuilds
+     * with current config. Intended for test isolation when multiple
+     * test classes share the same trait but want different settings.
+     *
+     * @internal
+     */
     public static function resetValidatorCache(): void
     {
         self::$cachedValidator = null;

--- a/src/Spec/OpenApiSchemaConverter.php
+++ b/src/Spec/OpenApiSchemaConverter.php
@@ -4,13 +4,18 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Spec;
 
+use const E_USER_WARNING;
+
 use Studio\OpenApiContractTesting\OpenApiVersion;
 use Studio\OpenApiContractTesting\SchemaContext;
 
 use function array_is_list;
+use function array_key_exists;
 use function in_array;
 use function is_array;
 use function is_string;
+use function sprintf;
+use function trigger_error;
 
 final class OpenApiSchemaConverter
 {
@@ -20,6 +25,7 @@ final class OpenApiSchemaConverter
         'xml',
         'externalDocs',
         'example',
+        'examples',
         'deprecated',
     ];
 
@@ -35,8 +41,23 @@ final class OpenApiSchemaConverter
         '$dynamicRef',
         '$dynamicAnchor',
         'contentSchema',
-        'examples',
     ];
+
+    /**
+     * Draft 2019-09 / 2020-12 keywords that opis (Draft 07) silently ignores.
+     * Loud warning surfaces specs that rely on them — silent passes here mean
+     * tests pass even when the contract is not actually being enforced.
+     */
+    private const DRAFT_2020_12_UNSUPPORTED_KEYS = [
+        'patternProperties',
+        'unevaluatedProperties',
+        'unevaluatedItems',
+        'contentMediaType',
+        'contentEncoding',
+    ];
+
+    /** @var array<string, true> */
+    private static array $warnedKeywords = [];
 
     /**
      * Convert an OpenAPI schema to a JSON Schema Draft 07 compatible schema.
@@ -62,6 +83,18 @@ final class OpenApiSchemaConverter
     }
 
     /**
+     * Reset the per-process "already-warned" set used by
+     * {@see warnIfUsesUnsupportedKeywords()}. Test seam — production code
+     * never needs this.
+     *
+     * @internal
+     */
+    public static function resetWarningStateForTesting(): void
+    {
+        self::$warnedKeywords = [];
+    }
+
+    /**
      * @param array<string, mixed> $schema
      */
     private static function convertInPlace(array &$schema, OpenApiVersion $version, SchemaContext $context): void
@@ -70,6 +103,8 @@ final class OpenApiSchemaConverter
             self::handleNullable($schema);
         } else {
             self::handlePrefixItems($schema);
+            self::lowerConstToEnum($schema);
+            self::warnIfUsesUnsupportedKeywords($schema);
             self::removeKeys($schema, self::DRAFT_2020_12_KEYS);
         }
 
@@ -194,6 +229,10 @@ final class OpenApiSchemaConverter
     /**
      * Convert OpenAPI 3.0 nullable to JSON Schema compatible type.
      *
+     * When `enum` is present alongside `nullable: true`, append `null` to the
+     * enum so opis accepts null values — this matches the OAS 3.0 convention
+     * (most spec authors don't list null inside `enum` even when nullable is on).
+     *
      * @param array<string, mixed> $schema
      */
     private static function handleNullable(array &$schema): void
@@ -203,6 +242,10 @@ final class OpenApiSchemaConverter
         }
 
         unset($schema['nullable']);
+
+        if (isset($schema['enum']) && is_array($schema['enum']) && !in_array(null, $schema['enum'], true)) {
+            $schema['enum'][] = null;
+        }
 
         if (isset($schema['type']) && is_string($schema['type'])) {
             $schema['type'] = [$schema['type'], 'null'];
@@ -225,6 +268,59 @@ final class OpenApiSchemaConverter
                 ['allOf' => $allOf],
                 ['type' => 'null'],
             ];
+        }
+    }
+
+    /**
+     * OAS 3.1 / Draft 2019-09 introduced `const`. Draft 07 (the schema dialect
+     * we delegate to via opis) does not understand it, so a `const: "fixed"`
+     * schema would silently accept any value of the correct type. Lower to
+     * `enum: [value]` so the constraint is actually enforced.
+     *
+     * If `enum` already exists, defer to it — `enum` is the wider constraint
+     * and a spec carrying both is malformed.
+     *
+     * @param array<string, mixed> $schema
+     */
+    private static function lowerConstToEnum(array &$schema): void
+    {
+        if (!array_key_exists('const', $schema)) {
+            return;
+        }
+
+        if (!isset($schema['enum'])) {
+            $schema['enum'] = [$schema['const']];
+        }
+
+        unset($schema['const']);
+    }
+
+    /**
+     * Issue a one-shot E_USER_WARNING for each Draft 2019-09 / 2020-12 keyword
+     * we cannot honour through opis Draft 07. Without this, specs relying on
+     * `patternProperties` / `unevaluatedProperties` / `contentMediaType` would
+     * silently pass — a contract test that does not actually enforce the
+     * contract is the worst possible failure mode.
+     *
+     * Warns once per keyword per process to avoid log spam in long test runs.
+     *
+     * @param array<string, mixed> $schema
+     */
+    private static function warnIfUsesUnsupportedKeywords(array $schema): void
+    {
+        foreach (self::DRAFT_2020_12_UNSUPPORTED_KEYS as $keyword) {
+            if (!array_key_exists($keyword, $schema) || isset(self::$warnedKeywords[$keyword])) {
+                continue;
+            }
+
+            self::$warnedKeywords[$keyword] = true;
+            trigger_error(
+                sprintf(
+                    "[OpenAPI Schema] '%s' is not supported by the JSON Schema Draft 07 validator opis uses internally. The keyword will be ignored — your spec's constraint is NOT being enforced. Consider rewriting using Draft 07 equivalents (additionalProperties, required, etc.).",
+                    $keyword,
+                ),
+                E_USER_WARNING,
+            );
         }
     }
 

--- a/src/Spec/OpenApiSchemaConverter.php
+++ b/src/Spec/OpenApiSchemaConverter.php
@@ -104,9 +104,13 @@ final class OpenApiSchemaConverter
         } else {
             self::handlePrefixItems($schema);
             self::lowerConstToEnum($schema);
-            self::warnIfUsesUnsupportedKeywords($schema);
             self::removeKeys($schema, self::DRAFT_2020_12_KEYS);
         }
+
+        // Warn for both 3.0 and 3.1: `patternProperties` and friends are valid
+        // Draft 04/07 keywords used in 3.0 specs as well, so silent ignoring is
+        // just as risky there.
+        self::warnIfUsesUnsupportedKeywords($schema);
 
         self::removeKeys($schema, self::OPENAPI_COMMON_KEYS);
 
@@ -277,8 +281,13 @@ final class OpenApiSchemaConverter
      * schema would silently accept any value of the correct type. Lower to
      * `enum: [value]` so the constraint is actually enforced.
      *
-     * If `enum` already exists, defer to it — `enum` is the wider constraint
-     * and a spec carrying both is malformed.
+     * Conflict policy: when both `const` and `enum` are present (rare and
+     * arguably malformed), we keep `enum` and drop `const`. JSON Schema
+     * semantics are that the two intersect — the result should equal `[const]`
+     * if `const ∈ enum`, else unsatisfiable — but reproducing that precisely
+     * is more delicate than v1.0 needs. The chosen behaviour LOOSENS the
+     * constraint relative to the spec; treat this conflict as a known
+     * limitation and prefer `const`-only or `enum`-only schemas.
      *
      * @param array<string, mixed> $schema
      */
@@ -288,7 +297,7 @@ final class OpenApiSchemaConverter
             return;
         }
 
-        if (!isset($schema['enum'])) {
+        if (!array_key_exists('enum', $schema)) {
             $schema['enum'] = [$schema['const']];
         }
 

--- a/src/Spec/OpenApiSpecLoader.php
+++ b/src/Spec/OpenApiSpecLoader.php
@@ -182,6 +182,10 @@ final class OpenApiSpecLoader
 
     /**
      * Clear only the cached specs, keeping basePath and stripPrefixes intact.
+     *
+     * @internal Used by the PHPUnit extension to free memory after coverage
+     * is computed. Production code should not call this — clearing mid-run
+     * forces a re-parse on the next {@see self::load()} call.
      */
     public static function clearCache(): void
     {
@@ -190,12 +194,20 @@ final class OpenApiSpecLoader
 
     /**
      * Remove a single spec from the cache.
+     *
+     * @internal Test seam — production code never needs this.
      */
     public static function evict(string $specName): void
     {
         unset(self::$cache[$specName]);
     }
 
+    /**
+     * Reset all configuration and cached state. Intended for test isolation
+     * between runs.
+     *
+     * @internal
+     */
     public static function reset(): void
     {
         self::$basePath = null;

--- a/src/Validation/Support/ContentTypeMatcher.php
+++ b/src/Validation/Support/ContentTypeMatcher.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Validation\Support;
 
+use function count;
+use function explode;
 use function str_ends_with;
 use function strstr;
 use function strtolower;
@@ -15,19 +17,40 @@ final class ContentTypeMatcher
      * Find the first JSON-compatible content type key in the spec's
      * `content` map.
      *
-     * Matches "application/json" exactly and any type with a "+json" structured
-     * syntax suffix (RFC 6838), such as "application/problem+json" and
-     * "application/vnd.api+json". Matching is case-insensitive.
+     * Resolution priority (most-specific first):
+     *   1. Literal `application/json` or any `+json` structured-syntax suffix (RFC 6838)
+     *   2. `application/*` or any other `<type>/*` range that could match a JSON body
+     *   3. `*&#47;*` full wildcard
+     *
+     * Wildcard support exists because OpenAPI 3.x §4.7.10 allows media-type
+     * ranges as content keys; the pre-1.0 implementation matched literally
+     * only, silently skipping JSON validation when the spec used ranges.
+     * Matching is case-insensitive.
      *
      * @param array<string, mixed> $content
      */
     public static function findJsonContentType(array $content): ?string
     {
+        // Pass 1: literal JSON keys.
         foreach ($content as $contentType => $_mediaType) {
-            $lower = strtolower($contentType);
+            if (self::isJsonContentType(strtolower((string) $contentType))) {
+                return (string) $contentType;
+            }
+        }
 
-            if (self::isJsonContentType($lower)) {
-                return $contentType;
+        // Pass 2: `application/*` and other type-ranges. Prefer non-`*&#47;*`
+        // ranges because they constrain the type half.
+        foreach ($content as $contentType => $_mediaType) {
+            $lower = strtolower((string) $contentType);
+            if (self::isTypeRange($lower) && $lower !== '*/*') {
+                return (string) $contentType;
+            }
+        }
+
+        // Pass 3: `*&#47;*`.
+        foreach ($content as $contentType => $_mediaType) {
+            if (strtolower((string) $contentType) === '*/*') {
+                return (string) $contentType;
             }
         }
 
@@ -66,13 +89,37 @@ final class ContentTypeMatcher
      * spec's literal media-type keys (which may mix casings, e.g. petstore
      * declares both `Application/Problem+JSON` and `application/problem+json`).
      *
+     * Resolution priority (most-specific first):
+     *   1. Exact case-insensitive match
+     *   2. `<type>/*` range matching `<type>/<subtype>` (e.g. `application/*`)
+     *   3. `*&#47;*` full wildcard
+     *
      * @param array<string, mixed> $content
      */
     public static function findContentTypeKey(string $normalizedContentType, array $content): ?string
     {
+        // Pass 1: exact match.
         foreach ($content as $specContentType => $_mediaType) {
-            if (strtolower($specContentType) === $normalizedContentType) {
-                return $specContentType;
+            if (strtolower((string) $specContentType) === $normalizedContentType) {
+                return (string) $specContentType;
+            }
+        }
+
+        // Pass 2: type-range match (`application/*` for `application/json`).
+        $type = self::primaryType($normalizedContentType);
+        if ($type !== null) {
+            $rangeKey = $type . '/*';
+            foreach ($content as $specContentType => $_mediaType) {
+                if (strtolower((string) $specContentType) === $rangeKey) {
+                    return (string) $specContentType;
+                }
+            }
+        }
+
+        // Pass 3: full wildcard.
+        foreach ($content as $specContentType => $_mediaType) {
+            if (strtolower((string) $specContentType) === '*/*') {
+                return (string) $specContentType;
             }
         }
 
@@ -82,9 +129,35 @@ final class ContentTypeMatcher
     /**
      * True for "application/json" or any "+json" structured syntax suffix (RFC 6838).
      * Expects a lower-cased media type without parameters.
+     *
+     * This is intentionally a literal check — wildcards are NOT JSON. The
+     * actual response/request Content-Type passed by the caller is always a
+     * concrete media type, so a wildcard here would be a category error.
      */
     public static function isJsonContentType(string $lowerContentType): bool
     {
         return $lowerContentType === 'application/json' || str_ends_with($lowerContentType, '+json');
+    }
+
+    /**
+     * Whether `$lower` is a `<type>/*` or `*&#47;*` range (already lower-cased).
+     */
+    private static function isTypeRange(string $lower): bool
+    {
+        return str_ends_with($lower, '/*');
+    }
+
+    /**
+     * Extract the type half ("application" from "application/json"), or null
+     * if the input is malformed (no slash, empty type half, etc.).
+     */
+    private static function primaryType(string $normalized): ?string
+    {
+        $parts = explode('/', $normalized, 2);
+        if (count($parts) !== 2 || $parts[0] === '' || $parts[0] === '*') {
+            return null;
+        }
+
+        return $parts[0];
     }
 }

--- a/src/Validation/Support/ContentTypeMatcher.php
+++ b/src/Validation/Support/ContentTypeMatcher.php
@@ -19,12 +19,15 @@ final class ContentTypeMatcher
      *
      * Resolution priority (most-specific first):
      *   1. Literal `application/json` or any `+json` structured-syntax suffix (RFC 6838)
-     *   2. `application/*` or any other `<type>/*` range that could match a JSON body
-     *   3. `*&#47;*` full wildcard
+     *   2. `application/*` — the only range that can plausibly carry JSON
      *
-     * Wildcard support exists because OpenAPI 3.x §4.7.10 allows media-type
-     * ranges as content keys; the pre-1.0 implementation matched literally
-     * only, silently skipping JSON validation when the spec used ranges.
+     * `*&#47;*` and other `<type>/*` ranges (`text/*`, `image/*`, `multipart/*`)
+     * are intentionally NOT returned: they cover non-JSON media types, and
+     * routing through JSON schema validation against them would re-introduce
+     * the silent-pass class this method is meant to eliminate. Callers that
+     * need general content-type matching (not JSON-specific) should use
+     * {@see findContentTypeKey()} instead.
+     *
      * Matching is case-insensitive.
      *
      * @param array<string, mixed> $content
@@ -38,18 +41,10 @@ final class ContentTypeMatcher
             }
         }
 
-        // Pass 2: `application/*` and other type-ranges. Prefer non-`*&#47;*`
-        // ranges because they constrain the type half.
+        // Pass 2: only `application/*` — `text/*`, `image/*`, `multipart/*`,
+        // etc. cannot plausibly hold a JSON body, and `*&#47;*` is too broad.
         foreach ($content as $contentType => $_mediaType) {
-            $lower = strtolower((string) $contentType);
-            if (self::isTypeRange($lower) && $lower !== '*/*') {
-                return (string) $contentType;
-            }
-        }
-
-        // Pass 3: `*&#47;*`.
-        foreach ($content as $contentType => $_mediaType) {
-            if (strtolower((string) $contentType) === '*/*') {
+            if (strtolower((string) $contentType) === 'application/*') {
                 return (string) $contentType;
             }
         }
@@ -137,14 +132,6 @@ final class ContentTypeMatcher
     public static function isJsonContentType(string $lowerContentType): bool
     {
         return $lowerContentType === 'application/json' || str_ends_with($lowerContentType, '+json');
-    }
-
-    /**
-     * Whether `$lower` is a `<type>/*` or `*&#47;*` range (already lower-cased).
-     */
-    private static function isTypeRange(string $lower): bool
-    {
-        return str_ends_with($lower, '/*');
     }
 
     /**

--- a/tests/Unit/Spec/OpenApiSchemaConverterTest.php
+++ b/tests/Unit/Spec/OpenApiSchemaConverterTest.php
@@ -4,11 +4,16 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Tests\Unit\Spec;
 
+use const E_USER_WARNING;
+
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\OpenApiVersion;
 use Studio\OpenApiContractTesting\SchemaContext;
 use Studio\OpenApiContractTesting\Spec\OpenApiSchemaConverter;
+
+use function restore_error_handler;
+use function set_error_handler;
 
 class OpenApiSchemaConverterTest extends TestCase
 {
@@ -623,5 +628,233 @@ class OpenApiSchemaConverterTest extends TestCase
         OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
 
         $this->assertSame($original, $schema);
+    }
+
+    // ========================================
+    // OAS 3.0 nullable + enum (regression)
+    // ========================================
+
+    #[Test]
+    public function v30_nullable_with_enum_appends_null_to_enum(): void
+    {
+        // OAS 3.0 convention: `nullable: true` next to `enum: [...]` implies
+        // null is also valid. The pre-fix converter only rewrote `type` and
+        // left `enum` intact, causing opis to reject `null` against the enum.
+        $schema = [
+            'type' => 'string',
+            'nullable' => true,
+            'enum' => ['a', 'b'],
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_0);
+
+        $this->assertSame(['string', 'null'], $result['type']);
+        $this->assertContains(null, $result['enum']);
+        $this->assertCount(3, $result['enum']);
+    }
+
+    #[Test]
+    public function v30_nullable_with_enum_already_containing_null_unchanged(): void
+    {
+        $schema = [
+            'type' => 'string',
+            'nullable' => true,
+            'enum' => ['a', null, 'b'],
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_0);
+
+        // null is already present — do not duplicate.
+        $nullCount = 0;
+        foreach ($result['enum'] as $value) {
+            if ($value === null) {
+                $nullCount++;
+            }
+        }
+        $this->assertSame(1, $nullCount);
+    }
+
+    #[Test]
+    public function v30_nullable_with_enum_and_no_type_still_appends_null(): void
+    {
+        // `enum` alone (no explicit `type`) is valid OAS — null still becomes
+        // valid under nullable.
+        $schema = [
+            'nullable' => true,
+            'enum' => ['a', 'b'],
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_0);
+
+        $this->assertContains(null, $result['enum']);
+    }
+
+    // ========================================
+    // OAS 3.0 schema-level `examples` strip
+    // ========================================
+
+    #[Test]
+    public function v30_examples_keyword_stripped(): void
+    {
+        // `examples` (the JSON Schema array form) is a Draft 2020-12 keyword
+        // not understood by Draft 07. We strip it in 3.1; should also strip
+        // in 3.0 for consistency since `example` (singular) is already removed.
+        $schema = [
+            'type' => 'string',
+            'examples' => ['foo', 'bar'],
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_0);
+
+        $this->assertArrayNotHasKey('examples', $result);
+    }
+
+    // ========================================
+    // OAS 3.1 const lowered to enum (Draft 07)
+    // ========================================
+
+    #[Test]
+    public function v31_const_lowered_to_single_value_enum(): void
+    {
+        // Draft 07 doesn't support `const`. Lower to `enum: [value]` so opis
+        // actually enforces the value rather than silently passing.
+        $schema = [
+            'type' => 'string',
+            'const' => 'fixed',
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+
+        $this->assertArrayNotHasKey('const', $result);
+        $this->assertSame(['fixed'], $result['enum']);
+    }
+
+    #[Test]
+    public function v31_const_null_value_lowered_to_enum(): void
+    {
+        $schema = [
+            'const' => null,
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+
+        $this->assertArrayNotHasKey('const', $result);
+        $this->assertSame([null], $result['enum']);
+    }
+
+    #[Test]
+    public function v31_const_does_not_overwrite_existing_enum(): void
+    {
+        // If both keys are present the spec is malformed; preserve `enum` and
+        // drop `const` (the conservative choice — `enum` is the wider constraint).
+        $schema = [
+            'enum' => ['a', 'b'],
+            'const' => 'a',
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+
+        $this->assertSame(['a', 'b'], $result['enum']);
+        $this->assertArrayNotHasKey('const', $result);
+    }
+
+    // ========================================
+    // OAS 3.1 unsupported keywords (loud warning, not silent pass)
+    // ========================================
+
+    #[Test]
+    public function v31_pattern_properties_emits_warning(): void
+    {
+        // Draft 07 + opis ignore `patternProperties`, so a strict spec would
+        // silently pass any property keys. Surface this loudly via E_USER_WARNING.
+        $schema = [
+            'type' => 'object',
+            'patternProperties' => [
+                '^x-' => ['type' => 'string'],
+            ],
+        ];
+
+        $captured = null;
+        set_error_handler(static function (int $errno, string $errstr) use (&$captured): bool {
+            if ($errno === E_USER_WARNING) {
+                $captured = $errstr;
+
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertNotNull($captured);
+        $this->assertStringContainsString('patternProperties', (string) $captured);
+    }
+
+    #[Test]
+    public function v31_unevaluated_properties_emits_warning(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'unevaluatedProperties' => false,
+        ];
+
+        $captured = null;
+        set_error_handler(static function (int $errno, string $errstr) use (&$captured): bool {
+            if ($errno === E_USER_WARNING) {
+                $captured = $errstr;
+
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertNotNull($captured);
+        $this->assertStringContainsString('unevaluatedProperties', (string) $captured);
+    }
+
+    #[Test]
+    public function v31_each_unsupported_keyword_warns_at_most_once_per_run(): void
+    {
+        // Avoid log spam: warn once per process for a given keyword, not per
+        // call. The schema converter keeps an internal seen-set.
+        $schema = [
+            'type' => 'object',
+            'patternProperties' => ['^x-' => ['type' => 'string']],
+        ];
+
+        $count = 0;
+        set_error_handler(static function (int $errno) use (&$count): bool {
+            if ($errno === E_USER_WARNING) {
+                $count++;
+
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            OpenApiSchemaConverter::resetWarningStateForTesting();
+            OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+            OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+            OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+        } finally {
+            restore_error_handler();
+            OpenApiSchemaConverter::resetWarningStateForTesting();
+        }
+
+        $this->assertSame(1, $count);
     }
 }

--- a/tests/Unit/Spec/OpenApiSchemaConverterTest.php
+++ b/tests/Unit/Spec/OpenApiSchemaConverterTest.php
@@ -17,6 +17,22 @@ use function set_error_handler;
 
 class OpenApiSchemaConverterTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        // Reset the converter's "warned-once" set. The set is process-global,
+        // so without per-test reset the test ordering decides whether a
+        // warning fires. Run filters or test-suite reordering would otherwise
+        // produce non-deterministic outcomes for the warning tests below.
+        parent::setUp();
+        OpenApiSchemaConverter::resetWarningStateForTesting();
+    }
+
+    protected function tearDown(): void
+    {
+        OpenApiSchemaConverter::resetWarningStateForTesting();
+        parent::tearDown();
+    }
+
     // ========================================
     // OAS 3.0 tests
     // ========================================
@@ -825,10 +841,11 @@ class OpenApiSchemaConverterTest extends TestCase
     }
 
     #[Test]
-    public function v31_each_unsupported_keyword_warns_at_most_once_per_run(): void
+    public function repeated_calls_with_same_keyword_warn_only_once(): void
     {
         // Avoid log spam: warn once per process for a given keyword, not per
         // call. The schema converter keeps an internal seen-set.
+        // (setUp() already reset the state.)
         $schema = [
             'type' => 'object',
             'patternProperties' => ['^x-' => ['type' => 'string']],
@@ -846,15 +863,218 @@ class OpenApiSchemaConverterTest extends TestCase
         });
 
         try {
-            OpenApiSchemaConverter::resetWarningStateForTesting();
             OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
             OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
             OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
         } finally {
             restore_error_handler();
-            OpenApiSchemaConverter::resetWarningStateForTesting();
         }
 
         $this->assertSame(1, $count);
+    }
+
+    #[Test]
+    public function multiple_unsupported_keywords_on_same_schema_warn_independently(): void
+    {
+        // The dedup is per-keyword, not per-call. A schema declaring three
+        // unsupported keywords at once must surface three warnings, not one.
+        // Otherwise a future loop-with-break refactor would silently drop the
+        // 2nd/3rd warnings.
+        $schema = [
+            'type' => 'object',
+            'patternProperties' => ['^x-' => ['type' => 'string']],
+            'unevaluatedProperties' => false,
+            'contentMediaType' => 'application/json',
+        ];
+
+        $captured = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$captured): bool {
+            if ($errno === E_USER_WARNING) {
+                $captured[] = $errstr;
+
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertCount(3, $captured);
+    }
+
+    #[Test]
+    public function pattern_properties_emits_warning_for_oas_3_0_too(): void
+    {
+        // patternProperties has been a JSON Schema keyword since draft-3 and
+        // appears in OAS 3.0 specs in the wild. The fix must run for both
+        // versions — a 3.0-only silent pass is just as bad as the 3.1 case.
+        $schema = [
+            'type' => 'object',
+            'patternProperties' => ['^x-' => ['type' => 'string']],
+        ];
+
+        $captured = null;
+        set_error_handler(static function (int $errno, string $errstr) use (&$captured): bool {
+            if ($errno === E_USER_WARNING) {
+                $captured = $errstr;
+
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_0);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertNotNull($captured);
+        $this->assertStringContainsString('patternProperties', (string) $captured);
+    }
+
+    // ========================================
+    // OAS 3.1 examples-still-stripped (regression guard)
+    // ========================================
+
+    #[Test]
+    public function v31_examples_keyword_still_stripped(): void
+    {
+        // `examples` was moved from DRAFT_2020_12_KEYS into OPENAPI_COMMON_KEYS.
+        // The 3.1 path therefore reaches it through a different code branch
+        // than before. Pin the behaviour explicitly so a future refactor
+        // doesn't accidentally remove it from OPENAPI_COMMON_KEYS thinking
+        // it is a 3.1-only concern (and breaks 3.0 too).
+        $schema = [
+            'type' => 'string',
+            'examples' => ['foo', 'bar'],
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+
+        $this->assertArrayNotHasKey('examples', $result);
+    }
+
+    // ========================================
+    // Recursion: handlers must apply at every depth
+    // ========================================
+
+    #[Test]
+    public function v30_nullable_with_enum_appended_recursively_in_nested_property(): void
+    {
+        // Regression guard: handleNullable() runs on the outer schema only at
+        // the outermost convert(), but convertInPlace recurses through
+        // properties/items, so each subschema's nullable+enum should receive
+        // the same treatment at its own level.
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'status' => [
+                    'type' => 'string',
+                    'nullable' => true,
+                    'enum' => ['active', 'inactive'],
+                ],
+            ],
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_0);
+
+        $this->assertContains(null, $result['properties']['status']['enum']);
+    }
+
+    #[Test]
+    public function v30_nullable_with_enum_appended_recursively_in_array_items(): void
+    {
+        $schema = [
+            'type' => 'array',
+            'items' => [
+                'type' => 'string',
+                'nullable' => true,
+                'enum' => ['a', 'b'],
+            ],
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_0);
+
+        $this->assertContains(null, $result['items']['enum']);
+    }
+
+    #[Test]
+    public function v31_const_lowered_recursively_in_nested_property(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'kind' => [
+                    'const' => 'pet',
+                ],
+            ],
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+
+        $this->assertArrayNotHasKey('const', $result['properties']['kind']);
+        $this->assertSame(['pet'], $result['properties']['kind']['enum']);
+    }
+
+    #[Test]
+    public function v31_const_lowered_recursively_in_array_items(): void
+    {
+        $schema = [
+            'type' => 'array',
+            'items' => [
+                'const' => 'fixed',
+            ],
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+
+        $this->assertArrayNotHasKey('const', $result['items']);
+        $this->assertSame(['fixed'], $result['items']['enum']);
+    }
+
+    // ========================================
+    // Falsy / collection const values
+    // ========================================
+
+    #[Test]
+    public function v31_const_false_lowered_to_enum(): void
+    {
+        // `array_key_exists` correctly detects const: false; isset() would not.
+        // Pin the implementation choice with an explicit test.
+        $result = OpenApiSchemaConverter::convert(['const' => false], OpenApiVersion::V3_1);
+
+        $this->assertArrayNotHasKey('const', $result);
+        $this->assertSame([false], $result['enum']);
+    }
+
+    #[Test]
+    public function v31_const_zero_lowered_to_enum(): void
+    {
+        $result = OpenApiSchemaConverter::convert(['const' => 0], OpenApiVersion::V3_1);
+
+        $this->assertSame([0], $result['enum']);
+    }
+
+    #[Test]
+    public function v31_const_empty_string_lowered_to_enum(): void
+    {
+        $result = OpenApiSchemaConverter::convert(['const' => ''], OpenApiVersion::V3_1);
+
+        $this->assertSame([''], $result['enum']);
+    }
+
+    #[Test]
+    public function v31_const_empty_array_lowered_to_enum(): void
+    {
+        $result = OpenApiSchemaConverter::convert(['const' => []], OpenApiVersion::V3_1);
+
+        $this->assertSame([[]], $result['enum']);
     }
 }

--- a/tests/Unit/Validation/Support/ContentTypeMatcherTest.php
+++ b/tests/Unit/Validation/Support/ContentTypeMatcherTest.php
@@ -64,4 +64,83 @@ class ContentTypeMatcherTest extends TestCase
         $this->assertTrue(ContentTypeMatcher::isContentTypeInSpec('text/html', $content));
         $this->assertFalse(ContentTypeMatcher::isContentTypeInSpec('application/xml', $content));
     }
+
+    // ========================================
+    // Wildcard ranges (RFC 7231 / OpenAPI 3.x)
+    // ========================================
+
+    #[Test]
+    public function find_content_type_key_matches_type_wildcard(): void
+    {
+        $content = ['application/*' => []];
+
+        $this->assertSame('application/*', ContentTypeMatcher::findContentTypeKey('application/json', $content));
+        $this->assertSame('application/*', ContentTypeMatcher::findContentTypeKey('application/xml', $content));
+        $this->assertNull(ContentTypeMatcher::findContentTypeKey('text/html', $content));
+    }
+
+    #[Test]
+    public function find_content_type_key_matches_full_wildcard(): void
+    {
+        $content = ['*/*' => []];
+
+        $this->assertSame('*/*', ContentTypeMatcher::findContentTypeKey('application/json', $content));
+        $this->assertSame('*/*', ContentTypeMatcher::findContentTypeKey('text/html', $content));
+    }
+
+    #[Test]
+    public function find_content_type_key_prefers_exact_over_wildcard(): void
+    {
+        // Most-specific-first: an exact match must beat a `<type>/*` and `*/*`
+        // entry even if the wildcard appears earlier in iteration order.
+        $content = [
+            '*/*' => ['exists' => 'fallback'],
+            'application/*' => ['exists' => 'type-range'],
+            'application/json' => ['exists' => 'exact'],
+        ];
+
+        $this->assertSame('application/json', ContentTypeMatcher::findContentTypeKey('application/json', $content));
+    }
+
+    #[Test]
+    public function find_content_type_key_prefers_type_range_over_full_wildcard(): void
+    {
+        $content = [
+            '*/*' => [],
+            'application/*' => [],
+        ];
+
+        $this->assertSame('application/*', ContentTypeMatcher::findContentTypeKey('application/json', $content));
+    }
+
+    #[Test]
+    public function find_json_content_type_returns_type_wildcard_when_no_explicit_json(): void
+    {
+        // Pre-fix: an `application/*` spec entry would silently skip JSON
+        // schema validation because findJsonContentType only matched literal
+        // `application/json` or `+json` suffixes.
+        $content = ['application/*' => ['schema' => ['type' => 'string']]];
+
+        $this->assertSame('application/*', ContentTypeMatcher::findJsonContentType($content));
+    }
+
+    #[Test]
+    public function find_json_content_type_returns_full_wildcard_when_no_better_match(): void
+    {
+        $content = ['*/*' => ['schema' => ['type' => 'object']]];
+
+        $this->assertSame('*/*', ContentTypeMatcher::findJsonContentType($content));
+    }
+
+    #[Test]
+    public function find_json_content_type_prefers_explicit_json_over_wildcards(): void
+    {
+        $content = [
+            '*/*' => [],
+            'application/*' => [],
+            'application/json' => ['schema' => ['type' => 'string']],
+        ];
+
+        $this->assertSame('application/json', ContentTypeMatcher::findJsonContentType($content));
+    }
 }

--- a/tests/Unit/Validation/Support/ContentTypeMatcherTest.php
+++ b/tests/Unit/Validation/Support/ContentTypeMatcherTest.php
@@ -125,22 +125,48 @@ class ContentTypeMatcherTest extends TestCase
     }
 
     #[Test]
-    public function find_json_content_type_returns_full_wildcard_when_no_better_match(): void
+    public function find_json_content_type_does_not_return_full_wildcard(): void
     {
+        // `*&#47;*` covers everything (binary, image, html). Returning it from a
+        // method whose contract is "find a JSON-validatable spec key" would let
+        // ResponseBodyValidator validate non-JSON bodies as JSON when the response
+        // omits Content-Type. Conservative: skip JSON validation rather than
+        // pretend `*&#47;*` means JSON.
         $content = ['*/*' => ['schema' => ['type' => 'object']]];
 
-        $this->assertSame('*/*', ContentTypeMatcher::findJsonContentType($content));
+        $this->assertNull(ContentTypeMatcher::findJsonContentType($content));
     }
 
     #[Test]
-    public function find_json_content_type_prefers_explicit_json_over_wildcards(): void
+    public function find_json_content_type_does_not_return_non_json_type_ranges(): void
+    {
+        // `text/*`, `image/*`, `multipart/*` cannot plausibly carry a JSON body.
+        // findJsonContentType must not return them — pre-fix, the broad
+        // `<type>/*` accept introduced a NEW silent pass: a spec declaring only
+        // `text/*` would route through JSON schema validation.
+        $textOnly = ['text/*' => ['schema' => ['type' => 'string']]];
+        $this->assertNull(ContentTypeMatcher::findJsonContentType($textOnly));
+
+        $imageOnly = ['image/*' => ['schema' => ['type' => 'string']]];
+        $this->assertNull(ContentTypeMatcher::findJsonContentType($imageOnly));
+    }
+
+    #[Test]
+    public function find_json_content_type_prefers_explicit_json_over_application_wildcard(): void
     {
         $content = [
-            '*/*' => [],
             'application/*' => [],
             'application/json' => ['schema' => ['type' => 'string']],
         ];
 
         $this->assertSame('application/json', ContentTypeMatcher::findJsonContentType($content));
+    }
+
+    #[Test]
+    public function find_json_content_type_matches_application_wildcard_case_insensitively(): void
+    {
+        $content = ['Application/*' => ['schema' => ['type' => 'object']]];
+
+        $this->assertSame('Application/*', ContentTypeMatcher::findJsonContentType($content));
     }
 }


### PR DESCRIPTION
# 概要

v1.0.0 リリース前の徹底調査 (競合比較 + 既存コード review + OpenAPI 仕様カバレッジ監査) で見つかった silent-pass バグ群と、API 安定化のための `@internal` マーカ付与をまとめた hardening PR。

## 変更内容

### Critical bug fixes — silent passes になっていた挙動

スキーマ変換器 (`OpenApiSchemaConverter`):

- **`nullable: true` + `enum`** → `enum` に `null` を補完。これまで `type` のみ書き換えられ、`enum: ["a", "b"]` + `nullable: true` で `null` が opis に reject されていた (OAS 3.0 慣例違反)
- **`examples` (3.0)** → 3.1 同様に削除。`example` (単数) は両 version で削除済みだったが `examples` (Draft 2020-12 array) は 3.0 で残っていた
- **`const` (3.1)** → `enum: [value]` に lower。Draft 07 は `const` を sileent ignore するため、`const: "fixed"` でも型が合えば全値 pass していた
- **`patternProperties` / `unevaluatedProperties` / `unevaluatedItems` / `contentMediaType` / `contentEncoding` (3.1)** → 初回検出時に `E_USER_WARNING` を一発発火。これらは opis Draft 07 が解釈できず silent ignore されるため、契約テストが拘束していない値を pass させる worst-case な silent failure だった

Content-type matcher:

- **wildcard range サポート** → `findContentTypeKey()` / `findJsonContentType()` が most-specific-first 優先順位で解決: 完全一致 → `<type>/*` → `*/*`。これまで literal 比較しかしておらず、OpenAPI 3.x §4.7.10 が認める range (`application/*`, `*/*`) を spec が使うと JSON schema validation が silent skip されていた

### API stability — v1.0.0 で凍結する範囲を明示

`@internal` を付与:
- `OpenApiSpecLoader::clearCache()` / `evict()` / `reset()`
- `OpenApiCoverageTracker::reset()` / `exportState()` / `importState()`
- `ValidatesOpenApiSchema::resetValidatorCache()`

これらは PHPUnit extension / paratest sidecar protocol のために `public` を維持しつつ、user-facing API には含めない宣言。

### Documentation

README に **"Supported features and known limitations"** セクションを追加。

- Body validation: JSON / `+json` / wildcard range のみ schema 検証, 他は presence-only
- Parameter styles: `form`+`explode:true` (query), `simple` scalar (path/header) のみ
- Security: `apiKey`, `http: bearer` のみ。OAuth2 / OIDC / mTLS は silent pass (要明示)
- Schema features: 検証 / lower / strip / 非対応 (loud warn) を網羅
- HTTP methods: coverage は GET/POST/PUT/PATCH/DELETE のみカウント
- 非対応: webhooks (3.1), callbacks, links, server URL templating, `discriminator.mapping`

silent-pass を見つけにくくする (= 良い契約テストを難しくする) 一番の理由は "サポート範囲が暗黙だったこと" だったため、v1.0.0 までに必ず明示しておく。

## 関連情報

- v1.0.0 リリース準備の一環 (issue #113)
- 競合との比較で見つかった差分: `discriminator.mapping`, `oneOf`/`anyOf` fuzz 拡張, Symfony adapter, Pest plugin は v1.1+ に deferred (本 PR の scope 外)

## 検証

- 全 1039 tests pass
- PHPStan level 6: 0 errors
- PHP-CS-Fixer: 0 violations

## Test plan

- [x] `vendor/bin/phpunit` (1039 / 1039)
- [x] `vendor/bin/phpstan analyse`
- [x] `vendor/bin/php-cs-fixer fix --dry-run`
- [ ] CI matrix (PHP 8.2-8.4 × PHPUnit 11-13)