### PR TITLE
feat(schema): resolve #[BoundToOpenApiEnum] from optional enum_spec_base_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,7 +672,7 @@ enum NotificationCodeEnum: string
 }
 ```
 
-When this parameter is omitted (the default), `#[BoundToOpenApiEnum]` paths resolve against `spec_base_path` exactly as before — single-root projects don't need to change anything. Setting it to the same value as `spec_base_path` is a no-op.
+When this parameter is omitted (the default), `#[BoundToOpenApiEnum]` paths resolve against `spec_base_path` exactly as before — single-root projects don't need to change anything. Setting it to the same value as `spec_base_path` is functionally equivalent (the opt-in branch additionally validates that the directory exists with `is_dir()` before resolving any binding, while the fallback branch defers that check to per-file `file_exists()` lookups).
 
 If `enum_spec_base_path` is configured but the directory does not exist, the asserter throws `EnumBindingException` with `EnumBindingReason::EnumBasePathNotFound` so a typo cannot silently fall through to a misleading `SpecFileNotFound` on every binding. From PHP, the manual `OpenApiSpecLoader::configure(basePath: …, enumBasePath: …)` call accepts the same parameter for non-PHPUnit setups (e.g. dedicated drift CI scripts).
 

--- a/README.md
+++ b/README.md
@@ -636,6 +636,46 @@ The path is resolved relative to the configured spec root (`OpenApiSpecLoader::g
 }
 ```
 
+#### Bundled-external enum sources (`enum_spec_base_path`)
+
+Some projects bundle their OpenAPI documents (`front.json` / `admin.json` / …) into one directory while keeping individual `enum:` schemas elsewhere — so orval / Stoplight can `$ref` them without baking the values into the bundle. Concretely:
+
+```
+openapi/
+├── _shared/
+│   └── components/schemas/enums/
+│       └── NotificationCodeEnum.json     ← per-enum source files
+├── admin/   front/   store/              ← per-app sources
+└── bundled/                              ← orval-readable aggregate
+    ├── admin.json
+    ├── front.json
+    └── store.json
+```
+
+`spec_base_path` has to point at `openapi/bundled/` (that's where `{spec}.json` lookup for runtime contract tests lives), but the per-enum JSONs are deliberately *outside* that root. To bind a PHP enum to one without leaking the bundle directory choice into the attribute (`'../_shared/...'`), set `enum_spec_base_path` to a higher root used only for `#[BoundToOpenApiEnum]` resolution:
+
+```xml
+<extensions>
+    <bootstrap class="Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension">
+        <parameter name="spec_base_path" value="openapi/bundled"/>
+        <parameter name="enum_spec_base_path" value="openapi"/>
+        <parameter name="specs" value="front,store,admin"/>
+    </bootstrap>
+</extensions>
+```
+
+```php
+#[BoundToOpenApiEnum('_shared/components/schemas/enums/NotificationCodeEnum.json')]
+enum NotificationCodeEnum: string
+{
+    // ...
+}
+```
+
+When this parameter is omitted (the default), `#[BoundToOpenApiEnum]` paths resolve against `spec_base_path` exactly as before — single-root projects don't need to change anything. Setting it to the same value as `spec_base_path` is a no-op.
+
+If `enum_spec_base_path` is configured but the directory does not exist, the asserter throws `EnumBindingException` with `EnumBindingReason::EnumBasePathNotFound` so a typo cannot silently fall through to a misleading `SpecFileNotFound` on every binding. From PHP, the manual `OpenApiSpecLoader::configure(basePath: …, enumBasePath: …)` call accepts the same parameter for non-PHPUnit setups (e.g. dedicated drift CI scripts).
+
 ### `EnumDriftAsserter::assertNoDrift()`
 
 Call from any test (or from a dedicated drift-only test) to verify all bound enums match their spec files:
@@ -711,7 +751,8 @@ Add the opt-in parameters to your `phpunit.xml`:
 | `enum_drift_enabled` | `false` | Master opt-in. Empty value (`<parameter name="enum_drift_enabled"/>`) is also treated as `true`, mirroring `min_coverage_strict`. |
 | `enum_drift_scan_namespaces` | _none_ | Comma-separated PSR-4 namespace prefixes (whitespace tolerated). Each prefix must match — directly or as a sub-namespace of — an entry in your `composer.json` `autoload.psr-4` map. |
 | `enum_drift_fail_on_drift` | `true` | `true` aborts the run with a `[OpenAPI Enum Drift] FATAL` block on stderr (and `GITHUB_STEP_SUMMARY` when set). `false` emits a `WARNING` block but lets PHPUnit continue. |
-| _misconfiguration_ | _n/a_ | No namespaces configured, an unresolvable namespace prefix, a missing Composer `ClassLoader`, or any `EnumBindingException` raised by a discovered enum **always** produces a FATAL exit regardless of `enum_drift_fail_on_drift`. These are setup errors and would otherwise hide a real drift signal. |
+| `enum_spec_base_path` | _none_ | Optional secondary root used only for `#[BoundToOpenApiEnum]` path resolution. Set this when per-enum JSONs live outside `spec_base_path` (e.g. `openapi/_shared/...` while bundles live in `openapi/bundled/`). Relative values resolve against `getcwd()`. See [Bundled-external enum sources](#bundled-external-enum-sources-enum_spec_base_path) for the full layout. |
+| _misconfiguration_ | _n/a_ | No namespaces configured, an unresolvable namespace prefix, a missing Composer `ClassLoader`, an `enum_spec_base_path` that does not point at a directory, or any `EnumBindingException` raised by a discovered enum **always** produces a FATAL exit regardless of `enum_drift_fail_on_drift`. These are setup errors and would otherwise hide a real drift signal. |
 
 Discovery merges results from Composer's classmap (`getClassMap()`) and a recursive scan of each PSR-4-registered directory, deduplicating across both sources. Production deployments using `--optimize-autoloader` or `--classmap-authoritative` are covered by the classmap pass; default dev installs are covered by the PSR-4 directory walk. Only backed enums carrying `#[BoundToOpenApiEnum]` are passed to `EnumDriftAsserter`; pure enums, traits, abstract classes, and unattributed classes in the same directory are silently skipped.
 

--- a/src/Exception/EnumBindingException.php
+++ b/src/Exception/EnumBindingException.php
@@ -59,4 +59,20 @@ final class EnumBindingException extends RuntimeException
     ): self {
         return new self($reason, $message, null, null, $previous);
     }
+
+    /**
+     * Build an exception for a configuration-level failure that is global
+     * to the test run rather than per-binding (`EnumBasePathNotFound`,
+     * `EnumSpecBasePathOrphaned`). Structurally identical to {@see forScan}
+     * — no `$enumFqcn` / `$specPath` — but documented separately so callers
+     * branching on the reason aren't misled by an arbitrary "first failing
+     * binding" enumFqcn surfacing on a global error.
+     */
+    public static function forConfig(
+        EnumBindingReason $reason,
+        string $message,
+        ?Throwable $previous = null,
+    ): self {
+        return new self($reason, $message, null, null, $previous);
+    }
 }

--- a/src/Exception/EnumBindingReason.php
+++ b/src/Exception/EnumBindingReason.php
@@ -17,6 +17,7 @@ enum EnumBindingReason
     case ReflectionFailed;
     case AttributeMissing;
     case BasePathNotConfigured;
+    case EnumBasePathNotFound;
     case SpecFileNotFound;
     case MalformedJson;
     case NonMappingRoot;

--- a/src/Exception/EnumBindingReason.php
+++ b/src/Exception/EnumBindingReason.php
@@ -18,6 +18,7 @@ enum EnumBindingReason
     case AttributeMissing;
     case BasePathNotConfigured;
     case EnumBasePathNotFound;
+    case EnumSpecBasePathOrphaned;
     case SpecFileNotFound;
     case MalformedJson;
     case NonMappingRoot;

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -130,7 +130,23 @@ final class OpenApiCoverageExtension implements Extension
                 $stripPrefixes = array_map('trim', explode(',', $parameters->get('strip_prefixes')));
             }
 
-            OpenApiSpecLoader::configure($basePath, $stripPrefixes);
+            // Issue #170: secondary base path used only for
+            // #[BoundToOpenApiEnum] resolution. Absent → loader returns
+            // null and the asserter falls back to spec_base_path, keeping
+            // existing single-root setups bit-for-bit identical.
+            $enumBasePath = null;
+            if ($parameters->has('enum_spec_base_path')) {
+                $enumBasePath = $parameters->get('enum_spec_base_path');
+                if (!str_starts_with($enumBasePath, '/')) {
+                    $enumBasePath = getcwd() . '/' . $enumBasePath;
+                }
+            }
+
+            OpenApiSpecLoader::configure(
+                $basePath,
+                $stripPrefixes,
+                enumBasePath: $enumBasePath,
+            );
         }
 
         $specs = ['front'];

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -119,6 +119,13 @@ final class OpenApiCoverageExtension implements Extension
      */
     public function setupExtension(?Facade $facade, ParameterCollection $parameters, ?string $githubSummaryPath): void
     {
+        // Issue #170: secondary base path used only for
+        // #[BoundToOpenApiEnum] resolution. Read independently of
+        // spec_base_path so that an orphaned `enum_spec_base_path`
+        // (e.g. a typo in the spec_base_path attribute) is detected as a
+        // misconfiguration instead of being silently dropped together.
+        $enumBasePath = self::resolveEnumSpecBasePathParameter($parameters, $githubSummaryPath);
+
         if ($parameters->has('spec_base_path')) {
             $basePath = $parameters->get('spec_base_path');
             if (!str_starts_with($basePath, '/')) {
@@ -128,18 +135,6 @@ final class OpenApiCoverageExtension implements Extension
             $stripPrefixes = [];
             if ($parameters->has('strip_prefixes')) {
                 $stripPrefixes = array_map('trim', explode(',', $parameters->get('strip_prefixes')));
-            }
-
-            // Issue #170: secondary base path used only for
-            // #[BoundToOpenApiEnum] resolution. Absent → loader returns
-            // null and the asserter falls back to spec_base_path, keeping
-            // existing single-root setups bit-for-bit identical.
-            $enumBasePath = null;
-            if ($parameters->has('enum_spec_base_path')) {
-                $enumBasePath = $parameters->get('enum_spec_base_path');
-                if (!str_starts_with($enumBasePath, '/')) {
-                    $enumBasePath = getcwd() . '/' . $enumBasePath;
-                }
             }
 
             OpenApiSpecLoader::configure(
@@ -223,6 +218,63 @@ final class OpenApiCoverageExtension implements Extension
             minResponseCoverage: $minResponseCoverage,
             minCoverageStrict: $minCoverageStrict,
         ));
+    }
+
+    /**
+     * Read and validate the optional `enum_spec_base_path` parameter (issue
+     * #170). Returns the absolutised path or `null` when the parameter is
+     * absent (or set to whitespace-only, which is treated as absent so XML
+     * editing artefacts like a leading newline don't silently coerce the
+     * value to `getcwd()`).
+     *
+     * Detected misconfigurations are FATAL — a silent drop would defeat the
+     * fail-loud-on-misconfiguration policy this extension enforces:
+     *  - empty / whitespace value: rejected with a hint to remove the
+     *    parameter.
+     *  - set without `spec_base_path`: rejected because the loader's
+     *    `configure()` requires `spec_base_path` to be passed too, so an
+     *    orphaned `enum_spec_base_path` would never reach the loader.
+     */
+    private static function resolveEnumSpecBasePathParameter(
+        ParameterCollection $parameters,
+        ?string $githubSummaryPath,
+    ): ?string {
+        if (!$parameters->has('enum_spec_base_path')) {
+            return null;
+        }
+
+        $raw = trim($parameters->get('enum_spec_base_path'));
+        if ($raw === '') {
+            $reason = 'enum_spec_base_path is set but empty. '
+                . 'Either provide a directory path or remove the parameter to fall back to spec_base_path.';
+            self::writeStderr("[OpenAPI Enum Drift] FATAL: {$reason}\n");
+            self::appendGithubStepSummaryEnumDriftBlock($githubSummaryPath, $reason, isFatal: true);
+
+            throw EnumBindingException::forConfig(
+                EnumBindingReason::EnumSpecBasePathOrphaned,
+                $reason,
+            );
+        }
+
+        if (!$parameters->has('spec_base_path')) {
+            $reason = 'enum_spec_base_path is set but spec_base_path is not. '
+                . 'enum_spec_base_path is a secondary root that complements spec_base_path; '
+                . 'the loader currently requires spec_base_path to be configured for any spec-name lookup. '
+                . "Set spec_base_path too, or remove enum_spec_base_path if you don't need it.";
+            self::writeStderr("[OpenAPI Enum Drift] FATAL: {$reason}\n");
+            self::appendGithubStepSummaryEnumDriftBlock($githubSummaryPath, $reason, isFatal: true);
+
+            throw EnumBindingException::forConfig(
+                EnumBindingReason::EnumSpecBasePathOrphaned,
+                $reason,
+            );
+        }
+
+        if (!str_starts_with($raw, '/')) {
+            $raw = getcwd() . '/' . $raw;
+        }
+
+        return $raw;
     }
 
     /**

--- a/src/Schema/EnumDriftAsserter.php
+++ b/src/Schema/EnumDriftAsserter.php
@@ -30,6 +30,7 @@ use function file_get_contents;
 use function get_debug_type;
 use function implode;
 use function is_array;
+use function is_dir;
 use function is_int;
 use function is_string;
 use function json_decode;
@@ -268,12 +269,41 @@ final class EnumDriftAsserter
     }
 
     /**
-     * @return list<int|string>
+     * Pick the base path against which `$specPath` should resolve.
+     *
+     * When `enum_spec_base_path` (issue #170) is configured we consult it
+     * exclusively — `spec_base_path` is irrelevant for `#[BoundToOpenApiEnum]`
+     * resolution in that mode, including the case where `spec_base_path` is
+     * not configured at all. When it is not configured we fall back to the
+     * legacy single-root behavior via {@see OpenApiSpecLoader::getBasePath()},
+     * preserving bit-for-bit identical resolution for projects that never
+     * touch the new parameter.
      */
-    private static function loadSpecEnumValues(string $fqcn, string $specPath): array
+    private static function resolveEnumBasePath(string $fqcn, string $specPath): string
     {
+        $enumBasePath = OpenApiSpecLoader::getEnumBasePath();
+        if ($enumBasePath !== null) {
+            // We validate the directory only on the opt-in branch. Misconfigured
+            // enum_spec_base_path would otherwise surface as a generic
+            // SpecFileNotFound on every binding, hiding the real cause.
+            if (!is_dir($enumBasePath)) {
+                throw new EnumBindingException(
+                    EnumBindingReason::EnumBasePathNotFound,
+                    sprintf(
+                        'Configured enum_spec_base_path is not a directory: %s. '
+                        . 'Either fix the path or remove the parameter to fall back to spec_base_path.',
+                        $enumBasePath,
+                    ),
+                    enumFqcn: $fqcn,
+                    specPath: $specPath,
+                );
+            }
+
+            return $enumBasePath;
+        }
+
         try {
-            $basePath = OpenApiSpecLoader::getBasePath();
+            return OpenApiSpecLoader::getBasePath();
         } catch (InvalidOpenApiSpecException $e) {
             // The loader currently only throws BasePathNotConfigured here.
             // If a future loader change leaks a different reason through
@@ -298,6 +328,14 @@ final class EnumDriftAsserter
                 previous: $e,
             );
         }
+    }
+
+    /**
+     * @return list<int|string>
+     */
+    private static function loadSpecEnumValues(string $fqcn, string $specPath): array
+    {
+        $basePath = self::resolveEnumBasePath($fqcn, $specPath);
 
         $absolute = rtrim($basePath, '/') . '/' . $specPath;
 

--- a/src/Schema/EnumDriftAsserter.php
+++ b/src/Schema/EnumDriftAsserter.php
@@ -272,12 +272,13 @@ final class EnumDriftAsserter
      * Pick the base path against which `$specPath` should resolve.
      *
      * When `enum_spec_base_path` (issue #170) is configured we consult it
-     * exclusively — `spec_base_path` is irrelevant for `#[BoundToOpenApiEnum]`
-     * resolution in that mode, including the case where `spec_base_path` is
-     * not configured at all. When it is not configured we fall back to the
-     * legacy single-root behavior via {@see OpenApiSpecLoader::getBasePath()},
-     * preserving bit-for-bit identical resolution for projects that never
-     * touch the new parameter.
+     * exclusively; `spec_base_path` is not consulted in that mode, so the
+     * asserter still operates correctly when only `enum_spec_base_path` is
+     * set (the loader's `configure()` API requires `spec_base_path` to be
+     * passed too, so this case is mostly theoretical). When the new parameter
+     * is absent we fall back to the legacy single-root behavior via
+     * {@see OpenApiSpecLoader::getBasePath()}, preserving identical
+     * resolution for projects that never touch the new parameter.
      */
     private static function resolveEnumBasePath(string $fqcn, string $specPath): string
     {
@@ -286,16 +287,18 @@ final class EnumDriftAsserter
             // We validate the directory only on the opt-in branch. Misconfigured
             // enum_spec_base_path would otherwise surface as a generic
             // SpecFileNotFound on every binding, hiding the real cause.
+            // Do not mirror this is_dir() check on the fallback branch:
+            // getBasePath()'s contract is path-string-only, and adding the
+            // check there would break existing setups whose spec_base_path
+            // resolves files via getcwd-relative tricks.
             if (!is_dir($enumBasePath)) {
-                throw new EnumBindingException(
+                throw EnumBindingException::forConfig(
                     EnumBindingReason::EnumBasePathNotFound,
                     sprintf(
                         'Configured enum_spec_base_path is not a directory: %s. '
                         . 'Either fix the path or remove the parameter to fall back to spec_base_path.',
                         $enumBasePath,
                     ),
-                    enumFqcn: $fqcn,
-                    specPath: $specPath,
                 );
             }
 

--- a/src/Spec/OpenApiSpecLoader.php
+++ b/src/Spec/OpenApiSpecLoader.php
@@ -26,6 +26,7 @@ use function json_decode;
 use function realpath;
 use function rtrim;
 use function sprintf;
+use function trim;
 
 final class OpenApiSpecLoader
 {
@@ -77,8 +78,8 @@ final class OpenApiSpecLoader
      *                                  bundled aggregate root (e.g. `openapi/bundled/`) while
      *                                  individual enum JSONs live elsewhere (e.g.
      *                                  `openapi/_shared/...`). When `null` the asserter falls
-     *                                  back to `$basePath`, keeping single-root setups bit-for-
-     *                                  bit identical to pre-1.2.0 behavior.
+     *                                  back to `$basePath`, keeping single-root setups
+     *                                  bit-for-bit identical to the pre-issue-#170 behavior.
      *
      * @throws InvalidArgumentException for any misconfigured pair: `$allowRemoteRefs` true
      *                                  without client/factory, OR client provided without
@@ -111,6 +112,20 @@ final class OpenApiSpecLoader
                 'OpenApiSpecLoader::configure(): an HTTP client was provided but '
                 . 'allowRemoteRefs is false. HTTP $refs would be rejected silently. '
                 . 'Either pass allowRemoteRefs: true, or omit the client entirely.',
+            );
+        }
+
+        if ($enumBasePath !== null && trim($enumBasePath) === '') {
+            // Empty / whitespace-only `enumBasePath` would otherwise survive
+            // rtrim() as the empty string and surface later as
+            // `EnumBasePathNotFound: Configured enum_spec_base_path is not a
+            // directory: ` — an unhelpful diagnostic that hides the real
+            // misconfiguration. Reject at the API surface instead, matching
+            // the allowRemoteRefs pairing checks above. Pass `null` to
+            // intentionally disable the parameter.
+            throw new InvalidArgumentException(
+                'OpenApiSpecLoader::configure(): $enumBasePath is empty or whitespace-only. '
+                . 'Pass a valid directory path, or null to fall back to spec_base_path.',
             );
         }
 

--- a/src/Spec/OpenApiSpecLoader.php
+++ b/src/Spec/OpenApiSpecLoader.php
@@ -38,6 +38,14 @@ final class OpenApiSpecLoader
     private const SEARCH_EXTENSIONS = ['json', 'yaml', 'yml'];
     private static ?string $basePath = null;
 
+    /**
+     * Optional secondary base path used exclusively for resolving
+     * `#[BoundToOpenApiEnum]` paths (issue #170). When `null`, those paths
+     * fall back to {@see $basePath} so existing single-root projects
+     * keep their previous behavior unchanged.
+     */
+    private static ?string $enumBasePath = null;
+
     /** @var string[] */
     private static array $stripPrefixes = [];
 
@@ -63,6 +71,14 @@ final class OpenApiSpecLoader
      * @param bool $allowRemoteRefs Opt-in for HTTP(S) `$ref` resolution. Defaults to false:
      *                              every external HTTP(S) ref throws `RemoteRefDisallowed` so a
      *                              spec can never silently reach the network during tests.
+     * @param null|string $enumBasePath Optional secondary base path used only when resolving
+     *                                  `#[BoundToOpenApiEnum]` attribute paths (issue #170).
+     *                                  Lets projects keep `spec_base_path` pointed at a
+     *                                  bundled aggregate root (e.g. `openapi/bundled/`) while
+     *                                  individual enum JSONs live elsewhere (e.g.
+     *                                  `openapi/_shared/...`). When `null` the asserter falls
+     *                                  back to `$basePath`, keeping single-root setups bit-for-
+     *                                  bit identical to pre-1.2.0 behavior.
      *
      * @throws InvalidArgumentException for any misconfigured pair: `$allowRemoteRefs` true
      *                                  without client/factory, OR client provided without
@@ -75,6 +91,7 @@ final class OpenApiSpecLoader
         ?ClientInterface $httpClient = null,
         ?RequestFactoryInterface $requestFactory = null,
         bool $allowRemoteRefs = false,
+        ?string $enumBasePath = null,
     ): void {
         if ($allowRemoteRefs && ($httpClient === null || $requestFactory === null)) {
             throw new InvalidArgumentException(
@@ -98,6 +115,7 @@ final class OpenApiSpecLoader
         }
 
         self::$basePath = rtrim($basePath, '/');
+        self::$enumBasePath = $enumBasePath !== null ? rtrim($enumBasePath, '/') : null;
         self::$stripPrefixes = $stripPrefixes;
         self::$httpClient = $httpClient;
         self::$requestFactory = $requestFactory;
@@ -119,6 +137,19 @@ final class OpenApiSpecLoader
         }
 
         return self::$basePath;
+    }
+
+    /**
+     * Secondary base path for `#[BoundToOpenApiEnum]` resolution (issue #170).
+     *
+     * Returns `null` when not configured — `EnumDriftAsserter` is expected
+     * to fall back to {@see getBasePath()} in that case. The deliberate
+     * non-throwing shape mirrors how `enum_spec_base_path` is opt-in at the
+     * extension layer: absence is the documented default, not an error.
+     */
+    public static function getEnumBasePath(): ?string
+    {
+        return self::$enumBasePath;
     }
 
     /** @return string[] */
@@ -211,6 +242,7 @@ final class OpenApiSpecLoader
     public static function reset(): void
     {
         self::$basePath = null;
+        self::$enumBasePath = null;
         self::$stripPrefixes = [];
         self::$cache = [];
         self::$httpClient = null;

--- a/tests/Integration/EnumDriftIntegrationTest.php
+++ b/tests/Integration/EnumDriftIntegrationTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\Exception\EnumDriftException;
 use Studio\OpenApiContractTesting\Schema\EnumDriftAsserter;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\Tests\Integration\Schema\Fixture\IntegrationBundledExternalEnum;
 use Studio\OpenApiContractTesting\Tests\Integration\Schema\Fixture\IntegrationNotificationCodeEnum;
 use Studio\OpenApiContractTesting\Tests\Integration\Schema\Fixture\IntegrationPetStatusEnum;
 
@@ -86,5 +87,30 @@ class EnumDriftIntegrationTest extends TestCase
         $this->assertFalse($reports[0]->hasDrift());
         $this->assertSame(IntegrationNotificationCodeEnum::class, $reports[1]->enumFqcn);
         $this->assertTrue($reports[1]->hasDrift());
+    }
+
+    #[Test]
+    public function bundled_external_layout_resolves_via_enum_spec_base_path(): void
+    {
+        // Issue #170 dogfood: spec_base_path points at `issue-170/bundled/`
+        // (where front.json / store.json / admin.json would live), while
+        // enum_spec_base_path points one level higher so per-enum JSONs
+        // under `_shared/components/schemas/enums/` resolve from a clean
+        // attribute path — no `..` traversal required.
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(
+            basePath: __DIR__ . '/../fixtures/specs/issue-170/bundled',
+            enumBasePath: __DIR__ . '/../fixtures/specs/issue-170',
+        );
+
+        EnumDriftAsserter::assertNoDrift([IntegrationBundledExternalEnum::class]);
+
+        $reports = EnumDriftAsserter::detectAll([IntegrationBundledExternalEnum::class]);
+        $this->assertCount(1, $reports);
+        $this->assertFalse($reports[0]->hasDrift());
+        $this->assertSame(
+            '_shared/components/schemas/enums/BundledExternalEnum.json',
+            $reports[0]->specPath,
+        );
     }
 }

--- a/tests/Integration/OpenApiCoverageExtensionEnumDriftBootstrapTest.php
+++ b/tests/Integration/OpenApiCoverageExtensionEnumDriftBootstrapTest.php
@@ -117,12 +117,78 @@ class OpenApiCoverageExtensionEnumDriftBootstrapTest extends TestCase
         $this->assertStringContainsString('enum_drift_scan_namespaces', $output);
     }
 
+    #[Test]
+    public function phpunit_exits_zero_when_auto_discovery_resolves_via_enum_spec_base_path(): void
+    {
+        // Issue #170 end-to-end: scan a namespace whose enum's
+        // #[BoundToOpenApiEnum] path is bundle-relative (no `..` traversal),
+        // configure spec_base_path → bundled root and enum_spec_base_path
+        // → one level above. Bootstrap must order configure() before
+        // runEnumDriftCheck() so the asserter consults the secondary root.
+        [$exit, $output] = $this->runPhpunit(
+            [
+                'enum_drift_enabled' => 'true',
+                'enum_drift_scan_namespaces' =>
+                    'Studio\\OpenApiContractTesting\\Tests\\Integration\\Schema\\Fixture\\AutoDiscovery\\Issue170\\',
+                'enum_spec_base_path' => $this->repoRoot . '/tests/fixtures/specs/issue-170',
+            ],
+            specBasePath: $this->repoRoot . '/tests/fixtures/specs/issue-170/bundled',
+            specs: 'front',
+        );
+
+        $this->assertSame(0, $exit, "Expected zero exit; output was:\n" . $output);
+        $this->assertStringNotContainsString('[OpenAPI Enum Drift]', $output);
+    }
+
+    #[Test]
+    public function phpunit_exits_non_zero_when_auto_discovery_drift_resolves_via_enum_spec_base_path(): void
+    {
+        // Negative round-trip: same wiring as the clean test, but the bound
+        // enum has a PHP-only case. Drift must be detected through the
+        // enum_spec_base_path resolution and fail the run with FATAL.
+        [$exit, $output] = $this->runPhpunit(
+            [
+                'enum_drift_enabled' => 'true',
+                'enum_drift_scan_namespaces' =>
+                    'Studio\\OpenApiContractTesting\\Tests\\Integration\\Schema\\Fixture\\AutoDiscovery\\Issue170Drifting\\',
+                'enum_spec_base_path' => $this->repoRoot . '/tests/fixtures/specs/issue-170',
+            ],
+            specBasePath: $this->repoRoot . '/tests/fixtures/specs/issue-170/bundled',
+            specs: 'front',
+        );
+
+        $this->assertNotSame(0, $exit, "Expected non-zero exit; output was:\n" . $output);
+        $this->assertStringContainsString('[OpenAPI Enum Drift] FATAL', $output);
+        $this->assertStringContainsString('AutoDiscoveryIssue170DriftingEnum', $output);
+        $this->assertStringContainsString('PHP-only', $output);
+        $this->assertStringContainsString('delta', $output);
+    }
+
+    #[Test]
+    public function phpunit_exits_non_zero_for_orphaned_enum_spec_base_path(): void
+    {
+        // Issue #170 review C1: setting enum_spec_base_path without
+        // spec_base_path used to be silently dropped. The extension now
+        // FATALs at bootstrap so the misconfiguration surfaces immediately.
+        [$exit, $output] = $this->runPhpunitWithoutSpecBasePath([
+            'enum_spec_base_path' => $this->repoRoot . '/tests/fixtures/specs/issue-170',
+        ]);
+
+        $this->assertNotSame(0, $exit, "Expected non-zero exit; output was:\n" . $output);
+        $this->assertStringContainsString('[OpenAPI Enum Drift] FATAL', $output);
+        $this->assertStringContainsString('spec_base_path is not', $output);
+    }
+
     /**
+     * Run PHPUnit with extension parameters but NO `spec_base_path` line in
+     * the XML — used only by the orphaned-enum_spec_base_path test, which
+     * needs to exercise the parameter-validation FATAL path.
+     *
      * @param array<string, string> $extensionParameters
      *
-     * @return array{0: int, 1: string} [exit code, combined stderr+stdout]
+     * @return array{0: int, 1: string}
      */
-    private function runPhpunit(array $extensionParameters): array
+    private function runPhpunitWithoutSpecBasePath(array $extensionParameters): array
     {
         $paramXml = '';
         foreach ($extensionParameters as $name => $value) {
@@ -138,15 +204,83 @@ class OpenApiCoverageExtensionEnumDriftBootstrapTest extends TestCase
             . '<phpunit bootstrap="%s/vendor/autoload.php" cacheDirectory="%s/.phpunit.cache" colors="false">'
             . '<testsuites><testsuite name="Smoke"><directory>%s/tests/Integration/Fixture/Smoke</directory></testsuite></testsuites>'
             . '<extensions><bootstrap class="Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension">'
-            . '<parameter name="spec_base_path" value="%s/tests/fixtures/specs"/>'
-            . '<parameter name="specs" value="refs-valid"/>'
             . '%s'
             . '</bootstrap></extensions>'
             . '</phpunit>',
             $this->repoRoot,
             $this->repoRoot,
             $this->repoRoot,
+            $paramXml,
+        );
+
+        $tmp = tempnam(sys_get_temp_dir(), 'openapi-enum-drift-integration-') ?: null;
+        if ($tmp === null) {
+            $this->fail('Could not create temp phpunit config');
+        }
+        $this->configPath = $tmp;
+        file_put_contents($tmp, $xml);
+
+        $cmd = sprintf(
+            '%s/vendor/bin/phpunit -c %s',
+            escapeshellarg($this->repoRoot),
+            escapeshellarg($tmp),
+        );
+
+        $descriptors = [
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+        $process = proc_open($cmd, $descriptors, $pipes, $this->repoRoot);
+        if (!is_resource($process)) {
+            $this->fail('Could not spawn phpunit subprocess');
+        }
+
+        $stdout = (string) stream_get_contents($pipes[1]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        foreach ($pipes as $pipe) {
+            fclose($pipe);
+        }
+        $exit = proc_close($process);
+
+        return [$exit, $stdout . $stderr];
+    }
+
+    /**
+     * @param array<string, string> $extensionParameters
+     *
+     * @return array{0: int, 1: string} [exit code, combined stderr+stdout]
+     */
+    private function runPhpunit(array $extensionParameters, ?string $specBasePath = null, string $specs = 'refs-valid'): array
+    {
+        // Default: tests/fixtures/specs with refs-valid. Tests exercising
+        // alternate fixture trees (issue #170 bundled-external) override
+        // both arguments.
+        $specBasePath ??= $this->repoRoot . '/tests/fixtures/specs';
+
+        $paramXml = '';
+        foreach ($extensionParameters as $name => $value) {
+            $paramXml .= sprintf(
+                '<parameter name="%s" value="%s"/>',
+                htmlspecialchars($name, ENT_XML1 | ENT_QUOTES),
+                htmlspecialchars($value, ENT_XML1 | ENT_QUOTES),
+            );
+        }
+
+        $xml = sprintf(
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            . '<phpunit bootstrap="%s/vendor/autoload.php" cacheDirectory="%s/.phpunit.cache" colors="false">'
+            . '<testsuites><testsuite name="Smoke"><directory>%s/tests/Integration/Fixture/Smoke</directory></testsuite></testsuites>'
+            . '<extensions><bootstrap class="Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension">'
+            . '<parameter name="spec_base_path" value="%s"/>'
+            . '<parameter name="specs" value="%s"/>'
+            . '%s'
+            . '</bootstrap></extensions>'
+            . '</phpunit>',
             $this->repoRoot,
+            $this->repoRoot,
+            $this->repoRoot,
+            htmlspecialchars($specBasePath, ENT_XML1 | ENT_QUOTES),
+            htmlspecialchars($specs, ENT_XML1 | ENT_QUOTES),
             $paramXml,
         );
 

--- a/tests/Integration/Schema/Fixture/AutoDiscovery/Issue170/AutoDiscoveryIssue170BundledExternalEnum.php
+++ b/tests/Integration/Schema/Fixture/AutoDiscovery/Issue170/AutoDiscoveryIssue170BundledExternalEnum.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Integration\Schema\Fixture\AutoDiscovery\Issue170;
+
+use Studio\OpenApiContractTesting\Attribute\BoundToOpenApiEnum;
+
+/**
+ * Auto-discovery + enum_spec_base_path round-trip fixture (issue #170).
+ *
+ * The attribute path is bundle-relative (no `..` traversal) and resolves
+ * only when `enum_spec_base_path` is set to one level above the bundled
+ * root. Used by `OpenApiCoverageExtensionEnumDriftBootstrapTest` to pin
+ * that the extension's auto-discovery path consults the new parameter
+ * after bootstrap, not the legacy `spec_base_path`.
+ */
+#[BoundToOpenApiEnum('_shared/components/schemas/enums/BundledExternalEnum.json')]
+enum AutoDiscoveryIssue170BundledExternalEnum: string
+{
+    case Alpha = 'alpha';
+    case Beta = 'beta';
+    case Gamma = 'gamma';
+}

--- a/tests/Integration/Schema/Fixture/AutoDiscovery/Issue170Drifting/AutoDiscoveryIssue170DriftingEnum.php
+++ b/tests/Integration/Schema/Fixture/AutoDiscovery/Issue170Drifting/AutoDiscoveryIssue170DriftingEnum.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Integration\Schema\Fixture\AutoDiscovery\Issue170Drifting;
+
+use Studio\OpenApiContractTesting\Attribute\BoundToOpenApiEnum;
+
+/**
+ * Auto-discovery + enum_spec_base_path drift fixture (issue #170).
+ *
+ * Bound to the same JSON as the clean fixture, but with a PHP-only `Delta`
+ * case missing from the spec. Pins that drift detected through the
+ * `enum_spec_base_path` resolution path correctly fails the run when
+ * `enum_drift_fail_on_drift` defaults to true.
+ */
+#[BoundToOpenApiEnum('_shared/components/schemas/enums/BundledExternalEnum.json')]
+enum AutoDiscoveryIssue170DriftingEnum: string
+{
+    case Alpha = 'alpha';
+    case Beta = 'beta';
+    case Gamma = 'gamma';
+    case Delta = 'delta'; // PHP-only — not in spec
+}

--- a/tests/Integration/Schema/Fixture/IntegrationBundledExternalEnum.php
+++ b/tests/Integration/Schema/Fixture/IntegrationBundledExternalEnum.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Integration\Schema\Fixture;
+
+use Studio\OpenApiContractTesting\Attribute\BoundToOpenApiEnum;
+
+/**
+ * Issue #170 dogfood case: the bundled aggregate (`bundled/front.json`)
+ * lives under `spec_base_path`, but the per-enum source JSON lives under
+ * `_shared/...`, deliberately outside the bundle root. The attribute path
+ * is written *without* `..` traversal — resolution relies on
+ * `enum_spec_base_path` pointing one level above `bundled/`.
+ */
+#[BoundToOpenApiEnum('_shared/components/schemas/enums/BundledExternalEnum.json')]
+enum IntegrationBundledExternalEnum: string
+{
+    case Alpha = 'alpha';
+    case Beta = 'beta';
+    case Gamma = 'gamma';
+}

--- a/tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php
+++ b/tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php
@@ -23,6 +23,7 @@ use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 use function fclose;
 use function file_get_contents;
 use function fopen;
+use function getcwd;
 use function restore_error_handler;
 use function rewind;
 use function set_error_handler;
@@ -120,6 +121,58 @@ class OpenApiCoverageExtensionTest extends TestCase
         $extension->setupExtension(null, $parameters, null);
 
         $this->assertSame('', $this->readStderr());
+    }
+
+    #[Test]
+    public function bootstrap_leaves_enum_base_path_unset_when_parameter_omitted(): void
+    {
+        // Issue #170: enum_spec_base_path is opt-in. When the parameter is
+        // not present the loader must report null so EnumDriftAsserter
+        // falls back to spec_base_path — keeping pre-1.2.0 setups
+        // bit-for-bit identical.
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+        ]);
+
+        $extension->setupExtension(null, $parameters, null);
+
+        $this->assertNull(OpenApiSpecLoader::getEnumBasePath());
+    }
+
+    #[Test]
+    public function bootstrap_passes_absolute_enum_spec_base_path_to_loader(): void
+    {
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'enum_spec_base_path' => '/absolute/path/to/openapi',
+        ]);
+
+        $extension->setupExtension(null, $parameters, null);
+
+        $this->assertSame('/absolute/path/to/openapi', OpenApiSpecLoader::getEnumBasePath());
+    }
+
+    #[Test]
+    public function bootstrap_resolves_relative_enum_spec_base_path_against_cwd(): void
+    {
+        // Pin that the extension absolutises a relative `enum_spec_base_path`
+        // against `getcwd()`, mirroring `spec_base_path` / `output_file` /
+        // `sidecar_dir`. Without this the asserter would silently look in the
+        // wrong place when paratest workers run with a different cwd.
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'enum_spec_base_path' => 'relative/openapi',
+        ]);
+
+        $extension->setupExtension(null, $parameters, null);
+
+        $this->assertSame(getcwd() . '/relative/openapi', OpenApiSpecLoader::getEnumBasePath());
     }
 
     #[Test]

--- a/tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php
+++ b/tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php
@@ -176,6 +176,103 @@ class OpenApiCoverageExtensionTest extends TestCase
     }
 
     #[Test]
+    public function bootstrap_trims_whitespace_around_enum_spec_base_path(): void
+    {
+        // XML editors sometimes wrap parameter values in stray newlines or
+        // spaces. Without trim() those would silently flow as
+        // `getcwd()."/   /openapi"` and produce a confusing
+        // EnumBasePathNotFound diagnostic later.
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'enum_spec_base_path' => "  \n /absolute/path/to/openapi  \n",
+        ]);
+
+        $extension->setupExtension(null, $parameters, null);
+
+        $this->assertSame('/absolute/path/to/openapi', OpenApiSpecLoader::getEnumBasePath());
+    }
+
+    #[Test]
+    public function bootstrap_fatal_when_enum_spec_base_path_is_empty(): void
+    {
+        // <parameter name="enum_spec_base_path" value=""/> would otherwise
+        // flow as the empty string and silently coerce to getcwd(), masking
+        // the misconfiguration.
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'enum_spec_base_path' => '',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+            $this->fail('expected EnumBindingException');
+        } catch (EnumBindingException $e) {
+            $this->assertSame(EnumBindingReason::EnumSpecBasePathOrphaned, $e->reason);
+            $this->assertNull($e->enumFqcn);
+            $this->assertNull($e->specPath);
+            $this->assertStringContainsString('empty', $e->getMessage());
+        }
+
+        $this->assertStringContainsString('FATAL', $this->readStderr());
+    }
+
+    #[Test]
+    public function bootstrap_fatal_when_enum_spec_base_path_set_without_spec_base_path(): void
+    {
+        // C1 from review: a typo in spec_base_path that leaves
+        // enum_spec_base_path orphaned must FATAL instead of silently
+        // dropping the parameter.
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'enum_spec_base_path' => '/some/path/openapi',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+            $this->fail('expected EnumBindingException');
+        } catch (EnumBindingException $e) {
+            $this->assertSame(EnumBindingReason::EnumSpecBasePathOrphaned, $e->reason);
+            $this->assertStringContainsString('spec_base_path is not', $e->getMessage());
+        }
+
+        $this->assertStringContainsString('FATAL', $this->readStderr());
+    }
+
+    #[Test]
+    public function bootstrap_fatal_writes_block_to_github_step_summary_for_orphaned_enum_spec_base_path(): void
+    {
+        // FATAL diagnostics for spec misconfiguration already land in
+        // GITHUB_STEP_SUMMARY (issue #134); the new orphaned-parameter
+        // diagnostic must follow the same convention so reviewers see it
+        // in the PR summary, not buried in CI logs.
+        $tmp = tempnam(sys_get_temp_dir(), 'openapi-summary-');
+        if ($tmp === false) {
+            $this->fail('Could not create temp file for GITHUB_STEP_SUMMARY');
+        }
+        $this->githubSummaryTmp = $tmp;
+
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'enum_spec_base_path' => '/some/path/openapi',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, $tmp);
+            $this->fail('expected EnumBindingException');
+        } catch (EnumBindingException) {
+            // Expected — block must still be written before re-throw.
+        }
+
+        $contents = (string) file_get_contents($tmp);
+        $this->assertStringContainsString('FATAL OpenAPI enum drift', $contents);
+        $this->assertStringContainsString('spec_base_path is not', $contents);
+    }
+
+    #[Test]
     public function bootstrap_appends_fatal_block_to_github_step_summary(): void
     {
         $tmp = tempnam(sys_get_temp_dir(), 'openapi-summary-');

--- a/tests/Unit/Schema/EnumDriftAsserterTest.php
+++ b/tests/Unit/Schema/EnumDriftAsserterTest.php
@@ -30,6 +30,8 @@ use Studio\OpenApiContractTesting\Tests\Unit\Schema\Fixture\UnattributedEnum;
 
 use function restore_error_handler;
 use function set_error_handler;
+use function sys_get_temp_dir;
+use function uniqid;
 
 class EnumDriftAsserterTest extends TestCase
 {
@@ -382,6 +384,103 @@ class EnumDriftAsserterTest extends TestCase
         } catch (EnumDriftException $e) {
             $this->assertSame(['a', 'b'], $e->reports[0]->phpOnly);
             $this->assertSame([], $e->reports[0]->specOnly);
+        }
+    }
+
+    #[Test]
+    public function enum_base_path_resolves_attribute_paths_independently_of_spec_base_path(): void
+    {
+        // Issue #170: bundled-external layout. spec_base_path can point at
+        // an unrelated bundle root while #[BoundToOpenApiEnum] paths still
+        // resolve correctly under enum_spec_base_path.
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(
+            basePath: sys_get_temp_dir(),
+            enumBasePath: self::SPEC_BASE_PATH,
+        );
+
+        EnumDriftAsserter::assertNoDrift([MatchingEnum::class]);
+
+        $reports = EnumDriftAsserter::detectAll([MatchingEnum::class]);
+        $this->assertCount(1, $reports);
+        $this->assertFalse($reports[0]->hasDrift());
+    }
+
+    #[Test]
+    public function enum_base_path_unset_falls_back_to_spec_base_path(): void
+    {
+        // Default setUp() configures only spec_base_path. Existing tests
+        // already imply the fallback works; this test pins the contract
+        // explicitly so a future loader refactor can't drift it silently.
+        $this->assertNull(OpenApiSpecLoader::getEnumBasePath());
+
+        EnumDriftAsserter::assertNoDrift([MatchingEnum::class]);
+    }
+
+    #[Test]
+    public function enum_base_path_equal_to_spec_base_path_is_a_no_op(): void
+    {
+        // Setting enum_spec_base_path to the same value as spec_base_path
+        // must produce the same result as not setting it at all — proves
+        // the new branch never alters resolution when the user opts in
+        // unnecessarily.
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(
+            basePath: self::SPEC_BASE_PATH,
+            enumBasePath: self::SPEC_BASE_PATH,
+        );
+
+        EnumDriftAsserter::assertNoDrift([MatchingEnum::class]);
+
+        try {
+            EnumDriftAsserter::assertNoDrift([PhpExtraEnum::class]);
+            $this->fail('expected EnumDriftException');
+        } catch (EnumDriftException $e) {
+            $this->assertSame(['blue'], $e->reports[0]->phpOnly);
+            $this->assertSame([], $e->reports[0]->specOnly);
+        }
+    }
+
+    #[Test]
+    public function enum_base_path_set_but_spec_file_missing_throws_spec_file_not_found(): void
+    {
+        // enum_spec_base_path resolves to a real directory, but the
+        // attribute path doesn't land on a file under it. Should surface
+        // the existing SpecFileNotFound reason — not the new
+        // EnumBasePathNotFound, which is reserved for the dir-itself-missing
+        // case.
+        $emptyDir = sys_get_temp_dir();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(
+            basePath: self::SPEC_BASE_PATH,
+            enumBasePath: $emptyDir,
+        );
+
+        try {
+            EnumDriftAsserter::assertNoDrift([MatchingEnum::class]);
+            $this->fail('expected EnumBindingException');
+        } catch (EnumBindingException $e) {
+            $this->assertSame(EnumBindingReason::SpecFileNotFound, $e->reason);
+            $this->assertSame('enum-drift/matching.json', $e->specPath);
+        }
+    }
+
+    #[Test]
+    public function enum_base_path_pointing_at_nonexistent_dir_throws_enum_base_path_not_found(): void
+    {
+        $missing = sys_get_temp_dir() . '/openapi-contract-testing-missing-' . uniqid();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(
+            basePath: self::SPEC_BASE_PATH,
+            enumBasePath: $missing,
+        );
+
+        try {
+            EnumDriftAsserter::assertNoDrift([MatchingEnum::class]);
+            $this->fail('expected EnumBindingException');
+        } catch (EnumBindingException $e) {
+            $this->assertSame(EnumBindingReason::EnumBasePathNotFound, $e->reason);
+            $this->assertStringContainsString($missing, $e->getMessage());
         }
     }
 }

--- a/tests/Unit/Schema/EnumDriftAsserterTest.php
+++ b/tests/Unit/Schema/EnumDriftAsserterTest.php
@@ -420,25 +420,51 @@ class EnumDriftAsserterTest extends TestCase
     #[Test]
     public function enum_base_path_equal_to_spec_base_path_is_a_no_op(): void
     {
-        // Setting enum_spec_base_path to the same value as spec_base_path
-        // must produce the same result as not setting it at all — proves
-        // the new branch never alters resolution when the user opts in
-        // unnecessarily.
+        // Compare report objects field-by-field between the fallback branch
+        // (no enumBasePath) and the opt-in branch (enumBasePath = basePath).
+        // A subtle bug where the opt-in branch produced a different
+        // specPath / phpOnly / specOnly would slip through a "did it throw?"
+        // shaped test — this one fails it.
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(basePath: self::SPEC_BASE_PATH);
+        $baseline = EnumDriftAsserter::detectAll([MatchingEnum::class, PhpExtraEnum::class]);
+
         OpenApiSpecLoader::reset();
         OpenApiSpecLoader::configure(
             basePath: self::SPEC_BASE_PATH,
             enumBasePath: self::SPEC_BASE_PATH,
         );
+        $optIn = EnumDriftAsserter::detectAll([MatchingEnum::class, PhpExtraEnum::class]);
+
+        $this->assertCount(2, $optIn);
+        foreach ($optIn as $i => $report) {
+            $this->assertSame($baseline[$i]->enumFqcn, $report->enumFqcn);
+            $this->assertSame($baseline[$i]->specPath, $report->specPath);
+            $this->assertSame($baseline[$i]->phpOnly, $report->phpOnly);
+            $this->assertSame($baseline[$i]->specOnly, $report->specOnly);
+            $this->assertSame($baseline[$i]->hasDrift(), $report->hasDrift());
+        }
+    }
+
+    #[Test]
+    public function enum_base_path_with_trailing_slash_resolves_identically(): void
+    {
+        // OpenApiSpecLoader::configure() trims trailing slashes (covered at
+        // the loader unit level). End-to-end through the asserter pins that
+        // the trim survives the full resolution path — a future refactor
+        // that stops trimming and instead concatenates blindly would still
+        // pass the loader-level test alone.
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(
+            basePath: self::SPEC_BASE_PATH,
+            enumBasePath: self::SPEC_BASE_PATH . '/',
+        );
 
         EnumDriftAsserter::assertNoDrift([MatchingEnum::class]);
 
-        try {
-            EnumDriftAsserter::assertNoDrift([PhpExtraEnum::class]);
-            $this->fail('expected EnumDriftException');
-        } catch (EnumDriftException $e) {
-            $this->assertSame(['blue'], $e->reports[0]->phpOnly);
-            $this->assertSame([], $e->reports[0]->specOnly);
-        }
+        $reports = EnumDriftAsserter::detectAll([MatchingEnum::class]);
+        $this->assertFalse($reports[0]->hasDrift());
+        $this->assertSame('enum-drift/matching.json', $reports[0]->specPath);
     }
 
     #[Test]

--- a/tests/Unit/Spec/OpenApiSpecLoaderTest.php
+++ b/tests/Unit/Spec/OpenApiSpecLoaderTest.php
@@ -98,6 +98,38 @@ class OpenApiSpecLoaderTest extends TestCase
     }
 
     #[Test]
+    public function configure_rejects_empty_enum_base_path(): void
+    {
+        // Reject at the API surface. Without this, an empty string would
+        // surface later as `EnumBasePathNotFound: ... is not a directory: `
+        // (with nothing after the colon) — a confusing diagnostic that hides
+        // the real misconfiguration.
+        try {
+            OpenApiSpecLoader::configure(
+                basePath: '/path/to/specs',
+                enumBasePath: '',
+            );
+            $this->fail('expected InvalidArgumentException');
+        } catch (InvalidArgumentException $e) {
+            $this->assertStringContainsString('$enumBasePath is empty', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function configure_rejects_whitespace_only_enum_base_path(): void
+    {
+        try {
+            OpenApiSpecLoader::configure(
+                basePath: '/path/to/specs',
+                enumBasePath: "  \n\t ",
+            );
+            $this->fail('expected InvalidArgumentException');
+        } catch (InvalidArgumentException $e) {
+            $this->assertStringContainsString('whitespace-only', $e->getMessage());
+        }
+    }
+
+    #[Test]
     public function get_base_path_throws_when_not_configured(): void
     {
         try {

--- a/tests/Unit/Spec/OpenApiSpecLoaderTest.php
+++ b/tests/Unit/Spec/OpenApiSpecLoaderTest.php
@@ -65,6 +65,39 @@ class OpenApiSpecLoaderTest extends TestCase
     }
 
     #[Test]
+    public function get_enum_base_path_returns_null_when_not_configured(): void
+    {
+        // Issue #170: enum_spec_base_path is opt-in. Absence is the
+        // documented default — getEnumBasePath() must not throw the way
+        // getBasePath() does, because the asserter relies on the null
+        // return to fall back to spec_base_path.
+        $this->assertNull(OpenApiSpecLoader::getEnumBasePath());
+    }
+
+    #[Test]
+    public function configure_stores_enum_base_path_with_trailing_slash_trimmed(): void
+    {
+        OpenApiSpecLoader::configure(
+            basePath: '/path/to/specs',
+            enumBasePath: '/path/to/openapi/',
+        );
+
+        $this->assertSame('/path/to/openapi', OpenApiSpecLoader::getEnumBasePath());
+    }
+
+    #[Test]
+    public function reset_clears_enum_base_path(): void
+    {
+        OpenApiSpecLoader::configure(
+            basePath: '/path/to/specs',
+            enumBasePath: '/path/to/openapi',
+        );
+        OpenApiSpecLoader::reset();
+
+        $this->assertNull(OpenApiSpecLoader::getEnumBasePath());
+    }
+
+    #[Test]
     public function get_base_path_throws_when_not_configured(): void
     {
         try {

--- a/tests/fixtures/specs/issue-170/_shared/components/schemas/enums/BundledExternalEnum.json
+++ b/tests/fixtures/specs/issue-170/_shared/components/schemas/enums/BundledExternalEnum.json
@@ -1,0 +1,5 @@
+{
+  "type": "string",
+  "enum": ["alpha", "beta", "gamma"],
+  "description": "Bundle-external enum source from issue #170 dogfood layout."
+}

--- a/tests/fixtures/specs/issue-170/bundled/front.json
+++ b/tests/fixtures/specs/issue-170/bundled/front.json
@@ -1,0 +1,5 @@
+{
+  "openapi": "3.1.0",
+  "info": {"title": "Issue #170 bundled aggregate", "version": "0.0.0"},
+  "paths": {}
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `enum_spec_base_path` extension parameter (and matching `OpenApiSpecLoader::configure(enumBasePath: ...)` argument) used **only** when resolving `#[BoundToOpenApiEnum]` paths. When the parameter is omitted, behaviour is bit-for-bit identical to v1.1.x — single-root projects need to change nothing.

```xml
<extensions>
    <bootstrap class="Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension">
        <parameter name="spec_base_path" value="openapi/bundled"/>
        <parameter name="enum_spec_base_path" value="openapi"/>     <!-- new -->
        <parameter name="specs" value="front,store,admin"/>
    </bootstrap>
</extensions>
```

```php
// before — leaks the bundled root choice into the attribute
#[BoundToOpenApiEnum('../_shared/components/schemas/enums/NotificationCodeEnum.json')]

// after
#[BoundToOpenApiEnum('_shared/components/schemas/enums/NotificationCodeEnum.json')]
```

## Why

Per #170: `#[BoundToOpenApiEnum]` resolution is currently coupled to `spec_base_path`. Projects that point `spec_base_path` at `openapi/bundled/` (where orval-readable aggregates live) have to write `'../_shared/...'` in every attribute to reach per-enum source JSONs that deliberately live outside the bundle root. The parent-traversal is awkward, fragile under bundle-layout refactors, and visually leaks the bundle directory choice into every attributed enum.

Workarounds rejected for the reasons spelled out in #170 — duplicating per-enum JSONs under `bundled/` re-creates the exact drift this library exists to detect, and re-pointing `spec_base_path` at `openapi/` would break the existing `{base}/{spec}.json` lookup.

Fixes #170.

## Verification

- [x] `composer test` passes — 1252 tests, 3018 assertions (+10 new across the review fixup commit, on top of the original +10 from the feature commit)
- [x] `composer stan` passes (PHPStan level 6 clean)
- [x] `composer cs-check` passes (PHP-CS-Fixer clean)

End-to-end exercise: `tests/Integration/EnumDriftIntegrationTest::bundled_external_layout_resolves_via_enum_spec_base_path` and three new bootstrap-level cases in `OpenApiCoverageExtensionEnumDriftBootstrapTest` (auto-discovery clean, auto-discovery drift, orphaned-parameter FATAL) drive the headline dogfood layout end-to-end.

## Notes for reviewers

**Public API surface added (intentionally additive — SemVer minor):**
- `OpenApiSpecLoader::configure(..., ?string $enumBasePath = null)` — optional 6th argument, defaults preserve all existing call sites. Empty / whitespace-only value rejected with `InvalidArgumentException` to avoid the unhelpful "is not a directory: " (empty) diagnostic later.
- `OpenApiSpecLoader::getEnumBasePath(): ?string` — non-throwing on purpose. Absence is the documented default and the asserter relies on the null return to fall back to `spec_base_path`. (Contrast with `getBasePath()` which throws because `spec_base_path` is functionally required for spec lookup.)
- `OpenApiCoverageExtension` parameter `enum_spec_base_path` — relative paths resolve against `getcwd()`, identical to `spec_base_path` / `output_file` / `sidecar_dir`. `trim()`'d on read so XML editing artefacts (leading newlines, etc.) don't silently coerce to `getcwd()`.
- `EnumBindingException::forConfig()` — sibling to `forScan` for global configuration failures (no `enumFqcn` / `specPath` because the failure isn't tied to any specific binding).
- New `EnumBindingReason` cases: `EnumBasePathNotFound` (parameter set but path doesn't exist) and `EnumSpecBasePathOrphaned` (parameter set without `spec_base_path`, or empty/whitespace value).

**Design notes:**
- `EnumDriftAsserter::resolveEnumBasePath()` is the new private helper — it consults `getEnumBasePath()` first and only falls back to `getBasePath()` when the new parameter is unset.
- Setting `enum_spec_base_path` to the same value as `spec_base_path` is functionally equivalent to omitting it (the opt-in branch additionally validates with `is_dir()` before resolving any binding; the fallback branch defers that check to per-file `file_exists()` lookups). Pinned by a field-by-field `detectAll()` comparison test.
- `EnumBasePathNotFound` / `EnumSpecBasePathOrphaned` are both routed through `forConfig()` — the misconfiguration is global, so `enumFqcn` / `specPath` are intentionally null instead of being set to an arbitrary "first failing binding".
- Fail-loud-on-misconfiguration is preserved: empty / whitespace / orphaned `enum_spec_base_path` all FATAL at PHPUnit bootstrap with diagnostics also written to `GITHUB_STEP_SUMMARY`.
- `oneOf` enum union resolution is explicitly out of scope (called out in #170 as a known limitation tracked from #166).

## Review fixups

Commit `8376c8c` addresses the multi-agent code review on the initial commit:
- Critical: orphaned and empty `enum_spec_base_path` no longer silently dropped (review C1, C2)
- Important: `forConfig()` factory for global config failures (I4); docblock / README accuracy (I1, I2, I3); auto-discovery + bootstrap integration tests (I5); strengthened no-op + trailing-slash unit tests (I6, S3)
- Suggestion: empty `enumBasePath` rejected at the loader's `configure()` API surface (S1)

## Follow-up

- #172 — `CoverageMergeCommand` does not yet plumb `enum_spec_base_path` through to `OpenApiSpecLoader::configure()`. Latent today (the merge CLI does not invoke `EnumDriftAsserter`); worth closing alongside the next merge-CLI enum-drift feature.