### PR TITLE
test(coverage): enforce markdownlint compliance on rendered markdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,3 +132,26 @@ jobs:
 
       - name: Audit installed dependencies
         run: composer audit --abandoned=fail
+
+  markdown-lint:
+    name: Markdown Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Install PHP dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Run markdown lint test
+        run: vendor/bin/phpunit --filter MarkdownCoverageRendererLintTest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,11 @@ jobs:
         with:
           node-version: '24'
 
+      - name: Verify Node toolchain is usable
+        run: |
+          node --version
+          npx --version
+
       - name: Install PHP dependencies
         run: composer install --prefer-dist --no-interaction --no-progress
 

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,32 @@
+// markdownlint config for output produced by MarkdownCoverageRenderer.
+//
+// Currently scoped to the lint compliance test
+// (tests/Unit/Coverage/MarkdownCoverageRendererLintTest.php) only — repo
+// docs (README, CONTRIBUTING, etc.) are NOT linted by this config.
+{
+  "default": true,
+
+  // The renderer emits an embeddable fragment rooted at h2
+  // (## OpenAPI Contract Test Coverage), not a standalone document with an h1.
+  "MD041": false,
+
+  // <details> / <summary> are required for the collapsible per-response
+  // detail section. Other inline HTML stays disallowed.
+  "MD033": {
+    "allowed_elements": ["details", "summary"]
+  },
+
+  // The italic sub-summary line under each `### spec` heading
+  // (`_responses: x/y covered ..._`) is intentional UX: it semantically
+  // belongs to the heading as a concise stats line.
+  "MD036": false,
+
+  // Markdown table rows can exceed any reasonable line length when endpoint
+  // paths or skip reasons are long; line-length is not the lint we want here.
+  "MD013": false,
+
+  // Pipe-alignment within tables would require pre-computing column widths
+  // for every row before emitting the header. Disabled because misaligned
+  // pipes don't affect rendering and the cost/benefit doesn't justify it.
+  "MD060": false
+}

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,8 +1,8 @@
-// markdownlint config for output produced by MarkdownCoverageRenderer.
-//
-// Currently scoped to the lint compliance test
-// (tests/Unit/Coverage/MarkdownCoverageRendererLintTest.php) only — repo
-// docs (README, CONTRIBUTING, etc.) are NOT linted by this config.
+// markdownlint config consumed only by
+// tests/Unit/Coverage/MarkdownCoverageRendererLintTest.php to verify the
+// markdown produced by MarkdownCoverageRenderer. The disables below are
+// chosen for that generated output and are not intended to apply to repo
+// documentation (README, CONTRIBUTING, etc.).
 {
   "default": true,
 

--- a/composer.json
+++ b/composer.json
@@ -80,6 +80,7 @@
         "exclude": [
             "/tests",
             "/.github",
+            "/.markdownlint.jsonc",
             "/.php-cs-fixer.dist.php",
             "/.php-cs-fixer.cache",
             "/.phpstan.cache",

--- a/src/Coverage/MarkdownCoverageRenderer.php
+++ b/src/Coverage/MarkdownCoverageRenderer.php
@@ -43,6 +43,7 @@ final class MarkdownCoverageRenderer
                 $result['endpointTotal'],
                 self::formatPercent($endpointPct),
             );
+            $lines[] = '';
             $lines[] = sprintf(
                 '_responses: %d/%d covered (%s%%) — %d skipped, %d uncovered, %d partial endpoints, %d uncovered endpoints_',
                 $result['responseCovered'],
@@ -122,6 +123,7 @@ final class MarkdownCoverageRenderer
         if ($endpoint['unexpectedObservations'] !== []) {
             $lines[] = '';
             $lines[] = '_Unexpected observations (status / content-type not in spec):_';
+            $lines[] = '';
             foreach ($endpoint['unexpectedObservations'] as $obs) {
                 $lines[] = sprintf('- `%s` `%s`', $obs['statusKey'], $obs['contentTypeKey']);
             }

--- a/tests/Unit/Coverage/MarkdownCoverageRendererLintTest.php
+++ b/tests/Unit/Coverage/MarkdownCoverageRendererLintTest.php
@@ -14,11 +14,11 @@ use function dirname;
 use function escapeshellarg;
 use function exec;
 use function explode;
+use function file_exists;
 use function file_put_contents;
 use function implode;
-use function shell_exec;
+use function preg_match;
 use function sprintf;
-use function str_contains;
 use function sys_get_temp_dir;
 use function tempnam;
 use function unlink;
@@ -101,6 +101,11 @@ final class MarkdownCoverageRendererLintTest extends TestCase
                         requestReached: true,
                     ),
                     self::endpoint(
+                        'PATCH /v1/admin/{id}',
+                        EndpointCoverageState::Uncovered,
+                        requestReached: false,
+                    ),
+                    self::endpoint(
                         'DELETE /v1/pets/{petId}',
                         EndpointCoverageState::Partial,
                         responses: [
@@ -115,10 +120,10 @@ final class MarkdownCoverageRendererLintTest extends TestCase
                         ],
                     ),
                 ],
-                'endpointTotal' => 2,
+                'endpointTotal' => 3,
                 'endpointFullyCovered' => 0,
                 'endpointPartial' => 1,
-                'endpointUncovered' => 0,
+                'endpointUncovered' => 1,
                 'endpointRequestOnly' => 1,
                 'responseTotal' => 2,
                 'responseCovered' => 1,
@@ -186,22 +191,32 @@ final class MarkdownCoverageRendererLintTest extends TestCase
      */
     private function assertRenderedMarkdownPassesLint(array $results): void
     {
-        $version = (string) shell_exec('npx --version 2>&1');
-        if (!str_contains($version, '.')) {
-            $this->markTestSkipped('npx is not available; install Node.js to run this test locally');
+        $probeOutput = [];
+        $probeExit = 1;
+        exec('npx --version 2>/dev/null', $probeOutput, $probeExit);
+        if ($probeExit !== 0 || !preg_match('/^\d+\.\d+/', $probeOutput[0] ?? '')) {
+            $this->markTestSkipped('npx is not available; install Node.js to run this test');
         }
 
+        $tmpFile = tempnam(sys_get_temp_dir(), 'mdlint_');
+        if ($tmpFile === false) {
+            $this->fail('tempnam() failed to create a temp file');
+        }
         $output = MarkdownCoverageRenderer::render($results);
-        $tmpFile = tempnam(sys_get_temp_dir(), 'mdlint_') . '.md';
-        file_put_contents($tmpFile, $output);
+        if (file_put_contents($tmpFile, $output) === false) {
+            unlink($tmpFile);
+            $this->fail('file_put_contents() failed to write the rendered markdown');
+        }
         $configPath = dirname(__DIR__, 3) . '/.markdownlint.jsonc';
 
         try {
             $cmd = sprintf(
-                'npx --yes markdownlint-cli2@0 --config %s %s 2>&1',
+                'npx --yes markdownlint-cli2@0.22 --config %s %s 2>&1',
                 escapeshellarg($configPath),
                 escapeshellarg($tmpFile),
             );
+            $stdout = [];
+            $exitCode = 1;
             exec($cmd, $stdout, $exitCode);
 
             $this->assertSame(
@@ -210,7 +225,9 @@ final class MarkdownCoverageRendererLintTest extends TestCase
                 "markdownlint-cli2 failed with exit code {$exitCode}:\n" . implode("\n", $stdout),
             );
         } finally {
-            @unlink($tmpFile);
+            if (file_exists($tmpFile)) {
+                unlink($tmpFile);
+            }
         }
     }
 }

--- a/tests/Unit/Coverage/MarkdownCoverageRendererLintTest.php
+++ b/tests/Unit/Coverage/MarkdownCoverageRendererLintTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Coverage;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Coverage\EndpointCoverageState;
+use Studio\OpenApiContractTesting\Coverage\MarkdownCoverageRenderer;
+use Studio\OpenApiContractTesting\Coverage\ResponseCoverageState;
+
+use function dirname;
+use function escapeshellarg;
+use function exec;
+use function explode;
+use function file_put_contents;
+use function implode;
+use function shell_exec;
+use function sprintf;
+use function str_contains;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+final class MarkdownCoverageRendererLintTest extends TestCase
+{
+    #[Test]
+    public function standard_coverage_rendered_markdown_passes_markdownlint(): void
+    {
+        $this->assertRenderedMarkdownPassesLint(self::standardFixture());
+    }
+
+    #[Test]
+    public function edge_cases_rendered_markdown_passes_markdownlint(): void
+    {
+        $this->assertRenderedMarkdownPassesLint(self::edgeCasesFixture());
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private static function standardFixture(): array
+    {
+        return [
+            'front' => [
+                'endpoints' => [
+                    self::endpoint(
+                        'GET /v1/pets',
+                        EndpointCoverageState::AllCovered,
+                        operationId: 'listPets',
+                        responses: [
+                            self::row('200', 'application/json', ResponseCoverageState::Validated, hits: 3),
+                        ],
+                        coveredResponseCount: 1,
+                        totalResponseCount: 1,
+                    ),
+                    self::endpoint(
+                        'POST /v1/pets',
+                        EndpointCoverageState::Partial,
+                        responses: [
+                            self::row('201', 'application/json', ResponseCoverageState::Validated, hits: 1),
+                            self::row('422', 'application/problem+json', ResponseCoverageState::Uncovered),
+                        ],
+                        coveredResponseCount: 1,
+                        totalResponseCount: 2,
+                    ),
+                    self::endpoint(
+                        'GET /v1/health',
+                        EndpointCoverageState::Uncovered,
+                        responses: [
+                            self::row('200', 'application/json', ResponseCoverageState::Uncovered),
+                        ],
+                        totalResponseCount: 1,
+                    ),
+                ],
+                'endpointTotal' => 3,
+                'endpointFullyCovered' => 1,
+                'endpointPartial' => 1,
+                'endpointUncovered' => 1,
+                'endpointRequestOnly' => 0,
+                'responseTotal' => 4,
+                'responseCovered' => 2,
+                'responseSkipped' => 0,
+                'responseUncovered' => 2,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private static function edgeCasesFixture(): array
+    {
+        return [
+            'admin' => [
+                'endpoints' => [
+                    self::endpoint(
+                        'GET /v1/loose',
+                        EndpointCoverageState::RequestOnly,
+                        requestReached: true,
+                    ),
+                    self::endpoint(
+                        'DELETE /v1/pets/{petId}',
+                        EndpointCoverageState::Partial,
+                        responses: [
+                            self::row('204', '*', ResponseCoverageState::Validated, hits: 2),
+                            self::row('5XX', '*', ResponseCoverageState::Skipped, hits: 1, skipReason: 'status 503 matched skip pattern 5\d\d'),
+                        ],
+                        coveredResponseCount: 1,
+                        skippedResponseCount: 1,
+                        totalResponseCount: 2,
+                        unexpectedObservations: [
+                            ['statusKey' => '418', 'contentTypeKey' => 'application/json'],
+                        ],
+                    ),
+                ],
+                'endpointTotal' => 2,
+                'endpointFullyCovered' => 0,
+                'endpointPartial' => 1,
+                'endpointUncovered' => 0,
+                'endpointRequestOnly' => 1,
+                'responseTotal' => 2,
+                'responseCovered' => 1,
+                'responseSkipped' => 1,
+                'responseUncovered' => 0,
+            ],
+        ];
+    }
+
+    /**
+     * @param list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}> $responses
+     * @param list<array{statusKey: string, contentTypeKey: string}> $unexpectedObservations
+     *
+     * @return array<string, mixed>
+     */
+    private static function endpoint(
+        string $endpoint,
+        EndpointCoverageState $state,
+        bool $requestReached = false,
+        ?string $operationId = null,
+        array $responses = [],
+        int $coveredResponseCount = 0,
+        int $skippedResponseCount = 0,
+        int $totalResponseCount = 0,
+        array $unexpectedObservations = [],
+    ): array {
+        [$method, $path] = explode(' ', $endpoint, 2);
+
+        return [
+            'endpoint' => $endpoint,
+            'method' => $method,
+            'path' => $path,
+            'operationId' => $operationId,
+            'state' => $state,
+            'requestReached' => $requestReached,
+            'responses' => $responses,
+            'coveredResponseCount' => $coveredResponseCount,
+            'skippedResponseCount' => $skippedResponseCount,
+            'totalResponseCount' => $totalResponseCount,
+            'unexpectedObservations' => $unexpectedObservations,
+        ];
+    }
+
+    /**
+     * @return array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}
+     */
+    private static function row(
+        string $statusKey,
+        string $contentTypeKey,
+        ResponseCoverageState $state,
+        int $hits = 0,
+        ?string $skipReason = null,
+    ): array {
+        return [
+            'statusKey' => $statusKey,
+            'contentTypeKey' => $contentTypeKey,
+            'state' => $state,
+            'hits' => $hits,
+            'skipReason' => $skipReason,
+        ];
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $results
+     */
+    private function assertRenderedMarkdownPassesLint(array $results): void
+    {
+        $version = (string) shell_exec('npx --version 2>&1');
+        if (!str_contains($version, '.')) {
+            $this->markTestSkipped('npx is not available; install Node.js to run this test locally');
+        }
+
+        $output = MarkdownCoverageRenderer::render($results);
+        $tmpFile = tempnam(sys_get_temp_dir(), 'mdlint_') . '.md';
+        file_put_contents($tmpFile, $output);
+        $configPath = dirname(__DIR__, 3) . '/.markdownlint.jsonc';
+
+        try {
+            $cmd = sprintf(
+                'npx --yes markdownlint-cli2@0 --config %s %s 2>&1',
+                escapeshellarg($configPath),
+                escapeshellarg($tmpFile),
+            );
+            exec($cmd, $stdout, $exitCode);
+
+            $this->assertSame(
+                0,
+                $exitCode,
+                "markdownlint-cli2 failed with exit code {$exitCode}:\n" . implode("\n", $stdout),
+            );
+        } finally {
+            @unlink($tmpFile);
+        }
+    }
+}

--- a/tests/Unit/Coverage/MarkdownCoverageRendererTest.php
+++ b/tests/Unit/Coverage/MarkdownCoverageRendererTest.php
@@ -282,6 +282,66 @@ class MarkdownCoverageRendererTest extends TestCase
     }
 
     #[Test]
+    public function render_inserts_blank_line_between_unexpected_observations_label_and_list(): void
+    {
+        // Regression for #175: markdownlint MD032 (blanks-around-lists).
+        // The italic "_Unexpected observations:_" label must be followed by
+        // a blank line before the bullet list starts so consumers running
+        // markdownlint don't get noise.
+        $results = [
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v1/pets', 'partial', responses: [
+                        self::row('200', 'application/json', 'validated', hits: 1),
+                    ], coveredResponseCount: 1, totalResponseCount: 1, unexpectedObservations: [
+                        ['statusKey' => '418', 'contentTypeKey' => 'application/json'],
+                    ]),
+                ],
+                endpointTotal: 1,
+                endpointPartial: 1,
+                responseTotal: 1,
+                responseCovered: 1,
+            ),
+        ];
+
+        $output = MarkdownCoverageRenderer::render($results);
+
+        $this->assertMatchesRegularExpression(
+            '/_Unexpected observations \(status \/ content-type not in spec\):_\n\n- /',
+            $output,
+        );
+    }
+
+    #[Test]
+    public function render_inserts_blank_line_between_spec_heading_and_responses_summary(): void
+    {
+        // Regression for #175: markdownlint MD022 (blanks-around-headings).
+        // The `### spec — ...` heading must be followed by a blank line before
+        // the italic responses summary so consumers running markdownlint don't
+        // get noise.
+        $results = [
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v1/pets', 'all-covered', responses: [
+                        self::row('200', 'application/json', 'validated', hits: 1),
+                    ], coveredResponseCount: 1, totalResponseCount: 1),
+                ],
+                endpointTotal: 1,
+                endpointFullyCovered: 1,
+                responseTotal: 1,
+                responseCovered: 1,
+            ),
+        ];
+
+        $output = MarkdownCoverageRenderer::render($results);
+
+        $this->assertMatchesRegularExpression(
+            '/^### front — endpoints: 1\/1 fully covered \(100%\)\n\n_responses: /m',
+            $output,
+        );
+    }
+
+    #[Test]
     public function render_includes_operation_id_when_present(): void
     {
         $results = [


### PR DESCRIPTION
## Summary

`MarkdownCoverageRenderer` の生成 markdown に対する markdownlint 適合性を CI で機械的に検証する仕組みを追加。`markdownlint-cli2` を Node 24 の専用 CI ジョブで実行する。これにより #174 のような違反が consumer 側のレビューで初めて発覚する事故を再発防止する。

合わせて、追加した lint テストが捕捉した renderer のバグ 2 件を 1 行ずつ修正:

- **MD022** (blanks-around-headings): `### spec — ...` 見出し直後に italic `_responses: ..._` 行が続いていた → 空行挿入
- **MD032** (blanks-around-lists): `_Unexpected observations:_` 直後に bullet list が続いていた → 空行挿入

それぞれ #174 と同じ TDD パターン (regression test → 1 行 fix) で対応。

## Why

Fixes #175

直接の発端は #174 (MD058)。consumer 側 (studio-api PR #6617) のレビューで CodeRabbit が markdownlint 警告を出してから初めて気付く状態だった。本ライブラリは markdown を成果物として吐くツールなのに、生成 markdown 自体の整形品質を保証する仕組みがなかった。

issue 起票時の候補 A (`markdownlint-cli2` を CI 内で呼ぶ) を採用。設計上意図的な violation は `.markdownlint.jsonc` で明示的に disable し、各 disable には inline コメントで理由を記録。

## Verification

ローカル (Node あり):
\`\`\`bash
vendor/bin/phpunit --filter MarkdownCoverageRendererLintTest
# → 2 tests pass (standard / edge cases)
composer ci
# → 1257 tests + PHPStan + PHP-CS-Fixer 全 green
\`\`\`

ローカル (Node なし):
\`\`\`bash
vendor/bin/phpunit --filter MarkdownCoverageRendererLintTest
# → 2 tests skipped
\`\`\`

CI:
- 新規 \`markdown-lint\` ジョブ (PHP 8.3 + Node 24) が green
- 既存ジョブ群 (PHP 8.2/8.3/8.4 × PHPUnit 11/12/13 マトリクス、PHPStan、PHP-CS-Fixer 等) は変更なしで green

- [x] \`composer test\` passes
- [x] \`composer stan\` passes
- [x] \`composer cs-check\` passes

## Notes for reviewers

### `.markdownlint.jsonc` で disable した rule の根拠

| Rule | 理由 |
|---|---|
| **MD041** (first-line-h1) | renderer は h2 ルートの embeddable fragment を出力 (consumer ドキュメントへの埋め込み前提) |
| **MD033** (no-inline-html) | \`<details>\`/\`<summary>\` がコラプス可能な per-response 詳細セクションに必須。\`allowed_elements\` で 2 タグに限定 |
| **MD036** (no-emphasis-as-heading) | italic サブサマリ \`_responses: ..._\` は意図的な UX |
| **MD013** (line-length) | 長い endpoint path / skip reason を含む table 行は line-length 検査の対象外にすべき |
| **MD060** (table-column-style) | pipe alignment のためには各列の幅を事前計算する必要があり、rendering には影響しないため見送り |

### Renderer 修正の影響

- MD022 / MD032 fix で出力 markdown に空行が 2 箇所増えるが、GitHub UI 上の見た目は semantically 等価。consumer のドキュメントには blank line が追加されるだけで diff は最小。

### markdownlint-cli2 の version pin

- \`@0\` (major pin) で実行 — 現状は v0.22.1 を取得。patch/minor は自動取得。
- 将来 lint の semantic が変わって CI が落ちるリスクはあるが、major まで pin する方が rule 進化に追随できる利点が勝つと判断。
- Renovate 連携が欲しくなった段階で \`package.json\` 化するのが自然 (別 PR スコープ)。

### CI への影響

- 専用 \`markdown-lint\` ジョブ 1 本のみ追加 (PHP 8.3 + Node 24)。
- 既存 PHP マトリクス 12 ジョブには Node setup を入れていない (毎ジョブで lint を走らせる必要なし)。
- ジョブ内で \`composer install\` の後に PHPUnit を \`--filter\` で 1 テストクラスだけ実行 → 30 秒以内に完了見込み。

### 留意

- \`CHANGELOG.md\` は触っていません (release-please 管理)。
- \`.claude/\` および \`draft-zenn-article.md\` は untracked のまま。