### PR TITLE
fix(coverage): blank line between endpoint heading and response table

### DIFF
--- a/src/Coverage/MarkdownCoverageRenderer.php
+++ b/src/Coverage/MarkdownCoverageRenderer.php
@@ -96,7 +96,7 @@ final class MarkdownCoverageRenderer
         $heading = $endpoint['operationId'] !== null
             ? sprintf('#### `%s` (%s)', $endpoint['endpoint'], $endpoint['operationId'])
             : sprintf('#### `%s`', $endpoint['endpoint']);
-        $lines = [$heading];
+        $lines = [$heading, ''];
 
         if ($endpoint['responses'] === []) {
             $lines[] = $endpoint['requestReached']

--- a/tests/Unit/Coverage/MarkdownCoverageRendererTest.php
+++ b/tests/Unit/Coverage/MarkdownCoverageRendererTest.php
@@ -254,6 +254,34 @@ class MarkdownCoverageRendererTest extends TestCase
     }
 
     #[Test]
+    public function render_inserts_blank_line_between_endpoint_heading_and_response_table(): void
+    {
+        // Regression for #174: markdownlint MD058 (blanks-around-tables).
+        // The `#### ...` heading must be followed by a blank line before the
+        // response table starts so consumers running markdownlint don't get noise.
+        $results = [
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v1/pets', 'all-covered', responses: [
+                        self::row('200', 'application/json', 'validated', hits: 1),
+                    ], coveredResponseCount: 1, totalResponseCount: 1),
+                ],
+                endpointTotal: 1,
+                endpointFullyCovered: 1,
+                responseTotal: 1,
+                responseCovered: 1,
+            ),
+        ];
+
+        $output = MarkdownCoverageRenderer::render($results);
+
+        $this->assertMatchesRegularExpression(
+            '/^#### `GET \/v1\/pets`\n\n\| Status \| Content-Type \| State \|$/m',
+            $output,
+        );
+    }
+
+    #[Test]
     public function render_includes_operation_id_when_present(): void
     {
         $results = [


### PR DESCRIPTION
## Summary

`MarkdownCoverageRenderer::renderEndpointDetail()` で生成する `####` 見出しの直後に空行を 1 行挿入する。これだけで markdownlint [MD058 (blanks-around-tables)](https://github.com/DavidAnson/markdownlint/blob/main/doc/md058.md) 違反が解消する。

## Why

Fixes #174

consumer 側 (e.g. `studio-api` PR #6617 の `docs/openapi-coverage.md`) で、生成 markdown を CodeRabbit / markdownlint が評価したときに MD058 警告が複数発生していた (line 1516, 2301, 3170, 3176)。生成元はこの renderer のため、consumer 側では根本対処できない。

修正方針は issue 本文と一致 (`$lines = [$heading]` → `$lines = [$heading, '']`)。`render()` 側の高レベル table は既に直前で空行を入れているため変更不要。`responses === []` ブランチも table を生成しないため MD058 対象外。

副次的に `#### ...\n\n_no response definitions in spec_` の形になり MD022 (headings-surrounded-by-blank-lines) にも適合する (改善方向のみ、後方互換性問題なし)。

## Verification

TDD で対応:

1. `tests/Unit/Coverage/MarkdownCoverageRendererTest.php` に MD058 退行検知テスト `render_inserts_blank_line_between_endpoint_heading_and_response_table` を追加
2. failing を確認 (`#### ...\n| Status |...` でブランクなし) してから修正適用
3. 全 1253 テスト + PHPStan level 6 + PHP-CS-Fixer すべて green (`composer ci`)

- [x] `composer test` passes
- [x] `composer stan` passes
- [x] `composer cs-check` passes

## Notes for reviewers

- 既存テストは全て `assertStringContainsString` ベースで heading-table 間の空行有無に依存していなかったため影響なし。
- 出力 markdown はレンダリング結果が同等 (空行 1 行は no-op)。consumer の永続化済み markdown はファイル末尾が 1 行ずつ伸びるだけ。
- `CHANGELOG.md` は触っていません (release-please 管理)。
- 兄弟 issue #175 (CI で markdown lint 退行検知) は別 PR で対応予定です。