### PR TITLE
docs(warnings): pin trigger_error E_USER_WARNING as v1.0 warning channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ until 1.0.0 ships. Each entry below tags whether it is breaking.
 
 ## Unreleased
 
+### Documentation
+
+- **Warning channel contract** is now documented in README under
+  "Supported features and known limitations". Pins
+  `trigger_error(..., E_USER_WARNING)` with category-tagged messages
+  (`[security]`, `[OpenAPI Schema]`) as the v1.0 official API surface
+  for silent-pass signals. Includes consumption recipes (PHPUnit
+  `failOnWarning`, programmatic capture via `set_error_handler`,
+  per-category suppression) and an explicit deferral note for the
+  structured-channel alternatives (typed exceptions, PSR-3 logger,
+  `OpenApiValidationResult` warnings array) — those can be added in
+  v1.x as additive enhancements without breaking the v1.0 contract.
+  Closes #149.
+
 ### Fixed
 
 - **Schema converter — `discriminator.mapping` silent-strip** now emits a

--- a/README.md
+++ b/README.md
@@ -985,6 +985,35 @@ The PHPUnit coverage report counts `GET`, `POST`, `PUT`, `PATCH`, `DELETE`. Oper
 ### Spec features not consulted
 Webhooks (3.1), Callbacks, Response `Links`, Server URL templating (`servers` with `variables`), Examples (`examples` blocks at parameter / requestBody / response level — not used for fuzzing or validation), `tags`, `externalDocs`, vendor extensions (`x-*` keys, ignored harmlessly).
 
+### Warning channel (`E_USER_WARNING` contract)
+
+The library uses PHP's native `trigger_error(..., E_USER_WARNING)` as the loud-signal channel for silent-pass conditions the validator cannot enforce. **This is the v1.0 official API**: warnings are dedup'd per-process and prefixed with a category tag so callers can route or filter them mechanically.
+
+| Category prefix | Source | Dedup key |
+|---|---|---|
+| `[security]` | `SecurityValidator` (`oauth2`, `openIdConnect`, `mutualTLS`, `http-basic`, `http-digest`) | scheme name |
+| `[OpenAPI Schema]` | `OpenApiSchemaConverter` (`unevaluatedProperties` / `unevaluatedItems`, `discriminator.mapping`, unknown / malformed `format`) | per-keyword / per-format-value |
+
+**How to consume:**
+
+- **Default** (PHPUnit `failOnWarning="true"`): the first warning fails the test. Recommended for contract-testing pipelines, since silent-pass on auth or unknown formats is the worst-class failure mode.
+- **Stay green, surface warnings in output**: omit `failOnWarning` (PHPUnit 10+ default is `false`). Warnings show in the test report but do not fail.
+- **Capture programmatically** (e.g. for a custom report):
+  ```php
+  set_error_handler(static function (int $errno, string $errstr): bool {
+      if ($errno === E_USER_WARNING && str_starts_with($errstr, '[security]')) {
+          MyReport::record($errstr);
+          return true; // suppress
+      }
+      return false; // bubble
+  });
+  ```
+- **Suppress one category** (e.g. acknowledged limitation): match on the category prefix in your error handler. Do not blanket-suppress all `E_USER_WARNING`s — unrelated warnings would silently disappear.
+
+**Why not exceptions / PSR-3 logger / structured payload on `OpenApiValidationResult`?** The simple channel is zero-dep, integrates with every PHP framework's existing error handler, and stays out of the v1.0 SemVer surface. A structured channel (`WarningCollector`, PSR-3 sink, or `result->warnings()`) can be added in v1.x as additive without breaking — we are deliberately deferring until real-world usage demands it. See [issue #149](https://github.com/studio-design/openapi-contract-testing/issues/149) for the design discussion.
+
+**Per-process dedup vs per-test:** the dedup state is process-global. PHPUnit runs all tests in one process by default, so a warning fired in test A is not fired again in test B even if both schemas exhibit the issue. The `*::resetWarningStateForTesting()` helpers (annotated `@internal`) exist as test seams for the converter / security validator's own tests; downstream tests rarely need them.
+
 ## API Reference
 
 ### `OpenApiResponseValidator`


### PR DESCRIPTION
## Summary

Resolves the #149 design discussion: keep the current `trigger_error(..., E_USER_WARNING)` channel as the **v1.0 official API surface** for silent-pass signals, with category-tagged messages (`[security]`, `[OpenAPI Schema]`). Documents the contract in README so users (and v1.0 SemVer commitments) have a clear reference.

Closes #149.

## What's documented

- **Category prefixes & dedup keys** — `[security]` (per scheme name), `[OpenAPI Schema]` (per keyword / per format value), mapped to their source classes.
- **Consumption recipes**:
  - PHPUnit `failOnWarning=\"true\"` (recommended for contract-testing CI)
  - Stay green, surface in test output (default)
  - Programmatic capture via `set_error_handler` with prefix matching
  - Per-category suppression patterns (and the warning against blanket-suppressing all `E_USER_WARNING`s)
- **Per-process dedup semantics** and the `@internal` reset helpers.
- **Why not exceptions / PSR-3 / structured payload?** Explicit rationale: the simple channel is zero-dep, integrates with every PHP framework's existing handler, and can be extended additively in v1.x without breaking.

## Why this approach

The four warning sources we now have (oauth2 / OIDC / mTLS / http-basic / http-digest, plus unevaluatedProperties / discriminator.mapping / unknown format / malformed format) all share the same shape: silent-pass detected, fire one-shot loud signal, validation outcome unchanged. PHP's native `E_USER_WARNING` already covers every consumption pattern users have today:

| Need | Mechanism |
|---|---|
| Fail CI on first encounter | `failOnWarning=\"true\"` |
| Show in test report but stay green | Default PHPUnit behaviour |
| Custom routing | `set_error_handler` with prefix filter |
| Per-category suppression | Same, return `true` for matched, `false` for unmatched |

Adding a `WarningCollector` interface or PSR-3 sink today would be premature infrastructure. v1.x can layer those on top once real demand surfaces.

## Test plan

- [x] Documentation-only PR; `vendor/bin/phpunit` continues to pass (1120 tests)
- [x] No code changes — pure README + CHANGELOG additions
- [x] Recipes in the new section are syntactically valid PHP

## Files

- `README.md` — new "Warning channel" subsection under "Supported features and known limitations"
- `CHANGELOG.md` — Unreleased / Documentation entry