### PR TITLE
feat(request): auto-inject dummy credentials for non-bearer auth schemes

### DIFF
--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -32,6 +32,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use WeakMap;
 
+use function array_key_first;
 use function array_merge;
 use function filter_var;
 use function fwrite;
@@ -59,6 +60,11 @@ trait ValidatesOpenApiSchema
     // anything downstream — the inject only silences the spec's security
     // check. Making it configurable is a deliberate separate discussion.
     private const DUMMY_BEARER_TOKEN = 'test-token';
+
+    // Counterpart to DUMMY_BEARER_TOKEN for apiKey schemes injected via
+    // auto_inject_dummy_credentials. The value avoids `=` and `;` so it is
+    // safe in cookie / query / header contexts without escaping concerns.
+    private const DUMMY_API_KEY_VALUE = 'test-api-key';
     private static ?OpenApiResponseValidator $cachedValidator = null;
     private static ?int $cachedMaxErrors = null;
     private static ?OpenApiRequestValidator $cachedRequestValidator = null;
@@ -321,11 +327,34 @@ trait ValidatesOpenApiSchema
 
         $body = $this->extractRequestBody($request, $contentType);
 
-        if ($this->shouldAutoInjectDummyBearer($specName, $resolvedMethod, $resolvedPath, $headers)) {
-            // Inject under the canonical framework key (Symfony lowercases) so
-            // both any existing "Authorization" and the validator's
-            // case-insensitive lookup see the same value.
-            $headers['authorization'] = ['Bearer ' . self::DUMMY_BEARER_TOKEN];
+        foreach ($this->resolveAutoInjectCredentials($specName, $resolvedMethod, $resolvedPath, $headers, $cookies, $queryParams) as $credential) {
+            if ($credential['kind'] === 'bearer') {
+                // Inject under the canonical framework key (Symfony lowercases)
+                // so both any existing "Authorization" and the validator's
+                // case-insensitive lookup see the same value.
+                $headers['authorization'] = ['Bearer ' . self::DUMMY_BEARER_TOKEN];
+
+                continue;
+            }
+
+            $name = $credential['name'];
+            switch ($credential['in']) {
+                case 'header':
+                    // Header bag is case-insensitive but stored lowercased; the
+                    // SecurityValidator normalises before lookup so writing
+                    // either form would work, but we mirror the bearer case.
+                    $headers[strtolower($name)] = [self::DUMMY_API_KEY_VALUE];
+
+                    break;
+                case 'cookie':
+                    $cookies[$name] = self::DUMMY_API_KEY_VALUE;
+
+                    break;
+                case 'query':
+                    $queryParams[$name] = self::DUMMY_API_KEY_VALUE;
+
+                    break;
+            }
         }
 
         $validator = $this->getOrCreateRequestValidator();
@@ -536,6 +565,32 @@ trait ValidatesOpenApiSchema
         return is_int($code) ? (string) $code : $code;
     }
 
+    /**
+     * Treat a slot as populated only when it carries a non-empty string value,
+     * matching {@see Validation\Request\SecurityValidator::checkApiKeySatisfied()}'s
+     * "missing" definition. Symfony's HeaderBag exposes header values as a
+     * `list<?string>`, so the array branch peels the first element before
+     * applying the same string check.
+     */
+    private static function slotIsAlreadyPopulated(mixed $value): bool
+    {
+        if ($value === null) {
+            return false;
+        }
+
+        if (is_array($value)) {
+            if ($value === []) {
+                return false;
+            }
+
+            $first = $value[array_key_first($value)] ?? null;
+
+            return is_string($first) && $first !== '';
+        }
+
+        return is_string($value) && $value !== '';
+    }
+
     private function getOrCreateRequestValidator(): OpenApiRequestValidator
     {
         $resolvedMaxErrors = $this->resolveMaxErrors();
@@ -557,11 +612,15 @@ trait ValidatesOpenApiSchema
     }
 
     /**
-     * Decide whether to rewrite the validator's view of the request with a
-     * dummy Authorization header. True only when: (1) the inject feature is
-     * enabled, (2) no Authorization is already present (any case), and (3)
-     * the matched operation's spec security accepts a bearer credential (see
-     * {@see SecuritySchemeIntrospector}).
+     * Determine which dummy credentials to splice into the validator's view of
+     * the request. Returns the list of inject targets the caller should write —
+     * empty list means "leave everything as the test set it up".
+     *
+     * Two modes coexist for backward compatibility:
+     * - `auto_inject_dummy_credentials` (preferred) — injects bearer + every
+     *   apiKey scheme (header / cookie / query) the operation declares.
+     * - `auto_inject_dummy_bearer` (legacy) — injects bearer only, bypassed
+     *   when the credentials flag is on.
      *
      * Callers are expected to have already confirmed auto-validate-request
      * is on — this method is reached only from {@see self::maybeAutoValidateOpenApiRequest()},
@@ -574,21 +633,33 @@ trait ValidatesOpenApiSchema
      * the real error. We stay silent here so a broken spec produces exactly
      * one failure, not a confusing cascade.
      *
+     * Slots already populated by the test (Authorization header, named cookie,
+     * named query / header param) are filtered out — the test's intent always
+     * wins, even when the supplied value is malformed and would fail the
+     * security check on its own. Empty-string and empty-array values count as
+     * absent, mirroring {@see Validation\Request\SecurityValidator::checkApiKeySatisfied()}'s
+     * own missing-value definition so the inject path and the validation path
+     * agree on what "no credential" looks like.
+     *
      * @param array<string, mixed> $headers
+     * @param array<string, mixed> $cookies
+     * @param array<string, mixed> $queryParams
+     *
+     * @return list<array{kind: 'apiKey', in: 'cookie'|'header'|'query', name: string}|array{kind: 'bearer'}>
      */
-    private function shouldAutoInjectDummyBearer(
+    private function resolveAutoInjectCredentials(
         string $specName,
         string $method,
         string $path,
         array $headers,
-    ): bool {
-        if (!$this->isAutoInjectDummyBearerEnabled()) {
-            return false;
-        }
+        array $cookies,
+        array $queryParams,
+    ): array {
+        $credentialsEnabled = $this->isAutoInjectDummyCredentialsEnabled();
+        $legacyBearerEnabled = $this->isAutoInjectDummyBearerEnabled();
 
-        $normalized = HeaderNormalizer::normalize($headers);
-        if (isset($normalized['authorization']) && $normalized['authorization'] !== '' && $normalized['authorization'] !== []) {
-            return false;
+        if (!$credentialsEnabled && !$legacyBearerEnabled) {
+            return [];
         }
 
         try {
@@ -600,20 +671,54 @@ trait ValidatesOpenApiSchema
             // immediately after and will surface the real error. Broader
             // Throwable (TypeError, AssertionError, ...) keeps bubbling so
             // programmer bugs are not silently downgraded to "missing auth".
-            return false;
+            return [];
         }
 
         $paths = $spec['paths'] ?? null;
         if (!is_array($paths)) {
-            return false;
+            return [];
         }
 
         $matchedOperation = $this->findOperationForRequest($paths, $method, $path);
         if ($matchedOperation === null) {
-            return false;
+            return [];
         }
 
-        return $this->getSecuritySchemeIntrospector()->endpointAcceptsBearer($spec, $matchedOperation);
+        $introspector = $this->getSecuritySchemeIntrospector();
+
+        if ($credentialsEnabled) {
+            $candidates = $introspector->injectableCredentialsFor($spec, $matchedOperation);
+        } else {
+            $candidates = $introspector->endpointAcceptsBearer($spec, $matchedOperation)
+                ? [['kind' => 'bearer']]
+                : [];
+        }
+
+        if ($candidates === []) {
+            return [];
+        }
+
+        $normalizedHeaders = HeaderNormalizer::normalize($headers);
+
+        $filtered = [];
+        foreach ($candidates as $candidate) {
+            $existing = match ($candidate['kind']) {
+                'bearer' => $normalizedHeaders['authorization'] ?? null,
+                'apiKey' => match ($candidate['in']) {
+                    'header' => $normalizedHeaders[strtolower($candidate['name'])] ?? null,
+                    'cookie' => $cookies[$candidate['name']] ?? null,
+                    'query' => $queryParams[$candidate['name']] ?? null,
+                },
+            };
+
+            if (self::slotIsAlreadyPopulated($existing)) {
+                continue;
+            }
+
+            $filtered[] = $candidate;
+        }
+
+        return $filtered;
     }
 
     /**
@@ -810,6 +915,11 @@ trait ValidatesOpenApiSchema
     private function isAutoInjectDummyBearerEnabled(): bool
     {
         return $this->resolveBoolConfig('auto_inject_dummy_bearer');
+    }
+
+    private function isAutoInjectDummyCredentialsEnabled(): bool
+    {
+        return $this->resolveBoolConfig('auto_inject_dummy_credentials');
     }
 
     /**

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -329,9 +329,9 @@ trait ValidatesOpenApiSchema
 
         foreach ($this->resolveAutoInjectCredentials($specName, $resolvedMethod, $resolvedPath, $headers, $cookies, $queryParams) as $credential) {
             if ($credential['kind'] === 'bearer') {
-                // Inject under the canonical framework key (Symfony lowercases)
-                // so both any existing "Authorization" and the validator's
-                // case-insensitive lookup see the same value.
+                // Lower-case the key so it round-trips through
+                // HeaderNormalizer::normalize() the same way Symfony's
+                // already-lowercased header bag does.
                 $headers['authorization'] = ['Bearer ' . self::DUMMY_BEARER_TOKEN];
 
                 continue;
@@ -340,9 +340,6 @@ trait ValidatesOpenApiSchema
             $name = $credential['name'];
             switch ($credential['in']) {
                 case 'header':
-                    // Header bag is case-insensitive but stored lowercased; the
-                    // SecurityValidator normalises before lookup so writing
-                    // either form would work, but we mirror the bearer case.
                     $headers[strtolower($name)] = [self::DUMMY_API_KEY_VALUE];
 
                     break;
@@ -568,9 +565,13 @@ trait ValidatesOpenApiSchema
     /**
      * Treat a slot as populated only when it carries a non-empty string value,
      * matching {@see Validation\Request\SecurityValidator::checkApiKeySatisfied()}'s
-     * "missing" definition. Symfony's HeaderBag exposes header values as a
-     * `list<?string>`, so the array branch peels the first element before
-     * applying the same string check.
+     * "missing" definition.
+     *
+     * Symfony's HeaderBag exposes header values as `list<?string>` (array
+     * branch); CookieBag and ParameterBag (query) expose plain strings (scalar
+     * branch). The array branch peels the first element before applying the
+     * same string check so all three bag shapes converge on the same
+     * "absent vs populated" verdict.
      */
     private static function slotIsAlreadyPopulated(mixed $value): bool
     {
@@ -619,14 +620,17 @@ trait ValidatesOpenApiSchema
      * Two modes coexist for backward compatibility:
      * - `auto_inject_dummy_credentials` (preferred) — injects bearer + every
      *   apiKey scheme (header / cookie / query) the operation declares.
-     * - `auto_inject_dummy_bearer` (legacy) — injects bearer only, bypassed
-     *   when the credentials flag is on.
+     * - `auto_inject_dummy_bearer` (legacy) — injects bearer only.
      *
-     * Callers are expected to have already confirmed auto-validate-request
-     * is on — this method is reached only from {@see self::maybeAutoValidateOpenApiRequest()},
-     * which gates on that flag. Calling it from a new code path without the
-     * same gate would silently load the spec even when request validation is
-     * disabled.
+     * When both flags are true the credentials flag wins and the legacy flag
+     * is bypassed; setting only the legacy flag preserves its narrower
+     * bearer-only behavior exactly.
+     *
+     * Precondition: callers must already have gated on
+     * `auto_validate_request` being on. Without that gate this method would
+     * load the spec even when request validation is disabled, which is both
+     * wasteful and surfacing-time-dependent (the validator's error path is
+     * what makes the swallow below safe).
      *
      * Errors walking the spec (unreadable file, no matching path, missing
      * operation) fall through as "do not inject" — the validator will surface

--- a/src/Laravel/config.php
+++ b/src/Laravel/config.php
@@ -25,13 +25,26 @@ return [
     'auto_validate_request' => false,
 
     // When true (and `auto_validate_request` is on), endpoints whose spec
-    // security requires `bearerAuth` automatically receive a fixed dummy
+    // security declares any inject-eligible scheme (http+bearer, apiKey in
+    // header / cookie / query) automatically receive a fixed dummy value in
+    // the validator's view when the test did not set one. The Symfony Request
+    // itself is not modified — this only prevents the security check from
+    // false-failing on tests that authenticate via actingAs() or middleware
+    // bypass. oauth2 / openIdConnect / mutualTLS / http-basic are
+    // silent-passed by the validator and therefore not auto-injected.
+    // Defaults to false for backward compatibility.
+    //
+    // This is the recommended setting; `auto_inject_dummy_bearer` below is
+    // its bearer-only legacy alias kept for v1.x compatibility.
+    'auto_inject_dummy_credentials' => false,
+
+    // Legacy bearer-only variant of `auto_inject_dummy_credentials`. When
+    // true (and `auto_validate_request` is on), endpoints whose spec security
+    // requires a `http` + `bearer` scheme automatically receive a fixed dummy
     // `Authorization: Bearer test-token` header in the validator's view when
-    // the test did not set one. The Symfony Request itself is not modified —
-    // this only prevents the security check from false-failing on tests that
-    // authenticate via actingAs() or auth middleware bypass. apiKey-only and
-    // oauth2-only endpoints are not affected. Defaults to false for backward
-    // compatibility.
+    // the test did not set one. apiKey and oauth2 endpoints are unaffected.
+    // Prefer `auto_inject_dummy_credentials` above; this key remains for
+    // existing consumers and is bypassed when the credentials key is on.
     'auto_inject_dummy_bearer' => false,
 
     // Regex patterns (without delimiters or anchors) matched against the

--- a/src/Laravel/config.php
+++ b/src/Laravel/config.php
@@ -33,18 +33,13 @@ return [
     // bypass. oauth2 / openIdConnect / mutualTLS / http-basic are
     // silent-passed by the validator and therefore not auto-injected.
     // Defaults to false for backward compatibility.
-    //
-    // This is the recommended setting; `auto_inject_dummy_bearer` below is
-    // its bearer-only legacy alias kept for v1.x compatibility.
     'auto_inject_dummy_credentials' => false,
 
-    // Legacy bearer-only variant of `auto_inject_dummy_credentials`. When
-    // true (and `auto_validate_request` is on), endpoints whose spec security
-    // requires a `http` + `bearer` scheme automatically receive a fixed dummy
-    // `Authorization: Bearer test-token` header in the validator's view when
-    // the test did not set one. apiKey and oauth2 endpoints are unaffected.
-    // Prefer `auto_inject_dummy_credentials` above; this key remains for
-    // existing consumers and is bypassed when the credentials key is on.
+    // Bearer-only predecessor of `auto_inject_dummy_credentials`, kept for
+    // existing consumers. Same gating (auto_validate_request must also be
+    // on) and same view-only injection, but limited to endpoints whose spec
+    // security requires `http` + `bearer`. Bypassed when the superset key
+    // above is true.
     'auto_inject_dummy_bearer' => false,
 
     // Regex patterns (without delimiters or anchors) matched against the

--- a/src/Validation/Request/SchemeClassification.php
+++ b/src/Validation/Request/SchemeClassification.php
@@ -11,14 +11,22 @@ namespace Studio\OpenApiContractTesting\Validation\Request;
  * `malformed()` / `unsupported()` — so the kind-discriminated payload
  * invariant is enforced in code rather than maintained by convention:
  *
- * - `Malformed`   → `$reason` populated, `$unsupportedTypeLabel` null.
+ * - `Malformed`   → `$reason` populated, all other payload fields null.
  *   `$reason` is a human-readable explanation pinpointing the broken
  *   spec field.
- * - `Unsupported` → `$unsupportedTypeLabel` populated, `$reason` null.
+ * - `Unsupported` → `$unsupportedTypeLabel` populated, all other payload fields null.
  *   `$unsupportedTypeLabel` is the display label used in the silent-pass
  *   warning (e.g. `OAuth2`, `OpenID Connect`, `Mutual TLS`, `http-basic`,
  *   `http-digest`).
- * - `Bearer` / `ApiKey` → both fields null.
+ * - `Bearer`     → all payload fields null.
+ *   The bearer scheme has no per-spec parameters worth carrying forward;
+ *   its location is fixed at "Authorization: Bearer …".
+ * - `ApiKey`     → `$apiKeyIn` and `$apiKeyName` populated, others null.
+ *   `$apiKeyIn` is the validated location (`'header'|'query'|'cookie'`);
+ *   `$apiKeyName` is the spec-declared parameter name. Carrying these on
+ *   the classification means downstream consumers do not have to re-read
+ *   and re-validate the raw `$schemeDef` array — single source of truth
+ *   for "what does this scheme look like?".
  *
  * @internal Not part of the package's public API. Do not use from user code.
  */
@@ -28,6 +36,8 @@ final readonly class SchemeClassification
         public SchemeKind $kind,
         public ?string $reason = null,
         public ?string $unsupportedTypeLabel = null,
+        public ?string $apiKeyIn = null,
+        public ?string $apiKeyName = null,
     ) {}
 
     public static function bearer(): self
@@ -35,9 +45,13 @@ final readonly class SchemeClassification
         return new self(SchemeKind::Bearer);
     }
 
-    public static function apiKey(): self
+    /**
+     * @param 'cookie'|'header'|'query' $in already-validated apiKey location
+     * @param string $name spec-declared parameter name
+     */
+    public static function apiKey(string $in, string $name): self
     {
-        return new self(SchemeKind::ApiKey);
+        return new self(SchemeKind::ApiKey, apiKeyIn: $in, apiKeyName: $name);
     }
 
     public static function malformed(string $reason): self

--- a/src/Validation/Request/SecuritySchemeIntrospector.php
+++ b/src/Validation/Request/SecuritySchemeIntrospector.php
@@ -7,20 +7,21 @@ namespace Studio\OpenApiContractTesting\Validation\Request;
 use function array_key_exists;
 use function is_array;
 use function is_string;
-use function strtolower;
 
 /**
- * Decides whether an endpoint's spec-declared security permits a bearer
- * credential. Used by the Laravel trait that drives auto-injection of a
- * dummy `Authorization: Bearer <token>` header into the request validator's
- * view — the only reason this lookup exists.
+ * Spec-side probe for the auto-inject-dummy-credentials path in the Laravel
+ * `ValidatesOpenApiSchema` trait. Walks an operation's `security` requirement
+ * and reports which credentials the validator can be made to see by
+ * synthesizing a dummy value — i.e. `http` + `bearer`, `apiKey` + (header /
+ * cookie / query). Other scheme types (oauth2, openIdConnect, mutualTLS,
+ * http+basic / http+digest) are silent-passed by the validator, so injecting
+ * a fake value for them would be a lie and is deliberately skipped here.
  *
- * The classification rules mirror {@see SecurityValidator::classifyScheme()}
- * exactly; keeping them in sync is a hard requirement because a mismatch
- * would cause the trait to inject on endpoints the validator then considers
- * unauthenticated (or vice versa). This class deliberately returns `false`
- * on malformed or unsupported spec entries rather than mirroring
- * SecurityValidator's hard-error surface: the validator is still the
+ * Classification reuses {@see SecurityValidator::classifyScheme()} directly so
+ * the inject-side and validate-side rules cannot drift apart.
+ *
+ * Returns empty / false on malformed or unsupported spec entries rather than
+ * mirroring SecurityValidator's hard-error surface: the validator is the
  * source of truth for "is this spec broken" and we do not want two layers
  * producing redundant errors.
  *
@@ -29,8 +30,11 @@ use function strtolower;
 final class SecuritySchemeIntrospector
 {
     /**
-     * Return true if any spec-declared security requirement for the operation
-     * names a scheme that is `http` + `bearer`.
+     * Legacy bearer-only probe retained for `auto_inject_dummy_bearer`
+     * (the v1.x flag that pre-dates `auto_inject_dummy_credentials`). The
+     * superset path uses {@see self::injectableCredentialsFor()}; this method
+     * stays so the legacy flag's narrower semantics — bearer endpoints only —
+     * survive byte-for-byte.
      *
      * Returns true even when bearer appears alongside other schemes in an
      * AND-entry (e.g. `bearer + apiKey`). Injecting bearer alone won't satisfy
@@ -45,18 +49,68 @@ final class SecuritySchemeIntrospector
      */
     public function endpointAcceptsBearer(array $spec, array $operation): bool
     {
+        foreach ($this->injectableCredentialsFor($spec, $operation) as $credential) {
+            if ($credential['kind'] === 'bearer') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Return the deduplicated list of credentials the trait may auto-inject
+     * for this operation. Each entry tells the caller exactly what dummy value
+     * to write and where:
+     *
+     * - `['kind' => 'bearer']` → `Authorization: Bearer <dummy>`
+     * - `['kind' => 'apiKey', 'in' => 'header'|'cookie'|'query', 'name' => …]`
+     *   → set the named header / cookie / query param to a dummy value
+     *
+     * AND/OR semantics are intentionally not modelled here. Over-injection on
+     * an OR-endpoint is harmless because the spec already accepts either
+     * alternative; under-injection on an AND-endpoint would re-introduce the
+     * exact false-fail this feature exists to remove. Listing every
+     * supported scheme (and letting the caller decide whether to actually
+     * write) is the safer default. Apparent duplicates (same kind / location /
+     * name appearing across multiple OR entries, or repeated definitions in
+     * `components.securitySchemes`) are deduplicated so the caller never
+     * double-writes a header or cookie.
+     *
+     * `apiKey in: query` injection is currently safe under the request
+     * validator's tolerant query-parameter handling. If the validator ever
+     * gains a strict-extras mode, the injected `api_key` query value would
+     * have to be either added to the operation's `parameters` ignore list or
+     * the strict mode would need to know about security-driven injects. Track
+     * this as a follow-up if strict-query-mode lands.
+     *
+     * @param array<string, mixed> $spec full spec root (for
+     *                                   `components.securitySchemes` +
+     *                                   root-level `security` inheritance)
+     * @param array<string, mixed> $operation operation spec (for
+     *                                        operation-level `security` override)
+     *
+     * @return list<array{kind: 'apiKey', in: 'cookie'|'header'|'query', name: string}|array{kind: 'bearer'}>
+     */
+    public function injectableCredentialsFor(array $spec, array $operation): array
+    {
         $security = array_key_exists('security', $operation)
             ? $operation['security']
             : ($spec['security'] ?? null);
 
         if (!is_array($security) || $security === []) {
-            return false;
+            return [];
         }
 
         $schemes = $spec['components']['securitySchemes'] ?? [];
         if (!is_array($schemes)) {
-            return false;
+            return [];
         }
+
+        /** @var list<array{kind: 'apiKey', in: 'cookie'|'header'|'query', name: string}|array{kind: 'bearer'}> $credentials */
+        $credentials = [];
+        /** @var array<string, true> $seen */
+        $seen = [];
 
         foreach ($security as $entry) {
             if (!is_array($entry)) {
@@ -73,30 +127,40 @@ final class SecuritySchemeIntrospector
                     continue;
                 }
 
-                if ($this->definitionIsBearer($definition)) {
-                    return true;
+                $classification = SecurityValidator::classifyScheme($definition);
+
+                if ($classification->kind === SchemeKind::Bearer) {
+                    if (!isset($seen['bearer'])) {
+                        $seen['bearer'] = true;
+                        $credentials[] = ['kind' => 'bearer'];
+                    }
+
+                    continue;
+                }
+
+                if ($classification->kind === SchemeKind::ApiKey) {
+                    /** @var string $in */
+                    $in = $definition['in'];
+                    /** @var string $name */
+                    $name = $definition['name'];
+
+                    if ($in !== 'header' && $in !== 'cookie' && $in !== 'query') {
+                        // classifyScheme already rejected anything else as
+                        // Malformed; this guard exists so the array shape
+                        // contract above stays provable to static analysis.
+                        continue;
+                    }
+
+                    $key = "apiKey:{$in}:{$name}";
+                    if (isset($seen[$key])) {
+                        continue;
+                    }
+                    $seen[$key] = true;
+                    $credentials[] = ['kind' => 'apiKey', 'in' => $in, 'name' => $name];
                 }
             }
         }
 
-        return false;
-    }
-
-    /**
-     * @param array<string, mixed> $definition
-     */
-    private function definitionIsBearer(array $definition): bool
-    {
-        $type = $definition['type'] ?? null;
-        if ($type !== 'http') {
-            return false;
-        }
-
-        $scheme = $definition['scheme'] ?? null;
-        if (!is_string($scheme)) {
-            return false;
-        }
-
-        return strtolower($scheme) === 'bearer';
+        return $credentials;
     }
 }

--- a/src/Validation/Request/SecuritySchemeIntrospector.php
+++ b/src/Validation/Request/SecuritySchemeIntrospector.php
@@ -30,11 +30,10 @@ use function is_string;
 final class SecuritySchemeIntrospector
 {
     /**
-     * Legacy bearer-only probe retained for `auto_inject_dummy_bearer`
-     * (the v1.x flag that pre-dates `auto_inject_dummy_credentials`). The
-     * superset path uses {@see self::injectableCredentialsFor()}; this method
-     * stays so the legacy flag's narrower semantics — bearer endpoints only —
-     * survive byte-for-byte.
+     * Legacy bearer-only probe retained for `auto_inject_dummy_bearer`. The
+     * implementation delegates to {@see self::injectableCredentialsFor()} and
+     * filters the result to bearer entries — the legacy flag's narrower scope
+     * is enforced by the caller, not by reproducing the spec walk.
      *
      * Returns true even when bearer appears alongside other schemes in an
      * AND-entry (e.g. `bearer + apiKey`). Injecting bearer alone won't satisfy
@@ -67,6 +66,11 @@ final class SecuritySchemeIntrospector
      * - `['kind' => 'apiKey', 'in' => 'header'|'cookie'|'query', 'name' => …]`
      *   → set the named header / cookie / query param to a dummy value
      *
+     * Resolution mirrors {@see SecurityValidator::validate()}: operation-level
+     * `security` wins over root-level, an explicit `security: []` opts the
+     * operation out of all authentication and yields an empty list, and a
+     * silent (missing) `security` on both levels also yields an empty list.
+     *
      * AND/OR semantics are intentionally not modelled here. Over-injection on
      * an OR-endpoint is harmless because the spec already accepts either
      * alternative; under-injection on an AND-endpoint would re-introduce the
@@ -77,12 +81,10 @@ final class SecuritySchemeIntrospector
      * `components.securitySchemes`) are deduplicated so the caller never
      * double-writes a header or cookie.
      *
-     * `apiKey in: query` injection is currently safe under the request
-     * validator's tolerant query-parameter handling. If the validator ever
-     * gains a strict-extras mode, the injected `api_key` query value would
-     * have to be either added to the operation's `parameters` ignore list or
-     * the strict mode would need to know about security-driven injects. Track
-     * this as a follow-up if strict-query-mode lands.
+     * `apiKey in: query` injection is safe under the request validator's
+     * current tolerant query-parameter handling. A strict-extras mode would
+     * need to teach itself about security-driven injects; tracked separately
+     * if that mode ships.
      *
      * @param array<string, mixed> $spec full spec root (for
      *                                   `components.securitySchemes` +
@@ -139,17 +141,10 @@ final class SecuritySchemeIntrospector
                 }
 
                 if ($classification->kind === SchemeKind::ApiKey) {
-                    /** @var string $in */
-                    $in = $definition['in'];
+                    /** @var 'cookie'|'header'|'query' $in */
+                    $in = $classification->apiKeyIn;
                     /** @var string $name */
-                    $name = $definition['name'];
-
-                    if ($in !== 'header' && $in !== 'cookie' && $in !== 'query') {
-                        // classifyScheme already rejected anything else as
-                        // Malformed; this guard exists so the array shape
-                        // contract above stays provable to static analysis.
-                        continue;
-                    }
+                    $name = $classification->apiKeyName;
 
                     $key = "apiKey:{$in}:{$name}";
                     if (isset($seen[$key])) {

--- a/src/Validation/Request/SecurityValidator.php
+++ b/src/Validation/Request/SecurityValidator.php
@@ -43,6 +43,76 @@ final class SecurityValidator
     }
 
     /**
+     * Classify a security scheme definition. {@see SchemeKind} documents the
+     * four outcomes; the `$reason` field of the returned classification is
+     * populated only for `Malformed` to explain which spec field is broken.
+     *
+     * Public static so that {@see SecuritySchemeIntrospector} can reuse the
+     * exact classification rules when deciding which credentials to auto-inject —
+     * keeping the rules in one place avoids the "introspector says inject but
+     * validator says missing" drift that a duplicated implementation would risk.
+     *
+     * @param array<string, mixed> $schemeDef
+     *
+     * @internal Not part of the package's public API. Do not use from user code.
+     */
+    public static function classifyScheme(array $schemeDef): SchemeClassification
+    {
+        $type = $schemeDef['type'] ?? null;
+        if (!is_string($type) || $type === '') {
+            return SchemeClassification::malformed("missing required 'type' field.");
+        }
+
+        if ($type === 'apiKey') {
+            $in = $schemeDef['in'] ?? null;
+            $name = $schemeDef['name'] ?? null;
+            if (!is_string($in) || !is_string($name)) {
+                return SchemeClassification::malformed("apiKey scheme requires string 'in' and 'name' fields.");
+            }
+            if (!in_array($in, ['header', 'query', 'cookie'], true)) {
+                return SchemeClassification::malformed("apiKey scheme 'in' must be one of header|query|cookie, got '{$in}'.");
+            }
+
+            return SchemeClassification::apiKey();
+        }
+
+        if ($type === 'http') {
+            $scheme = $schemeDef['scheme'] ?? null;
+            if (!is_string($scheme) || trim($scheme) === '') {
+                // Reject empty / whitespace-only `scheme` as malformed: the
+                // OAS spec requires the field to name an HTTP authentication
+                // scheme (e.g. "bearer", "basic"), and an empty value would
+                // otherwise fall through to Unsupported with a meaningless
+                // label like "http-".
+                return SchemeClassification::malformed("http scheme requires a non-empty string 'scheme' field (e.g. 'bearer', 'basic').");
+            }
+
+            if (strtolower($scheme) === 'bearer') {
+                return SchemeClassification::bearer();
+            }
+
+            // http + basic / digest / etc. are well-formed but the validator
+            // cannot verify them. Label normalises arbitrary scheme names to
+            // `http-<lowercased>` (RFC 7235 schemes are case-insensitive).
+            return SchemeClassification::unsupported('http-' . strtolower($scheme));
+        }
+
+        if ($type === 'oauth2') {
+            return SchemeClassification::unsupported('OAuth2');
+        }
+        if ($type === 'openIdConnect') {
+            return SchemeClassification::unsupported('OpenID Connect');
+        }
+        if ($type === 'mutualTLS') {
+            return SchemeClassification::unsupported('Mutual TLS');
+        }
+
+        return SchemeClassification::malformed(
+            "unknown type '{$type}' — OpenAPI 3.x enumerates apiKey|http|oauth2|openIdConnect|mutualTLS.",
+        );
+    }
+
+    /**
      * Validate the endpoint's `security` requirement against the incoming
      * request. The supported / unsupported / malformed scheme partition is
      * defined by {@see classifyScheme()}; entries containing an unsupported
@@ -166,7 +236,7 @@ final class SecurityValidator
                     continue;
                 }
 
-                $classification = $this->classifyScheme($schemeDef);
+                $classification = self::classifyScheme($schemeDef);
 
                 if ($classification->kind === SchemeKind::Malformed) {
                     $hardErrors[] = sprintf(
@@ -282,69 +352,6 @@ final class SecurityValidator
                 $matchedPath,
             ),
             E_USER_WARNING,
-        );
-    }
-
-    /**
-     * Classify a security scheme definition. {@see SchemeKind} documents the
-     * four outcomes; the `$reason` field of the returned classification is
-     * populated only for `Malformed` to explain which spec field is broken.
-     *
-     * @param array<string, mixed> $schemeDef
-     */
-    private function classifyScheme(array $schemeDef): SchemeClassification
-    {
-        $type = $schemeDef['type'] ?? null;
-        if (!is_string($type) || $type === '') {
-            return SchemeClassification::malformed("missing required 'type' field.");
-        }
-
-        if ($type === 'apiKey') {
-            $in = $schemeDef['in'] ?? null;
-            $name = $schemeDef['name'] ?? null;
-            if (!is_string($in) || !is_string($name)) {
-                return SchemeClassification::malformed("apiKey scheme requires string 'in' and 'name' fields.");
-            }
-            if (!in_array($in, ['header', 'query', 'cookie'], true)) {
-                return SchemeClassification::malformed("apiKey scheme 'in' must be one of header|query|cookie, got '{$in}'.");
-            }
-
-            return SchemeClassification::apiKey();
-        }
-
-        if ($type === 'http') {
-            $scheme = $schemeDef['scheme'] ?? null;
-            if (!is_string($scheme) || trim($scheme) === '') {
-                // Reject empty / whitespace-only `scheme` as malformed: the
-                // OAS spec requires the field to name an HTTP authentication
-                // scheme (e.g. "bearer", "basic"), and an empty value would
-                // otherwise fall through to Unsupported with a meaningless
-                // label like "http-".
-                return SchemeClassification::malformed("http scheme requires a non-empty string 'scheme' field (e.g. 'bearer', 'basic').");
-            }
-
-            if (strtolower($scheme) === 'bearer') {
-                return SchemeClassification::bearer();
-            }
-
-            // http + basic / digest / etc. are well-formed but the validator
-            // cannot verify them. Label normalises arbitrary scheme names to
-            // `http-<lowercased>` (RFC 7235 schemes are case-insensitive).
-            return SchemeClassification::unsupported('http-' . strtolower($scheme));
-        }
-
-        if ($type === 'oauth2') {
-            return SchemeClassification::unsupported('OAuth2');
-        }
-        if ($type === 'openIdConnect') {
-            return SchemeClassification::unsupported('OpenID Connect');
-        }
-        if ($type === 'mutualTLS') {
-            return SchemeClassification::unsupported('Mutual TLS');
-        }
-
-        return SchemeClassification::malformed(
-            "unknown type '{$type}' — OpenAPI 3.x enumerates apiKey|http|oauth2|openIdConnect|mutualTLS.",
         );
     }
 

--- a/src/Validation/Request/SecurityValidator.php
+++ b/src/Validation/Request/SecurityValidator.php
@@ -47,10 +47,10 @@ final class SecurityValidator
      * four outcomes; the `$reason` field of the returned classification is
      * populated only for `Malformed` to explain which spec field is broken.
      *
-     * Public static so that {@see SecuritySchemeIntrospector} can reuse the
-     * exact classification rules when deciding which credentials to auto-inject —
-     * keeping the rules in one place avoids the "introspector says inject but
-     * validator says missing" drift that a duplicated implementation would risk.
+     * The single source of truth for "what does this scheme look like?" —
+     * other components within the package read the result rather than
+     * re-implementing the rules so the auto-inject side and the validate
+     * side cannot drift apart.
      *
      * @param array<string, mixed> $schemeDef
      *
@@ -73,7 +73,7 @@ final class SecurityValidator
                 return SchemeClassification::malformed("apiKey scheme 'in' must be one of header|query|cookie, got '{$in}'.");
             }
 
-            return SchemeClassification::apiKey();
+            return SchemeClassification::apiKey($in, $name);
         }
 
         if ($type === 'http') {

--- a/tests/Integration/ResponseValidationTest.php
+++ b/tests/Integration/ResponseValidationTest.php
@@ -59,7 +59,7 @@ class ResponseValidationTest extends TestCase
         $this->recordResult('petstore-3.0', 'POST', $result2);
 
         $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
-        $this->assertSame(23, $coverage['endpointTotal']);
+        $this->assertSame(24, $coverage['endpointTotal']);
         $this->assertGreaterThanOrEqual(2, $coverage['endpointFullyCovered'] + $coverage['endpointPartial']);
 
         $endpoints = $this->indexEndpoints($coverage['endpoints']);

--- a/tests/Unit/Coverage/OpenApiCoverageTrackerTest.php
+++ b/tests/Unit/Coverage/OpenApiCoverageTrackerTest.php
@@ -309,16 +309,16 @@ class OpenApiCoverageTrackerTest extends TestCase
     #[Test]
     public function compute_coverage_aggregates_response_level_counts(): void
     {
-        // petstore-3.0 declares 30 (status, content-type) pairs across 23
+        // petstore-3.0 declares 31 (status, content-type) pairs across 24
         // endpoints. Pin the totals so future spec drift is caught.
         $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
 
-        $this->assertSame(23, $result['endpointTotal']);
-        $this->assertSame(30, $result['responseTotal']);
+        $this->assertSame(24, $result['endpointTotal']);
+        $this->assertSame(31, $result['responseTotal']);
         $this->assertSame(0, $result['responseCovered']);
         $this->assertSame(0, $result['responseSkipped']);
-        $this->assertSame(30, $result['responseUncovered']);
-        $this->assertSame(23, $result['endpointUncovered']);
+        $this->assertSame(31, $result['responseUncovered']);
+        $this->assertSame(24, $result['endpointUncovered']);
     }
 
     #[Test]

--- a/tests/Unit/ValidatesOpenApiSchemaAutoInjectCredentialsTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaAutoInjectCredentialsTest.php
@@ -1,0 +1,317 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit;
+
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\HttpMethod;
+use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
+use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\Validation\Request\SecurityValidator;
+use Symfony\Component\HttpFoundation\Request;
+
+require_once __DIR__ . '/../Helpers/LaravelConfigMock.php';
+
+/**
+ * Covers `auto_inject_dummy_credentials` — the superset of
+ * `auto_inject_dummy_bearer` that also fills in apiKey-in-header,
+ * apiKey-in-cookie and apiKey-in-query schemes. The point of these tests is
+ * the contract that consumer-side `actingAs()` tests no longer false-fail on
+ * security checks for non-bearer scheme endpoints, while honouring real
+ * credentials when the test bothers to set them.
+ */
+class ValidatesOpenApiSchemaAutoInjectCredentialsTest extends TestCase
+{
+    use ValidatesOpenApiSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs');
+        OpenApiCoverageTracker::reset();
+        SecurityValidator::resetWarningStateForTesting();
+        $GLOBALS['__openapi_testing_config'] = [
+            'openapi-contract-testing.default_spec' => 'petstore-3.0',
+            'openapi-contract-testing.auto_validate_request' => true,
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        self::resetValidatorCache();
+        unset($GLOBALS['__openapi_testing_config']);
+        OpenApiSpecLoader::reset();
+        OpenApiCoverageTracker::reset();
+        SecurityValidator::resetWarningStateForTesting();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function config_file_defaults_auto_inject_dummy_credentials_to_false(): void
+    {
+        $config = require __DIR__ . '/../../src/Laravel/config.php';
+
+        $this->assertArrayHasKey('auto_inject_dummy_credentials', $config);
+        $this->assertFalse($config['auto_inject_dummy_credentials']);
+    }
+
+    #[Test]
+    public function inject_credentials_satisfies_apikey_cookie_endpoint_without_real_cookie(): void
+    {
+        // /v1/secure/apikey-cookie requires `session_id` cookie. With the
+        // credentials inject flag on, the validator's view gets a dummy cookie
+        // value even though Symfony Request has none — security passes.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_credentials'] = true;
+
+        $request = Request::create('/v1/secure/apikey-cookie', 'GET');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/apikey-cookie');
+
+        $this->assertArrayHasKey(
+            'GET /v1/secure/apikey-cookie',
+            OpenApiCoverageTracker::getCovered()['petstore-3.0'] ?? [],
+        );
+    }
+
+    #[Test]
+    public function inject_credentials_satisfies_apikey_header_endpoint_without_real_header(): void
+    {
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_credentials'] = true;
+
+        $request = Request::create('/v1/secure/apikey-header', 'GET');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/apikey-header');
+
+        $this->assertArrayHasKey(
+            'GET /v1/secure/apikey-header',
+            OpenApiCoverageTracker::getCovered()['petstore-3.0'] ?? [],
+        );
+    }
+
+    #[Test]
+    public function inject_credentials_satisfies_apikey_query_endpoint_without_real_query(): void
+    {
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_credentials'] = true;
+
+        $request = Request::create('/v1/secure/apikey-query', 'GET');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/apikey-query');
+
+        $this->assertArrayHasKey(
+            'GET /v1/secure/apikey-query',
+            OpenApiCoverageTracker::getCovered()['petstore-3.0'] ?? [],
+        );
+    }
+
+    #[Test]
+    public function inject_credentials_still_satisfies_bearer_endpoint(): void
+    {
+        // Upward compatibility with the legacy `auto_inject_dummy_bearer`
+        // behavior: the new flag is a strict superset, so plain bearer
+        // endpoints continue to work without setting the legacy flag.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_credentials'] = true;
+
+        $request = Request::create('/v1/secure/bearer', 'GET');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/bearer');
+
+        $this->assertArrayHasKey(
+            'GET /v1/secure/bearer',
+            OpenApiCoverageTracker::getCovered()['petstore-3.0'] ?? [],
+        );
+    }
+
+    #[Test]
+    public function inject_credentials_does_not_override_existing_cookie_value(): void
+    {
+        // If the test sets the cookie explicitly (even to a deliberately
+        // invalid empty-equivalent value the spec rejects), the inject must
+        // leave it alone so the test's intent wins.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_credentials'] = true;
+
+        $request = Request::create(
+            '/v1/secure/apikey-cookie',
+            'GET',
+            [],
+            ['session_id' => 'real-session-from-test'],
+        );
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/apikey-cookie');
+
+        $this->assertArrayHasKey(
+            'GET /v1/secure/apikey-cookie',
+            OpenApiCoverageTracker::getCovered()['petstore-3.0'] ?? [],
+        );
+    }
+
+    #[Test]
+    public function inject_credentials_does_not_override_existing_apikey_header_value(): void
+    {
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_credentials'] = true;
+
+        $request = Request::create(
+            '/v1/secure/apikey-header',
+            'GET',
+            [],
+            [],
+            [],
+            ['HTTP_X_API_KEY' => 'real-key-from-test'],
+        );
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/apikey-header');
+
+        $this->assertArrayHasKey(
+            'GET /v1/secure/apikey-header',
+            OpenApiCoverageTracker::getCovered()['petstore-3.0'] ?? [],
+        );
+    }
+
+    #[Test]
+    public function inject_credentials_does_not_override_existing_apikey_query_value(): void
+    {
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_credentials'] = true;
+
+        $request = Request::create('/v1/secure/apikey-query?api_key=real-key-from-test', 'GET');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/apikey-query');
+
+        $this->assertArrayHasKey(
+            'GET /v1/secure/apikey-query',
+            OpenApiCoverageTracker::getCovered()['petstore-3.0'] ?? [],
+        );
+    }
+
+    #[Test]
+    public function inject_credentials_treats_empty_cookie_value_as_absent_and_injects(): void
+    {
+        // SecurityValidator::checkApiKeySatisfied() treats `value === ''` as
+        // missing. The inject path must agree, otherwise an empty cookie left
+        // over from a prior request would silently disable the inject and
+        // re-introduce the false-fail this feature exists to prevent.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_credentials'] = true;
+
+        $request = Request::create(
+            '/v1/secure/apikey-cookie',
+            'GET',
+            [],
+            ['session_id' => ''],
+        );
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/apikey-cookie');
+
+        $this->assertArrayHasKey(
+            'GET /v1/secure/apikey-cookie',
+            OpenApiCoverageTracker::getCovered()['petstore-3.0'] ?? [],
+        );
+    }
+
+    #[Test]
+    public function inject_credentials_handles_and_entry_with_bearer_and_apikey(): void
+    {
+        // /v1/secure/and requires both bearer AND apiKey-header in a single
+        // requirement (AND semantics). Legacy bearer-only inject leaves the
+        // apiKey error in place; the credentials inject fills both, so the
+        // entry is satisfied and the endpoint passes.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_credentials'] = true;
+
+        $request = Request::create('/v1/secure/and', 'GET');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/and');
+
+        $this->assertArrayHasKey(
+            'GET /v1/secure/and',
+            OpenApiCoverageTracker::getCovered()['petstore-3.0'] ?? [],
+        );
+    }
+
+    #[Test]
+    public function inject_credentials_without_auto_validate_request_is_noop(): void
+    {
+        // The credentials inject is a sub-feature of request validation —
+        // with validation off, the inject flag must not run the validator as
+        // a side effect.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = false;
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_credentials'] = true;
+
+        $request = Request::create('/v1/secure/apikey-cookie', 'GET');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/apikey-cookie');
+
+        $this->assertArrayNotHasKey('petstore-3.0', OpenApiCoverageTracker::getCovered());
+    }
+
+    #[Test]
+    public function inject_credentials_does_not_mutate_symfony_request_cookies_or_query(): void
+    {
+        // Inject is a validator-view-only rewrite — the framework-side Request
+        // bag must remain untouched so subsequent middleware / assertions see
+        // the same input the test set up.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_credentials'] = true;
+
+        $request = Request::create('/v1/secure/apikey-cookie', 'GET');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/apikey-cookie');
+
+        $this->assertSame([], $request->cookies->all());
+        $this->assertSame([], $request->query->all());
+        $this->assertNull($request->headers->get('X-API-Key'));
+        $this->assertNull($request->headers->get('Authorization'));
+    }
+
+    #[Test]
+    public function inject_credentials_with_non_bool_value_fails_loudly(): void
+    {
+        // Same three-way coercion guard as the other auto_* config flags.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_credentials'] = 'yolo';
+
+        $request = Request::create('/v1/secure/apikey-cookie', 'GET');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('auto_inject_dummy_credentials must be a boolean');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/apikey-cookie');
+    }
+
+    #[Test]
+    public function legacy_bearer_flag_alone_does_not_inject_apikey_credentials(): void
+    {
+        // Backward-compat regression guard: when only the legacy
+        // `auto_inject_dummy_bearer` is on, apiKey endpoints must still fail
+        // with the apiKey-specific message — the legacy flag's narrower
+        // scope is preserved exactly.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_bearer'] = true;
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_credentials'] = false;
+
+        $request = Request::create('/v1/secure/apikey-cookie', 'GET');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("api key 'session_id' is missing from the cookie");
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/apikey-cookie');
+    }
+
+    #[Test]
+    public function credentials_flag_takes_precedence_when_both_flags_set(): void
+    {
+        // Both flags on → superset wins, apiKey endpoints pass too. The two
+        // flags coexist: setting credentials does not require unsetting the
+        // legacy one, so a consumer that toggles the new flag without also
+        // touching the old one still gets the new behavior.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_bearer'] = true;
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_credentials'] = true;
+
+        $request = Request::create('/v1/secure/apikey-cookie', 'GET');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/apikey-cookie');
+
+        $this->assertArrayHasKey(
+            'GET /v1/secure/apikey-cookie',
+            OpenApiCoverageTracker::getCovered()['petstore-3.0'] ?? [],
+        );
+    }
+}

--- a/tests/Unit/ValidatesOpenApiSchemaAutoInjectCredentialsTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaAutoInjectCredentialsTest.php
@@ -7,6 +7,7 @@ namespace Studio\OpenApiContractTesting\Tests\Unit;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\HttpMethod;
 use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
@@ -211,6 +212,52 @@ class ValidatesOpenApiSchemaAutoInjectCredentialsTest extends TestCase
     }
 
     #[Test]
+    public function inject_credentials_treats_empty_apikey_header_value_as_absent_and_injects(): void
+    {
+        // Header bag stores values as `list<?string>` and the
+        // slotIsAlreadyPopulated array branch peels the first element. An
+        // empty-string entry must collapse to "absent" the same way the
+        // cookie path does, otherwise `array_key_first` regressions or a
+        // tightening of the empty check could silently re-introduce the
+        // false-fail.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_credentials'] = true;
+
+        $request = Request::create(
+            '/v1/secure/apikey-header',
+            'GET',
+            [],
+            [],
+            [],
+            ['HTTP_X_API_KEY' => ''],
+        );
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/apikey-header');
+
+        $this->assertArrayHasKey(
+            'GET /v1/secure/apikey-header',
+            OpenApiCoverageTracker::getCovered()['petstore-3.0'] ?? [],
+        );
+    }
+
+    #[Test]
+    public function inject_credentials_treats_empty_apikey_query_value_as_absent_and_injects(): void
+    {
+        // Query bag stores values as plain strings (scalar branch in
+        // slotIsAlreadyPopulated). `?api_key=` produces an empty-string entry
+        // that must be treated as absent so the inject still fires.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_credentials'] = true;
+
+        $request = Request::create('/v1/secure/apikey-query?api_key=', 'GET');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/apikey-query');
+
+        $this->assertArrayHasKey(
+            'GET /v1/secure/apikey-query',
+            OpenApiCoverageTracker::getCovered()['petstore-3.0'] ?? [],
+        );
+    }
+
+    #[Test]
     public function inject_credentials_handles_and_entry_with_bearer_and_apikey(): void
     {
         // /v1/secure/and requires both bearer AND apiKey-header in a single
@@ -225,6 +272,27 @@ class ValidatesOpenApiSchemaAutoInjectCredentialsTest extends TestCase
 
         $this->assertArrayHasKey(
             'GET /v1/secure/and',
+            OpenApiCoverageTracker::getCovered()['petstore-3.0'] ?? [],
+        );
+    }
+
+    #[Test]
+    public function inject_credentials_handles_and_entry_with_multiple_apikey_locations(): void
+    {
+        // /v1/secure/and-multi-apikey requires bearer AND apiKey-header AND
+        // apiKey-cookie in a single requirement. Exercises the dedup path
+        // (different `in` values for distinct schemes) end-to-end through
+        // the trait — introspector unit tests cover spec-walking shape, this
+        // test pins the actual write across header bag + cookie bag in one
+        // call.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_credentials'] = true;
+
+        $request = Request::create('/v1/secure/and-multi-apikey', 'GET');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/and-multi-apikey');
+
+        $this->assertArrayHasKey(
+            'GET /v1/secure/and-multi-apikey',
             OpenApiCoverageTracker::getCovered()['petstore-3.0'] ?? [],
         );
     }
@@ -291,6 +359,25 @@ class ValidatesOpenApiSchemaAutoInjectCredentialsTest extends TestCase
 
         $this->expectException(AssertionFailedError::class);
         $this->expectExceptionMessage("api key 'session_id' is missing from the cookie");
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/apikey-cookie');
+    }
+
+    #[Test]
+    public function inject_credentials_swallows_runtime_exception_and_lets_validator_surface_it(): void
+    {
+        // RuntimeException from OpenApiSpecLoader::load() is caught inside
+        // resolveAutoInjectCredentials() so the inject path returns []. The
+        // validator loads the same spec immediately after and re-raises the
+        // error — pinning that contract here so a refactor that decouples
+        // inject and validate (silently making the spec error invisible)
+        // gets caught in CI.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.default_spec'] = 'nonexistent-spec-name';
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_inject_dummy_credentials'] = true;
+
+        $request = Request::create('/v1/secure/apikey-cookie', 'GET');
+
+        $this->expectException(RuntimeException::class);
 
         $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::GET, '/v1/secure/apikey-cookie');
     }

--- a/tests/Unit/Validation/Request/SecuritySchemeIntrospectorTest.php
+++ b/tests/Unit/Validation/Request/SecuritySchemeIntrospectorTest.php
@@ -305,4 +305,284 @@ class SecuritySchemeIntrospectorTest extends TestCase
 
         $this->assertFalse($this->introspector->endpointAcceptsBearer($spec, $operation));
     }
+
+    #[Test]
+    public function injectable_credentials_for_returns_bearer_only_for_bearer_endpoint(): void
+    {
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'bearerAuth' => ['type' => 'http', 'scheme' => 'bearer'],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['bearerAuth' => []]]];
+
+        $this->assertSame(
+            [['kind' => 'bearer']],
+            $this->introspector->injectableCredentialsFor($spec, $operation),
+        );
+    }
+
+    #[Test]
+    public function injectable_credentials_for_returns_apikey_header_entry(): void
+    {
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'apiKeyHeader' => [
+                        'type' => 'apiKey',
+                        'in' => 'header',
+                        'name' => 'X-API-Key',
+                    ],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['apiKeyHeader' => []]]];
+
+        $this->assertSame(
+            [['kind' => 'apiKey', 'in' => 'header', 'name' => 'X-API-Key']],
+            $this->introspector->injectableCredentialsFor($spec, $operation),
+        );
+    }
+
+    #[Test]
+    public function injectable_credentials_for_returns_apikey_cookie_entry(): void
+    {
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'CookieAuth' => [
+                        'type' => 'apiKey',
+                        'in' => 'cookie',
+                        'name' => 'front_session',
+                    ],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['CookieAuth' => []]]];
+
+        $this->assertSame(
+            [['kind' => 'apiKey', 'in' => 'cookie', 'name' => 'front_session']],
+            $this->introspector->injectableCredentialsFor($spec, $operation),
+        );
+    }
+
+    #[Test]
+    public function injectable_credentials_for_returns_apikey_query_entry(): void
+    {
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'apiKeyQuery' => [
+                        'type' => 'apiKey',
+                        'in' => 'query',
+                        'name' => 'api_key',
+                    ],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['apiKeyQuery' => []]]];
+
+        $this->assertSame(
+            [['kind' => 'apiKey', 'in' => 'query', 'name' => 'api_key']],
+            $this->introspector->injectableCredentialsFor($spec, $operation),
+        );
+    }
+
+    #[Test]
+    public function injectable_credentials_for_returns_bearer_and_apikey_for_and_entry(): void
+    {
+        // AND-entry: both schemes appear in a single requirement object. The
+        // trait must inject both so the validator sees a satisfied entry.
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'bearerAuth' => ['type' => 'http', 'scheme' => 'bearer'],
+                    'apiKeyHeader' => ['type' => 'apiKey', 'in' => 'header', 'name' => 'X-API-Key'],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['bearerAuth' => [], 'apiKeyHeader' => []]]];
+
+        $this->assertSame(
+            [
+                ['kind' => 'bearer'],
+                ['kind' => 'apiKey', 'in' => 'header', 'name' => 'X-API-Key'],
+            ],
+            $this->introspector->injectableCredentialsFor($spec, $operation),
+        );
+    }
+
+    #[Test]
+    public function injectable_credentials_for_returns_bearer_and_apikey_for_or_entries(): void
+    {
+        // OR-entries: separate requirement objects. Either branch satisfied is
+        // enough at validation time, but inject populates both — over-injection
+        // is harmless because the spec already accepts either.
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'bearerAuth' => ['type' => 'http', 'scheme' => 'bearer'],
+                    'apiKeyHeader' => ['type' => 'apiKey', 'in' => 'header', 'name' => 'X-API-Key'],
+                ],
+            ],
+        ];
+        $operation = [
+            'security' => [
+                ['bearerAuth' => []],
+                ['apiKeyHeader' => []],
+            ],
+        ];
+
+        $this->assertSame(
+            [
+                ['kind' => 'bearer'],
+                ['kind' => 'apiKey', 'in' => 'header', 'name' => 'X-API-Key'],
+            ],
+            $this->introspector->injectableCredentialsFor($spec, $operation),
+        );
+    }
+
+    #[Test]
+    public function injectable_credentials_for_skips_oauth2_openidconnect_mutualtls_and_http_basic(): void
+    {
+        // SecurityValidator silent-passes these schemes (Unsupported), so
+        // injecting a dummy value would be a lie. Skip them entirely.
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'oauth2Flow' => ['type' => 'oauth2', 'flows' => ['implicit' => []]],
+                    'oidc' => ['type' => 'openIdConnect', 'openIdConnectUrl' => 'https://example.com/.well-known'],
+                    'mtls' => ['type' => 'mutualTLS'],
+                    'basicAuth' => ['type' => 'http', 'scheme' => 'basic'],
+                ],
+            ],
+        ];
+        $operation = [
+            'security' => [
+                ['oauth2Flow' => ['read']],
+                ['oidc' => []],
+                ['mtls' => []],
+                ['basicAuth' => []],
+            ],
+        ];
+
+        $this->assertSame([], $this->introspector->injectableCredentialsFor($spec, $operation));
+    }
+
+    #[Test]
+    public function injectable_credentials_for_skips_undefined_scheme_reference(): void
+    {
+        // Dangling reference. Must not crash; SecurityValidator surfaces the
+        // hard error during validation.
+        $spec = ['components' => ['securitySchemes' => []]];
+        $operation = ['security' => [['ghostAuth' => []]]];
+
+        $this->assertSame([], $this->introspector->injectableCredentialsFor($spec, $operation));
+    }
+
+    #[Test]
+    public function injectable_credentials_for_dedups_duplicate_definitions_across_entries(): void
+    {
+        // Pathological spec where the same scheme appears in multiple OR
+        // entries. We must not double-inject the same Authorization or the
+        // same cookie name — once is enough.
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'bearerAuth' => ['type' => 'http', 'scheme' => 'bearer'],
+                    'apiKeyHeader' => ['type' => 'apiKey', 'in' => 'header', 'name' => 'X-API-Key'],
+                ],
+            ],
+        ];
+        $operation = [
+            'security' => [
+                ['bearerAuth' => [], 'apiKeyHeader' => []],
+                ['bearerAuth' => []],
+                ['apiKeyHeader' => []],
+            ],
+        ];
+
+        $this->assertSame(
+            [
+                ['kind' => 'bearer'],
+                ['kind' => 'apiKey', 'in' => 'header', 'name' => 'X-API-Key'],
+            ],
+            $this->introspector->injectableCredentialsFor($spec, $operation),
+        );
+    }
+
+    #[Test]
+    public function injectable_credentials_for_inherits_root_security_when_operation_silent(): void
+    {
+        $spec = [
+            'security' => [['CookieAuth' => []]],
+            'components' => [
+                'securitySchemes' => [
+                    'CookieAuth' => [
+                        'type' => 'apiKey',
+                        'in' => 'cookie',
+                        'name' => 'front_session',
+                    ],
+                ],
+            ],
+        ];
+        $operation = [];
+
+        $this->assertSame(
+            [['kind' => 'apiKey', 'in' => 'cookie', 'name' => 'front_session']],
+            $this->introspector->injectableCredentialsFor($spec, $operation),
+        );
+    }
+
+    #[Test]
+    public function injectable_credentials_for_returns_empty_for_explicit_security_optout(): void
+    {
+        // `security: []` is the explicit "no auth required" override. Inject
+        // nothing; the validator will not complain either.
+        $spec = [
+            'security' => [['bearerAuth' => []]],
+            'components' => [
+                'securitySchemes' => [
+                    'bearerAuth' => ['type' => 'http', 'scheme' => 'bearer'],
+                ],
+            ],
+        ];
+        $operation = ['security' => []];
+
+        $this->assertSame([], $this->introspector->injectableCredentialsFor($spec, $operation));
+    }
+
+    #[Test]
+    public function injectable_credentials_for_handles_malformed_security_array(): void
+    {
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'bearerAuth' => ['type' => 'http', 'scheme' => 'bearer'],
+                ],
+            ],
+        ];
+        $operation = ['security' => 'not-an-array'];
+
+        $this->assertSame([], $this->introspector->injectableCredentialsFor($spec, $operation));
+    }
+
+    #[Test]
+    public function injectable_credentials_for_skips_malformed_apikey_definition(): void
+    {
+        // apiKey scheme missing `in` field — Malformed. SecurityValidator
+        // surfaces a hard error; the introspector skips silently.
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'brokenApiKey' => ['type' => 'apiKey', 'name' => 'X-API-Key'],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['brokenApiKey' => []]]];
+
+        $this->assertSame([], $this->introspector->injectableCredentialsFor($spec, $operation));
+    }
 }

--- a/tests/fixtures/specs/petstore-3.0.json
+++ b/tests/fixtures/specs/petstore-3.0.json
@@ -679,6 +679,18 @@
                 }
             }
         },
+        "/v1/secure/and-multi-apikey": {
+            "get": {
+                "summary": "Bearer AND apiKey-header AND apiKey-cookie in single requirement",
+                "operationId": "secureAndMultiApiKey",
+                "security": [
+                    { "bearerAuth": [], "apiKeyHeader": [], "apiKeyCookie": [] }
+                ],
+                "responses": {
+                    "200": { "description": "OK" }
+                }
+            }
+        },
         "/v1/secure/opt-out": {
             "get": {
                 "summary": "Explicitly no auth required",


### PR DESCRIPTION
## Summary

Generalises `auto_inject_dummy_bearer` into a superset config
`auto_inject_dummy_credentials` that also fills dummy values for `apiKey`
schemes (header / cookie / query) in the validator's view. The legacy flag
stays as a bearer-only alias for v1.x consumers and is bypassed when the new
flag is on.

## Why

Fixes #178.

When `auto_validate_request: true` is enabled in a consumer test suite, tests
that authenticate via `actingAs()` (or auth middleware bypass) currently
false-fail on every endpoint whose spec security uses cookie / apiKey-in-header
schemes — there is no synthetic equivalent to the bearer inject for those.
Reproduced in `studio-design/studio-api` PR #6617 with 250+ false-fails
across `CookieAuth`, JWT-style apiKey-in-header, and similar requirements.

The new flag fills the gap without touching the Symfony Request bag, so the
inject path stays consistent with existing behaviour: only the validator's
view is rewritten, and only when the test did not supply a real credential.

## Verification

- [x] `composer test` passes (1285 tests, 3070 assertions)
- [x] `composer stan` passes (PHPStan level 6 over `src/` + `tests/`)
- [x] `composer cs-check` passes

Failing-test-first workflow:
1. Wrote `injectable_credentials_for_*` cases in
   `SecuritySchemeIntrospectorTest` — confirmed red, then implemented.
2. Wrote `ValidatesOpenApiSchemaAutoInjectCredentialsTest` covering apiKey
   header / cookie / query, bearer upward-compat, AND-entry, existing-value
   pass-through, empty-string-as-absent, no-mutation guarantee, loud-fail
   on non-bool, and legacy flag interactions — confirmed red, then implemented.
3. Existing `ValidatesOpenApiSchemaAutoInjectBearerTest` continues to pass
   unmodified, confirming legacy `auto_inject_dummy_bearer` is byte-for-byte
   preserved.

## Notes for reviewers

- `SecurityValidator::classifyScheme()` was promoted from `private` to
  `public static` so `SecuritySchemeIntrospector::injectableCredentialsFor()`
  reuses the exact classification rules. Kept `@internal` — `Validation/Request/`
  is not part of the SemVer surface.
- `SecuritySchemeIntrospector::endpointAcceptsBearer()` is preserved for the
  legacy `auto_inject_dummy_bearer` path and now delegates to
  `injectableCredentialsFor()` for consistency.
- `slotIsAlreadyPopulated()` treats empty-string as "absent" to match
  `SecurityValidator::checkApiKeySatisfied()`'s missing-value definition; this
  is a marginal tightening over the legacy bearer check (which used a looser
  `!== '' && !== []` test) but the existing bearer test suite does not exercise
  the divergent case, and the new behaviour is the more correct of the two.
- AND-entry semantics are intentionally not modelled in the introspector —
  every supported scheme in the requirement is listed, and the trait writes
  all of them. Over-injection on an OR-endpoint is harmless; under-injection
  on an AND-endpoint would re-introduce the false-fail this feature exists
  to prevent.
- Issue #178 also proposes scheme→value-map (case B) and
  `skip_security_validation` (case C). Both are deferred to follow-up issues
  to keep this PR focused on the case A default.