### PR TITLE
feat(response-validator): per-content-type schema selection for multi-JSON specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ until 1.0.0 ships. Each entry below tags whether it is breaking.
 
 ## Unreleased
 
+### Changed
+
+- **Response validator — per-content-type schema selection for multi-JSON
+  specs**. When a response carries a JSON-flavoured `Content-Type` and the
+  spec declares multiple JSON keys for the same status (e.g.
+  `application/json` AND `application/problem+json`), the validator now
+  prefers the spec key that exactly matches the actual `Content-Type` before
+  falling back to the first JSON key. Previously the first JSON key always
+  won, so a problem-details body served as `application/problem+json` would
+  be judged against the success-shape `application/json` schema — silently
+  passing if the body happened to satisfy the success shape, or wrongly
+  failing if it didn't. This is a behavioural change for users relying on
+  the legacy first-JSON-wins semantics with multi-JSON specs; single-JSON
+  specs and vendor `+json` suffixes the spec doesn't enumerate are
+  unaffected. Closes #152.
+
 ### Documentation
 
 - **Warning channel contract** is now documented in README under

--- a/README.md
+++ b/README.md
@@ -949,6 +949,7 @@ This is a contract-testing tool: where we can't enforce a constraint precisely, 
 
 ### Body validation
 - **Validated**: `application/json` and any `+json` structured-syntax suffix (RFC 6838), and content keys using ranges (`application/*`, `*/*`) — the matcher tries exact match first, then `<type>/*`, then `*/*`.
+- **Multi-JSON-per-status specs** (e.g. `application/json` + `application/problem+json` for the same status): when the actual response Content-Type is supplied, schema validation prefers the spec key that exactly matches the response Content-Type before falling back to the first JSON key. A problem-details body served as `application/problem+json` is judged against its own schema, not the success-shape `application/json` schema. Vendor `+json` suffixes the spec doesn't enumerate (e.g. `application/vnd.example.v1+json`) still fall through to the first JSON key, preserving the legacy interchangeable-JSON behaviour for that case.
 - **Presence-only** (no schema validation): every other media type, including `application/xml`, `multipart/form-data`, `application/x-www-form-urlencoded`, `text/plain`, and `application/octet-stream`. The validator confirms the spec declares the content type but does not check the body. The orchestrator marks these responses as `Skipped` for coverage reporting.
 - **Multipart `encoding` object**: per-part `contentType` / `headers` / `style` / `explode` are not consulted.
 

--- a/src/Validation/Response/ResponseBodyValidator.php
+++ b/src/Validation/Response/ResponseBodyValidator.php
@@ -58,7 +58,12 @@ final class ResponseBodyValidator
     ): ResponseBodyValidationResult {
         // When the actual response Content-Type is provided, handle content negotiation:
         // non-JSON types are checked for spec presence only, while JSON-compatible types
-        // fall through to schema validation against the first JSON media type in the spec.
+        // fall through to schema validation. For JSON-flavoured response Content-Types
+        // we prefer the spec key that exactly matches the response Content-Type before
+        // falling back to the first JSON key — this lets multi-JSON specs (e.g.
+        // `application/json` + `application/problem+json` for the same status) validate
+        // each Content-Type against its own schema.
+        $jsonContentType = null;
         if ($responseContentType !== null) {
             $normalizedType = ContentTypeMatcher::normalizeMediaType($responseContentType);
 
@@ -79,13 +84,13 @@ final class ResponseBodyValidator
                 );
             }
 
-            // JSON-compatible response: continue to JSON schema validation below.
-            // JSON types are treated as interchangeable (e.g. application/vnd.api+json
-            // validates against an application/json spec entry) because the schema is
-            // the same regardless of the specific JSON media type.
+            // JSON-compatible response: prefer exact match, then fall back to the first JSON key.
+            $jsonContentType = ContentTypeMatcher::findJsonContentTypeForResponse($normalizedType, $content);
         }
 
-        $jsonContentType = ContentTypeMatcher::findJsonContentType($content);
+        if ($jsonContentType === null) {
+            $jsonContentType = ContentTypeMatcher::findJsonContentType($content);
+        }
 
         // If no JSON-compatible content type is defined, skip body validation.
         // This validator only handles JSON schemas; non-JSON types (e.g. text/html,

--- a/src/Validation/Support/ContentTypeMatcher.php
+++ b/src/Validation/Support/ContentTypeMatcher.php
@@ -53,6 +53,46 @@ final class ContentTypeMatcher
     }
 
     /**
+     * Find the JSON-compatible content type key that best matches a given
+     * actual response Content-Type. Behaves like {@see findJsonContentType()}
+     * but prefers an exact spec key match before falling back to the first
+     * JSON key in the spec.
+     *
+     * Resolution priority (most-specific first):
+     *   1. Exact case-insensitive match between the response Content-Type
+     *      and a JSON-flavoured spec key (e.g. response
+     *      `application/problem+json` → spec key `application/problem+json`)
+     *   2. {@see findJsonContentType()} fallback (first JSON key, then
+     *      `application/*`)
+     *
+     * The exact-match-first preference is what allows multi-JSON specs
+     * (e.g. `application/json` AND `application/problem+json` for the same
+     * status) to validate each Content-Type against its own schema. Without
+     * it, a problem-details body would be wrongly judged against the first
+     * key's success-shape schema.
+     *
+     * `$normalizedResponseType` must be the response Content-Type stripped
+     * of parameters and lower-cased, as produced by
+     * {@see normalizeMediaType()}. Callers that pass non-JSON types should
+     * route to {@see findContentTypeKey()} instead — this method is only
+     * useful when the actual Content-Type is JSON-flavoured.
+     *
+     * @param array<string, mixed> $content
+     */
+    public static function findJsonContentTypeForResponse(
+        string $normalizedResponseType,
+        array $content,
+    ): ?string {
+        foreach ($content as $contentType => $_mediaType) {
+            if (strtolower((string) $contentType) === $normalizedResponseType) {
+                return (string) $contentType;
+            }
+        }
+
+        return self::findJsonContentType($content);
+    }
+
+    /**
      * Extract the media type portion before any parameters (e.g. charset),
      * and return it lower-cased.
      *

--- a/tests/Integration/FixtureCoverageTest.php
+++ b/tests/Integration/FixtureCoverageTest.php
@@ -635,14 +635,18 @@ class FixtureCoverageTest extends TestCase
     }
 
     #[Test]
-    public function v31_multi_content_type_routes_json_through_first_json_schema(): void
+    public function v31_multi_content_type_validates_each_json_against_its_own_schema(): void
     {
-        // The validator's documented behaviour: for a JSON-flavoured response
-        // Content-Type, schema validation runs against the FIRST JSON-compatible
-        // spec key, since JSON media types are treated as interchangeable
-        // (RFC 6838 +json suffix). This pins that behaviour for the multi-content
-        // case so a future change that switches to per-content-type schema
-        // selection will surface here.
+        // Per-content-type schema selection (#152): for a JSON-flavoured
+        // response Content-Type, schema validation prefers the spec key that
+        // exactly matches the response Content-Type before falling back to
+        // the first JSON key. The fixture defines DIFFERENT shapes for
+        // `application/json` (requires `data`) and `application/problem+json`
+        // (requires `title`), so we can prove each is judged against its own
+        // schema and not interchangeably as the legacy "first JSON wins"
+        // behaviour did.
+
+        // application/json body with `data` (the success shape).
         $jsonResp = $this->responseValidator->validate(
             'petstore-3.1',
             'GET',
@@ -653,10 +657,24 @@ class FixtureCoverageTest extends TestCase
         );
         $this->assertTrue($jsonResp->isValid(), implode(' | ', $jsonResp->errors()));
 
-        // Same body, served with the +json suffix: still validates against the
-        // first JSON schema (application/json `data` schema). This matches the
-        // documented "JSON types are interchangeable" semantics.
+        // application/problem+json body with `title` (the problem shape).
+        // Under the legacy first-JSON-wins behaviour this body would have
+        // failed against the application/json schema (missing `data`).
         $problemResp = $this->responseValidator->validate(
+            'petstore-3.1',
+            'GET',
+            '/v1/v31/multi-content',
+            200,
+            ['title' => 'Not Found'],
+            'application/problem+json',
+        );
+        $this->assertTrue($problemResp->isValid(), implode(' | ', $problemResp->errors()));
+
+        // application/problem+json body that DOES NOT match the +json schema
+        // (it has `data`, which is the application/json shape). Under the
+        // legacy behaviour this would have silently passed; per-content-type
+        // selection correctly fails it for missing `title`.
+        $wrongShape = $this->responseValidator->validate(
             'petstore-3.1',
             'GET',
             '/v1/v31/multi-content',
@@ -664,7 +682,8 @@ class FixtureCoverageTest extends TestCase
             ['data' => 'hello'],
             'application/problem+json',
         );
-        $this->assertTrue($problemResp->isValid(), implode(' | ', $problemResp->errors()));
+        $this->assertFalse($wrongShape->isValid(), 'wrong shape under +json must fail');
+        $this->assertStringContainsString('title', $wrongShape->errorMessage());
 
         // Non-JSON branch: text/plain is presence-only, must pass without
         // schema validation against the JSON schemas.
@@ -677,6 +696,27 @@ class FixtureCoverageTest extends TestCase
             'text/plain',
         );
         $this->assertTrue($textResp->isValid(), 'text/plain is presence-only, must pass');
+    }
+
+    #[Test]
+    public function v31_multi_content_type_falls_back_to_first_json_when_no_exact_match(): void
+    {
+        // When the response Content-Type is JSON-flavoured but does NOT
+        // exactly match any spec key (e.g. `application/vnd.example.v1+json`
+        // when the spec only declares `application/json` and
+        // `application/problem+json`), fall back to the first JSON key. This
+        // preserves the legacy interchangeable-JSON behaviour for users that
+        // rely on it for vendor-specific +json suffixes.
+        $resp = $this->responseValidator->validate(
+            'petstore-3.1',
+            'GET',
+            '/v1/v31/multi-content',
+            200,
+            ['data' => 'hello'],
+            'application/vnd.example.v1+json',
+        );
+
+        $this->assertTrue($resp->isValid(), implode(' | ', $resp->errors()));
     }
 
     #[Test]

--- a/tests/Unit/Validation/Support/ContentTypeMatcherTest.php
+++ b/tests/Unit/Validation/Support/ContentTypeMatcherTest.php
@@ -169,4 +169,89 @@ class ContentTypeMatcherTest extends TestCase
 
         $this->assertSame('Application/*', ContentTypeMatcher::findJsonContentType($content));
     }
+
+    // ========================================
+    // findJsonContentTypeForResponse — exact-match-first (#152)
+    // ========================================
+
+    #[Test]
+    public function find_json_content_type_for_response_prefers_exact_match_over_first_key(): void
+    {
+        // Multi-JSON spec with `application/json` and `application/problem+json`
+        // for the same status. A `+json` response Content-Type must route to
+        // its own schema, not the first-declared `application/json`.
+        $content = [
+            'application/json' => ['schema' => ['type' => 'object', 'required' => ['data']]],
+            'application/problem+json' => ['schema' => ['type' => 'object', 'required' => ['title']]],
+        ];
+
+        $this->assertSame(
+            'application/problem+json',
+            ContentTypeMatcher::findJsonContentTypeForResponse('application/problem+json', $content),
+        );
+    }
+
+    #[Test]
+    public function find_json_content_type_for_response_falls_back_to_first_json_when_no_exact_match(): void
+    {
+        // Vendor +json suffix that the spec doesn't enumerate explicitly:
+        // fall back to the first JSON key (legacy interchangeable behaviour).
+        $content = [
+            'application/json' => ['schema' => ['type' => 'object']],
+            'application/problem+json' => ['schema' => ['type' => 'object']],
+        ];
+
+        $this->assertSame(
+            'application/json',
+            ContentTypeMatcher::findJsonContentTypeForResponse('application/vnd.example.v1+json', $content),
+        );
+    }
+
+    #[Test]
+    public function find_json_content_type_for_response_exact_match_is_case_insensitive(): void
+    {
+        // Spec mixes casing on a JSON key (some style guides allow it). The
+        // exact-match pass must hit it regardless of the response's casing.
+        $content = [
+            'application/json' => ['schema' => ['type' => 'object']],
+            'Application/Problem+JSON' => ['schema' => ['type' => 'object']],
+        ];
+
+        $this->assertSame(
+            'Application/Problem+JSON',
+            ContentTypeMatcher::findJsonContentTypeForResponse('application/problem+json', $content),
+        );
+    }
+
+    #[Test]
+    public function find_json_content_type_for_response_returns_null_when_no_json_defined(): void
+    {
+        // Spec has no JSON keys at all — even the fallback can't resolve.
+        // (Callers route this case to non-JSON handling upstream, but pin
+        // the contract here so a future caller change doesn't break it.)
+        $content = ['text/html' => ['schema' => ['type' => 'string']]];
+
+        $this->assertNull(
+            ContentTypeMatcher::findJsonContentTypeForResponse('application/json', $content),
+        );
+    }
+
+    #[Test]
+    public function find_json_content_type_for_response_single_json_case_unchanged(): void
+    {
+        // Backward-compat regression guard: when the spec has a single JSON
+        // key, the exact-match-first behaviour resolves to it identically to
+        // the legacy first-JSON-wins path. No silent regression for the
+        // dominant single-content-per-status spec shape.
+        $content = ['application/json' => ['schema' => ['type' => 'object']]];
+
+        $this->assertSame(
+            'application/json',
+            ContentTypeMatcher::findJsonContentTypeForResponse('application/json', $content),
+        );
+        $this->assertSame(
+            'application/json',
+            ContentTypeMatcher::findJsonContentTypeForResponse('application/vnd.foo+json', $content),
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Resolves #152. When a response carries a JSON-flavoured `Content-Type` and the spec declares multiple JSON keys for the same status (e.g. `application/json` + `application/problem+json`), the validator now prefers the spec key that exactly matches the actual `Content-Type` before falling back to the first JSON key.

This is the most impactful design limitation surfaced by the PR #150 silent-failure-hunter audit — previously, a problem-details body served as `application/problem+json` would be judged against the success-shape `application/json` schema, silently passing or wrongly failing.

Closes #152.

## Behaviour matrix

| Spec content keys | Response Content-Type | Schema used | Change vs. main |
|---|---|---|---|
| `application/json` only | `application/json` or any `+json` | `application/json` | unchanged |
| `application/json` + `application/problem+json` | `application/json` | `application/json` (exact) | unchanged |
| `application/json` + `application/problem+json` | `application/problem+json` | `application/problem+json` (exact) | **new** |
| `application/json` + `application/problem+json` | `application/vnd.foo+json` | `application/json` (fallback) | unchanged |
| no JSON keys | any | no schema validation | unchanged |

## Backwards-compat

This is a behavioural change. **Breaking only for users relying on the legacy first-JSON-wins behaviour with multi-JSON specs**; single-JSON specs and vendor `+json` suffixes the spec doesn't enumerate are unaffected. The v0.x SemVer contract explicitly permits this kind of correctness fix.

Real-world impact: most specs declare a single JSON content key per status, so this change is invisible to them. Specs with both `application/json` and `application/problem+json` (or similar) are the affected case — and for them, this change makes their tests more accurate, not less.

## Test plan

- [x] 5 new unit tests in `ContentTypeMatcherTest`:
  - `find_json_content_type_for_response_prefers_exact_match_over_first_key`
  - `find_json_content_type_for_response_falls_back_to_first_json_when_no_exact_match`
  - `find_json_content_type_for_response_exact_match_is_case_insensitive`
  - `find_json_content_type_for_response_returns_null_when_no_json_defined`
  - `find_json_content_type_for_response_single_json_case_unchanged` (regression guard)
- [x] 2 new integration tests in `FixtureCoverageTest`:
  - `v31_multi_content_type_validates_each_json_against_its_own_schema` — end-to-end pin (success shape, problem shape, wrong-shape fail)
  - `v31_multi_content_type_falls_back_to_first_json_when_no_exact_match` — vendor-suffix fallback
- [x] Old `v31_multi_content_type_routes_json_through_first_json_schema` removed — pinned the legacy behaviour
- [x] `vendor/bin/phpunit` — 1126 tests pass
- [x] `vendor/bin/phpstan analyse` — 0 errors
- [x] `vendor/bin/php-cs-fixer fix --dry-run` — 0 violations

## Files

- `src/Validation/Support/ContentTypeMatcher.php` — new `findJsonContentTypeForResponse()` method
- `src/Validation/Response/ResponseBodyValidator.php` — wires the new method into the validation flow
- `tests/Unit/Validation/Support/ContentTypeMatcherTest.php` — unit tests
- `tests/Integration/FixtureCoverageTest.php` — integration tests
- `README.md` — Body validation subsection updated
- `CHANGELOG.md` — Unreleased / Changed entry