### PR TITLE
feat(security): warn loudly on oauth2 / openIdConnect / mutualTLS / http-basic silent pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,16 @@ the public API without those leaking into the SemVer contract.
   Specs using OpenAPI 3.x §4.7.10 media-type ranges previously skipped
   JSON schema validation silently because the matcher only compared
   literally.
+- **Security validator — `oauth2` / `openIdConnect` / `mutualTLS` / `http`
+  (non-`bearer`) silent-pass** now emits a one-shot `E_USER_WARNING` per
+  scheme name on first encounter. The validator continues to silently pass
+  requirements containing only these schemes (false-negative avoidance —
+  blocking a test for a spec we cannot evaluate is worse than letting it
+  through), but the warning surfaces the limitation so a green test against
+  an unauthenticated request does not stay invisible. This is the
+  worst-class silent failure for a contract-testing tool, and matches the
+  schema-converter precedent of warning loudly when a constraint is not
+  being enforced. Closes #146.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ class SecureEndpointTest extends TestCase
 Notes:
 
 - **View-only rewrite**: the Symfony `Request` itself is not modified; Laravel has already dispatched by the time the trait runs. The inject exists purely to prevent the security check from false-failing.
-- **Bearer only**: `apiKey` and `oauth2` endpoints are not affected (the header name for `apiKey` is arbitrary per spec; `oauth2` is classified as unsupported in phase 1 anyway).
+- **Bearer only**: `apiKey` and `oauth2` endpoints are not affected (the header name for `apiKey` is arbitrary per spec; `oauth2` is classified as unsupported anyway).
 - **Never overrides user values**: if the test already set an `Authorization` header (in any case), the user's value wins.
 - **Requires `auto_validate_request=true`** — the inject is a sub-feature of request validation. Setting the inject flag alone has no effect.
 
@@ -960,14 +960,10 @@ This is a contract-testing tool: where we can't enforce a constraint precisely, 
 
 ### Security schemes
 - **Validated**: `apiKey` (in `header` / `query` / `cookie`) and `http` + `bearer` — presence checks for the named header/query/cookie / RFC 6750 `Bearer` token.
-- **Loud `E_USER_WARNING` on first encounter**: `oauth2`, `openIdConnect`, `mutualTLS`, and `http` schemes other than `bearer` (`basic`, `digest`). When every scheme in a security requirement is unsupported the requirement still passes (false-negative avoidance — blocking the test for a spec we cannot evaluate is worse than letting it through), but the validator fires a one-shot per-scheme-name warning so the silent pass does not stay invisible:
+- **Loud `E_USER_WARNING` on first encounter**: `oauth2`, `openIdConnect`, `mutualTLS`, and `http` schemes other than `bearer` (`basic`, `digest`). When every scheme in a security requirement is unsupported the requirement still passes (false-negative avoidance — blocking the test for a spec we cannot evaluate is worse than letting it through), but the validator fires a one-shot per-scheme-name warning so the silent pass does not stay invisible. The warning is emitted as a single line (shown wrapped here for readability):
 
   ```
-  [security] OAuth2 scheme 'oauth2_user' is silently passed (no token check) — POST /v1/users.
-  The opis/json-schema-based validator cannot verify oauth2 / openIdConnect / mutualTLS /
-  http-basic / http-digest credentials. Your test will not detect a missing or invalid token.
-  Workaround: split the bearer-token surface into a separate test, or assert the
-  Authorization header presence manually.
+  [security] OAuth2 scheme 'oauth2_user' is silently passed (no token check) — POST /v1/users. The opis/json-schema-based validator cannot verify oauth2 / openIdConnect / mutualTLS / http-basic / http-digest credentials. Your test will not detect a missing or invalid token. Workaround: split the bearer-token surface into a separate test, or assert the Authorization header presence manually.
   ```
 
   Under `phpunit.xml` `failOnWarning="true"` this surfaces as a test failure on first encounter — the recommended setting if your spec contains any of these scheme types, since green tests against unauthenticated requests are the worst-class silent failure for a contract-testing tool.

--- a/README.md
+++ b/README.md
@@ -960,7 +960,17 @@ This is a contract-testing tool: where we can't enforce a constraint precisely, 
 
 ### Security schemes
 - **Validated**: `apiKey` (in `header` / `query` / `cookie`) and `http` + `bearer` — presence checks for the named header/query/cookie / RFC 6750 `Bearer` token.
-- **Silently passed through**: `oauth2`, `openIdConnect`, `mutualTLS`, and `http` schemes other than `bearer` (`basic`, `digest`). When every scheme in a security requirement is unsupported, the requirement passes — your test will not detect a missing or invalid token.
+- **Loud `E_USER_WARNING` on first encounter**: `oauth2`, `openIdConnect`, `mutualTLS`, and `http` schemes other than `bearer` (`basic`, `digest`). When every scheme in a security requirement is unsupported the requirement still passes (false-negative avoidance — blocking the test for a spec we cannot evaluate is worse than letting it through), but the validator fires a one-shot per-scheme-name warning so the silent pass does not stay invisible:
+
+  ```
+  [security] OAuth2 scheme 'oauth2_user' is silently passed (no token check) — POST /v1/users.
+  The opis/json-schema-based validator cannot verify oauth2 / openIdConnect / mutualTLS /
+  http-basic / http-digest credentials. Your test will not detect a missing or invalid token.
+  Workaround: split the bearer-token surface into a separate test, or assert the
+  Authorization header presence manually.
+  ```
+
+  Under `phpunit.xml` `failOnWarning="true"` this surfaces as a test failure on first encounter — the recommended setting if your spec contains any of these scheme types, since green tests against unauthenticated requests are the worst-class silent failure for a contract-testing tool.
 
 ### Schema features
 - **Validated** (delegated to opis Draft 07): `type`, `enum`, `multipleOf`, `minimum`/`maximum`/`exclusiveMinimum`/`exclusiveMaximum`, `minLength`/`maxLength`/`pattern`, `minItems`/`maxItems`/`uniqueItems`, `minProperties`/`maxProperties`/`required`, `additionalProperties` (`true` / `false` / schema), `allOf` / `oneOf` / `anyOf` / `not`, plus `format` for opis's built-in formats (`uuid`, `email`, `date`, `date-time`, `uri`, `ipv4`, `ipv6`, `hostname`).

--- a/src/Validation/Request/SchemeClassification.php
+++ b/src/Validation/Request/SchemeClassification.php
@@ -5,15 +5,22 @@ declare(strict_types=1);
 namespace Studio\OpenApiContractTesting\Validation\Request;
 
 /**
- * Immutable result of classifying a security scheme definition. The `$reason`
- * field is populated only when `$kind` is {@see SchemeKind::Malformed}, and
- * carries a human-readable explanation that {@see SecurityValidator} embeds
- * in its error output so the spec author can locate the offending field.
+ * Immutable result of classifying a security scheme definition.
+ *
+ * - `$reason` is populated only when `$kind` is {@see SchemeKind::Malformed},
+ *   and carries a human-readable explanation that {@see SecurityValidator}
+ *   embeds in its error output so the spec author can locate the offending
+ *   field.
+ * - `$unsupportedTypeLabel` is populated only when `$kind` is
+ *   {@see SchemeKind::Unsupported}, and carries the display label
+ *   ({@see SecurityValidator::warnIfFirstEncounter()} embeds it in the
+ *   silent-pass warning, e.g. `OAuth2`, `OpenID Connect`, `http-basic`).
  */
 final readonly class SchemeClassification
 {
     public function __construct(
         public SchemeKind $kind,
         public ?string $reason = null,
+        public ?string $unsupportedTypeLabel = null,
     ) {}
 }

--- a/src/Validation/Request/SchemeClassification.php
+++ b/src/Validation/Request/SchemeClassification.php
@@ -7,20 +7,44 @@ namespace Studio\OpenApiContractTesting\Validation\Request;
 /**
  * Immutable result of classifying a security scheme definition.
  *
- * - `$reason` is populated only when `$kind` is {@see SchemeKind::Malformed},
- *   and carries a human-readable explanation that {@see SecurityValidator}
- *   embeds in its error output so the spec author can locate the offending
- *   field.
- * - `$unsupportedTypeLabel` is populated only when `$kind` is
- *   {@see SchemeKind::Unsupported}, and carries the display label
- *   ({@see SecurityValidator::warnIfFirstEncounter()} embeds it in the
- *   silent-pass warning, e.g. `OAuth2`, `OpenID Connect`, `http-basic`).
+ * Construct only via the named factories — `bearer()` / `apiKey()` /
+ * `malformed()` / `unsupported()` — so the kind-discriminated payload
+ * invariant is enforced in code rather than maintained by convention:
+ *
+ * - `Malformed`   → `$reason` populated, `$unsupportedTypeLabel` null.
+ *   `$reason` is a human-readable explanation pinpointing the broken
+ *   spec field.
+ * - `Unsupported` → `$unsupportedTypeLabel` populated, `$reason` null.
+ *   `$unsupportedTypeLabel` is the display label used in the silent-pass
+ *   warning (e.g. `OAuth2`, `OpenID Connect`, `Mutual TLS`, `http-basic`,
+ *   `http-digest`).
+ * - `Bearer` / `ApiKey` → both fields null.
  */
 final readonly class SchemeClassification
 {
-    public function __construct(
+    private function __construct(
         public SchemeKind $kind,
         public ?string $reason = null,
         public ?string $unsupportedTypeLabel = null,
     ) {}
+
+    public static function bearer(): self
+    {
+        return new self(SchemeKind::Bearer);
+    }
+
+    public static function apiKey(): self
+    {
+        return new self(SchemeKind::ApiKey);
+    }
+
+    public static function malformed(string $reason): self
+    {
+        return new self(SchemeKind::Malformed, reason: $reason);
+    }
+
+    public static function unsupported(string $typeLabel): self
+    {
+        return new self(SchemeKind::Unsupported, unsupportedTypeLabel: $typeLabel);
+    }
 }

--- a/src/Validation/Request/SchemeKind.php
+++ b/src/Validation/Request/SchemeKind.php
@@ -8,10 +8,12 @@ namespace Studio\OpenApiContractTesting\Validation\Request;
  * Classification result produced by {@see SecurityValidator::classifyScheme()}.
  *
  * - `Bearer` / `ApiKey` — well-formed schemes that this library can validate.
- * - `Unsupported`       — well-formed but intentionally deferred for phase 1
+ * - `Unsupported`       — well-formed but the validator cannot enforce them
  *                         (oauth2, openIdConnect, mutualTLS, http+non-bearer).
  *                         A requirement entry containing any `Unsupported`
- *                         scheme is skipped entirely to avoid false negatives.
+ *                         scheme is skipped entirely to avoid false negatives,
+ *                         but a loud one-shot warning is emitted so the
+ *                         silent pass does not stay invisible.
  * - `Malformed`         — the spec declaration is broken (missing fields or
  *                         an unknown `type`). Always surfaced as a hard error
  *                         so the spec author is pushed to fix it, even if a

--- a/src/Validation/Request/SecurityValidator.php
+++ b/src/Validation/Request/SecurityValidator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Validation\Request;
 
+use const E_USER_WARNING;
+
 use Studio\OpenApiContractTesting\Validation\Support\HeaderNormalizer;
 
 use function array_key_exists;
@@ -16,15 +18,35 @@ use function is_string;
 use function preg_match;
 use function sprintf;
 use function strtolower;
+use function trigger_error;
 
 final class SecurityValidator
 {
+    /** @var array<string, true> */
+    private static array $warnedSchemeNames = [];
+
+    /**
+     * Reset the per-process "already-warned" set used by
+     * {@see warnIfFirstEncounter()}. Test seam — production code never needs
+     * this. The convention mirrors {@see OpenApiSchemaConverter}'s same-named
+     * method so test setUp/tearDown patterns stay symmetric across the codebase.
+     *
+     * @internal
+     */
+    public static function resetWarningStateForTesting(): void
+    {
+        self::$warnedSchemeNames = [];
+    }
+
     /**
      * Validate the endpoint's `security` requirement against the incoming
      * request. Supports `http` + `bearer` and `apiKey` (in: header|query|cookie)
-     * schemes. OAuth2 / OpenID Connect are out of scope for phase 1 and are
-     * treated as unsupported: any requirement entry containing an unsupported
-     * scheme is skipped entirely (contributes neither pass nor fail).
+     * schemes. OAuth2 / OpenID Connect / mutualTLS / `http` + `basic` /
+     * `http` + `digest` are out of scope: any requirement entry containing one
+     * of these is skipped entirely (contributes neither pass nor fail) AND
+     * triggers a one-shot {@see E_USER_WARNING} per scheme name to surface the
+     * silent-pass to users — a green test against an unauthenticated request
+     * is the worst-class failure mode for a contract-testing tool.
      *
      * Resolution: operation-level `security` takes precedence; otherwise the
      * root-level `security` is inherited. `security: []` (empty array) explicitly
@@ -163,6 +185,12 @@ final class SecurityValidator
                 }
 
                 if ($classification->kind === SchemeKind::Unsupported) {
+                    self::warnIfFirstEncounter(
+                        $schemeName,
+                        $classification->unsupportedTypeLabel ?? 'unknown',
+                        $method,
+                        $matchedPath,
+                    );
                     $entryHasUnsupported = true;
 
                     continue;
@@ -225,6 +253,45 @@ final class SecurityValidator
     }
 
     /**
+     * Issue a one-shot E_USER_WARNING for security schemes the validator
+     * cannot enforce (`oauth2`, `openIdConnect`, `mutualTLS`,
+     * `http` + non-`bearer`). Without this, requirement entries containing
+     * only unsupported schemes silently pass — a green test against an
+     * unauthenticated request misleads users into thinking the endpoint is
+     * actually verified.
+     *
+     * Dedup is per `components.securitySchemes` key, not per type: a spec
+     * that defines both `oauth2_user` and `oauth2_admin` will warn twice (once
+     * each), so users can see how many silent-pass schemes exist in their spec.
+     */
+    private static function warnIfFirstEncounter(
+        string $schemeName,
+        string $typeLabel,
+        string $method,
+        string $matchedPath,
+    ): void {
+        if (isset(self::$warnedSchemeNames[$schemeName])) {
+            return;
+        }
+
+        self::$warnedSchemeNames[$schemeName] = true;
+        trigger_error(
+            sprintf(
+                "[security] %s scheme '%s' is silently passed (no token check) — %s %s. "
+                    . 'The opis/json-schema-based validator cannot verify oauth2 / openIdConnect / '
+                    . 'mutualTLS / http-basic / http-digest credentials. Your test will not detect '
+                    . 'a missing or invalid token. Workaround: split the bearer-token surface into '
+                    . 'a separate test, or assert the Authorization header presence manually.',
+                $typeLabel,
+                $schemeName,
+                $method,
+                $matchedPath,
+            ),
+            E_USER_WARNING,
+        );
+    }
+
+    /**
      * Classify a security scheme definition. {@see SchemeKind} documents the
      * four outcomes; the `$reason` field of the returned classification is
      * populated only for `Malformed` to explain which spec field is broken.
@@ -261,12 +328,23 @@ final class SecurityValidator
                 return new SchemeClassification(SchemeKind::Bearer);
             }
 
-            // http + basic / digest / etc. are well-formed but phase 1 cannot validate them.
-            return new SchemeClassification(SchemeKind::Unsupported);
+            // http + basic / digest / etc. are well-formed but the validator
+            // cannot verify them. Label normalises arbitrary scheme names to
+            // `http-<lowercased>` (RFC 7235 schemes are case-insensitive).
+            return new SchemeClassification(
+                SchemeKind::Unsupported,
+                unsupportedTypeLabel: 'http-' . strtolower($scheme),
+            );
         }
 
-        if ($type === 'oauth2' || $type === 'openIdConnect' || $type === 'mutualTLS') {
-            return new SchemeClassification(SchemeKind::Unsupported);
+        if ($type === 'oauth2') {
+            return new SchemeClassification(SchemeKind::Unsupported, unsupportedTypeLabel: 'OAuth2');
+        }
+        if ($type === 'openIdConnect') {
+            return new SchemeClassification(SchemeKind::Unsupported, unsupportedTypeLabel: 'OpenID Connect');
+        }
+        if ($type === 'mutualTLS') {
+            return new SchemeClassification(SchemeKind::Unsupported, unsupportedTypeLabel: 'Mutual TLS');
         }
 
         return new SchemeClassification(

--- a/src/Validation/Request/SecurityValidator.php
+++ b/src/Validation/Request/SecurityValidator.php
@@ -19,6 +19,7 @@ use function preg_match;
 use function sprintf;
 use function strtolower;
 use function trigger_error;
+use function trim;
 
 final class SecurityValidator
 {
@@ -40,28 +41,21 @@ final class SecurityValidator
 
     /**
      * Validate the endpoint's `security` requirement against the incoming
-     * request. Supports `http` + `bearer` and `apiKey` (in: header|query|cookie)
-     * schemes. OAuth2 / OpenID Connect / mutualTLS / `http` + `basic` /
-     * `http` + `digest` are out of scope: any requirement entry containing one
-     * of these is skipped entirely (contributes neither pass nor fail) AND
-     * triggers a one-shot {@see E_USER_WARNING} per scheme name to surface the
-     * silent-pass to users — a green test against an unauthenticated request
-     * is the worst-class failure mode for a contract-testing tool.
+     * request. The supported / unsupported / malformed scheme partition is
+     * defined by {@see classifyScheme()}; entries containing an unsupported
+     * scheme are skipped (contributes neither pass nor fail) and emit a
+     * one-shot per-scheme-name {@see E_USER_WARNING} so the silent pass does
+     * not stay invisible. Malformed entries are always surfaced as hard
+     * errors so the spec author is pushed to fix the broken declaration.
      *
      * Resolution: operation-level `security` takes precedence; otherwise the
-     * root-level `security` is inherited. `security: []` (empty array) explicitly
-     * opts out of all authentication, so it returns `[]` immediately regardless
-     * of root-level definitions. Missing `security` on both levels also returns
-     * `[]` (no authentication required).
+     * root-level `security` is inherited. `security: []` (empty array)
+     * explicitly opts out of all authentication. Missing `security` on both
+     * levels also returns `[]` (no authentication required).
      *
-     * OR / AND semantics (per OpenAPI):
+     * OR / AND semantics (per OpenAPI 3.x):
      * - Multiple entries in the `security` array → OR (any one satisfied is enough)
      * - Multiple schemes within a single entry object → AND (all must be satisfied)
-     *
-     * Malformed spec elements (undefined scheme references, scalar entries,
-     * missing `type` / `scheme` / `name` / `in` fields) are always surfaced as
-     * hard errors, even if another requirement entry is satisfied — a broken
-     * security declaration is something the spec author must fix.
      *
      * @param array<string, mixed> $spec full spec root (for `components.securitySchemes` + root-level `security`)
      * @param array<string, mixed> $operation operation spec (for operation-level `security`)
@@ -185,12 +179,9 @@ final class SecurityValidator
                 }
 
                 if ($classification->kind === SchemeKind::Unsupported) {
-                    self::warnIfFirstEncounter(
-                        $schemeName,
-                        $classification->unsupportedTypeLabel ?? 'unknown',
-                        $method,
-                        $matchedPath,
-                    );
+                    /** @var string $typeLabel */
+                    $typeLabel = $classification->unsupportedTypeLabel;
+                    self::warnIfFirstEncounter($schemeName, $typeLabel, $method, $matchedPath);
                     $entryHasUnsupported = true;
 
                     continue;
@@ -302,53 +293,54 @@ final class SecurityValidator
     {
         $type = $schemeDef['type'] ?? null;
         if (!is_string($type) || $type === '') {
-            return new SchemeClassification(SchemeKind::Malformed, "missing required 'type' field.");
+            return SchemeClassification::malformed("missing required 'type' field.");
         }
 
         if ($type === 'apiKey') {
             $in = $schemeDef['in'] ?? null;
             $name = $schemeDef['name'] ?? null;
             if (!is_string($in) || !is_string($name)) {
-                return new SchemeClassification(SchemeKind::Malformed, "apiKey scheme requires string 'in' and 'name' fields.");
+                return SchemeClassification::malformed("apiKey scheme requires string 'in' and 'name' fields.");
             }
             if (!in_array($in, ['header', 'query', 'cookie'], true)) {
-                return new SchemeClassification(SchemeKind::Malformed, "apiKey scheme 'in' must be one of header|query|cookie, got '{$in}'.");
+                return SchemeClassification::malformed("apiKey scheme 'in' must be one of header|query|cookie, got '{$in}'.");
             }
 
-            return new SchemeClassification(SchemeKind::ApiKey);
+            return SchemeClassification::apiKey();
         }
 
         if ($type === 'http') {
             $scheme = $schemeDef['scheme'] ?? null;
-            if (!is_string($scheme)) {
-                return new SchemeClassification(SchemeKind::Malformed, "http scheme requires a string 'scheme' field (e.g. 'bearer', 'basic').");
+            if (!is_string($scheme) || trim($scheme) === '') {
+                // Reject empty / whitespace-only `scheme` as malformed: the
+                // OAS spec requires the field to name an HTTP authentication
+                // scheme (e.g. "bearer", "basic"), and an empty value would
+                // otherwise fall through to Unsupported with a meaningless
+                // label like "http-".
+                return SchemeClassification::malformed("http scheme requires a non-empty string 'scheme' field (e.g. 'bearer', 'basic').");
             }
 
             if (strtolower($scheme) === 'bearer') {
-                return new SchemeClassification(SchemeKind::Bearer);
+                return SchemeClassification::bearer();
             }
 
             // http + basic / digest / etc. are well-formed but the validator
             // cannot verify them. Label normalises arbitrary scheme names to
             // `http-<lowercased>` (RFC 7235 schemes are case-insensitive).
-            return new SchemeClassification(
-                SchemeKind::Unsupported,
-                unsupportedTypeLabel: 'http-' . strtolower($scheme),
-            );
+            return SchemeClassification::unsupported('http-' . strtolower($scheme));
         }
 
         if ($type === 'oauth2') {
-            return new SchemeClassification(SchemeKind::Unsupported, unsupportedTypeLabel: 'OAuth2');
+            return SchemeClassification::unsupported('OAuth2');
         }
         if ($type === 'openIdConnect') {
-            return new SchemeClassification(SchemeKind::Unsupported, unsupportedTypeLabel: 'OpenID Connect');
+            return SchemeClassification::unsupported('OpenID Connect');
         }
         if ($type === 'mutualTLS') {
-            return new SchemeClassification(SchemeKind::Unsupported, unsupportedTypeLabel: 'Mutual TLS');
+            return SchemeClassification::unsupported('Mutual TLS');
         }
 
-        return new SchemeClassification(
-            SchemeKind::Malformed,
+        return SchemeClassification::malformed(
             "unknown type '{$type}' — OpenAPI 3.x enumerates apiKey|http|oauth2|openIdConnect|mutualTLS.",
         );
     }

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -21,6 +21,7 @@ use function implode;
 use function restore_error_handler;
 use function set_error_handler;
 use function str_contains;
+use function str_starts_with;
 use function strtolower;
 
 class OpenApiRequestValidatorTest extends TestCase
@@ -3007,17 +3008,22 @@ class OpenApiRequestValidatorTest extends TestCase
     }
 
     /**
-     * Run a callable while suppressing E_USER_WARNING. Used by tests that
-     * exercise oauth2 / openIdConnect / mutualTLS / http-basic / http-digest
-     * endpoints — these now fire a one-shot per-scheme silent-pass warning
-     * (issue #146). The warning *contents* are covered by SecurityValidatorTest;
-     * the integration tests here only verify the {@see OpenApiRequestValidator}
-     * return value, so the warning is captured-and-discarded.
+     * Run a callable while suppressing the silent-pass `[security]`
+     * `E_USER_WARNING` emitted for oauth2 / openIdConnect / mutualTLS /
+     * http-basic / http-digest endpoints. Warning *contents* are covered by
+     * `SecurityValidatorTest`; the integration tests here only verify the
+     * {@see OpenApiRequestValidator} return value, so the warning is
+     * captured-and-discarded.
+     *
+     * Filter is intent-driven: only warnings starting with `[security]` are
+     * absorbed. Unrelated `E_USER_WARNING`s (e.g. a future deprecation in
+     * the validator pipeline) bubble up so they cannot silently pass — the
+     * exact pattern this PR was created to prevent.
      */
     private function suppressSilentPassWarning(callable $fn): mixed
     {
-        set_error_handler(static function (int $errno): bool {
-            return $errno === E_USER_WARNING;
+        set_error_handler(static function (int $errno, string $errstr): bool {
+            return $errno === E_USER_WARNING && str_starts_with($errstr, '[security]');
         });
 
         try {

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -4,17 +4,22 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Tests\Unit;
 
+use const E_USER_WARNING;
+
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Studio\OpenApiContractTesting\OpenApiRequestValidator;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\Validation\Request\SecurityValidator;
 
 use function array_filter;
 use function fclose;
 use function fopen;
 use function implode;
+use function restore_error_handler;
+use function set_error_handler;
 use function str_contains;
 use function strtolower;
 
@@ -28,11 +33,19 @@ class OpenApiRequestValidatorTest extends TestCase
         OpenApiSpecLoader::reset();
         OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs');
         $this->validator = new OpenApiRequestValidator();
+        // Several integration-style tests below exercise oauth2 / openIdConnect
+        // endpoints that now fire a one-shot E_USER_WARNING per scheme name.
+        // Reset so each test starts with a clean warning ledger and run order
+        // does not affect outcomes. SecurityValidatorTest covers the warning
+        // contents; the tests here only check the silent-pass return value,
+        // so warnings are captured-and-discarded per test where necessary.
+        SecurityValidator::resetWarningStateForTesting();
     }
 
     protected function tearDown(): void
     {
         OpenApiSpecLoader::reset();
+        SecurityValidator::resetWarningStateForTesting();
         parent::tearDown();
     }
 
@@ -2457,7 +2470,7 @@ class OpenApiRequestValidatorTest extends TestCase
         // When every requirement entry contains only unsupported schemes
         // (oauth2 / openIdConnect) we have nothing we can validate — pass
         // rather than block the test (false-negative avoidance).
-        $result = $this->validator->validate(
+        $result = $this->suppressSilentPassWarning(fn() => $this->validator->validate(
             'petstore-3.0',
             'GET',
             '/v1/secure/oauth2-only',
@@ -2465,7 +2478,7 @@ class OpenApiRequestValidatorTest extends TestCase
             [],
             null,
             null,
-        );
+        ));
 
         $this->assertTrue($result->isValid(), $result->errorMessage());
     }
@@ -2492,7 +2505,7 @@ class OpenApiRequestValidatorTest extends TestCase
         // Bearer entry is validatable and fails; OAuth2 entry is skipped.
         // Since the only validatable entry failed and no other entry passed,
         // overall result is fail.
-        $result = $this->validator->validate(
+        $result = $this->suppressSilentPassWarning(fn() => $this->validator->validate(
             'petstore-3.0',
             'GET',
             '/v1/secure/bearer-or-oauth2',
@@ -2500,7 +2513,7 @@ class OpenApiRequestValidatorTest extends TestCase
             [],
             null,
             null,
-        );
+        ));
 
         $this->assertFalse($result->isValid());
         $this->assertStringContainsString('[security]', $result->errorMessage());
@@ -2756,7 +2769,7 @@ class OpenApiRequestValidatorTest extends TestCase
     #[Test]
     public function v31_security_oauth2_only_silent_skips(): void
     {
-        $result = $this->validator->validate(
+        $result = $this->suppressSilentPassWarning(fn() => $this->validator->validate(
             'petstore-3.1',
             'GET',
             '/v1/secure/oauth2-only',
@@ -2764,7 +2777,7 @@ class OpenApiRequestValidatorTest extends TestCase
             [],
             null,
             null,
-        );
+        ));
 
         $this->assertTrue($result->isValid(), $result->errorMessage());
     }
@@ -2871,7 +2884,7 @@ class OpenApiRequestValidatorTest extends TestCase
         // Two entries (oauth2 + oidc) are both unsupported. With no validatable
         // entries remaining, overall result must be pass — prevents a regression
         // where "no satisfied entry" is conflated with "no evaluable entry".
-        $result = $this->validator->validate(
+        $result = $this->suppressSilentPassWarning(fn() => $this->validator->validate(
             'security-edge-cases',
             'GET',
             '/two-unsupported-entries',
@@ -2879,7 +2892,7 @@ class OpenApiRequestValidatorTest extends TestCase
             [],
             null,
             null,
-        );
+        ));
 
         $this->assertTrue($result->isValid(), $result->errorMessage());
     }
@@ -2892,7 +2905,7 @@ class OpenApiRequestValidatorTest extends TestCase
         // as unevaluable (we cannot check oauth2, so we cannot confirm AND).
         // Overall result: pass. Pins the documented tradeoff so a future policy
         // change is an explicit decision, not an accidental regression.
-        $result = $this->validator->validate(
+        $result = $this->suppressSilentPassWarning(fn() => $this->validator->validate(
             'security-edge-cases',
             'GET',
             '/and-with-unsupported',
@@ -2900,7 +2913,7 @@ class OpenApiRequestValidatorTest extends TestCase
             [],
             null,
             null,
-        );
+        ));
 
         $this->assertTrue($result->isValid(), $result->errorMessage());
     }
@@ -2991,5 +3004,26 @@ class OpenApiRequestValidatorTest extends TestCase
         $this->assertStringContainsString('[path.id]', $joined, 'path-param error must survive body throw');
         $this->assertStringContainsString('[request-body]', $joined, 'body throw must surface as boundary error');
         $this->assertStringContainsString('InvalidKeywordException', $joined, 'exception class name preserved for diagnostics');
+    }
+
+    /**
+     * Run a callable while suppressing E_USER_WARNING. Used by tests that
+     * exercise oauth2 / openIdConnect / mutualTLS / http-basic / http-digest
+     * endpoints — these now fire a one-shot per-scheme silent-pass warning
+     * (issue #146). The warning *contents* are covered by SecurityValidatorTest;
+     * the integration tests here only verify the {@see OpenApiRequestValidator}
+     * return value, so the warning is captured-and-discarded.
+     */
+    private function suppressSilentPassWarning(callable $fn): mixed
+    {
+        set_error_handler(static function (int $errno): bool {
+            return $errno === E_USER_WARNING;
+        });
+
+        try {
+            return $fn();
+        } finally {
+            restore_error_handler();
+        }
     }
 }

--- a/tests/Unit/ValidatesOpenApiSchemaAutoInjectBearerTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaAutoInjectBearerTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 use function restore_error_handler;
 use function set_error_handler;
+use function str_starts_with;
 
 // Load namespace-level config() mock before the trait resolves the function call.
 require_once __DIR__ . '/../Helpers/LaravelConfigMock.php';
@@ -140,16 +141,19 @@ class ValidatesOpenApiSchemaAutoInjectBearerTest extends TestCase
     #[Test]
     public function inject_is_noop_on_oauth2_only_endpoint(): void
     {
-        // oauth2-only endpoints are classified as Unsupported by the
-        // validator (phase 1), so the requirement entry is skipped; injecting
-        // bearer would be a lie. Validation must pass on its own (skipped).
-        // Issue #146: the silent-pass now also fires a one-shot E_USER_WARNING;
-        // suppress here because SecurityValidatorTest covers warning contents.
+        // oauth2-only endpoints are classified as Unsupported, so the
+        // requirement entry is skipped; injecting bearer would be a lie.
+        // Validation must pass on its own (skipped). The silent-pass now
+        // also fires a one-shot E_USER_WARNING; suppress locally because
+        // SecurityValidatorTest covers warning contents.
         $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_bearer'] = true;
 
         $request = Request::create('/v1/secure/oauth2-only', 'GET');
 
-        set_error_handler(static fn(int $errno): bool => $errno === E_USER_WARNING);
+        set_error_handler(
+            static fn(int $errno, string $errstr): bool => $errno === E_USER_WARNING &&
+                str_starts_with($errstr, '[security]'),
+        );
 
         try {
             $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/oauth2-only');

--- a/tests/Unit/ValidatesOpenApiSchemaAutoInjectBearerTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaAutoInjectBearerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Tests\Unit;
 
+use const E_USER_WARNING;
+
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -12,7 +14,11 @@ use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\HttpMethod;
 use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\Validation\Request\SecurityValidator;
 use Symfony\Component\HttpFoundation\Request;
+
+use function restore_error_handler;
+use function set_error_handler;
 
 // Load namespace-level config() mock before the trait resolves the function call.
 require_once __DIR__ . '/../Helpers/LaravelConfigMock.php';
@@ -34,6 +40,7 @@ class ValidatesOpenApiSchemaAutoInjectBearerTest extends TestCase
         OpenApiSpecLoader::reset();
         OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs');
         OpenApiCoverageTracker::reset();
+        SecurityValidator::resetWarningStateForTesting();
         $GLOBALS['__openapi_testing_config'] = [
             'openapi-contract-testing.default_spec' => 'petstore-3.0',
             'openapi-contract-testing.auto_validate_request' => true,
@@ -46,6 +53,7 @@ class ValidatesOpenApiSchemaAutoInjectBearerTest extends TestCase
         unset($GLOBALS['__openapi_testing_config']);
         OpenApiSpecLoader::reset();
         OpenApiCoverageTracker::reset();
+        SecurityValidator::resetWarningStateForTesting();
         parent::tearDown();
     }
 
@@ -135,11 +143,19 @@ class ValidatesOpenApiSchemaAutoInjectBearerTest extends TestCase
         // oauth2-only endpoints are classified as Unsupported by the
         // validator (phase 1), so the requirement entry is skipped; injecting
         // bearer would be a lie. Validation must pass on its own (skipped).
+        // Issue #146: the silent-pass now also fires a one-shot E_USER_WARNING;
+        // suppress here because SecurityValidatorTest covers warning contents.
         $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_bearer'] = true;
 
         $request = Request::create('/v1/secure/oauth2-only', 'GET');
 
-        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/oauth2-only');
+        set_error_handler(static fn(int $errno): bool => $errno === E_USER_WARNING);
+
+        try {
+            $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/oauth2-only');
+        } finally {
+            restore_error_handler();
+        }
 
         $this->assertArrayHasKey(
             'GET /v1/secure/oauth2-only',

--- a/tests/Unit/Validation/Request/SecurityValidatorTest.php
+++ b/tests/Unit/Validation/Request/SecurityValidatorTest.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Tests\Unit\Validation\Request;
 
+use const E_USER_WARNING;
+
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\Validation\Request\SecurityValidator;
+
+use function restore_error_handler;
+use function set_error_handler;
 
 class SecurityValidatorTest extends TestCase
 {
@@ -16,6 +21,16 @@ class SecurityValidatorTest extends TestCase
     {
         parent::setUp();
         $this->validator = new SecurityValidator();
+        // Reset the per-process "warned-once" set so tests are deterministic
+        // regardless of run order or filter selection. Same convention as
+        // OpenApiSchemaConverterTest.
+        SecurityValidator::resetWarningStateForTesting();
+    }
+
+    protected function tearDown(): void
+    {
+        SecurityValidator::resetWarningStateForTesting();
+        parent::tearDown();
     }
 
     #[Test]
@@ -82,27 +97,6 @@ class SecurityValidatorTest extends TestCase
     }
 
     #[Test]
-    public function validate_skips_oauth2_as_unsupported_without_pass_or_fail(): void
-    {
-        // OAuth2 is well-formed but phase 1 cannot validate bearer-token
-        // presence semantics, so the requirement is skipped entirely. With
-        // no other validatable entries, the result is an empty error list
-        // (neither satisfied nor failed).
-        $spec = [
-            'components' => [
-                'securitySchemes' => [
-                    'OAuth' => ['type' => 'oauth2', 'flows' => []],
-                ],
-            ],
-        ];
-        $operation = ['security' => [['OAuth' => ['read']]]];
-
-        $errors = $this->validator->validate('GET', '/pets', $spec, $operation, [], [], []);
-
-        $this->assertSame([], $errors);
-    }
-
-    #[Test]
     public function validate_surfaces_hard_error_for_malformed_scheme_type(): void
     {
         // A typo like `type: htpp` must be surfaced as a hard error — otherwise
@@ -163,5 +157,371 @@ class SecurityValidatorTest extends TestCase
         $errors = $this->validator->validate('GET', '/pets', $spec, $operation, [], [], []);
 
         $this->assertSame([], $errors);
+    }
+
+    // ========================================
+    // Loud-warning behaviour for unsupported security schemes (issue #146).
+    //
+    // The validator silent-passes oauth2 / openIdConnect / mutualTLS / http
+    // (non-bearer) requirement entries (false-negative avoidance), but it
+    // also fires a one-shot E_USER_WARNING per scheme name so users notice
+    // the silent pass — green tests against an unauthenticated request are
+    // the worst-class failure mode for a contract-testing tool.
+    // ========================================
+
+    #[Test]
+    public function oauth2_emits_loud_warning_on_first_encounter(): void
+    {
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'OAuth' => ['type' => 'oauth2', 'flows' => []],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['OAuth' => ['read']]]];
+
+        [$errors, $warnings] = $this->validateCapturingWarnings(
+            'POST',
+            '/v1/users',
+            $spec,
+            $operation,
+        );
+
+        $this->assertSame([], $errors, 'silent-pass behaviour preserved');
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString('[security] OAuth2 scheme', $warnings[0]);
+        $this->assertStringContainsString("'OAuth'", $warnings[0]);
+        $this->assertStringContainsString('POST /v1/users', $warnings[0]);
+    }
+
+    #[Test]
+    public function openid_connect_emits_loud_warning_on_first_encounter(): void
+    {
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'OIDC' => ['type' => 'openIdConnect', 'openIdConnectUrl' => 'https://idp.example/.well-known/openid-configuration'],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['OIDC' => []]]];
+
+        [$errors, $warnings] = $this->validateCapturingWarnings(
+            'GET',
+            '/v1/me',
+            $spec,
+            $operation,
+        );
+
+        $this->assertSame([], $errors);
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString('OpenID Connect scheme', $warnings[0]);
+        $this->assertStringContainsString("'OIDC'", $warnings[0]);
+    }
+
+    #[Test]
+    public function mutual_tls_emits_loud_warning_on_first_encounter(): void
+    {
+        // mutualTLS is OAS 3.1 only.
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'mTLS' => ['type' => 'mutualTLS'],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['mTLS' => []]]];
+
+        [$errors, $warnings] = $this->validateCapturingWarnings(
+            'POST',
+            '/v1/internal/sync',
+            $spec,
+            $operation,
+        );
+
+        $this->assertSame([], $errors);
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString('Mutual TLS scheme', $warnings[0]);
+        $this->assertStringContainsString("'mTLS'", $warnings[0]);
+    }
+
+    #[Test]
+    public function http_basic_emits_loud_warning_on_first_encounter(): void
+    {
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'Basic' => ['type' => 'http', 'scheme' => 'basic'],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['Basic' => []]]];
+
+        [$errors, $warnings] = $this->validateCapturingWarnings(
+            'GET',
+            '/v1/admin',
+            $spec,
+            $operation,
+        );
+
+        $this->assertSame([], $errors);
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString('http-basic scheme', $warnings[0]);
+        $this->assertStringContainsString("'Basic'", $warnings[0]);
+    }
+
+    #[Test]
+    public function http_digest_emits_loud_warning_on_first_encounter(): void
+    {
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'Digest' => ['type' => 'http', 'scheme' => 'digest'],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['Digest' => []]]];
+
+        [$errors, $warnings] = $this->validateCapturingWarnings(
+            'GET',
+            '/v1/legacy',
+            $spec,
+            $operation,
+        );
+
+        $this->assertSame([], $errors);
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString('http-digest scheme', $warnings[0]);
+        $this->assertStringContainsString("'Digest'", $warnings[0]);
+    }
+
+    #[Test]
+    public function repeated_calls_with_same_scheme_name_warn_only_once(): void
+    {
+        // Avoid log spam: warn once per process per scheme name. Three calls
+        // referencing the same scheme name must surface exactly one warning.
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'OAuth' => ['type' => 'oauth2', 'flows' => []],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['OAuth' => []]]];
+
+        $count = 0;
+        set_error_handler(static function (int $errno) use (&$count): bool {
+            if ($errno === E_USER_WARNING) {
+                $count++;
+
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            $this->validator->validate('GET', '/v1/a', [...$spec], $operation, [], [], []);
+            $this->validator->validate('GET', '/v1/b', [...$spec], $operation, [], [], []);
+            $this->validator->validate('GET', '/v1/c', [...$spec], $operation, [], [], []);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame(1, $count);
+    }
+
+    #[Test]
+    public function two_distinct_oauth2_scheme_names_each_warn_once(): void
+    {
+        // Dedup is per scheme name (the components.securitySchemes key), not
+        // per type. Two oauth2 definitions named differently both warn.
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'oauth2_user' => ['type' => 'oauth2', 'flows' => []],
+                    'oauth2_admin' => ['type' => 'oauth2', 'flows' => []],
+                ],
+            ],
+        ];
+
+        $captured = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$captured): bool {
+            if ($errno === E_USER_WARNING) {
+                $captured[] = $errstr;
+
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            $this->validator->validate(
+                'GET',
+                '/v1/a',
+                $spec,
+                ['security' => [['oauth2_user' => []]]],
+                [],
+                [],
+                [],
+            );
+            $this->validator->validate(
+                'GET',
+                '/v1/b',
+                $spec,
+                ['security' => [['oauth2_admin' => []]]],
+                [],
+                [],
+                [],
+            );
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertCount(2, $captured);
+        $this->assertStringContainsString("'oauth2_user'", $captured[0]);
+        $this->assertStringContainsString("'oauth2_admin'", $captured[1]);
+    }
+
+    #[Test]
+    public function bearer_and_api_key_do_not_warn(): void
+    {
+        // Regression guard: supported schemes must not trigger the silent-pass
+        // warning. Two operations exercise both validatable scheme types.
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'BearerAuth' => ['type' => 'http', 'scheme' => 'bearer'],
+                    'ApiKey' => ['type' => 'apiKey', 'in' => 'header', 'name' => 'X-Api-Key'],
+                ],
+            ],
+        ];
+
+        $captured = null;
+        set_error_handler(static function (int $errno, string $errstr) use (&$captured): bool {
+            if ($errno === E_USER_WARNING) {
+                $captured = $errstr;
+
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            $this->validator->validate(
+                'GET',
+                '/v1/x',
+                $spec,
+                ['security' => [['BearerAuth' => []]]],
+                ['Authorization' => 'Bearer t'],
+                [],
+                [],
+            );
+            $this->validator->validate(
+                'GET',
+                '/v1/y',
+                $spec,
+                ['security' => [['ApiKey' => []]]],
+                ['X-Api-Key' => 'k'],
+                [],
+                [],
+            );
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertNull($captured, 'supported schemes (bearer, apiKey) must not warn');
+    }
+
+    #[Test]
+    public function warning_does_not_change_validation_outcome(): void
+    {
+        // OAuth2 is silently passed (false-negative avoidance) — the warning
+        // is purely a side-channel. The actual return value must remain `[]`
+        // even when the warning fires, otherwise the issue #146 fix would
+        // accidentally regress the false-negative-avoidance behaviour.
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'OAuth' => ['type' => 'oauth2', 'flows' => []],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['OAuth' => ['read']]]];
+
+        [$errors] = $this->validateCapturingWarnings('GET', '/pets', $spec, $operation);
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function oauth2_inside_and_entry_with_supported_scheme_still_warns(): void
+    {
+        // An AND-entry mixing an unsupported scheme with a supported one is
+        // still skipped by the validator (the unsupported member taints the
+        // whole entry). The warning must fire on the unsupported member so the
+        // user is told that the test is not actually verifying the oauth2 leg.
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'oauth2_user' => ['type' => 'oauth2', 'flows' => []],
+                    'BearerAuth' => ['type' => 'http', 'scheme' => 'bearer'],
+                ],
+            ],
+        ];
+        $operation = [
+            'security' => [
+                ['oauth2_user' => [], 'BearerAuth' => []],
+            ],
+        ];
+
+        [$errors, $warnings] = $this->validateCapturingWarnings(
+            'POST',
+            '/v1/secure',
+            $spec,
+            $operation,
+            ['Authorization' => 'Bearer t'],
+        );
+
+        $this->assertSame([], $errors);
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString("'oauth2_user'", $warnings[0]);
+    }
+
+    /**
+     * @param array<string, mixed> $spec
+     * @param array<string, mixed> $operation
+     * @param array<array-key, mixed> $headers
+     *
+     * @return array{0: string[], 1: string[]} [errors, warnings]
+     */
+    private function validateCapturingWarnings(
+        string $method,
+        string $path,
+        array $spec,
+        array $operation,
+        array $headers = [],
+    ): array {
+        $captured = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$captured): bool {
+            if ($errno === E_USER_WARNING) {
+                $captured[] = $errstr;
+
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            $errors = $this->validator->validate($method, $path, $spec, $operation, $headers, [], []);
+        } finally {
+            restore_error_handler();
+        }
+
+        return [$errors, $captured];
     }
 }

--- a/tests/Unit/Validation/Request/SecurityValidatorTest.php
+++ b/tests/Unit/Validation/Request/SecurityValidatorTest.php
@@ -12,6 +12,7 @@ use Studio\OpenApiContractTesting\Validation\Request\SecurityValidator;
 
 use function restore_error_handler;
 use function set_error_handler;
+use function str_starts_with;
 
 class SecurityValidatorTest extends TestCase
 {
@@ -160,13 +161,7 @@ class SecurityValidatorTest extends TestCase
     }
 
     // ========================================
-    // Loud-warning behaviour for unsupported security schemes (issue #146).
-    //
-    // The validator silent-passes oauth2 / openIdConnect / mutualTLS / http
-    // (non-bearer) requirement entries (false-negative avoidance), but it
-    // also fires a one-shot E_USER_WARNING per scheme name so users notice
-    // the silent pass — green tests against an unauthenticated request are
-    // the worst-class failure mode for a contract-testing tool.
+    // Loud-warning behaviour for unsupported security schemes.
     // ========================================
 
     #[Test]
@@ -311,8 +306,8 @@ class SecurityValidatorTest extends TestCase
         $operation = ['security' => [['OAuth' => []]]];
 
         $count = 0;
-        set_error_handler(static function (int $errno) use (&$count): bool {
-            if ($errno === E_USER_WARNING) {
+        set_error_handler(static function (int $errno, string $errstr) use (&$count): bool {
+            if ($errno === E_USER_WARNING && str_starts_with($errstr, '[security]')) {
                 $count++;
 
                 return true;
@@ -348,7 +343,7 @@ class SecurityValidatorTest extends TestCase
 
         $captured = [];
         set_error_handler(static function (int $errno, string $errstr) use (&$captured): bool {
-            if ($errno === E_USER_WARNING) {
+            if ($errno === E_USER_WARNING && str_starts_with($errstr, '[security]')) {
                 $captured[] = $errstr;
 
                 return true;
@@ -401,7 +396,7 @@ class SecurityValidatorTest extends TestCase
 
         $captured = null;
         set_error_handler(static function (int $errno, string $errstr) use (&$captured): bool {
-            if ($errno === E_USER_WARNING) {
+            if ($errno === E_USER_WARNING && str_starts_with($errstr, '[security]')) {
                 $captured = $errstr;
 
                 return true;
@@ -440,8 +435,8 @@ class SecurityValidatorTest extends TestCase
     public function warning_does_not_change_validation_outcome(): void
     {
         // OAuth2 is silently passed (false-negative avoidance) — the warning
-        // is purely a side-channel. The actual return value must remain `[]`
-        // even when the warning fires, otherwise the issue #146 fix would
+        // is purely a side-channel. The return value must remain `[]` even
+        // when the warning fires, otherwise the warning emission would
         // accidentally regress the false-negative-avoidance behaviour.
         $spec = [
             'components' => [
@@ -491,6 +486,179 @@ class SecurityValidatorTest extends TestCase
         $this->assertStringContainsString("'oauth2_user'", $warnings[0]);
     }
 
+    #[Test]
+    public function http_with_missing_scheme_field_is_hard_error_not_warning(): void
+    {
+        // `type: http` with no `scheme` key is malformed per OAS 3.x. It must
+        // surface as a hard error rather than fall through to Unsupported
+        // (which would emit the silent-pass warning). Without the malformed
+        // guard the next code path would `strtolower(null)` and fatal — so
+        // this also pins that the malformed branch fires before label
+        // construction.
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'Broken' => ['type' => 'http'],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['Broken' => []]]];
+
+        [$errors, $warnings] = $this->validateCapturingWarnings(
+            'GET',
+            '/v1/x',
+            $spec,
+            $operation,
+        );
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('is malformed', $errors[0]);
+        $this->assertStringContainsString("'scheme' field", $errors[0]);
+        $this->assertSame([], $warnings, 'malformed must take precedence over Unsupported warning');
+    }
+
+    #[Test]
+    public function http_with_empty_scheme_value_is_hard_error_not_warning(): void
+    {
+        // Empty / whitespace-only `scheme` is the same defect class as a
+        // missing field — it would otherwise fall through to Unsupported with
+        // a meaningless `http-` label. Pin the rejection at the malformed
+        // boundary so users are pushed to fix the spec.
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'Broken' => ['type' => 'http', 'scheme' => '   '],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['Broken' => []]]];
+
+        [$errors, $warnings] = $this->validateCapturingWarnings(
+            'GET',
+            '/v1/x',
+            $spec,
+            $operation,
+        );
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('is malformed', $errors[0]);
+        $this->assertSame([], $warnings, 'empty `scheme` is malformed, not silent-pass');
+    }
+
+    #[Test]
+    public function two_unsupported_types_in_same_entry_each_warn(): void
+    {
+        // An AND-entry combining two distinct unsupported types
+        // (oauth2 + openIdConnect) must produce two warnings — one per
+        // scheme name. Guards against an early-break refactor that would
+        // silently drop the second warning.
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'oauth2_user' => ['type' => 'oauth2', 'flows' => []],
+                    'OIDC' => ['type' => 'openIdConnect', 'openIdConnectUrl' => 'https://idp.example/.well-known/openid-configuration'],
+                ],
+            ],
+        ];
+        $operation = [
+            'security' => [
+                ['oauth2_user' => [], 'OIDC' => []],
+            ],
+        ];
+
+        [$errors, $warnings] = $this->validateCapturingWarnings(
+            'GET',
+            '/v1/x',
+            $spec,
+            $operation,
+        );
+
+        $this->assertSame([], $errors);
+        $this->assertCount(2, $warnings);
+        $this->assertStringContainsString("'oauth2_user'", $warnings[0]);
+        $this->assertStringContainsString("'OIDC'", $warnings[1]);
+    }
+
+    #[Test]
+    public function malformed_and_unsupported_in_same_entry_emits_both_signals(): void
+    {
+        // The validator iterates every scheme in the entry independently:
+        // a malformed sibling produces a hard error, AND the unsupported
+        // sibling fires its silent-pass warning. Pinning this prevents an
+        // accidental refactor that would short-circuit on the first
+        // malformed and lose the warning (or vice-versa).
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'Broken' => ['type' => 'htpp'],
+                    'OAuth' => ['type' => 'oauth2', 'flows' => []],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['Broken' => [], 'OAuth' => []]]];
+
+        [$errors, $warnings] = $this->validateCapturingWarnings(
+            'GET',
+            '/v1/x',
+            $spec,
+            $operation,
+        );
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('is malformed', $errors[0]);
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString("'OAuth'", $warnings[0]);
+    }
+
+    #[Test]
+    public function root_level_security_with_oauth2_warns(): void
+    {
+        // Operation-level `security` is absent → root-level inherited.
+        // Warning must fire identically to the operation-level path.
+        $spec = [
+            'security' => [['OAuth' => []]],
+            'components' => [
+                'securitySchemes' => [
+                    'OAuth' => ['type' => 'oauth2', 'flows' => []],
+                ],
+            ],
+        ];
+
+        [$errors, $warnings] = $this->validateCapturingWarnings(
+            'GET',
+            '/v1/inherited',
+            $spec,
+            [],
+        );
+
+        $this->assertSame([], $errors);
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString("'OAuth'", $warnings[0]);
+    }
+
+    #[Test]
+    public function warning_includes_actionable_workaround_text(): void
+    {
+        // The warning's value to users is the actionable closing line that
+        // tells them how to verify the bearer-token surface manually. If a
+        // future refactor trims the message, this assertion fires before the
+        // user-facing payload silently disappears.
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'OAuth' => ['type' => 'oauth2', 'flows' => []],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['OAuth' => []]]];
+
+        [, $warnings] = $this->validateCapturingWarnings('GET', '/v1/x', $spec, $operation);
+
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString('Workaround:', $warnings[0]);
+        $this->assertStringContainsString('split the bearer-token surface', $warnings[0]);
+    }
+
     /**
      * @param array<string, mixed> $spec
      * @param array<string, mixed> $operation
@@ -507,7 +675,7 @@ class SecurityValidatorTest extends TestCase
     ): array {
         $captured = [];
         set_error_handler(static function (int $errno, string $errstr) use (&$captured): bool {
-            if ($errno === E_USER_WARNING) {
+            if ($errno === E_USER_WARNING && str_starts_with($errstr, '[security]')) {
                 $captured[] = $errstr;
 
                 return true;


### PR DESCRIPTION
## Summary

- Emit a one-shot `E_USER_WARNING` per `components.securitySchemes` key the first time `oauth2` / `openIdConnect` / `mutualTLS` / `http` (non-`bearer`) is encountered. Validation outcome is unchanged — silent-pass remains for false-negative avoidance, but the warning surfaces the limitation.
- Matches the schema-converter precedent (`unevaluatedProperties`, `unevaluatedItems`) of warning loudly when a constraint is not being enforced.
- README and CHANGELOG updated.

Closes #146.

## Why this matters

A green test against an unauthenticated request is the worst-class silent failure mode for a contract-testing tool. PR #145 documented the silent-pass in README, but docs alone do not reach users with already-passing test suites against oauth2-protected endpoints. This PR converts the silent-pass into a loud signal.

## Behaviour

| Scheme type | Before | After |
|---|---|---|
| `oauth2` | silent pass | one-shot `E_USER_WARNING` per scheme name + silent pass |
| `openIdConnect` | silent pass | one-shot `E_USER_WARNING` per scheme name + silent pass |
| `mutualTLS` (3.1) | silent pass | one-shot `E_USER_WARNING` per scheme name + silent pass |
| `http` + `basic` / `digest` | silent pass | one-shot `E_USER_WARNING` per scheme name + silent pass |
| `http` + `bearer` | validated (presence check) | unchanged |
| `apiKey` | validated (presence check) | unchanged |

Sample output:

\`\`\`
[security] OAuth2 scheme 'oauth2_user' is silently passed (no token check) — POST /v1/users.
The opis/json-schema-based validator cannot verify oauth2 / openIdConnect / mutualTLS /
http-basic / http-digest credentials. Your test will not detect a missing or invalid token.
Workaround: split the bearer-token surface into a separate test, or assert the
Authorization header presence manually.
\`\`\`

Dedup is per scheme name (`components.securitySchemes` key), so a spec defining both `oauth2_user` and `oauth2_admin` warns twice (once each) — users see how many silent-pass schemes their spec contains.

## Backwards-compat

Not a breaking change. PHPUnit 10+ defaults `failOnWarning` to `false`, so existing test suites against oauth2-protected endpoints continue to pass with a visible warning. Suites that opted into `failOnWarning="true"` (strict mode) will see test failures on first encounter — that is the desired outcome for that opt-in.

## Test plan

- [x] 10 new tests in `tests/Unit/Validation/Request/SecurityValidatorTest.php` covering each unsupported type, dedup behaviour, regression on supported schemes, and AND-entry warning
- [x] Existing oauth2 integration tests updated to suppress the new warning locally (their focus is validation outcome, not warning contents)
- [x] `vendor/bin/phpunit` — 1099 tests pass
- [x] `vendor/bin/phpstan analyse` — 0 errors at level 6
- [x] `vendor/bin/php-cs-fixer fix --dry-run` — 0 violations