### PR TITLE
docs: v1.0リリースに合わせてリポジトリのドキュメントを整備

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -43,7 +43,7 @@ body:
     attributes:
       label: Library version
       description: Output of `composer show studio-design/openapi-contract-testing | grep versions`
-      placeholder: e.g. v0.15.0
+      placeholder: e.g. v1.0.0
     validations:
       required: true
   - type: input

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,13 @@ Subject must start lowercase. A CI check enforces this.
 - [ ] `composer test` passes
 - [ ] `composer stan` passes
 - [ ] `composer cs-check` passes
-- [ ] CHANGELOG.md updated under `## Unreleased` (skip for refactor/docs-only PRs)
+
+<!--
+CHANGELOG.md is managed by release-please and must NOT be edited in
+feature / fix PRs. The release PR updates it automatically based on
+Conventional Commits. See CONTRIBUTING.md → "Releases".
+-->
+
 
 ## Notes for reviewers
 

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ $validator = new OpenApiResponseValidator(maxErrors: 5);
 // Report all errors (unlimited)
 $validator = new OpenApiResponseValidator(maxErrors: 0);
 
-// Stop at first error (pre-v0.x default)
+// Stop at first error
 $validator = new OpenApiResponseValidator(maxErrors: 1);
 ```
 
@@ -1112,6 +1112,8 @@ OpenApiSpecLoader::reset(); // For testing
 Tracks which endpoints have been exercised, at `(method, path, statusCode, contentType)` granularity. The Laravel trait records via the tracker automatically; framework-agnostic adapters call it directly.
 
 ```php
+use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
+
 // Request-side: an endpoint was reached without a response assertion
 OpenApiCoverageTracker::recordRequest('front', 'GET', '/v1/pets');
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,14 +2,15 @@
 
 ## Supported Versions
 
-The most recent minor release line on the v1.x and v0.x branches receive
-security fixes. Pre-1.0 versions are best-effort.
+Only the latest minor of v1.x receives security fixes. There is no LTS
+branch for older minors — upgrade to the latest minor of v1.x to receive
+fixes. v0.x is no longer supported now that v1.0 has shipped.
 
 | Version  | Supported |
 | -------- | --------- |
-| 1.x      | ✓         |
-| 0.15.x   | ✓ (until 1.0 ships) |
-| < 0.15   | ✗         |
+| 1.x (latest minor) | ✓ |
+| 1.x (older minors) | ✗ — upgrade to the latest minor |
+| 0.x      | ✗ — upgrade to v1.x |
 
 ## Reporting a Vulnerability
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -41,16 +41,85 @@ in v1.0.0 is covered by SemVer for the v1.x line.
   (a test that passed only because of the silent pass may start failing —
   that's the bug fix doing its job, not a SemVer break)
 
-### Migration notes from v0.15.0
+### Migration notes by source version
 
-- No breaking source-code changes from v0.15.0.
-- New `E_USER_WARNING` may fire for specs using `patternProperties`,
-  `unevaluatedProperties`, `unevaluatedItems`, `contentMediaType`, or
-  `contentEncoding`. Tests configured with PHPUnit's `failOnWarning="true"`
-  (the default in this repo's `phpunit.xml.dist`) will fail loudly if
-  these are encountered. To suppress: rewrite the spec using Draft 07
-  equivalents, or set `failOnWarning="false"` in your project's
-  `phpunit.xml.dist`.
+There are **no breaking source-code changes** from any v0.16+ release to
+v1.0.0. v1.0.0 is a stability promotion of v0.19.0 — every fix from the
+v0.16 → v0.19 dogfood cycle is in v1.0.0 unchanged. The behavioural
+changes listed below ship as part of those minors and may surface when
+upgrading; review the section that matches your starting version and
+forward.
+
+If you are on v0.14.0 or older, apply the v0.14.0 → v0.15.0 namespace
+migration first (see the table below), then read this section top-to-bottom.
+
+#### Common to all v0.x → v1.0 upgrades — new `E_USER_WARNING`s
+
+The library uses `trigger_error(..., E_USER_WARNING)` as its v1.0 official
+silent-pass channel (see README → "Warning channel"). Tests configured
+with PHPUnit's `failOnWarning="true"` (the default in this repo's
+`phpunit.xml.dist`) will fail on first encounter. The categories that
+ship between v0.16.0 and v1.0.0 are:
+
+| Category prefix | Source | Warns on |
+|---|---|---|
+| `[security]` | `SecurityValidator` | `oauth2`, `openIdConnect`, `mutualTLS`, `http-basic`, `http-digest` schemes (silently passed before) |
+| `[OpenAPI Schema]` | `OpenApiSchemaConverter` | `unevaluatedProperties` / `unevaluatedItems` (Draft 07 has no equivalent), `discriminator.mapping` (stripped — mapping does not steer validation), unknown / malformed `format` values |
+
+Each warning is dedup'd per-process and prefixed with the category tag so
+you can filter them mechanically. To suppress one category, install a
+`set_error_handler` that matches the prefix; do NOT blanket-suppress
+`E_USER_WARNING`. To stay green without filtering, set
+`failOnWarning="false"` in your project's `phpunit.xml.dist`.
+
+#### From v0.15.0 → v1.0.0
+
+- No source-code changes required.
+- All warnings in the table above apply; previously these were silent passes.
+- v0.15.0 already required updating `use Studio\OpenApiContractTesting\X`
+  imports per the v0.14.0 → v0.15.0 migration table — that is unchanged.
+
+#### From v0.16.0 → v1.0.0
+
+- No source-code changes required.
+- **`discriminator.mapping`** now warns on first encounter (#147). Specs
+  with non-empty `mapping` previously silently dropped the keyword;
+  validation behaviour is unchanged (the underlying `oneOf` / `anyOf` is
+  still validated as a union).
+- **Unknown / malformed `format` keywords** now warn (#151). A typo like
+  `format: emial` previously silently passed every string; the converter
+  now emits a one-shot warning per unknown format value.
+
+#### From v0.17.0 → v1.0.0
+
+- No source-code changes required.
+- **Multi-JSON-per-status schema selection** behaves differently (#152).
+  When a spec declares multiple JSON keys for the same status (e.g.
+  `application/json` AND `application/problem+json`) and the response
+  carries a JSON-flavoured `Content-Type`, the validator now prefers the
+  spec key that exactly matches the actual `Content-Type` before falling
+  back to the first JSON key. Pre-v0.17 behaviour was first-JSON-wins —
+  problem-details bodies served as `application/problem+json` were judged
+  against the success-shape `application/json` schema. Single-JSON specs
+  and vendor `+json` suffixes the spec doesn't enumerate are unaffected.
+
+#### From v0.18.0 → v1.0.0
+
+- No source-code changes required.
+- **`additionalProperties: false` cascade dedup** strips the pseudo-error
+  that named declared properties as not-allowed when any sub-property
+  failed (#159). A 1-error failure that previously inflated to 2 errors
+  collapses back to 1. If a test was asserting the exact error count or
+  the cascade message, update the assertion.
+
+#### From v0.19.0 → v1.0.0
+
+- No source-code changes required.
+- **Cascade dedup now walks across array boundaries** (#161). Cascades
+  through `{ data: [Item] }`-shaped envelopes — including the shape
+  `OpenApiSchemaConverter` lowers OAS 3.1 `prefixItems` to — collapse the
+  same way as the root-level dedup did in v0.18.0. Same assertion-update
+  caveat as v0.18.0.
 
 ## v0.14.0 → v0.15.0
 


### PR DESCRIPTION
# 概要

v1.0.0 リリース (2026-05-01) 後に陳腐化／不整合を起こしているリポジトリ内ドキュメントを網羅的に整備する。

## 変更内容

リポジトリ内のドキュメントを v1.0 リリース後の状態に合わせて見直し、以下の不整合・古い記述を解消した。

- **SECURITY.md**: "until 1.0 ships" の条件付き表記を解消し、v0.x のサポート終了と v1.x は最新 minor のみサポートする方針を明示。README の "no LTS branch for older minors" との整合を取った。
- **`.github/PULL_REQUEST_TEMPLATE.md`**: 手動 CHANGELOG 更新チェックボックスを削除。release-please (#163) が CHANGELOG を管理する運用になっており、CONTRIBUTING.md の "Never edit CHANGELOG.md manually" と矛盾していた。
- **`.github/ISSUE_TEMPLATE/bug_report.yml`**: Library version 入力欄の placeholder を `v0.15.0` → `v1.0.0` に更新。
- **UPGRADING.md**: 既存の "Migration notes from v0.15.0" のみだった節を、v0.15.0 / v0.16.0 / v0.17.0 / v0.18.0 / v0.19.0 各バージョンからの v1.0.0 への移行ノートに分割。すべてのバージョンに共通する `E_USER_WARNING` カテゴリ (`[security]` / `[OpenAPI Schema]`) を 1 表に整理。v0.16 以降で導入された挙動変化 (`discriminator.mapping` 警告、未知 `format` 警告、multi-JSON content-type 選択ロジック、`additionalProperties: false` カスケード dedup の root / 配列境界対応) を 1 ファイルから参照可能にした。
- **README.md**: L321 の `// Stop at first error (pre-v0.x default)` コメントを修正 (文法的に意味不明だったため)。`OpenApiCoverageTracker` のサンプルに `use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;` の import 文を追加し、v0.15.0 namespace 再編後の正しい FQCN を示すようにした (同セクションの `OpenApiSpecLoader` サンプルと一貫性を取った)。

## 関連情報

- 関連 PR (v1.0 出荷): #163 (release-please 自動化)
- v1.0.0 タグ: https://github.com/studio-design/openapi-contract-testing/releases/tag/v1.0.0
- 関連 Issue: 直接対応する Issue はないが、v1.0.0 リリース直後に発生した典型的なドキュメント陳腐化の解消。