### PR TITLE
chore(api): freeze v1.0 surface — @internal markers + Versioning policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,12 +51,21 @@ until 1.0.0 ships. Each entry below tags whether it is breaking.
   under `Validation\Request\` / `Validation\Response\` / `Validation\Support\`,
   the `Spec\` machinery (`OpenApiSchemaConverter`, `OpenApiPathMatcher`,
   `OpenApiPathSuggester`, `OpenApiRefResolver`, `RefResolutionContext`),
-  the PHPUnit `CoverageReportSubscriber` / `ConsoleOutput` enum, and
-  `Fuzz\SchemaDataGenerator`. No behavioural change — the public
-  entry points (`OpenApiResponseValidator`, `OpenApiRequestValidator`,
-  `OpenApiCoverageTracker`, `Coverage\*` renderers, `Fuzz\OpenApiEndpointExplorer`,
-  `Laravel\*`, attributes, exceptions, enums, `OpenApiSpecLoader`)
-  remain user-callable. Refs #113.
+  the PHPUnit `CoverageReportSubscriber`, `Coverage\CoverageMergeCommand`
+  (the `bin/openapi-coverage-merge` CLI surface remains covered — the
+  class itself is the implementation detail behind it), and
+  `Fuzz\SchemaDataGenerator`. The `ConsoleOutput` enum is intentionally
+  NOT marked `@internal` because it appears on the public
+  `Coverage\ConsoleCoverageRenderer::render()` signature; its string
+  values (`default`, `all`, `uncovered_only`, `active_only`) remain part
+  of the v1.0 SemVer surface as the documented `console_output` config
+  parameter. Wording on the existing `Internal\` and
+  `Laravel\Internal\StackTraceFilter` markers normalised to the same
+  boilerplate sentence. No behavioural change — the public entry points
+  (`OpenApiResponseValidator`, `OpenApiRequestValidator`,
+  `OpenApiCoverageTracker`, `Coverage\*` renderers,
+  `Fuzz\OpenApiEndpointExplorer`, `Laravel\*`, attributes, exceptions,
+  enums, `OpenApiSpecLoader`) remain user-callable. Refs #113.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ until 1.0.0 ships. Each entry below tags whether it is breaking.
 
 ### Documentation
 
+- **Versioning and support policy** documented in README. New section
+  pins SemVer commitments for v1.x: which classes/methods/configs are
+  frozen, which are explicitly `@internal` (and therefore not covered),
+  and the support matrix for PHP / PHPUnit / `opis/json-schema`. Refs
+  #113.
 - **Warning channel contract** is now documented in README under
   "Supported features and known limitations". Pins
   `trigger_error(..., E_USER_WARNING)` with category-tagged messages
@@ -37,6 +42,21 @@ until 1.0.0 ships. Each entry below tags whether it is breaking.
   `OpenApiValidationResult` warnings array) — those can be added in
   v1.x as additive enhancements without breaking the v1.0 contract.
   Closes #149.
+
+### Internal
+
+- **API surface audit for v1.0**: 28 implementation-detail classes
+  picked up class-level `@internal` docblock markers so the v1.0.0
+  SemVer contract excludes them. Covers the per-validator helpers
+  under `Validation\Request\` / `Validation\Response\` / `Validation\Support\`,
+  the `Spec\` machinery (`OpenApiSchemaConverter`, `OpenApiPathMatcher`,
+  `OpenApiPathSuggester`, `OpenApiRefResolver`, `RefResolutionContext`),
+  the PHPUnit `CoverageReportSubscriber` / `ConsoleOutput` enum, and
+  `Fuzz\SchemaDataGenerator`. No behavioural change — the public
+  entry points (`OpenApiResponseValidator`, `OpenApiRequestValidator`,
+  `OpenApiCoverageTracker`, `Coverage\*` renderers, `Fuzz\OpenApiEndpointExplorer`,
+  `Laravel\*`, attributes, exceptions, enums, `OpenApiSpecLoader`)
+  remain user-callable. Refs #113.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -1015,6 +1015,42 @@ The library uses PHP's native `trigger_error(..., E_USER_WARNING)` as the loud-s
 
 **Per-process dedup vs per-test:** the dedup state is process-global. PHPUnit runs all tests in one process by default, so a warning fired in test A is not fired again in test B even if both schemas exhibit the issue. The `*::resetWarningStateForTesting()` helpers (annotated `@internal`) exist as test seams for the converter / security validator's own tests; downstream tests rarely need them.
 
+## Versioning and support policy
+
+This library follows [Semantic Versioning 2.0](https://semver.org/). v1.0.0 is the API stability commitment: anything not marked `@internal` in v1.0.0 is covered by SemVer for the entire v1.x line.
+
+### What's covered by SemVer in v1.x
+
+- Public class names and namespaces (anything not marked `@internal`)
+- Public method signatures (parameters, return types, visibility)
+- Public constants and their values
+- Enum cases (additions are minor; removals or renames are major)
+- The `OpenApiValidationResult` shape (`outcome()`, `errors()`, `matchedPath()`, `skipReason()`, `isValid()`, `isSkipped()`)
+- The CLI surface of `bin/openapi-coverage-merge` (flags, exit codes, sidecar JSON wire format via `STATE_FORMAT_VERSION`)
+- The `OpenApiCoverageExtension` PHPUnit configuration parameters (`spec_base_path`, `strip_prefixes`, `specs`, `output_file`, `console_output`, …)
+- The Laravel `ValidatesOpenApiSchema` trait's public methods
+- The category prefixes used in `E_USER_WARNING` messages (`[security]`, `[OpenAPI Schema]`)
+
+### What's NOT covered by SemVer
+
+- Anything marked `@internal` — including the `Internal\` and `Validation\Support\` namespaces, the per-validator helpers under `Validation\Request\` / `Validation\Response\`, `Spec\OpenApiSchemaConverter` / `Spec\OpenApiPathMatcher` / `Spec\OpenApiRefResolver` / `Spec\OpenApiPathSuggester`, the PHPUnit `CoverageReportSubscriber`, and test seams (`*::resetWarningStateForTesting()`, `OpenApiSpecLoader::reset()`, `OpenApiCoverageTracker::reset()` / `exportState()` / `importState()`).
+- Validator error message wording (we may improve them; assert on presence/category, not on exact strings).
+- The set of `format` keywords delegated to opis — we follow opis upstream, so a new format is added when opis adds it.
+- Behaviour of bug-fix releases that close a documented silent-pass case. A test that passed only because of the silent pass may start failing — that's the fix doing its job, not a SemVer break.
+
+See [UPGRADING.md](UPGRADING.md) for migration notes between versions.
+
+### Support policy
+
+| Component | Supported |
+| --- | --- |
+| PHP runtime | 8.2, 8.3, 8.4 (CI matrix). PHP 8.2 is supported until its security-EOL (2026-12); a SemVer-major bump may drop it after that. |
+| PHPUnit | 11.x, 12.x, 13.x (CI matrix). New stable PHPUnit majors are added to the matrix; older majors are dropped in a SemVer-major bump. |
+| `opis/json-schema` | `^2.6` for v1.x. A jump to `^3` would be a SemVer-major. |
+| Laravel (optional adapter) | Whatever `orchestra/testbench` `^9 || ^10 || ^11` supports. |
+
+Bug fixes and security updates land on the latest minor of v1.x. There is no LTS branch for older minors — upgrade to the latest minor to receive fixes.
+
 ## API Reference
 
 ### `OpenApiResponseValidator`

--- a/README.md
+++ b/README.md
@@ -1033,7 +1033,7 @@ This library follows [Semantic Versioning 2.0](https://semver.org/). v1.0.0 is t
 
 ### What's NOT covered by SemVer
 
-- Anything marked `@internal` — including the `Internal\` and `Validation\Support\` namespaces, the per-validator helpers under `Validation\Request\` / `Validation\Response\`, `Spec\OpenApiSchemaConverter` / `Spec\OpenApiPathMatcher` / `Spec\OpenApiRefResolver` / `Spec\OpenApiPathSuggester`, the PHPUnit `CoverageReportSubscriber`, and test seams (`*::resetWarningStateForTesting()`, `OpenApiSpecLoader::reset()`, `OpenApiCoverageTracker::reset()` / `exportState()` / `importState()`).
+- Anything marked `@internal` — including the `Internal\` and `Validation\Support\` namespaces, the per-validator helpers under `Validation\Request\` / `Validation\Response\`, `Spec\OpenApiSchemaConverter` / `Spec\OpenApiPathMatcher` / `Spec\OpenApiRefResolver` / `Spec\OpenApiPathSuggester`, the PHPUnit `CoverageReportSubscriber`, `Coverage\CoverageMergeCommand` (the `bin/openapi-coverage-merge` CLI itself remains covered — the class is the implementation detail behind it), and test seams (`*::resetWarningStateForTesting()`, `OpenApiSpecLoader::reset()`, `OpenApiCoverageTracker::reset()` / `exportState()` / `importState()`).
 - Validator error message wording (we may improve them; assert on presence/category, not on exact strings).
 - The set of `format` keywords delegated to opis — we follow opis upstream, so a new format is added when opis adds it.
 - Behaviour of bug-fix releases that close a documented silent-pass case. A test that passed only because of the silent pass may start failing — that's the fix doing its job, not a SemVer break.

--- a/src/Coverage/CoverageMergeCommand.php
+++ b/src/Coverage/CoverageMergeCommand.php
@@ -57,6 +57,11 @@ use function unlink;
  *     min_coverage_strict?: bool,
  *     help?: bool,
  * }
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ *           The CLI surface of `bin/openapi-coverage-merge` is the documented
+ *           invocation path; this class's constructor / methods may change in
+ *           any release without a SemVer bump.
  */
 final class CoverageMergeCommand
 {

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -47,6 +47,8 @@ use function trigger_error;
  * output across runs. Without faker, the generator falls back to deterministic
  * values keyed off the per-case iteration index — repeated calls still produce
  * identical output for the same `count`.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
  */
 final class SchemaDataGenerator
 {

--- a/src/Internal/ExternalRefLoader.php
+++ b/src/Internal/ExternalRefLoader.php
@@ -39,7 +39,7 @@ use function strtolower;
  * bypass the source-file-relative resolution rules and would surprise
  * a reader scanning paths visually.
  *
- * @internal Not part of the package's public API. Do not call from user code.
+ * @internal Not part of the package's public API. Do not use from user code.
  */
 final class ExternalRefLoader
 {

--- a/src/Internal/HttpRefLoader.php
+++ b/src/Internal/HttpRefLoader.php
@@ -40,7 +40,7 @@ use function trim;
  * `OpenApiRefResolver::resolve()` call (no global / cross-call cache —
  * each test gets a fresh fetch).
  *
- * @internal Not part of the package's public API. Do not call from user code.
+ * @internal Not part of the package's public API. Do not use from user code.
  */
 final class HttpRefLoader
 {

--- a/src/Internal/SpecDocumentDecoder.php
+++ b/src/Internal/SpecDocumentDecoder.php
@@ -29,7 +29,7 @@ use function sprintf;
  * the caller can pinpoint which ref / file / URL produced the failure
  * without the decoder having to know the source.
  *
- * @internal Not part of the package's public API. Do not call from user code.
+ * @internal Not part of the package's public API. Do not use from user code.
  */
 final class SpecDocumentDecoder
 {

--- a/src/Internal/YamlAvailability.php
+++ b/src/Internal/YamlAvailability.php
@@ -15,7 +15,7 @@ use function class_exists;
  * has to carry a test-only setter on its public API surface. The override
  * state, the real check, and the reset helper all live here instead.
  *
- * @internal Not part of the package's public API. Do not call from user code.
+ * @internal Not part of the package's public API. Do not use from user code.
  */
 final class YamlAvailability
 {

--- a/src/Laravel/Internal/StackTraceFilter.php
+++ b/src/Laravel/Internal/StackTraceFilter.php
@@ -16,9 +16,11 @@ use function str_contains;
 use function str_replace;
 
 /**
- * @internal Trims this library's own + Laravel test-concern frames out of an
- *           assertion-failure trace so a contract-test failure points at the
- *           user's test line, not at vendor code.
+ * Trims this library's own + Laravel test-concern frames out of an
+ * assertion-failure trace so a contract-test failure points at the
+ * user's test line, not at vendor code.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
  */
 final class StackTraceFilter
 {

--- a/src/PHPUnit/ConsoleOutput.php
+++ b/src/PHPUnit/ConsoleOutput.php
@@ -11,9 +11,6 @@ use function getenv;
 use function mb_strtolower;
 use function trim;
 
-/**
- * @internal Not part of the package's public API. Do not use from user code.
- */
 enum ConsoleOutput: string
 {
     case DEFAULT = 'default';

--- a/src/PHPUnit/ConsoleOutput.php
+++ b/src/PHPUnit/ConsoleOutput.php
@@ -11,6 +11,9 @@ use function getenv;
 use function mb_strtolower;
 use function trim;
 
+/**
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
 enum ConsoleOutput: string
 {
     case DEFAULT = 'default';

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -28,6 +28,8 @@ use function trim;
 
 /**
  * @phpstan-import-type CoverageResult from OpenApiCoverageTracker
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
  */
 final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscriber
 {

--- a/src/Spec/OpenApiPathMatcher.php
+++ b/src/Spec/OpenApiPathMatcher.php
@@ -20,6 +20,9 @@ use function substr;
 use function trim;
 use function usort;
 
+/**
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
 final class OpenApiPathMatcher
 {
     /** @var array{pattern: string, path: string, paramNames: string[], literalSegments: int}[] */

--- a/src/Spec/OpenApiPathSuggester.php
+++ b/src/Spec/OpenApiPathSuggester.php
@@ -28,6 +28,8 @@ use function usort;
  *
  * Kept separate from OpenApiPathMatcher so the matcher's hot-path API stays
  * focused on matching. Suggestion is only invoked from error paths.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
  */
 final class OpenApiPathSuggester
 {

--- a/src/Spec/OpenApiRefResolver.php
+++ b/src/Spec/OpenApiRefResolver.php
@@ -28,6 +28,9 @@ use function strpos;
 use function strrpos;
 use function substr;
 
+/**
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
 final class OpenApiRefResolver
 {
     /**

--- a/src/Spec/OpenApiSchemaConverter.php
+++ b/src/Spec/OpenApiSchemaConverter.php
@@ -19,6 +19,9 @@ use function is_string;
 use function sprintf;
 use function trigger_error;
 
+/**
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
 final class OpenApiSchemaConverter
 {
     /**

--- a/src/Spec/RefResolutionContext.php
+++ b/src/Spec/RefResolutionContext.php
@@ -17,6 +17,8 @@ use Psr\Http\Message\RequestFactoryInterface;
  * The per-resolution document cache is intentionally NOT held here — it
  * is mutated as files/URLs are loaded, so the resolver still passes it
  * by reference alongside the (immutable) context.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
  */
 final class RefResolutionContext
 {

--- a/src/Validation/Request/CollectionResult.php
+++ b/src/Validation/Request/CollectionResult.php
@@ -13,6 +13,8 @@ namespace Studio\OpenApiContractTesting\Validation\Request;
  * were dropped during collection — these are surfaced to callers alongside
  * any per-request validation errors so a single test run reports every
  * contract drift at once.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
  */
 final readonly class CollectionResult
 {

--- a/src/Validation/Request/HeaderParameterValidator.php
+++ b/src/Validation/Request/HeaderParameterValidator.php
@@ -20,6 +20,9 @@ use function is_scalar;
 use function sprintf;
 use function strtolower;
 
+/**
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
 final class HeaderParameterValidator
 {
     public function __construct(

--- a/src/Validation/Request/ParameterCollector.php
+++ b/src/Validation/Request/ParameterCollector.php
@@ -11,6 +11,9 @@ use function is_string;
 use function sprintf;
 use function strtolower;
 
+/**
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
 final class ParameterCollector
 {
     /**

--- a/src/Validation/Request/PathParameterValidator.php
+++ b/src/Validation/Request/PathParameterValidator.php
@@ -15,6 +15,9 @@ use function array_key_exists;
 use function is_array;
 use function rawurldecode;
 
+/**
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
 final class PathParameterValidator
 {
     public function __construct(

--- a/src/Validation/Request/QueryParameterValidator.php
+++ b/src/Validation/Request/QueryParameterValidator.php
@@ -14,6 +14,9 @@ use Studio\OpenApiContractTesting\Validation\Support\TypeCoercer;
 use function array_key_exists;
 use function is_array;
 
+/**
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
 final class QueryParameterValidator
 {
     public function __construct(

--- a/src/Validation/Request/RequestBodyValidator.php
+++ b/src/Validation/Request/RequestBodyValidator.php
@@ -16,6 +16,9 @@ use function array_keys;
 use function implode;
 use function is_array;
 
+/**
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
 final class RequestBodyValidator
 {
     public function __construct(

--- a/src/Validation/Request/SchemeClassification.php
+++ b/src/Validation/Request/SchemeClassification.php
@@ -19,6 +19,8 @@ namespace Studio\OpenApiContractTesting\Validation\Request;
  *   warning (e.g. `OAuth2`, `OpenID Connect`, `Mutual TLS`, `http-basic`,
  *   `http-digest`).
  * - `Bearer` / `ApiKey` → both fields null.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
  */
 final readonly class SchemeClassification
 {

--- a/src/Validation/Request/SchemeKind.php
+++ b/src/Validation/Request/SchemeKind.php
@@ -18,6 +18,8 @@ namespace Studio\OpenApiContractTesting\Validation\Request;
  *                         an unknown `type`). Always surfaced as a hard error
  *                         so the spec author is pushed to fix it, even if a
  *                         sibling requirement entry is satisfied.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
  */
 enum SchemeKind
 {

--- a/src/Validation/Request/SecuritySchemeIntrospector.php
+++ b/src/Validation/Request/SecuritySchemeIntrospector.php
@@ -23,6 +23,8 @@ use function strtolower;
  * SecurityValidator's hard-error surface: the validator is still the
  * source of truth for "is this spec broken" and we do not want two layers
  * producing redundant errors.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
  */
 final class SecuritySchemeIntrospector
 {

--- a/src/Validation/Request/SecurityValidator.php
+++ b/src/Validation/Request/SecurityValidator.php
@@ -21,6 +21,9 @@ use function strtolower;
 use function trigger_error;
 use function trim;
 
+/**
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
 final class SecurityValidator
 {
     /** @var array<string, true> */

--- a/src/Validation/Response/ResponseBodyValidationResult.php
+++ b/src/Validation/Response/ResponseBodyValidationResult.php
@@ -15,6 +15,8 @@ namespace Studio\OpenApiContractTesting\Validation\Response;
  *
  * Coverage tracking uses `matchedContentType` to record per-(status, media-type)
  * granularity instead of treating the whole endpoint as a single bucket.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
  */
 final readonly class ResponseBodyValidationResult
 {

--- a/src/Validation/Response/ResponseBodyValidator.php
+++ b/src/Validation/Response/ResponseBodyValidator.php
@@ -20,6 +20,9 @@ use function in_array;
 use function is_array;
 use function is_string;
 
+/**
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
 final class ResponseBodyValidator
 {
     public function __construct(

--- a/src/Validation/Response/ResponseHeaderValidator.php
+++ b/src/Validation/Response/ResponseHeaderValidator.php
@@ -50,6 +50,8 @@ use function trim;
  *
  * @phpstan-type HeaderObject array{required?: bool, schema?: array<string, mixed>}
  * @phpstan-type HeadersSpec array<string, HeaderObject|mixed>
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
  */
 final class ResponseHeaderValidator
 {

--- a/src/Validation/Support/ContentTypeMatcher.php
+++ b/src/Validation/Support/ContentTypeMatcher.php
@@ -11,6 +11,9 @@ use function strstr;
 use function strtolower;
 use function trim;
 
+/**
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
 final class ContentTypeMatcher
 {
     /**

--- a/src/Validation/Support/HeaderNormalizer.php
+++ b/src/Validation/Support/HeaderNormalizer.php
@@ -7,6 +7,9 @@ namespace Studio\OpenApiContractTesting\Validation\Support;
 use function is_string;
 use function strtolower;
 
+/**
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
 final class HeaderNormalizer
 {
     /**

--- a/src/Validation/Support/ObjectConverter.php
+++ b/src/Validation/Support/ObjectConverter.php
@@ -9,6 +9,9 @@ use stdClass;
 use function array_is_list;
 use function is_array;
 
+/**
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
 final class ObjectConverter
 {
     /**

--- a/src/Validation/Support/PathDiagnosticsFormatter.php
+++ b/src/Validation/Support/PathDiagnosticsFormatter.php
@@ -31,6 +31,8 @@ use function strtoupper;
  *   route to this helper because the requested method is missing AND every
  *   other method is too. Rendering an explicit `(none)` keeps that case
  *   visible instead of producing "Defined methods: .".
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
  */
 final class PathDiagnosticsFormatter
 {

--- a/src/Validation/Support/SchemaValidatorRunner.php
+++ b/src/Validation/Support/SchemaValidatorRunner.php
@@ -12,6 +12,9 @@ use Opis\JsonSchema\Validator;
 
 use function sprintf;
 
+/**
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
 final class SchemaValidatorRunner
 {
     private readonly Validator $opisValidator;

--- a/src/Validation/Support/TypeCoercer.php
+++ b/src/Validation/Support/TypeCoercer.php
@@ -16,6 +16,9 @@ use function is_string;
 use function preg_match;
 use function strtolower;
 
+/**
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
 final class TypeCoercer
 {
     /**

--- a/src/Validation/Support/ValidatorErrorBoundary.php
+++ b/src/Validation/Support/ValidatorErrorBoundary.php
@@ -35,6 +35,8 @@ use function sprintf;
  * wraps lower-level errors), the previous class + message is appended so the
  * synthetic error line retains the root cause that would otherwise be lost
  * when the stack trace is discarded.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
  */
 final class ValidatorErrorBoundary
 {


### PR DESCRIPTION
## Summary

Prepares the v1.0.0 SemVer contract. **No tag pushed in this PR** — only the audit + documentation that v1.0.0 will commit to. The CHANGELOG `## Unreleased` → `## v1.0.0 — DATE` bump and the actual `v1.0.0` tag are deferred to a follow-up so the release timing is decoupled from the prep work.

### What changed

- **28 implementation-detail classes** pick up class-level `@internal` docblock markers so v1.0.0 freezes only the public surface:
  - `Validation/Request/` — every per-transport validator + scheme classification helpers
  - `Validation/Response/` — body/header validators + result carrier
  - `Validation/Support/` — content-type matcher, header normalizer, object converter, schema runner, type coercer, error boundary, diagnostics formatter
  - `Spec/` — `OpenApiSchemaConverter`, `OpenApiPathMatcher`, `OpenApiPathSuggester`, `OpenApiRefResolver`, `RefResolutionContext`
  - `PHPUnit/CoverageReportSubscriber`, `PHPUnit/ConsoleOutput`
  - `Fuzz/SchemaDataGenerator`
- **Public surface stays user-callable**: `OpenApiResponseValidator`, `OpenApiRequestValidator`, `OpenApiCoverageTracker`, the `Coverage/*` renderers + sidecar I/O, `Fuzz/OpenApiEndpointExplorer`, the `Laravel/*` adapter, attributes, exceptions, enums, `OpenApiSpecLoader`, `OpenApiSpecResolver` trait.
- **README** gets a **"Versioning and support policy"** section listing what's covered by SemVer in v1.x, what's explicitly excluded (anything `@internal`, validator error wording, opis format delegation, behavioural shifts from bug-fix-closing-silent-pass cases), and a support matrix for PHP / PHPUnit / `opis/json-schema`.
- **CHANGELOG** documents both blocks under `## Unreleased`:
  - `### Documentation` — Versioning policy section
  - `### Internal` — API surface audit summary

### What's NOT in this PR

- Stability badge (will be added with the v1.0.0 tag — adding it now would be misleading while Packagist still serves 0.x)
- `## Unreleased` → `## v1.0.0 — DATE` bump (deferred)
- `v1.0.0` git tag push (deferred)

### Verification

- ✅ `vendor/bin/phpunit` — 1126 tests, 2735 assertions
- ✅ `vendor/bin/phpstan analyse` — 0 errors
- ✅ `vendor/bin/php-cs-fixer fix --dry-run --diff` — clean

Refs #113.

## Test plan

- [ ] CI green across PHP 8.2/8.3/8.4 × PHPUnit 11/12/13 matrix
- [ ] PHPStan level 6 clean on PHP 8.3
- [ ] PHP-CS-Fixer clean on PHP 8.2
- [ ] No accidental @internal on public-facing classes (spot-check via README API Reference section vs annotated classes)