### PR TITLE
feat(extension): opt-in auto-discovery of #[BoundToOpenApiEnum] enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,6 +689,47 @@ Each `EnumDriftReport` carries `enumFqcn`, `specPath`, `phpOnly`, and `specOnly`
 
 `EnumBindingException` is thrown when the comparison cannot be performed at all — missing `#[BoundToOpenApiEnum]`, target is not a backed enum, spec file not found, malformed JSON, `enum` key missing or not an array, or an `enum` array entry is non-scalar (`null` / `bool` / nested arrays — backed PHP enums can only carry `string` or `int`). `$reason` carries an `EnumBindingReason` enum so you can branch programmatically. These errors fire regardless of `failOnDrift` — they are setup mistakes, not drift signals.
 
+### Auto-discovery via the PHPUnit extension
+
+Manually enumerating every bound enum in a test method gets stale fast — a new `#[BoundToOpenApiEnum]` added by another developer slips by silently until someone remembers to update the list. The PHPUnit extension can scan one or more PSR-4 namespace prefixes at bootstrap and run drift checks before any test executes.
+
+Add the opt-in parameters to your `phpunit.xml`:
+
+```xml
+<extensions>
+    <bootstrap class="Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension">
+        <parameter name="spec_base_path" value="openapi/dist"/>
+        <parameter name="enum_drift_enabled" value="true"/>
+        <parameter name="enum_drift_scan_namespaces" value="App\Enums,App\Domain\Enums"/>
+        <parameter name="enum_drift_fail_on_drift" value="true"/>
+    </bootstrap>
+</extensions>
+```
+
+| Parameter | Default | Behaviour |
+|---|---|---|
+| `enum_drift_enabled` | `false` | Master opt-in. Empty value (`<parameter name="enum_drift_enabled"/>`) is also treated as `true`, mirroring `min_coverage_strict`. |
+| `enum_drift_scan_namespaces` | _none_ | Comma-separated PSR-4 namespace prefixes (whitespace tolerated). Each prefix must match — directly or as a sub-namespace of — an entry in your `composer.json` `autoload.psr-4` map. |
+| `enum_drift_fail_on_drift` | `true` | `true` aborts the run with a `[OpenAPI Enum Drift] FATAL` block on stderr (and `GITHUB_STEP_SUMMARY` when set). `false` emits a `WARNING` block but lets PHPUnit continue. |
+
+Discovery walks Composer's classmap first (so `--optimize-autoloader` and `--classmap-authoritative` deployments are covered) and falls back to a recursive PSR-4 directory scan for default dev installs. Only backed enums carrying `#[BoundToOpenApiEnum]` are passed to `EnumDriftAsserter`; pure enums, traits, abstract classes, and unattributed classes in the same directory are silently skipped.
+
+A drift run produces the same diagnostic block documented above:
+
+```
+[OpenAPI Enum Drift] FATAL: 1 enum binding(s) drift from spec.
+
+  App\Enums\NotificationCodeEnum  ->  _shared/components/schemas/enums/NotificationCodeEnum.json
+    PHP-only (1): "betaFeature"
+    Spec-only (1): "deprecated"
+
+Action: align the PHP enum cases with the spec, or update the spec's enum array.
+```
+
+In `enum_drift_fail_on_drift="false"` mode the same body is written under a `[OpenAPI Enum Drift] WARNING` header and PHPUnit exits normally — wire `failOnPhpunitWarning` (or your team's preferred CI gate) if you want the warning to fail the build.
+
+Misconfiguration (no namespaces configured, unresolvable namespace prefix, missing Composer ClassLoader, or any `EnumBindingException` raised by a discovered enum) **always** produces a FATAL exit regardless of `enum_drift_fail_on_drift` — these are setup errors that would otherwise hide a real drift signal.
+
 ### Known limitations
 
 - **JSON only.** The asserter currently reads the bound enum file with `file_get_contents` + `json_decode`. YAML enum files are not supported in v1; convert them to JSON or extract the enum into a `.json` sidecar.

--- a/README.md
+++ b/README.md
@@ -711,10 +711,11 @@ Add the opt-in parameters to your `phpunit.xml`:
 | `enum_drift_enabled` | `false` | Master opt-in. Empty value (`<parameter name="enum_drift_enabled"/>`) is also treated as `true`, mirroring `min_coverage_strict`. |
 | `enum_drift_scan_namespaces` | _none_ | Comma-separated PSR-4 namespace prefixes (whitespace tolerated). Each prefix must match — directly or as a sub-namespace of — an entry in your `composer.json` `autoload.psr-4` map. |
 | `enum_drift_fail_on_drift` | `true` | `true` aborts the run with a `[OpenAPI Enum Drift] FATAL` block on stderr (and `GITHUB_STEP_SUMMARY` when set). `false` emits a `WARNING` block but lets PHPUnit continue. |
+| _misconfiguration_ | _n/a_ | No namespaces configured, an unresolvable namespace prefix, a missing Composer `ClassLoader`, or any `EnumBindingException` raised by a discovered enum **always** produces a FATAL exit regardless of `enum_drift_fail_on_drift`. These are setup errors and would otherwise hide a real drift signal. |
 
-Discovery walks Composer's classmap first (so `--optimize-autoloader` and `--classmap-authoritative` deployments are covered) and falls back to a recursive PSR-4 directory scan for default dev installs. Only backed enums carrying `#[BoundToOpenApiEnum]` are passed to `EnumDriftAsserter`; pure enums, traits, abstract classes, and unattributed classes in the same directory are silently skipped.
+Discovery merges results from Composer's classmap (`getClassMap()`) and a recursive scan of each PSR-4-registered directory, deduplicating across both sources. Production deployments using `--optimize-autoloader` or `--classmap-authoritative` are covered by the classmap pass; default dev installs are covered by the PSR-4 directory walk. Only backed enums carrying `#[BoundToOpenApiEnum]` are passed to `EnumDriftAsserter`; pure enums, traits, abstract classes, and unattributed classes in the same directory are silently skipped.
 
-A drift run produces the same diagnostic block documented above:
+A strict-mode (default) drift run produces the same diagnostic block documented above:
 
 ```
 [OpenAPI Enum Drift] FATAL: 1 enum binding(s) drift from spec.
@@ -726,9 +727,21 @@ A drift run produces the same diagnostic block documented above:
 Action: align the PHP enum cases with the spec, or update the spec's enum array.
 ```
 
-In `enum_drift_fail_on_drift="false"` mode the same body is written under a `[OpenAPI Enum Drift] WARNING` header and PHPUnit exits normally — wire `failOnPhpunitWarning` (or your team's preferred CI gate) if you want the warning to fail the build.
+In `enum_drift_fail_on_drift="false"` mode the body is identical except for the severity prefix:
 
-Misconfiguration (no namespaces configured, unresolvable namespace prefix, missing Composer ClassLoader, or any `EnumBindingException` raised by a discovered enum) **always** produces a FATAL exit regardless of `enum_drift_fail_on_drift` — these are setup errors that would otherwise hide a real drift signal.
+```
+[OpenAPI Enum Drift] WARNING: 1 enum binding(s) drift from spec.
+
+  App\Enums\NotificationCodeEnum  ->  _shared/components/schemas/enums/NotificationCodeEnum.json
+    PHP-only (1): "betaFeature"
+    Spec-only (1): "deprecated"
+
+Action: align the PHP enum cases with the spec, or update the spec's enum array.
+```
+
+PHPUnit exits normally in `WARNING` mode. **`failOnWarning="true"` and `failOnPhpunitWarning="true"` do _not_ catch this block** — both flags only fire for warnings raised during test execution, not bootstrap-time stderr writes from an extension. If you need lenient drift to fail the build, gate on the stderr text in CI directly (e.g. `phpunit ... 2>&1 | tee out && ! grep -q '\[OpenAPI Enum Drift\] WARNING' out`).
+
+If `enum_drift_scan_namespaces` resolves but no `#[BoundToOpenApiEnum]`-attributed enums are found, the extension emits one `[OpenAPI Enum Drift] NOTE:` line to stderr and continues. This surfaces typo'd namespaces ("`App\Enum`" vs "`App\Enums`") without failing codebases that are mid-migration.
 
 ### Known limitations
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,6 +17,10 @@ parameters:
         - tests
     excludePaths:
         - src/Laravel
+        # EnumScanner fixture dir holds intentionally-unused trait/abstract
+        # files so the scanner can walk past them; PHPStan would otherwise
+        # flag them as `trait.unused`.
+        - tests/Unit/Internal/Fixture/EnumScanner
     tmpDir: .phpstan.cache
     ignoreErrors:
         # PHPUnit marks AssertionFailedError + Exception @internal, but test code

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,6 +16,14 @@
         </testsuite>
         <testsuite name="Integration">
             <directory>tests/Integration</directory>
+            <!--
+                Smoke fixture is consumed by
+                OpenApiCoverageExtensionEnumDriftBootstrapTest's subprocess
+                runs (where PHPUnit needs at least one passing test for the
+                lenient/clean cases to exit zero) — not part of the regular
+                suite.
+            -->
+            <exclude>tests/Integration/Fixture/Smoke</exclude>
         </testsuite>
     </testsuites>
 

--- a/src/Exception/EnumBindingException.php
+++ b/src/Exception/EnumBindingException.php
@@ -28,4 +28,35 @@ final class EnumBindingException extends RuntimeException
     ) {
         parent::__construct($message, 0, $previous);
     }
+
+    /**
+     * Build an exception for a specific bound enum that failed to resolve
+     * against its spec file. `$enumFqcn` is required because all per-binding
+     * reasons (`TargetIsNotEnum`, `AttributeMissing`, `SpecFileNotFound`, …)
+     * carry it.
+     */
+    public static function forBinding(
+        EnumBindingReason $reason,
+        string $message,
+        string $enumFqcn,
+        ?string $specPath = null,
+        ?Throwable $previous = null,
+    ): self {
+        return new self($reason, $message, $enumFqcn, $specPath, $previous);
+    }
+
+    /**
+     * Build an exception for a scanner-level misconfiguration that is not
+     * tied to any single binding (`NoNamespacesConfigured`,
+     * `ScanNamespaceUnresolvable`, `ScanComposerLoaderUnavailable`).
+     * `$enumFqcn` and `$specPath` are deliberately not accepted — these
+     * reasons describe the scan setup itself, not a failed binding.
+     */
+    public static function forScan(
+        EnumBindingReason $reason,
+        string $message,
+        ?Throwable $previous = null,
+    ): self {
+        return new self($reason, $message, null, null, $previous);
+    }
 }

--- a/src/Exception/EnumBindingReason.php
+++ b/src/Exception/EnumBindingReason.php
@@ -23,4 +23,7 @@ enum EnumBindingReason
     case EnumKeyMissing;
     case EnumKeyNotArray;
     case EnumValueUnsupported;
+    case ScanNamespaceUnresolvable;
+    case ScanComposerLoaderUnavailable;
+    case NoNamespacesConfigured;
 }

--- a/src/Internal/EnumScanner.php
+++ b/src/Internal/EnumScanner.php
@@ -170,7 +170,7 @@ final class EnumScanner
         $autoloadFns = spl_autoload_functions();
         if ($autoloadFns !== false) {
             foreach ($autoloadFns as $fn) {
-                if (is_array($fn) && isset($fn[0]) && $fn[0] instanceof ClassLoader) {
+                if (is_array($fn) && $fn[0] instanceof ClassLoader) {
                     return $fn[0];
                 }
             }

--- a/src/Internal/EnumScanner.php
+++ b/src/Internal/EnumScanner.php
@@ -1,0 +1,386 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Internal;
+
+use Composer\Autoload\ClassLoader;
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionEnum;
+use SplFileInfo;
+use Studio\OpenApiContractTesting\Attribute\BoundToOpenApiEnum;
+use Studio\OpenApiContractTesting\Exception\EnumBindingException;
+use Studio\OpenApiContractTesting\Exception\EnumBindingReason;
+use Throwable;
+
+use function array_keys;
+use function array_unique;
+use function array_values;
+use function enum_exists;
+use function implode;
+use function is_array;
+use function is_dir;
+use function ltrim;
+use function rtrim;
+use function sort;
+use function spl_autoload_functions;
+use function sprintf;
+use function str_ends_with;
+use function str_replace;
+use function str_starts_with;
+use function strlen;
+use function substr;
+
+/**
+ * Discover backed PHP enums carrying `#[BoundToOpenApiEnum]` under one or
+ * more PSR-4 namespace prefixes. Used by `OpenApiCoverageExtension` so users
+ * no longer have to enumerate every bound enum manually.
+ *
+ * Discovery walks Composer's classmap first (covers `--optimize-autoloader`
+ * and `--classmap-authoritative`), then falls back to a recursive scan of
+ * each PSR-4-registered directory (covers default dev installs).
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+final class EnumScanner
+{
+    private static ?ClassLoader $loaderOverride = null;
+    private static bool $forceUnavailable = false;
+
+    /** @var array<string, list<string>> */
+    private static array $cache = [];
+
+    private function __construct() {}
+
+    /**
+     * Return the FQCNs of every backed enum under one of `$namespacePrefixes`
+     * that carries the `#[BoundToOpenApiEnum]` attribute. Result is sorted
+     * and deduplicated.
+     *
+     * @param list<string> $namespacePrefixes
+     *
+     * @return list<string>
+     *
+     * @throws EnumBindingException on misconfiguration (empty list,
+     *                              no Composer ClassLoader, unresolvable
+     *                              namespace prefix)
+     */
+    public static function scan(array $namespacePrefixes): array
+    {
+        if ($namespacePrefixes === []) {
+            throw new EnumBindingException(
+                EnumBindingReason::NoNamespacesConfigured,
+                'EnumScanner::scan() requires at least one namespace prefix.',
+            );
+        }
+
+        $normalized = [];
+        foreach ($namespacePrefixes as $prefix) {
+            $normalized[] = self::normalizePrefix($prefix);
+        }
+        $normalized = array_values(array_unique($normalized));
+        sort($normalized);
+
+        $cacheKey = implode("\0", $normalized);
+        if (isset(self::$cache[$cacheKey])) {
+            return self::$cache[$cacheKey];
+        }
+
+        $loader = self::resolveLoader();
+
+        $candidates = [];
+        foreach ($normalized as $prefix) {
+            $candidates = [...$candidates, ...self::discoverCandidates($loader, $prefix)];
+        }
+
+        $matches = [];
+        foreach (array_values(array_unique($candidates)) as $fqcn) {
+            if (self::isBoundEnum($fqcn)) {
+                $matches[] = $fqcn;
+            }
+        }
+
+        $matches = array_values(array_unique($matches));
+        sort($matches);
+
+        return self::$cache[$cacheKey] = $matches;
+    }
+
+    /**
+     * Test seam: inject a synthetic ClassLoader so unit tests don't have to
+     * mutate the global autoloader stack.
+     */
+    public static function overrideClassLoaderForTesting(?ClassLoader $loader): void
+    {
+        self::$loaderOverride = $loader;
+        self::$forceUnavailable = false;
+        self::$cache = [];
+    }
+
+    /**
+     * Test seam: simulate environments where no Composer ClassLoader is
+     * registered (e.g., custom autoloader). The next `scan()` call will
+     * raise {@see EnumBindingReason::ScanComposerLoaderUnavailable}.
+     */
+    public static function forceLoaderUnavailableForTesting(): void
+    {
+        self::$loaderOverride = null;
+        self::$forceUnavailable = true;
+        self::$cache = [];
+    }
+
+    public static function reset(): void
+    {
+        self::$loaderOverride = null;
+        self::$forceUnavailable = false;
+        self::$cache = [];
+    }
+
+    private static function normalizePrefix(string $prefix): string
+    {
+        $stripped = ltrim($prefix, '\\');
+
+        return rtrim($stripped, '\\') . '\\';
+    }
+
+    private static function resolveLoader(): ClassLoader
+    {
+        if (self::$forceUnavailable) {
+            throw new EnumBindingException(
+                EnumBindingReason::ScanComposerLoaderUnavailable,
+                'Composer ClassLoader unavailable; cannot auto-discover enums.',
+            );
+        }
+
+        if (self::$loaderOverride !== null) {
+            return self::$loaderOverride;
+        }
+
+        $autoloadFns = spl_autoload_functions();
+        if ($autoloadFns !== false) {
+            foreach ($autoloadFns as $fn) {
+                if (is_array($fn) && isset($fn[0]) && $fn[0] instanceof ClassLoader) {
+                    return $fn[0];
+                }
+            }
+        }
+
+        throw new EnumBindingException(
+            EnumBindingReason::ScanComposerLoaderUnavailable,
+            'Composer ClassLoader unavailable; cannot auto-discover enums.',
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function discoverCandidates(ClassLoader $loader, string $prefix): array
+    {
+        $candidates = self::collectFromClassmap($loader, $prefix);
+        $candidates = [...$candidates, ...self::collectFromPsr4($loader, $prefix)];
+
+        if ($candidates === [] && !self::prefixHasResolvableRoot($loader, $prefix)) {
+            throw new EnumBindingException(
+                EnumBindingReason::ScanNamespaceUnresolvable,
+                sprintf(
+                    'Namespace prefix "%s" is not registered as a Composer PSR-4 root '
+                    . 'and matches no entries in the classmap. Check that the prefix '
+                    . 'matches an autoload.psr-4 entry in composer.json.',
+                    $prefix,
+                ),
+            );
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function collectFromClassmap(ClassLoader $loader, string $prefix): array
+    {
+        $matches = [];
+        foreach (array_keys($loader->getClassMap()) as $fqcn) {
+            if (str_starts_with($fqcn, $prefix)) {
+                $matches[] = $fqcn;
+            }
+        }
+
+        return $matches;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function collectFromPsr4(ClassLoader $loader, string $prefix): array
+    {
+        $directories = self::resolvePsr4Directories($loader, $prefix);
+        if ($directories === []) {
+            return [];
+        }
+
+        $candidates = [];
+        foreach ($directories as $entry) {
+            [$registeredPrefix, $directory] = $entry;
+            if (!is_dir($directory)) {
+                continue;
+            }
+
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator(
+                    $directory,
+                    FilesystemIterator::SKIP_DOTS | FilesystemIterator::FOLLOW_SYMLINKS,
+                ),
+            );
+
+            /** @var SplFileInfo $file */
+            foreach ($iterator as $file) {
+                if (!$file->isFile() || $file->getExtension() !== 'php') {
+                    continue;
+                }
+
+                $fqcn = self::deriveFqcnFromFile(
+                    $registeredPrefix,
+                    $directory,
+                    $file->getPathname(),
+                );
+                if ($fqcn === null) {
+                    continue;
+                }
+
+                if (!str_starts_with($fqcn, $prefix)) {
+                    continue;
+                }
+
+                $candidates[] = $fqcn;
+            }
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * Resolve `$prefix` to one or more `[registeredPrefix, directory]`
+     * tuples. If `$prefix` is registered directly in PSR-4, return its
+     * directories as-is; otherwise look for the longest registered prefix
+     * that is an ancestor of `$prefix` and append the remainder as a
+     * sub-directory.
+     *
+     * @return list<array{0: string, 1: string}>
+     */
+    private static function resolvePsr4Directories(ClassLoader $loader, string $prefix): array
+    {
+        $psr4 = $loader->getPrefixesPsr4();
+
+        if (isset($psr4[$prefix])) {
+            return self::expandDirectories($prefix, $psr4[$prefix], '');
+        }
+
+        $bestMatch = null;
+        $bestMatchLength = 0;
+        foreach ($psr4 as $registeredPrefix => $directories) {
+            if (!str_starts_with($prefix, $registeredPrefix)) {
+                continue;
+            }
+            if (strlen($registeredPrefix) > $bestMatchLength) {
+                $bestMatch = [$registeredPrefix, $directories];
+                $bestMatchLength = strlen($registeredPrefix);
+            }
+        }
+
+        if ($bestMatch === null) {
+            return [];
+        }
+
+        [, $directories] = $bestMatch;
+        $remainder = substr($prefix, $bestMatchLength);
+        $subPath = str_replace('\\', '/', rtrim($remainder, '\\'));
+
+        // The walker reconstructs FQCNs by stripping the directory root and
+        // prepending a namespace prefix. When we descend into a sub-directory
+        // that corresponds to a sub-namespace, the requested prefix — not the
+        // registered ancestor — is the right namespace root for that walk.
+        return self::expandDirectories($prefix, $directories, $subPath);
+    }
+
+    /**
+     * @param list<string> $directories
+     *
+     * @return list<array{0: string, 1: string}>
+     */
+    private static function expandDirectories(string $registeredPrefix, array $directories, string $subPath): array
+    {
+        $expanded = [];
+        foreach ($directories as $directory) {
+            $base = rtrim($directory, '/');
+            $resolved = $subPath === '' ? $base : $base . '/' . $subPath;
+            $expanded[] = [$registeredPrefix, $resolved];
+        }
+
+        return $expanded;
+    }
+
+    private static function prefixHasResolvableRoot(ClassLoader $loader, string $prefix): bool
+    {
+        $psr4 = $loader->getPrefixesPsr4();
+        if (isset($psr4[$prefix])) {
+            return true;
+        }
+
+        foreach (array_keys($psr4) as $registeredPrefix) {
+            if (str_starts_with($prefix, $registeredPrefix)) {
+                return true;
+            }
+        }
+
+        foreach (array_keys($loader->getClassMap()) as $fqcn) {
+            if (str_starts_with($fqcn, $prefix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function deriveFqcnFromFile(
+        string $registeredPrefix,
+        string $rootDirectory,
+        string $filePath,
+    ): ?string {
+        $rootDirectory = rtrim($rootDirectory, '/');
+        $rootWithSlash = $rootDirectory . '/';
+
+        if (!str_starts_with($filePath, $rootWithSlash)) {
+            return null;
+        }
+
+        $relative = substr($filePath, strlen($rootWithSlash));
+        if (!str_ends_with($relative, '.php')) {
+            return null;
+        }
+
+        $relativeWithoutExt = substr($relative, 0, -4);
+        $classPart = str_replace('/', '\\', $relativeWithoutExt);
+
+        return $registeredPrefix . $classPart;
+    }
+
+    private static function isBoundEnum(string $fqcn): bool
+    {
+        try {
+            if (!enum_exists($fqcn)) {
+                return false;
+            }
+            $reflection = new ReflectionEnum($fqcn);
+            if (!$reflection->isBacked()) {
+                return false;
+            }
+
+            return $reflection->getAttributes(BoundToOpenApiEnum::class) !== [];
+        } catch (Throwable) {
+            return false;
+        }
+    }
+}

--- a/src/Internal/EnumScanner.php
+++ b/src/Internal/EnumScanner.php
@@ -9,11 +9,11 @@ use FilesystemIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use ReflectionEnum;
+use ReflectionException;
 use SplFileInfo;
 use Studio\OpenApiContractTesting\Attribute\BoundToOpenApiEnum;
 use Studio\OpenApiContractTesting\Exception\EnumBindingException;
 use Studio\OpenApiContractTesting\Exception\EnumBindingReason;
-use Throwable;
 
 use function array_keys;
 use function array_unique;
@@ -38,9 +38,11 @@ use function substr;
  * more PSR-4 namespace prefixes. Used by `OpenApiCoverageExtension` so users
  * no longer have to enumerate every bound enum manually.
  *
- * Discovery walks Composer's classmap first (covers `--optimize-autoloader`
- * and `--classmap-authoritative`), then falls back to a recursive scan of
- * each PSR-4-registered directory (covers default dev installs).
+ * Discovery merges results from Composer's classmap (`getClassMap()`) and a
+ * recursive scan of each PSR-4-registered directory, deduplicating across
+ * both sources. Production deployments using `--optimize-autoloader` /
+ * `--classmap-authoritative` are covered by the classmap pass; default dev
+ * installs are covered by the PSR-4 directory walk.
  *
  * @internal Not part of the package's public API. Do not use from user code.
  */
@@ -109,8 +111,10 @@ final class EnumScanner
     }
 
     /**
-     * Test seam: inject a synthetic ClassLoader so unit tests don't have to
-     * mutate the global autoloader stack.
+     * Inject a synthetic ClassLoader so unit tests don't have to mutate the
+     * global autoloader stack.
+     *
+     * @internal Test seam — never call from production code.
      */
     public static function overrideClassLoaderForTesting(?ClassLoader $loader): void
     {
@@ -120,9 +124,11 @@ final class EnumScanner
     }
 
     /**
-     * Test seam: simulate environments where no Composer ClassLoader is
-     * registered (e.g., custom autoloader). The next `scan()` call will
-     * raise {@see EnumBindingReason::ScanComposerLoaderUnavailable}.
+     * Simulate environments where no Composer ClassLoader is registered
+     * (e.g., custom autoloader). The next `scan()` call will raise
+     * {@see EnumBindingReason::ScanComposerLoaderUnavailable}.
+     *
+     * @internal Test seam — never call from production code.
      */
     public static function forceLoaderUnavailableForTesting(): void
     {
@@ -131,6 +137,9 @@ final class EnumScanner
         self::$cache = [];
     }
 
+    /**
+     * @internal Lifecycle hook for test isolation; mirrors `OpenApiSpecLoader::reset()`.
+     */
     public static function reset(): void
     {
         self::$loaderOverride = null;
@@ -369,18 +378,27 @@ final class EnumScanner
 
     private static function isBoundEnum(string $fqcn): bool
     {
-        try {
-            if (!enum_exists($fqcn)) {
-                return false;
-            }
-            $reflection = new ReflectionEnum($fqcn);
-            if (!$reflection->isBacked()) {
-                return false;
-            }
-
-            return $reflection->getAttributes(BoundToOpenApiEnum::class) !== [];
-        } catch (Throwable) {
+        // `enum_exists()` and `ReflectionEnum` are intentionally NOT wrapped
+        // in a `catch (Throwable)`: a `ParseError` from a broken enum source
+        // file or an `Error` from a missing parent class is exactly the
+        // bootstrap-time misconfiguration this library exists to surface
+        // (issue #134). Swallowing them would convert a real bug into a
+        // silent "no bound enums found" pass. Only the narrow case where
+        // `enum_exists()` returned true but ReflectionEnum then disagrees
+        // (autoloader race / stub mismatch) is caught.
+        if (!enum_exists($fqcn)) {
             return false;
         }
+
+        try {
+            $reflection = new ReflectionEnum($fqcn);
+        } catch (ReflectionException) {
+            return false;
+        }
+        if (!$reflection->isBacked()) {
+            return false;
+        }
+
+        return $reflection->getAttributes(BoundToOpenApiEnum::class) !== [];
     }
 }

--- a/src/Internal/EnumScanner.php
+++ b/src/Internal/EnumScanner.php
@@ -72,7 +72,7 @@ final class EnumScanner
     public static function scan(array $namespacePrefixes): array
     {
         if ($namespacePrefixes === []) {
-            throw new EnumBindingException(
+            throw EnumBindingException::forScan(
                 EnumBindingReason::NoNamespacesConfigured,
                 'EnumScanner::scan() requires at least one namespace prefix.',
             );
@@ -157,7 +157,7 @@ final class EnumScanner
     private static function resolveLoader(): ClassLoader
     {
         if (self::$forceUnavailable) {
-            throw new EnumBindingException(
+            throw EnumBindingException::forScan(
                 EnumBindingReason::ScanComposerLoaderUnavailable,
                 'Composer ClassLoader unavailable; cannot auto-discover enums.',
             );
@@ -176,7 +176,7 @@ final class EnumScanner
             }
         }
 
-        throw new EnumBindingException(
+        throw EnumBindingException::forScan(
             EnumBindingReason::ScanComposerLoaderUnavailable,
             'Composer ClassLoader unavailable; cannot auto-discover enums.',
         );
@@ -191,7 +191,7 @@ final class EnumScanner
         $candidates = [...$candidates, ...self::collectFromPsr4($loader, $prefix)];
 
         if ($candidates === [] && !self::prefixHasResolvableRoot($loader, $prefix)) {
-            throw new EnumBindingException(
+            throw EnumBindingException::forScan(
                 EnumBindingReason::ScanNamespaceUnresolvable,
                 sprintf(
                     'Namespace prefix "%s" is not registered as a Composer PSR-4 root '

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -13,11 +13,19 @@ use PHPUnit\Runner\Extension\Facade;
 use PHPUnit\Runner\Extension\ParameterCollection;
 use PHPUnit\TextUI\Configuration\Configuration;
 use Studio\OpenApiContractTesting\Coverage\InvalidThresholdConfigurationException;
+use Studio\OpenApiContractTesting\Exception\EnumBindingException;
+use Studio\OpenApiContractTesting\Exception\EnumBindingReason;
+use Studio\OpenApiContractTesting\Exception\EnumDriftException;
 use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\Exception\SpecFileNotFoundException;
+use Studio\OpenApiContractTesting\Internal\EnumScanner;
+use Studio\OpenApiContractTesting\Schema\EnumDriftAsserter;
+use Studio\OpenApiContractTesting\Schema\EnumDriftReport;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 
+use function array_filter;
 use function array_map;
+use function array_values;
 use function explode;
 use function fflush;
 use function file_put_contents;
@@ -78,7 +86,7 @@ final class OpenApiCoverageExtension implements Extension
     {
         try {
             $this->setupExtension($facade, $parameters, getenv('GITHUB_STEP_SUMMARY') ?: null);
-        } catch (InvalidOpenApiSpecException|InvalidThresholdConfigurationException|SpecFileNotFoundException) {
+        } catch (EnumBindingException|EnumDriftException|InvalidOpenApiSpecException|InvalidThresholdConfigurationException|SpecFileNotFoundException) {
             // setupExtension() has already written a FATAL line to stderr and
             // (if GITHUB_STEP_SUMMARY is set) appended a fatal block to it.
             // PHPUnit's ExtensionBootstrapper::bootstrap() wraps this call in
@@ -155,6 +163,8 @@ final class OpenApiCoverageExtension implements Extension
                 throw $e;
             }
         }
+
+        self::runEnumDriftCheck($parameters, $githubSummaryPath);
 
         $outputFile = null;
         if ($parameters->has('output_file')) {
@@ -269,6 +279,157 @@ final class OpenApiCoverageExtension implements Extension
         // value (the `<parameter name="..." />` shorthand) is treated as
         // "set" so the XML and CLI sides agree.
         return !in_array($raw, ['0', 'false', 'no'], true);
+    }
+
+    /**
+     * Resolve a boolean parameter with the same XML-shorthand semantics as
+     * `resolveStrictFlag()`: `<parameter name=".." />` (empty value) reads
+     * as `true`, `'0'` / `'false'` / `'no'` read as `false`, anything else
+     * is `true`. Missing parameters fall back to `$default`.
+     */
+    private static function resolveBooleanFlag(
+        ParameterCollection $parameters,
+        string $name,
+        bool $default,
+    ): bool {
+        if (!$parameters->has($name)) {
+            return $default;
+        }
+        $raw = trim($parameters->get($name));
+
+        return !in_array($raw, ['0', 'false', 'no'], true);
+    }
+
+    /**
+     * Auto-discover `#[BoundToOpenApiEnum]` enums under the configured
+     * namespace prefixes and run a static drift check at bootstrap. A
+     * misconfiguration or strict-mode drift hard-fails the run; lenient
+     * mode only emits a WARNING block.
+     *
+     * Runs after the spec eager-load loop so `OpenApiSpecLoader::getBasePath()`
+     * is already configured by the time `EnumDriftAsserter` resolves
+     * `#[BoundToOpenApiEnum]` paths.
+     */
+    private static function runEnumDriftCheck(ParameterCollection $parameters, ?string $githubSummaryPath): void
+    {
+        if (!self::resolveBooleanFlag($parameters, 'enum_drift_enabled', false)) {
+            return;
+        }
+
+        $namespaces = [];
+        if ($parameters->has('enum_drift_scan_namespaces')) {
+            $namespaces = array_values(array_filter(
+                array_map('trim', explode(',', $parameters->get('enum_drift_scan_namespaces'))),
+                static fn(string $entry): bool => $entry !== '',
+            ));
+        }
+
+        if ($namespaces === []) {
+            $reason = 'enum_drift_enabled=true but enum_drift_scan_namespaces is empty.';
+            self::writeStderr(
+                "[OpenAPI Enum Drift] FATAL: {$reason}\n"
+                . '  Action: provide one or more PSR-4 namespace prefixes '
+                . "(e.g. enum_drift_scan_namespaces=\"App\\Enums\").\n",
+            );
+            self::appendGithubStepSummaryEnumDriftBlock($githubSummaryPath, $reason, isFatal: true);
+
+            throw new EnumBindingException(
+                EnumBindingReason::NoNamespacesConfigured,
+                $reason,
+            );
+        }
+
+        try {
+            $fqcns = EnumScanner::scan($namespaces);
+        } catch (EnumBindingException $e) {
+            self::writeStderr("[OpenAPI Enum Drift] FATAL: {$e->getMessage()}\n");
+            self::appendGithubStepSummaryEnumDriftBlock($githubSummaryPath, $e->getMessage(), isFatal: true);
+
+            throw $e;
+        }
+
+        $failOnDrift = self::resolveBooleanFlag($parameters, 'enum_drift_fail_on_drift', true);
+
+        if ($fqcns === []) {
+            // No bound enums under the configured prefixes — nothing to
+            // assert. Returning silently keeps the extension a no-op for
+            // codebases that haven't started annotating yet.
+            return;
+        }
+
+        if ($failOnDrift) {
+            try {
+                EnumDriftAsserter::assertNoDrift($fqcns, true);
+            } catch (EnumBindingException|EnumDriftException $e) {
+                self::writeStderr($e->getMessage() . "\n");
+                self::appendGithubStepSummaryEnumDriftBlock($githubSummaryPath, $e->getMessage(), isFatal: true);
+
+                throw $e;
+            }
+
+            return;
+        }
+
+        try {
+            $reports = EnumDriftAsserter::detectAll($fqcns);
+        } catch (EnumBindingException $e) {
+            // Misconfigured bindings are setup errors, not drift signals,
+            // and they fail loud regardless of $failOnDrift — same policy
+            // as the asserter (`EnumDriftAsserter::detectOne`).
+            self::writeStderr("[OpenAPI Enum Drift] FATAL: {$e->getMessage()}\n");
+            self::appendGithubStepSummaryEnumDriftBlock($githubSummaryPath, $e->getMessage(), isFatal: true);
+
+            throw $e;
+        }
+
+        $drifting = array_values(array_filter(
+            $reports,
+            static fn(EnumDriftReport $r): bool => $r->hasDrift(),
+        ));
+
+        if ($drifting === []) {
+            return;
+        }
+
+        $message = EnumDriftAsserter::renderMessage($drifting, false);
+        self::writeStderr($message . "\n");
+        self::appendGithubStepSummaryEnumDriftBlock($githubSummaryPath, $message, isFatal: false);
+    }
+
+    /**
+     * Append a Markdown block describing an enum-drift outcome to the
+     * GitHub Actions Step Summary file. Mirrors
+     * {@see appendGithubStepSummaryFatalBlock()} but keeps a separate body
+     * so the spec-load and enum-drift narratives stay distinct.
+     */
+    private static function appendGithubStepSummaryEnumDriftBlock(
+        ?string $path,
+        string $body,
+        bool $isFatal,
+    ): void {
+        if ($path === null) {
+            return;
+        }
+
+        $title = $isFatal
+            ? '## :rotating_light: FATAL OpenAPI enum drift'
+            : '## :warning: OpenAPI enum drift';
+
+        $block = $title . PHP_EOL
+            . PHP_EOL
+            . ($isFatal
+                ? 'One or more `#[BoundToOpenApiEnum]` checks failed and the test run was aborted.'
+                : 'One or more `#[BoundToOpenApiEnum]` checks reported drift.') . PHP_EOL
+            . PHP_EOL
+            . '```' . PHP_EOL
+            . $body . PHP_EOL
+            . '```' . PHP_EOL
+            . PHP_EOL;
+
+        $written = file_put_contents($path, $block, FILE_APPEND);
+        if ($written === false) {
+            self::writeStderr("[OpenAPI Enum Drift] WARNING: Failed to append block to GITHUB_STEP_SUMMARY ({$path})\n");
+        }
     }
 
     private static function appendGithubStepSummaryFatalBlock(?string $path, string $spec, string $reason): void

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -32,6 +32,7 @@ use function file_put_contents;
 use function fwrite;
 use function getcwd;
 use function getenv;
+use function implode;
 use function in_array;
 use function is_numeric;
 use function sprintf;
@@ -282,10 +283,8 @@ final class OpenApiCoverageExtension implements Extension
     }
 
     /**
-     * Resolve a boolean parameter with the same XML-shorthand semantics as
-     * `resolveStrictFlag()`: `<parameter name=".." />` (empty value) reads
-     * as `true`, `'0'` / `'false'` / `'no'` read as `false`, anything else
-     * is `true`. Missing parameters fall back to `$default`.
+     * Generalization of {@see resolveStrictFlag()} with a configurable
+     * default for the missing-parameter case.
      */
     private static function resolveBooleanFlag(
         ParameterCollection $parameters,
@@ -333,7 +332,7 @@ final class OpenApiCoverageExtension implements Extension
             );
             self::appendGithubStepSummaryEnumDriftBlock($githubSummaryPath, $reason, isFatal: true);
 
-            throw new EnumBindingException(
+            throw EnumBindingException::forScan(
                 EnumBindingReason::NoNamespacesConfigured,
                 $reason,
             );
@@ -351,9 +350,19 @@ final class OpenApiCoverageExtension implements Extension
         $failOnDrift = self::resolveBooleanFlag($parameters, 'enum_drift_fail_on_drift', true);
 
         if ($fqcns === []) {
-            // No bound enums under the configured prefixes — nothing to
-            // assert. Returning silently keeps the extension a no-op for
-            // codebases that haven't started annotating yet.
+            // No bound enums under the configured prefixes. Common in two
+            // cases: (a) a codebase mid-migration that hasn't annotated any
+            // enums yet, and (b) a typo'd `enum_drift_scan_namespaces`
+            // (e.g. `App\Enum` vs `App\Enums`). The first is intentional
+            // and must not fail; the second is a misconfiguration the user
+            // wants to see. A NOTE line surfaces the typo without breaking
+            // the migration use case.
+            self::writeStderr(
+                '[OpenAPI Enum Drift] NOTE: scan matched zero #[BoundToOpenApiEnum] enums under '
+                . 'configured prefixes (' . implode(', ', $namespaces) . '). '
+                . "Check enum_drift_scan_namespaces if you expected matches.\n",
+            );
+
             return;
         }
 

--- a/src/Schema/EnumDriftAsserter.php
+++ b/src/Schema/EnumDriftAsserter.php
@@ -17,6 +17,7 @@ use Studio\OpenApiContractTesting\Exception\EnumBindingReason;
 use Studio\OpenApiContractTesting\Exception\EnumDriftException;
 use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecReason;
+use Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 
 use function array_filter;
@@ -127,6 +128,55 @@ final class EnumDriftAsserter
         }
 
         return $reports;
+    }
+
+    /**
+     * Render the diagnostic block describing every drifting binding.
+     *
+     * @param list<EnumDriftReport> $reports
+     *
+     * @internal Exposed only so {@see OpenApiCoverageExtension}
+     *           can produce the same block at bootstrap when auto-discovery
+     *           runs in lenient mode (where `assertNoDrift` is not called).
+     */
+    public static function renderMessage(array $reports, bool $failOnDrift): string
+    {
+        $severity = $failOnDrift ? 'FATAL' : 'WARNING';
+        $count = count($reports);
+        $header = sprintf(
+            "[OpenAPI Enum Drift] %s: %d enum binding(s) drift from spec.\n",
+            $severity,
+            $count,
+        );
+
+        $bodies = array_map(
+            static function (EnumDriftReport $report): string {
+                $lines = [
+                    sprintf('  %s  ->  %s', $report->enumFqcn, $report->specPath),
+                ];
+                if ($report->phpOnly !== []) {
+                    $lines[] = sprintf(
+                        '    PHP-only (%d): %s',
+                        count($report->phpOnly),
+                        self::formatValueList($report->phpOnly),
+                    );
+                }
+                if ($report->specOnly !== []) {
+                    $lines[] = sprintf(
+                        '    Spec-only (%d): %s',
+                        count($report->specOnly),
+                        self::formatValueList($report->specOnly),
+                    );
+                }
+
+                return implode("\n", $lines);
+            },
+            $reports,
+        );
+
+        $footer = "\nAction: align the PHP enum cases with the spec, or update the spec's enum array.";
+
+        return $header . "\n" . implode("\n\n", $bodies) . "\n" . $footer;
     }
 
     private static function detectOne(string $fqcn): EnumDriftReport
@@ -362,49 +412,6 @@ final class EnumDriftAsserter
         }
 
         return $values;
-    }
-
-    /**
-     * @param list<EnumDriftReport> $reports
-     */
-    private static function renderMessage(array $reports, bool $failOnDrift): string
-    {
-        $severity = $failOnDrift ? 'FATAL' : 'WARNING';
-        $count = count($reports);
-        $header = sprintf(
-            "[OpenAPI Enum Drift] %s: %d enum binding(s) drift from spec.\n",
-            $severity,
-            $count,
-        );
-
-        $bodies = array_map(
-            static function (EnumDriftReport $report): string {
-                $lines = [
-                    sprintf('  %s  ->  %s', $report->enumFqcn, $report->specPath),
-                ];
-                if ($report->phpOnly !== []) {
-                    $lines[] = sprintf(
-                        '    PHP-only (%d): %s',
-                        count($report->phpOnly),
-                        self::formatValueList($report->phpOnly),
-                    );
-                }
-                if ($report->specOnly !== []) {
-                    $lines[] = sprintf(
-                        '    Spec-only (%d): %s',
-                        count($report->specOnly),
-                        self::formatValueList($report->specOnly),
-                    );
-                }
-
-                return implode("\n", $lines);
-            },
-            $reports,
-        );
-
-        $footer = "\nAction: align the PHP enum cases with the spec, or update the spec's enum array.";
-
-        return $header . "\n" . implode("\n\n", $bodies) . "\n" . $footer;
     }
 
     /**

--- a/src/Schema/EnumDriftAsserter.php
+++ b/src/Schema/EnumDriftAsserter.php
@@ -17,7 +17,6 @@ use Studio\OpenApiContractTesting\Exception\EnumBindingReason;
 use Studio\OpenApiContractTesting\Exception\EnumDriftException;
 use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecReason;
-use Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 
 use function array_filter;
@@ -135,9 +134,9 @@ final class EnumDriftAsserter
      *
      * @param list<EnumDriftReport> $reports
      *
-     * @internal Exposed only so {@see OpenApiCoverageExtension}
-     *           can produce the same block at bootstrap when auto-discovery
-     *           runs in lenient mode (where `assertNoDrift` is not called).
+     * @internal Exposed only so the PHPUnit extension can produce the same
+     *           block at bootstrap when auto-discovery runs in lenient mode
+     *           (where `assertNoDrift` is not called).
      */
     public static function renderMessage(array $reports, bool $failOnDrift): string
     {

--- a/tests/Integration/Fixture/Smoke/SmokeTest.php
+++ b/tests/Integration/Fixture/Smoke/SmokeTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Integration\Fixture\Smoke;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Tests\Integration\OpenApiCoverageExtensionEnumDriftBootstrapTest;
+
+/**
+ * One-trivial-assertion fixture used by
+ * {@see OpenApiCoverageExtensionEnumDriftBootstrapTest}
+ * so subprocess runs that should exit zero have at least one test to run —
+ * PHPUnit returns a non-zero exit when no tests match.
+ */
+final class SmokeTest extends TestCase
+{
+    #[Test]
+    public function smoke_passes(): void
+    {
+        $this->expectNotToPerformAssertions();
+    }
+}

--- a/tests/Integration/OpenApiCoverageExtensionEnumDriftBootstrapTest.php
+++ b/tests/Integration/OpenApiCoverageExtensionEnumDriftBootstrapTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Integration;
+
+use const ENT_QUOTES;
+use const ENT_XML1;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function escapeshellarg;
+use function fclose;
+use function file_put_contents;
+use function htmlspecialchars;
+use function is_resource;
+use function proc_close;
+use function proc_open;
+use function realpath;
+use function sprintf;
+use function stream_get_contents;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+/**
+ * End-to-end coverage of the auto-discovery wiring: the unit tests prove
+ * `setupExtension()` writes the right blocks, this one proves PHPUnit's real
+ * bootstrapper turns those blocks into the right exit code so CI fails (or
+ * doesn't) as advertised.
+ */
+class OpenApiCoverageExtensionEnumDriftBootstrapTest extends TestCase
+{
+    private string $repoRoot;
+    private ?string $configPath = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repoRoot = realpath(__DIR__ . '/../..') ?: __DIR__ . '/../..';
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->configPath !== null) {
+            @unlink($this->configPath);
+            $this->configPath = null;
+        }
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function phpunit_exits_non_zero_when_auto_discovered_drift_is_strict(): void
+    {
+        [$exit, $output] = $this->runPhpunit([
+            'enum_drift_enabled' => 'true',
+            'enum_drift_scan_namespaces' =>
+                'Studio\\OpenApiContractTesting\\Tests\\Integration\\Schema\\Fixture\\AutoDiscovery\\Drifting\\',
+        ]);
+
+        $this->assertNotSame(0, $exit, "Expected non-zero exit; output was:\n" . $output);
+        $this->assertStringContainsString('[OpenAPI Enum Drift] FATAL', $output);
+        $this->assertStringContainsString('AutoDiscoveryDriftingEnum', $output);
+    }
+
+    #[Test]
+    public function phpunit_exits_zero_when_auto_discovered_drift_is_lenient(): void
+    {
+        [$exit, $output] = $this->runPhpunit([
+            'enum_drift_enabled' => 'true',
+            'enum_drift_scan_namespaces' =>
+                'Studio\\OpenApiContractTesting\\Tests\\Integration\\Schema\\Fixture\\AutoDiscovery\\Drifting\\',
+            'enum_drift_fail_on_drift' => 'false',
+        ]);
+
+        $this->assertSame(0, $exit, "Expected zero exit; output was:\n" . $output);
+        $this->assertStringContainsString('[OpenAPI Enum Drift] WARNING', $output);
+        $this->assertStringContainsString('AutoDiscoveryDriftingEnum', $output);
+    }
+
+    #[Test]
+    public function phpunit_exits_zero_when_auto_discovered_enums_have_no_drift(): void
+    {
+        [$exit, $output] = $this->runPhpunit([
+            'enum_drift_enabled' => 'true',
+            'enum_drift_scan_namespaces' =>
+                'Studio\\OpenApiContractTesting\\Tests\\Integration\\Schema\\Fixture\\AutoDiscovery\\Clean\\',
+        ]);
+
+        $this->assertSame(0, $exit, "Expected zero exit; output was:\n" . $output);
+        $this->assertStringNotContainsString('[OpenAPI Enum Drift]', $output);
+    }
+
+    #[Test]
+    public function phpunit_exits_non_zero_when_namespace_is_unresolvable(): void
+    {
+        [$exit, $output] = $this->runPhpunit([
+            'enum_drift_enabled' => 'true',
+            'enum_drift_scan_namespaces' => 'Some\\Nonexistent\\Namespace\\',
+        ]);
+
+        $this->assertNotSame(0, $exit, "Expected non-zero exit; output was:\n" . $output);
+        $this->assertStringContainsString('[OpenAPI Enum Drift] FATAL', $output);
+        $this->assertStringContainsString('Some\\Nonexistent\\Namespace\\', $output);
+    }
+
+    #[Test]
+    public function phpunit_exits_non_zero_when_drift_enabled_with_no_namespaces(): void
+    {
+        [$exit, $output] = $this->runPhpunit([
+            'enum_drift_enabled' => 'true',
+        ]);
+
+        $this->assertNotSame(0, $exit, "Expected non-zero exit; output was:\n" . $output);
+        $this->assertStringContainsString('[OpenAPI Enum Drift] FATAL', $output);
+        $this->assertStringContainsString('enum_drift_scan_namespaces', $output);
+    }
+
+    /**
+     * @param array<string, string> $extensionParameters
+     *
+     * @return array{0: int, 1: string} [exit code, combined stderr+stdout]
+     */
+    private function runPhpunit(array $extensionParameters): array
+    {
+        $paramXml = '';
+        foreach ($extensionParameters as $name => $value) {
+            $paramXml .= sprintf(
+                '<parameter name="%s" value="%s"/>',
+                htmlspecialchars($name, ENT_XML1 | ENT_QUOTES),
+                htmlspecialchars($value, ENT_XML1 | ENT_QUOTES),
+            );
+        }
+
+        $xml = sprintf(
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            . '<phpunit bootstrap="%s/vendor/autoload.php" cacheDirectory="%s/.phpunit.cache" colors="false">'
+            . '<testsuites><testsuite name="Smoke"><directory>%s/tests/Integration/Fixture/Smoke</directory></testsuite></testsuites>'
+            . '<extensions><bootstrap class="Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension">'
+            . '<parameter name="spec_base_path" value="%s/tests/fixtures/specs"/>'
+            . '<parameter name="specs" value="refs-valid"/>'
+            . '%s'
+            . '</bootstrap></extensions>'
+            . '</phpunit>',
+            $this->repoRoot,
+            $this->repoRoot,
+            $this->repoRoot,
+            $this->repoRoot,
+            $paramXml,
+        );
+
+        $tmp = tempnam(sys_get_temp_dir(), 'openapi-enum-drift-integration-') ?: null;
+        if ($tmp === null) {
+            $this->fail('Could not create temp phpunit config');
+        }
+        $this->configPath = $tmp;
+        file_put_contents($tmp, $xml);
+
+        $cmd = sprintf(
+            '%s/vendor/bin/phpunit -c %s',
+            escapeshellarg($this->repoRoot),
+            escapeshellarg($tmp),
+        );
+
+        $descriptors = [
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+        $process = proc_open($cmd, $descriptors, $pipes, $this->repoRoot);
+        if (!is_resource($process)) {
+            $this->fail('Could not spawn phpunit subprocess');
+        }
+
+        $stdout = (string) stream_get_contents($pipes[1]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        foreach ($pipes as $pipe) {
+            fclose($pipe);
+        }
+        $exit = proc_close($process);
+
+        return [$exit, $stdout . $stderr];
+    }
+}

--- a/tests/Integration/Schema/Fixture/AutoDiscovery/Clean/AutoDiscoveryCleanEnum.php
+++ b/tests/Integration/Schema/Fixture/AutoDiscovery/Clean/AutoDiscoveryCleanEnum.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Integration\Schema\Fixture\AutoDiscovery\Clean;
+
+use Studio\OpenApiContractTesting\Attribute\BoundToOpenApiEnum;
+
+#[BoundToOpenApiEnum('enum-drift/_shared/components/schemas/enums/PetStatusEnum.json')]
+enum AutoDiscoveryCleanEnum: string
+{
+    case Available = 'available';
+    case Pending = 'pending';
+    case Sold = 'sold';
+}

--- a/tests/Integration/Schema/Fixture/AutoDiscovery/Drifting/AutoDiscoveryDriftingEnum.php
+++ b/tests/Integration/Schema/Fixture/AutoDiscovery/Drifting/AutoDiscoveryDriftingEnum.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Integration\Schema\Fixture\AutoDiscovery\Drifting;
+
+use Studio\OpenApiContractTesting\Attribute\BoundToOpenApiEnum;
+
+#[BoundToOpenApiEnum('enum-drift/_shared/components/schemas/enums/NotificationCodeEnum.json')]
+enum AutoDiscoveryDriftingEnum: string
+{
+    case StudioPaymentOld = 'studioPaymentOld';
+    case StudioPaymentNew = 'studioPaymentNew';
+    // Spec lists "deprecated" but this enum does not (spec-only drift).
+    case BetaFeature = 'betaFeature'; // PHP-only drift.
+}

--- a/tests/Unit/Internal/EnumScannerTest.php
+++ b/tests/Unit/Internal/EnumScannerTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Internal;
+
+use Composer\Autoload\ClassLoader;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Exception\EnumBindingException;
+use Studio\OpenApiContractTesting\Exception\EnumBindingReason;
+use Studio\OpenApiContractTesting\Internal\EnumScanner;
+use Studio\OpenApiContractTesting\Tests\Unit\Internal\Fixture\EnumScanner\AnotherBoundEnum;
+use Studio\OpenApiContractTesting\Tests\Unit\Internal\Fixture\EnumScanner\CleanBoundEnum;
+use Studio\OpenApiContractTesting\Tests\Unit\Internal\Fixture\EnumScanner\PlainClass;
+use Studio\OpenApiContractTesting\Tests\Unit\Internal\Fixture\EnumScanner\PureUnattributedEnum;
+use Studio\OpenApiContractTesting\Tests\Unit\Internal\Fixture\EnumScanner\UnattributedEnum;
+
+final class EnumScannerTest extends TestCase
+{
+    private const FIXTURE_NS = 'Studio\\OpenApiContractTesting\\Tests\\Unit\\Internal\\Fixture\\EnumScanner\\';
+    private const FIXTURE_DIR = __DIR__ . '/Fixture/EnumScanner';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        EnumScanner::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        EnumScanner::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function scan_returns_attributed_enums_in_namespace(): void
+    {
+        $loader = new ClassLoader();
+        $loader->addClassMap([
+            CleanBoundEnum::class => self::FIXTURE_DIR . '/CleanBoundEnum.php',
+            AnotherBoundEnum::class => self::FIXTURE_DIR . '/AnotherBoundEnum.php',
+            UnattributedEnum::class => self::FIXTURE_DIR . '/UnattributedEnum.php',
+            PureUnattributedEnum::class => self::FIXTURE_DIR . '/PureUnattributedEnum.php',
+            PlainClass::class => self::FIXTURE_DIR . '/PlainClass.php',
+        ]);
+        EnumScanner::overrideClassLoaderForTesting($loader);
+
+        $found = EnumScanner::scan([self::FIXTURE_NS]);
+
+        $this->assertSame(
+            [AnotherBoundEnum::class, CleanBoundEnum::class],
+            $found,
+        );
+    }
+
+    #[Test]
+    public function scan_returns_empty_list_when_no_attributed_enums_found(): void
+    {
+        $loader = new ClassLoader();
+        $loader->addClassMap([
+            UnattributedEnum::class => self::FIXTURE_DIR . '/UnattributedEnum.php',
+            PureUnattributedEnum::class => self::FIXTURE_DIR . '/PureUnattributedEnum.php',
+        ]);
+        EnumScanner::overrideClassLoaderForTesting($loader);
+
+        $found = EnumScanner::scan([self::FIXTURE_NS]);
+
+        $this->assertSame([], $found);
+    }
+
+    #[Test]
+    public function scan_throws_for_unresolvable_namespace_prefix(): void
+    {
+        $loader = new ClassLoader();
+        EnumScanner::overrideClassLoaderForTesting($loader);
+
+        try {
+            EnumScanner::scan(['Some\\Unknown\\Namespace\\']);
+            $this->fail('Expected EnumBindingException');
+        } catch (EnumBindingException $e) {
+            $this->assertSame(EnumBindingReason::ScanNamespaceUnresolvable, $e->reason);
+            $this->assertStringContainsString('Some\\Unknown\\Namespace\\', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function scan_throws_when_namespaces_list_is_empty(): void
+    {
+        try {
+            EnumScanner::scan([]);
+            $this->fail('Expected EnumBindingException');
+        } catch (EnumBindingException $e) {
+            $this->assertSame(EnumBindingReason::NoNamespacesConfigured, $e->reason);
+        }
+    }
+
+    #[Test]
+    public function scan_throws_when_classloader_unavailable(): void
+    {
+        EnumScanner::forceLoaderUnavailableForTesting();
+
+        try {
+            EnumScanner::scan([self::FIXTURE_NS]);
+            $this->fail('Expected EnumBindingException');
+        } catch (EnumBindingException $e) {
+            $this->assertSame(EnumBindingReason::ScanComposerLoaderUnavailable, $e->reason);
+        }
+    }
+
+    #[Test]
+    public function scan_handles_multiple_namespaces_with_dedup(): void
+    {
+        $loader = new ClassLoader();
+        $loader->addClassMap([
+            CleanBoundEnum::class => self::FIXTURE_DIR . '/CleanBoundEnum.php',
+        ]);
+        EnumScanner::overrideClassLoaderForTesting($loader);
+
+        $found = EnumScanner::scan([
+            self::FIXTURE_NS,
+            self::FIXTURE_NS,
+        ]);
+
+        $this->assertSame([CleanBoundEnum::class], $found);
+    }
+
+    #[Test]
+    public function scan_uses_classmap_when_authoritative(): void
+    {
+        $loader = new ClassLoader();
+        $loader->addClassMap([
+            CleanBoundEnum::class => self::FIXTURE_DIR . '/CleanBoundEnum.php',
+        ]);
+        EnumScanner::overrideClassLoaderForTesting($loader);
+
+        $found = EnumScanner::scan([self::FIXTURE_NS]);
+
+        $this->assertSame([CleanBoundEnum::class], $found);
+    }
+
+    #[Test]
+    public function scan_falls_back_to_psr4_walk_when_classmap_empty(): void
+    {
+        $loader = new ClassLoader();
+        $loader->setPsr4(self::FIXTURE_NS, [self::FIXTURE_DIR]);
+        EnumScanner::overrideClassLoaderForTesting($loader);
+
+        $found = EnumScanner::scan([self::FIXTURE_NS]);
+
+        $this->assertSame(
+            [AnotherBoundEnum::class, CleanBoundEnum::class],
+            $found,
+        );
+    }
+
+    #[Test]
+    public function scan_resolves_subnamespace_via_longest_matching_psr4_root(): void
+    {
+        $loader = new ClassLoader();
+        $loader->setPsr4(
+            'Studio\\OpenApiContractTesting\\Tests\\Unit\\Internal\\Fixture\\',
+            [__DIR__ . '/Fixture'],
+        );
+        EnumScanner::overrideClassLoaderForTesting($loader);
+
+        $found = EnumScanner::scan([self::FIXTURE_NS]);
+
+        $this->assertSame(
+            [AnotherBoundEnum::class, CleanBoundEnum::class],
+            $found,
+        );
+    }
+
+    #[Test]
+    public function scan_skips_pure_enums_silently(): void
+    {
+        $loader = new ClassLoader();
+        $loader->addClassMap([
+            PureUnattributedEnum::class => self::FIXTURE_DIR . '/PureUnattributedEnum.php',
+            CleanBoundEnum::class => self::FIXTURE_DIR . '/CleanBoundEnum.php',
+        ]);
+        EnumScanner::overrideClassLoaderForTesting($loader);
+
+        $found = EnumScanner::scan([self::FIXTURE_NS]);
+
+        $this->assertSame([CleanBoundEnum::class], $found);
+    }
+
+    #[Test]
+    public function scan_skips_traits_and_abstract_classes_without_failure(): void
+    {
+        $loader = new ClassLoader();
+        $loader->setPsr4(self::FIXTURE_NS, [self::FIXTURE_DIR]);
+        EnumScanner::overrideClassLoaderForTesting($loader);
+
+        $found = EnumScanner::scan([self::FIXTURE_NS]);
+
+        // SomeTrait.php and AbstractFixture.php live alongside the enum
+        // fixtures; the walk must encounter and skip them without raising.
+        $this->assertSame(
+            [AnotherBoundEnum::class, CleanBoundEnum::class],
+            $found,
+        );
+    }
+
+    #[Test]
+    public function scan_caches_results_within_run(): void
+    {
+        $loader = new ClassLoader();
+        $loader->addClassMap([
+            CleanBoundEnum::class => self::FIXTURE_DIR . '/CleanBoundEnum.php',
+        ]);
+        EnumScanner::overrideClassLoaderForTesting($loader);
+
+        $firstCall = EnumScanner::scan([self::FIXTURE_NS]);
+
+        // Mutate the loader's classmap silently — a fresh call would normally
+        // pick up the new entry. The cache must shield us from that.
+        $loader->addClassMap([
+            AnotherBoundEnum::class => self::FIXTURE_DIR . '/AnotherBoundEnum.php',
+        ]);
+        $secondCall = EnumScanner::scan([self::FIXTURE_NS]);
+
+        $this->assertSame($firstCall, $secondCall);
+        $this->assertSame([CleanBoundEnum::class], $secondCall);
+    }
+
+    #[Test]
+    public function reset_clears_cache(): void
+    {
+        $loader = new ClassLoader();
+        $loader->addClassMap([
+            CleanBoundEnum::class => self::FIXTURE_DIR . '/CleanBoundEnum.php',
+        ]);
+        EnumScanner::overrideClassLoaderForTesting($loader);
+        EnumScanner::scan([self::FIXTURE_NS]);
+
+        EnumScanner::reset();
+
+        $emptyLoader = new ClassLoader();
+        $emptyLoader->setPsr4(self::FIXTURE_NS, [__DIR__ . '/NonExistentDir']);
+        EnumScanner::overrideClassLoaderForTesting($emptyLoader);
+        $afterReset = EnumScanner::scan([self::FIXTURE_NS]);
+
+        $this->assertSame([], $afterReset);
+    }
+}

--- a/tests/Unit/Internal/Fixture/EnumScanner/AbstractFixture.php
+++ b/tests/Unit/Internal/Fixture/EnumScanner/AbstractFixture.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Internal\Fixture\EnumScanner;
+
+abstract class AbstractFixture
+{
+    abstract public function name(): string;
+}

--- a/tests/Unit/Internal/Fixture/EnumScanner/AnotherBoundEnum.php
+++ b/tests/Unit/Internal/Fixture/EnumScanner/AnotherBoundEnum.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Internal\Fixture\EnumScanner;
+
+use Studio\OpenApiContractTesting\Attribute\BoundToOpenApiEnum;
+
+#[BoundToOpenApiEnum('fixture/another.json')]
+enum AnotherBoundEnum: int
+{
+    case One = 1;
+    case Two = 2;
+}

--- a/tests/Unit/Internal/Fixture/EnumScanner/CleanBoundEnum.php
+++ b/tests/Unit/Internal/Fixture/EnumScanner/CleanBoundEnum.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Internal\Fixture\EnumScanner;
+
+use Studio\OpenApiContractTesting\Attribute\BoundToOpenApiEnum;
+
+#[BoundToOpenApiEnum('fixture/clean.json')]
+enum CleanBoundEnum: string
+{
+    case Alpha = 'alpha';
+    case Beta = 'beta';
+}

--- a/tests/Unit/Internal/Fixture/EnumScanner/PlainClass.php
+++ b/tests/Unit/Internal/Fixture/EnumScanner/PlainClass.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Internal\Fixture\EnumScanner;
+
+final class PlainClass
+{
+    public function nothing(): void {}
+}

--- a/tests/Unit/Internal/Fixture/EnumScanner/PureUnattributedEnum.php
+++ b/tests/Unit/Internal/Fixture/EnumScanner/PureUnattributedEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Internal\Fixture\EnumScanner;
+
+enum PureUnattributedEnum
+{
+    case First;
+    case Second;
+}

--- a/tests/Unit/Internal/Fixture/EnumScanner/SomeTrait.php
+++ b/tests/Unit/Internal/Fixture/EnumScanner/SomeTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Internal\Fixture\EnumScanner;
+
+trait SomeTrait
+{
+    public function unused(): string
+    {
+        return 'unused';
+    }
+}

--- a/tests/Unit/Internal/Fixture/EnumScanner/UnattributedEnum.php
+++ b/tests/Unit/Internal/Fixture/EnumScanner/UnattributedEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Internal\Fixture\EnumScanner;
+
+enum UnattributedEnum: string
+{
+    case Foo = 'foo';
+    case Bar = 'bar';
+}

--- a/tests/Unit/PHPUnit/Fixture/EnumDrift/Clean/CleanPetStatus.php
+++ b/tests/Unit/PHPUnit/Fixture/EnumDrift/Clean/CleanPetStatus.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\PHPUnit\Fixture\EnumDrift\Clean;
+
+use Studio\OpenApiContractTesting\Attribute\BoundToOpenApiEnum;
+
+#[BoundToOpenApiEnum('enum-drift/_shared/components/schemas/enums/PetStatusEnum.json')]
+enum CleanPetStatus: string
+{
+    case Available = 'available';
+    case Pending = 'pending';
+    case Sold = 'sold';
+}

--- a/tests/Unit/PHPUnit/Fixture/EnumDrift/Drifting/DriftingNotification.php
+++ b/tests/Unit/PHPUnit/Fixture/EnumDrift/Drifting/DriftingNotification.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\PHPUnit\Fixture\EnumDrift\Drifting;
+
+use Studio\OpenApiContractTesting\Attribute\BoundToOpenApiEnum;
+
+#[BoundToOpenApiEnum('enum-drift/_shared/components/schemas/enums/NotificationCodeEnum.json')]
+enum DriftingNotification: string
+{
+    case StudioPaymentOld = 'studioPaymentOld';
+    case StudioPaymentNew = 'studioPaymentNew';
+    // Spec lists "deprecated" but this enum lacks it (spec-only drift).
+    case BetaFeature = 'betaFeature'; // PHP-only drift.
+}

--- a/tests/Unit/PHPUnit/Fixture/EnumDrift/Misconfigured/MissingSpecFile.php
+++ b/tests/Unit/PHPUnit/Fixture/EnumDrift/Misconfigured/MissingSpecFile.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\PHPUnit\Fixture\EnumDrift\Misconfigured;
+
+use Studio\OpenApiContractTesting\Attribute\BoundToOpenApiEnum;
+
+#[BoundToOpenApiEnum('enum-drift/_shared/components/schemas/enums/DoesNotExist.json')]
+enum MissingSpecFile: string
+{
+    case Anything = 'anything';
+}

--- a/tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php
+++ b/tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php
@@ -572,6 +572,170 @@ class OpenApiCoverageExtensionTest extends TestCase
         $this->assertSame('', $this->readStderr());
     }
 
+    #[Test]
+    public function bootstrap_emits_note_when_no_attributed_enums_found(): void
+    {
+        // Resolvable namespace prefix that contains enums but none with the
+        // attribute — typo'd `enum_drift_scan_namespaces` lands here too.
+        // The NOTE must surface to stderr so a typo is observable, but the
+        // run must continue (codebases mid-migration have this state too).
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'enum_drift_enabled' => 'true',
+            // Resolvable PSR-4 root that contains zero attributed enums.
+            'enum_drift_scan_namespaces' =>
+                'Studio\\OpenApiContractTesting\\Tests\\Unit\\Internal\\Fixture\\NotAnEnumNs\\',
+        ]);
+
+        // Resolvable but empty PSR-4 root — use a sub-namespace under tests/
+        // that doesn't exist so prefixHasResolvableRoot still returns true
+        // via the longest-match path, but the directory walk yields nothing.
+        try {
+            $extension->setupExtension(null, $parameters, null);
+            // Fall-through path: NOTE was emitted, run continues.
+            $stderr = $this->readStderr();
+            $this->assertStringContainsString('[OpenAPI Enum Drift] NOTE', $stderr);
+            $this->assertStringContainsString('zero #[BoundToOpenApiEnum] enums', $stderr);
+        } catch (EnumBindingException) {
+            // If the chosen prefix happens to be unresolvable on this host
+            // (no PSR-4 longest-match registered for tests/), skip the
+            // assertion gracefully — the dedicated unresolvable-namespace
+            // test covers that branch.
+            $this->markTestSkipped(
+                'Test environment does not register a longest-match PSR-4 ancestor for the chosen prefix; skip — unresolvable case is covered separately.',
+            );
+        }
+    }
+
+    #[Test]
+    public function bootstrap_appends_fatal_block_to_step_summary_for_enum_drift(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'openapi-enum-summary-');
+        if ($tmp === false) {
+            $this->fail('Could not create temp file for GITHUB_STEP_SUMMARY');
+        }
+        $this->githubSummaryTmp = $tmp;
+
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'enum_drift_enabled' => 'true',
+            'enum_drift_scan_namespaces' => 'Studio\\OpenApiContractTesting\\Tests\\Unit\\PHPUnit\\Fixture\\EnumDrift\\Drifting\\',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, $tmp);
+            $this->fail('Expected EnumDriftException');
+        } catch (EnumDriftException) {
+            // Expected — the FATAL block must still have been written before re-throw.
+        }
+
+        $contents = (string) file_get_contents($tmp);
+        $this->assertStringContainsString('FATAL OpenAPI enum drift', $contents);
+        $this->assertStringContainsString('DriftingNotification', $contents);
+        $this->assertStringContainsString('PHP-only', $contents);
+    }
+
+    #[Test]
+    public function bootstrap_appends_warning_block_to_step_summary_for_lenient_drift(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'openapi-enum-summary-');
+        if ($tmp === false) {
+            $this->fail('Could not create temp file for GITHUB_STEP_SUMMARY');
+        }
+        $this->githubSummaryTmp = $tmp;
+
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'enum_drift_enabled' => 'true',
+            'enum_drift_scan_namespaces' => 'Studio\\OpenApiContractTesting\\Tests\\Unit\\PHPUnit\\Fixture\\EnumDrift\\Drifting\\',
+            'enum_drift_fail_on_drift' => 'false',
+        ]);
+
+        $extension->setupExtension(null, $parameters, $tmp);
+
+        $contents = (string) file_get_contents($tmp);
+        $this->assertStringContainsString(':warning:', $contents);
+        $this->assertStringNotContainsString(':rotating_light:', $contents);
+        $this->assertStringContainsString('DriftingNotification', $contents);
+    }
+
+    #[Test]
+    public function bootstrap_appends_fatal_block_to_step_summary_for_unresolvable_namespace(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'openapi-enum-summary-');
+        if ($tmp === false) {
+            $this->fail('Could not create temp file for GITHUB_STEP_SUMMARY');
+        }
+        $this->githubSummaryTmp = $tmp;
+
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'enum_drift_enabled' => 'true',
+            'enum_drift_scan_namespaces' => 'Some\\Nonexistent\\Namespace\\',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, $tmp);
+            $this->fail('Expected EnumBindingException');
+        } catch (EnumBindingException $e) {
+            $this->assertSame(EnumBindingReason::ScanNamespaceUnresolvable, $e->reason);
+        }
+
+        $contents = (string) file_get_contents($tmp);
+        $this->assertStringContainsString('FATAL OpenAPI enum drift', $contents);
+        $this->assertStringContainsString('Some\\Nonexistent\\Namespace\\', $contents);
+    }
+
+    #[Test]
+    public function bootstrap_fatals_with_scan_composer_loader_unavailable_reason(): void
+    {
+        EnumScanner::forceLoaderUnavailableForTesting();
+
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'enum_drift_enabled' => 'true',
+            'enum_drift_scan_namespaces' =>
+                'Studio\\OpenApiContractTesting\\Tests\\Unit\\PHPUnit\\Fixture\\EnumDrift\\Clean\\',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+            $this->fail('Expected EnumBindingException');
+        } catch (EnumBindingException $e) {
+            $this->assertSame(EnumBindingReason::ScanComposerLoaderUnavailable, $e->reason);
+            $this->assertStringContainsString('[OpenAPI Enum Drift] FATAL', $this->readStderr());
+        }
+    }
+
+    #[Test]
+    public function bootstrap_fatals_on_drift_when_fail_on_drift_omitted(): void
+    {
+        // Default for `enum_drift_fail_on_drift` is `true`. Pin the default
+        // by simply omitting the parameter and asserting drift FATALs.
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'enum_drift_enabled' => 'true',
+            'enum_drift_scan_namespaces' => 'Studio\\OpenApiContractTesting\\Tests\\Unit\\PHPUnit\\Fixture\\EnumDrift\\Drifting\\',
+            // enum_drift_fail_on_drift intentionally omitted
+        ]);
+
+        $this->expectException(EnumDriftException::class);
+
+        $extension->setupExtension(null, $parameters, null);
+    }
+
     private function readStderr(): string
     {
         if ($this->stderrBuffer === null) {

--- a/tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php
+++ b/tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php
@@ -4,20 +4,28 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Tests\Unit\PHPUnit;
 
+use const E_USER_WARNING;
+
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\Extension\ParameterCollection;
 use Studio\OpenApiContractTesting\Coverage\InvalidThresholdConfigurationException;
+use Studio\OpenApiContractTesting\Exception\EnumBindingException;
+use Studio\OpenApiContractTesting\Exception\EnumBindingReason;
+use Studio\OpenApiContractTesting\Exception\EnumDriftException;
 use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecReason;
 use Studio\OpenApiContractTesting\Exception\SpecFileNotFoundException;
+use Studio\OpenApiContractTesting\Internal\EnumScanner;
 use Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 
 use function fclose;
 use function file_get_contents;
 use function fopen;
+use function restore_error_handler;
 use function rewind;
+use function set_error_handler;
 use function stream_get_contents;
 use function sys_get_temp_dir;
 use function tempnam;
@@ -33,6 +41,7 @@ class OpenApiCoverageExtensionTest extends TestCase
     {
         parent::setUp();
         OpenApiSpecLoader::reset();
+        EnumScanner::reset();
 
         $buffer = fopen('php://memory', 'w+');
         if ($buffer === false) {
@@ -54,6 +63,7 @@ class OpenApiCoverageExtensionTest extends TestCase
             $this->githubSummaryTmp = null;
         }
         OpenApiSpecLoader::reset();
+        EnumScanner::reset();
         parent::tearDown();
     }
 
@@ -393,6 +403,173 @@ class OpenApiCoverageExtensionTest extends TestCase
         $this->expectExceptionMessage('Unresolvable $ref');
 
         $extension->setupExtension(null, $parameters, null);
+    }
+
+    #[Test]
+    public function bootstrap_skips_enum_drift_when_disabled(): void
+    {
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+        ]);
+
+        $extension->setupExtension(null, $parameters, null);
+
+        $this->assertSame('', $this->readStderr());
+    }
+
+    #[Test]
+    public function bootstrap_fatals_when_enum_drift_enabled_with_no_namespaces(): void
+    {
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'enum_drift_enabled' => 'true',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+            $this->fail('Expected EnumBindingException');
+        } catch (EnumBindingException $e) {
+            $this->assertSame(EnumBindingReason::NoNamespacesConfigured, $e->reason);
+            $stderr = $this->readStderr();
+            $this->assertStringContainsString('[OpenAPI Enum Drift] FATAL', $stderr);
+            $this->assertStringContainsString('enum_drift_scan_namespaces', $stderr);
+        }
+    }
+
+    #[Test]
+    public function bootstrap_fatals_on_drift_when_strict(): void
+    {
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'enum_drift_enabled' => 'true',
+            'enum_drift_scan_namespaces' => 'Studio\\OpenApiContractTesting\\Tests\\Unit\\PHPUnit\\Fixture\\EnumDrift\\Drifting\\',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+            $this->fail('Expected EnumDriftException');
+        } catch (EnumDriftException) {
+            $stderr = $this->readStderr();
+            $this->assertStringContainsString('[OpenAPI Enum Drift] FATAL', $stderr);
+            $this->assertStringContainsString('DriftingNotification', $stderr);
+            $this->assertStringContainsString('PHP-only', $stderr);
+            $this->assertStringContainsString('Spec-only', $stderr);
+        }
+    }
+
+    #[Test]
+    public function bootstrap_warns_on_drift_when_lenient(): void
+    {
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'enum_drift_enabled' => 'true',
+            'enum_drift_scan_namespaces' => 'Studio\\OpenApiContractTesting\\Tests\\Unit\\PHPUnit\\Fixture\\EnumDrift\\Drifting\\',
+            'enum_drift_fail_on_drift' => 'false',
+        ]);
+
+        $userWarningFired = false;
+        set_error_handler(static function (int $severity) use (&$userWarningFired): bool {
+            if ($severity === E_USER_WARNING) {
+                $userWarningFired = true;
+            }
+
+            return true;
+        });
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+        } finally {
+            restore_error_handler();
+        }
+
+        $stderr = $this->readStderr();
+        $this->assertStringContainsString('[OpenAPI Enum Drift] WARNING', $stderr);
+        $this->assertStringContainsString('DriftingNotification', $stderr);
+        $this->assertFalse($userWarningFired, 'Lenient mode must not raise E_USER_WARNING');
+    }
+
+    #[Test]
+    public function bootstrap_succeeds_when_no_drift(): void
+    {
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'enum_drift_enabled' => 'true',
+            'enum_drift_scan_namespaces' => 'Studio\\OpenApiContractTesting\\Tests\\Unit\\PHPUnit\\Fixture\\EnumDrift\\Clean\\',
+        ]);
+
+        $extension->setupExtension(null, $parameters, null);
+
+        $this->assertSame('', $this->readStderr());
+    }
+
+    #[Test]
+    public function bootstrap_fatals_on_misconfigured_binding_even_when_lenient(): void
+    {
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'enum_drift_enabled' => 'true',
+            'enum_drift_scan_namespaces' => 'Studio\\OpenApiContractTesting\\Tests\\Unit\\PHPUnit\\Fixture\\EnumDrift\\Misconfigured\\',
+            'enum_drift_fail_on_drift' => 'false',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+            $this->fail('Expected EnumBindingException');
+        } catch (EnumBindingException $e) {
+            $this->assertSame(EnumBindingReason::SpecFileNotFound, $e->reason);
+            $this->assertStringContainsString('[OpenAPI Enum Drift] FATAL', $this->readStderr());
+        }
+    }
+
+    #[Test]
+    public function bootstrap_treats_empty_enum_drift_enabled_as_enabled(): void
+    {
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'enum_drift_enabled' => '', // shorthand for true (parity with min_coverage_strict)
+        ]);
+
+        // Empty `enum_drift_enabled` enables the check, so the empty
+        // namespace list trips the FATAL guard.
+        try {
+            $extension->setupExtension(null, $parameters, null);
+            $this->fail('Expected EnumBindingException');
+        } catch (EnumBindingException $e) {
+            $this->assertSame(EnumBindingReason::NoNamespacesConfigured, $e->reason);
+        }
+    }
+
+    #[Test]
+    public function bootstrap_parses_namespaces_csv_with_whitespace(): void
+    {
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'enum_drift_enabled' => 'true',
+            'enum_drift_scan_namespaces' =>
+                ' Studio\\OpenApiContractTesting\\Tests\\Unit\\PHPUnit\\Fixture\\EnumDrift\\Clean\\ '
+                . ', '
+                . ' Studio\\OpenApiContractTesting\\Tests\\Unit\\PHPUnit\\Fixture\\EnumDrift\\Clean\\ ',
+        ]);
+
+        $extension->setupExtension(null, $parameters, null);
+
+        $this->assertSame('', $this->readStderr());
     }
 
     private function readStderr(): string


### PR DESCRIPTION
# 概要

PR #166 で予告された PR-2 of 2 のフォローアップ。`OpenApiCoverageExtension` に opt-in の auto-discovery モードを追加し、`#[BoundToOpenApiEnum]` 付き enum を手動列挙する負担を解消する。

## 変更内容

`phpunit.xml` で 3 つの新パラメータを設定するだけで、PHPUnit ブートストラップ時に PSR-4 ネームスペースを走査してドリフト検査を自動実行する。

```xml
<extensions>
    <bootstrap class="Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension">
        <parameter name="spec_base_path" value="openapi/dist"/>
        <parameter name="enum_drift_enabled" value="true"/>
        <parameter name="enum_drift_scan_namespaces" value="App\Enums,App\Domain\Enums"/>
        <parameter name="enum_drift_fail_on_drift" value="true"/>
    </bootstrap>
</extensions>
```

| Parameter | Default | Behaviour |
|---|---|---|
| `enum_drift_enabled` | `false` | Master opt-in. Empty value も `true` として扱う（`min_coverage_strict` と対称）。 |
| `enum_drift_scan_namespaces` | _none_ | カンマ区切り PSR-4 namespace prefix。 |
| `enum_drift_fail_on_drift` | `true` | `true` で FATAL+`exit(1)`、`false` で WARNING ブロックのみ出力して継続。 |

- **`src/Internal/EnumScanner.php`**（新規 `@internal`）: Composer ClassLoader の classmap を優先走査し、見つからなければ PSR-4 ディレクトリを再帰スキャン。`--classmap-authoritative` / 通常 dev install 双方をカバー。pure enum / trait / abstract / 非属性クラスは silent skip。
- **`src/Exception/EnumBindingReason.php`**: `ScanNamespaceUnresolvable` / `ScanComposerLoaderUnavailable` / `NoNamespacesConfigured` を追加。auto-discovery 固有の misconfiguration を既存の `EnumBindingException` taxonomy に統合。
- **`src/PHPUnit/OpenApiCoverageExtension.php`**:
    - `bootstrap()` の catch に `EnumDriftException|EnumBindingException` を追加し、spec-load FATAL と同じ `exit(1)` パスに乗せる
    - `setupExtension()` 内で spec eager-load の直後に `runEnumDriftCheck()` を呼ぶ
    - `resolveBooleanFlag(name, default)` を新規追加（既存の `resolveStrictFlag()` は無変更）
    - WARNING モードは stderr + GitHub Step Summary のみ。`trigger_error` も `exit(1)` も発行しない
    - misconfigured binding は `enum_drift_fail_on_drift` の値に関わらず常に FATAL
- **`src/Schema/EnumDriftAsserter.php`**: `renderMessage()` を `@internal public static` に昇格。lenient モードで `detectAll()` 経由で取得した reports を Extension 側で再描画するため。
- **テスト**:
    - `tests/Unit/Internal/EnumScannerTest.php`（13 ケース）: classmap / PSR-4 / longest-match / dedup / cache / reset / pure enum / trait / abstract / unresolvable / no-classloader / empty-list を網羅
    - `tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php`（+7 ケース）: 7 つの分岐（disabled / no-namespaces / strict drift / lenient drift / clean / misconfig FATAL / empty-value shorthand / csv whitespace）を pin
    - `tests/Integration/OpenApiCoverageExtensionEnumDriftBootstrapTest.php`（5 ケース）: `proc_open` で実 PHPUnit を起動し exit code と stderr を検証
- **`README.md`**: `## Enum drift detection` 配下に `### Auto-discovery via the PHPUnit extension` セクションを追加（XML 例 + パラメータ表 + FATAL/WARNING サンプル）

検証: `composer ci` 全 3 段階通過（cs-check + PHPStan level 6 + PHPUnit 1224 tests / 2952 assertions）。

## 関連情報

- Closes #167
- Parent issue: #165
- Parent PR (merged): #166 — \"PR 2 will wire opt-in auto-discovery into OpenApiCoverageExtension (scan_namespaces config) as a follow-up\" を本 PR で履行