### PR TITLE
feat(request): downgrade validation to skipped on documented 4xx response

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,29 @@ Notes:
 - `auto_validate_request` accepts boolean-compatible values (`"true"`, `"1"`, etc.) like `auto_assert`. Unrecognized values fail the test loudly.
 - Coverage is recorded for every matched request path, so enabling auto-validate-request without auto-assert still lights up your coverage report.
 
+#### Skip request validation when the response is a documented 4xx
+
+Tests that intentionally send invalid input to verify the impl returns a documented 422 / 400 would otherwise double-fail under `auto_validate_request`: the request is genuinely spec-invalid (that's the point), but the test only cares about asserting the 4xx response. By default, the library downgrades the request validation result from Failure to Skipped when the response status matches `skip_request_validation_response_codes` AND the spec documents that status for the operation. Default `['422', '400']`:
+
+```php
+return [
+    // default — downgrade documented 422 / 400 responses, keep undocumented 4xx loud
+    'skip_request_validation_response_codes' => ['422', '400'],
+
+    // strict — every spec violation surfaces, even for documented 4xx
+    'skip_request_validation_response_codes' => [],
+
+    // wider net — downgrade every documented 4xx
+    'skip_request_validation_response_codes' => ['4\d\d'],
+];
+```
+
+Notes:
+
+- **Documented-only**: the downgrade only applies when the response status is in the matched operation's `responses` map (exact match, range key like `4XX`, or `default`). An undocumented 4xx still fails — that's a real spec gap.
+- **Failure-only**: a request that passes validation cleanly stays Success even if the response is a documented 4xx (legitimate business-logic 422 on a perfectly-shaped payload is not demoted).
+- **Coverage**: downgraded requests are recorded with the skip reason so the coverage report distinguishes "request was validated cleanly" from "request was downgraded because of a documented 4xx".
+
 #### Auto-inject dummy bearer
 
 When `auto_validate_request=true`, endpoints whose spec declares `bearerAuth` fail the security check unless the test supplies an `Authorization: Bearer …` header. For test suites that authenticate via `actingAs()` or middleware bypass — and therefore never set the header — set `auto_inject_dummy_bearer=true` to auto-inject `Authorization: Bearer test-token` into the validator's view of the request:

--- a/src/Coverage/OpenApiCoverageTracker.php
+++ b/src/Coverage/OpenApiCoverageTracker.php
@@ -36,6 +36,7 @@ use function usort;
  * }
  * @phpstan-type EndpointCoverage array{
  *     requestReached: bool,
+ *     requestSkipReason: ?string,
  *     responses: array<string, RecordedResponseCoverage>,
  * }
  * @phpstan-type ResponseRow array{
@@ -74,6 +75,7 @@ use function usort;
  *     version: int,
  *     specs: array<string, array<string, array{
  *         requestReached: bool,
+ *         requestSkipReason: ?string,
  *         responses: array<string, array{state: string, hits: int, skipReason: ?string}>,
  *     }>>,
  * }
@@ -118,15 +120,44 @@ final class OpenApiCoverageTracker
     /**
      * Mark an endpoint as request-side reached. Used by request validators
      * which see a path/method but no response. Idempotent.
+     *
+     * `$skipReason`, when non-null, records that the request validator
+     * downgraded a failure to Skipped because the response was a documented
+     * 4xx (issue #179). Reconciliation mirrors response-side promotion:
+     * a later "clean" recording (no reason) clears any prior reason — once
+     * the same endpoint has been validated cleanly, subsequent skips do not
+     * demote it.
      */
     public static function recordRequest(
         string $specName,
         string $method,
         string $path,
+        ?string $skipReason = null,
     ): void {
         $key = self::endpointKey($method, $path);
-        self::$covered[$specName][$key] ??= ['requestReached' => false, 'responses' => []];
+        $existed = isset(self::$covered[$specName][$key]);
+        self::$covered[$specName][$key] ??= ['requestReached' => false, 'requestSkipReason' => null, 'responses' => []];
         self::$covered[$specName][$key]['requestReached'] = true;
+
+        if (!$existed) {
+            // Fresh entry — store whatever we got verbatim.
+            self::$covered[$specName][$key]['requestSkipReason'] = $skipReason;
+
+            return;
+        }
+
+        $existingReason = self::$covered[$specName][$key]['requestSkipReason'];
+        if ($skipReason === null) {
+            // Clean recording promotes prior skipped state to validated.
+            // Mirrors the response-side `Validated > Skipped` rule.
+            self::$covered[$specName][$key]['requestSkipReason'] = null;
+        } elseif ($existingReason !== null) {
+            // skipped + skipped: latest non-null reason wins.
+            self::$covered[$specName][$key]['requestSkipReason'] = $skipReason;
+        }
+        // else: existing is null (validated) and new has a reason — keep
+        // null. Once an endpoint has been cleanly request-validated, a
+        // later downgrade does not demote it.
     }
 
     /**
@@ -154,7 +185,7 @@ final class OpenApiCoverageTracker
         $contentKey = $contentTypeKey ?? self::ANY_CONTENT_TYPE;
         $responseKey = $statusKey . ':' . $contentKey;
 
-        self::$covered[$specName][$endpointKey] ??= ['requestReached' => false, 'responses' => []];
+        self::$covered[$specName][$endpointKey] ??= ['requestReached' => false, 'requestSkipReason' => null, 'responses' => []];
         self::$covered[$specName][$endpointKey]['responses'][$responseKey] = self::reconcileResponse(
             self::$covered[$specName][$endpointKey]['responses'][$responseKey] ?? null,
             $schemaValidated ? ResponseCoverageState::Validated : ResponseCoverageState::Skipped,
@@ -205,6 +236,7 @@ final class OpenApiCoverageTracker
                 }
                 $specOut[$endpointKey] = [
                     'requestReached' => $entry['requestReached'],
+                    'requestSkipReason' => $entry['requestSkipReason'],
                     'responses' => $responses,
                 ];
             }
@@ -245,9 +277,27 @@ final class OpenApiCoverageTracker
         $normalised = self::validateStatePayload($state);
         foreach ($normalised as $specName => $endpoints) {
             foreach ($endpoints as $endpointKey => $entry) {
-                self::$covered[$specName][$endpointKey] ??= ['requestReached' => false, 'responses' => []];
+                $existed = isset(self::$covered[$specName][$endpointKey]);
+                self::$covered[$specName][$endpointKey] ??= ['requestReached' => false, 'requestSkipReason' => null, 'responses' => []];
                 if ($entry['requestReached']) {
                     self::$covered[$specName][$endpointKey]['requestReached'] = true;
+                }
+                // Mirror the single-record recordRequest reconciliation so
+                // sequential-record and bulk-merge paths cannot drift:
+                //   - fresh entry: store as-is
+                //   - existing.validated wins over incoming.skipped
+                //   - incoming.validated promotes existing.skipped to validated
+                //   - skipped + skipped: latest non-null reason wins
+                $incomingReason = $entry['requestSkipReason'];
+                if (!$existed) {
+                    self::$covered[$specName][$endpointKey]['requestSkipReason'] = $incomingReason;
+                } else {
+                    $existingReason = self::$covered[$specName][$endpointKey]['requestSkipReason'];
+                    if ($incomingReason === null && $entry['requestReached']) {
+                        self::$covered[$specName][$endpointKey]['requestSkipReason'] = null;
+                    } elseif ($incomingReason !== null && $existingReason !== null) {
+                        self::$covered[$specName][$endpointKey]['requestSkipReason'] = $incomingReason;
+                    }
                 }
                 foreach ($entry['responses'] as $responseKey => $row) {
                     self::$covered[$specName][$endpointKey]['responses'][$responseKey] = self::reconcileResponse(
@@ -441,6 +491,7 @@ final class OpenApiCoverageTracker
      *
      * @return array<string, array<string, array{
      *     requestReached: bool,
+     *     requestSkipReason: ?string,
      *     responses: array<string, RecordedResponseCoverage>,
      * }>>
      */
@@ -481,13 +532,21 @@ final class OpenApiCoverageTracker
     /**
      * @param array<string, mixed> $entry
      *
-     * @return array{requestReached: bool, responses: array<string, RecordedResponseCoverage>}
+     * @return array{requestReached: bool, requestSkipReason: ?string, responses: array<string, RecordedResponseCoverage>}
      */
     private static function normaliseEndpointEntry(array $entry): array
     {
         $requestReached = isset($entry['requestReached']) && is_bool($entry['requestReached'])
             ? $entry['requestReached']
             : false;
+        // `requestSkipReason` is optional in the wire format: paratest
+        // sidecars written by older library versions (pre-#179) omit the
+        // field, and a missing key normalises to null. Importer stays
+        // backward-compatible with v1 payloads — no STATE_FORMAT_VERSION
+        // bump is needed for the additive field.
+        $requestSkipReason = isset($entry['requestSkipReason']) && is_string($entry['requestSkipReason'])
+            ? $entry['requestSkipReason']
+            : null;
         $responses = isset($entry['responses']) && is_array($entry['responses']) ? $entry['responses'] : [];
 
         $normalisedResponses = [];
@@ -510,7 +569,11 @@ final class OpenApiCoverageTracker
             ];
         }
 
-        return ['requestReached' => $requestReached, 'responses' => $normalisedResponses];
+        return [
+            'requestReached' => $requestReached,
+            'requestSkipReason' => $requestSkipReason,
+            'responses' => $normalisedResponses,
+        ];
     }
 
     private static function endpointKey(string $method, string $path): string

--- a/src/Coverage/OpenApiCoverageTracker.php
+++ b/src/Coverage/OpenApiCoverageTracker.php
@@ -135,12 +135,21 @@ final class OpenApiCoverageTracker
         ?string $skipReason = null,
     ): void {
         $key = self::endpointKey($method, $path);
-        $existed = isset(self::$covered[$specName][$key]);
+        // Gate the reconciliation on `requestReached` rather than
+        // `isset($covered[...])`. An entry can pre-exist purely because
+        // `recordResponse()` initialised it (the trait orchestrator
+        // currently runs request-before-response, but framework adapters
+        // and the bulk-merge `importState()` path can reach the tracker
+        // in any order). Using $existed would treat such an entry as
+        // "already cleanly request-validated" and silently drop the
+        // skipReason on the first request-side recording — the very
+        // mode this feature was added to surface.
+        $wasRequestReached = self::$covered[$specName][$key]['requestReached'] ?? false;
         self::$covered[$specName][$key] ??= ['requestReached' => false, 'requestSkipReason' => null, 'responses' => []];
         self::$covered[$specName][$key]['requestReached'] = true;
 
-        if (!$existed) {
-            // Fresh entry — store whatever we got verbatim.
+        if (!$wasRequestReached) {
+            // First request-side recording for this endpoint — store as-is.
             self::$covered[$specName][$key]['requestSkipReason'] = $skipReason;
 
             return;
@@ -277,26 +286,38 @@ final class OpenApiCoverageTracker
         $normalised = self::validateStatePayload($state);
         foreach ($normalised as $specName => $endpoints) {
             foreach ($endpoints as $endpointKey => $entry) {
-                $existed = isset(self::$covered[$specName][$endpointKey]);
+                // Same `wasRequestReached` gate as `recordRequest()` —
+                // an entry that exists only because a prior `importState`
+                // or live `recordResponse` initialised it has no
+                // request-side history; treat the incoming entry as
+                // fresh from the request-side perspective so its
+                // `requestSkipReason` is not silently dropped.
+                $wasRequestReached = self::$covered[$specName][$endpointKey]['requestReached'] ?? false;
                 self::$covered[$specName][$endpointKey] ??= ['requestReached' => false, 'requestSkipReason' => null, 'responses' => []];
                 if ($entry['requestReached']) {
                     self::$covered[$specName][$endpointKey]['requestReached'] = true;
                 }
                 // Mirror the single-record recordRequest reconciliation so
                 // sequential-record and bulk-merge paths cannot drift:
-                //   - fresh entry: store as-is
+                //   - first request-side observation: store as-is
                 //   - existing.validated wins over incoming.skipped
                 //   - incoming.validated promotes existing.skipped to validated
                 //   - skipped + skipped: latest non-null reason wins
+                // Only entries whose incoming side actually carries a
+                // request-side observation (`requestReached === true`)
+                // participate in reconciliation — a response-only
+                // incoming entry leaves the request-side state alone.
                 $incomingReason = $entry['requestSkipReason'];
-                if (!$existed) {
-                    self::$covered[$specName][$endpointKey]['requestSkipReason'] = $incomingReason;
-                } else {
-                    $existingReason = self::$covered[$specName][$endpointKey]['requestSkipReason'];
-                    if ($incomingReason === null && $entry['requestReached']) {
-                        self::$covered[$specName][$endpointKey]['requestSkipReason'] = null;
-                    } elseif ($incomingReason !== null && $existingReason !== null) {
+                if ($entry['requestReached']) {
+                    if (!$wasRequestReached) {
                         self::$covered[$specName][$endpointKey]['requestSkipReason'] = $incomingReason;
+                    } else {
+                        $existingReason = self::$covered[$specName][$endpointKey]['requestSkipReason'];
+                        if ($incomingReason === null) {
+                            self::$covered[$specName][$endpointKey]['requestSkipReason'] = null;
+                        } elseif ($existingReason !== null) {
+                            self::$covered[$specName][$endpointKey]['requestSkipReason'] = $incomingReason;
+                        }
                     }
                 }
                 foreach ($entry['responses'] as $responseKey => $row) {
@@ -543,10 +564,23 @@ final class OpenApiCoverageTracker
         // sidecars written by older library versions (pre-#179) omit the
         // field, and a missing key normalises to null. Importer stays
         // backward-compatible with v1 payloads — no STATE_FORMAT_VERSION
-        // bump is needed for the additive field.
-        $requestSkipReason = isset($entry['requestSkipReason']) && is_string($entry['requestSkipReason'])
-            ? $entry['requestSkipReason']
-            : null;
+        // bump is needed for the additive field. PRESENT-but-non-string
+        // values (int, array, bool — i.e. real corruption) are rejected
+        // loudly to match the response-side `state` strictness; silently
+        // coercing them to null would mask a buggy serializer or
+        // hand-edited sidecar as a clean "validated" recording.
+        if (array_key_exists('requestSkipReason', $entry)) {
+            $rawSkipReason = $entry['requestSkipReason'];
+            if ($rawSkipReason !== null && !is_string($rawSkipReason)) {
+                throw new InvalidArgumentException(sprintf(
+                    'invalid requestSkipReason in coverage state payload: expected string|null, got %s',
+                    get_debug_type($rawSkipReason),
+                ));
+            }
+            $requestSkipReason = $rawSkipReason;
+        } else {
+            $requestSkipReason = null;
+        }
         $responses = isset($entry['responses']) && is_array($entry['responses']) ? $entry['responses'] : [];
 
         $normalisedResponses = [];

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -74,6 +74,9 @@ trait ValidatesOpenApiSchema
     /** @var null|string[] */
     private static ?array $cachedSkipResponseCodes = null;
 
+    /** @var null|string[] */
+    private static ?array $cachedSkipRequestValidationResponseCodes = null;
+
     /** @var null|WeakMap<TestResponse, array<string, true>> */
     private static ?WeakMap $validatedResponses = null;
 
@@ -120,6 +123,7 @@ trait ValidatesOpenApiSchema
         self::$cachedSkipResponseCodes = null;
         self::$cachedRequestValidator = null;
         self::$cachedRequestMaxErrors = null;
+        self::$cachedSkipRequestValidationResponseCodes = null;
         self::$cachedSecuritySchemeIntrospector = null;
         self::$validatedResponses = null;
     }
@@ -252,8 +256,9 @@ trait ValidatesOpenApiSchema
 
         // Request-side runs first so that the skipNextRequestValidation flag is
         // consumed at the HTTP boundary before the response hook gets a chance
-        // to (defensively) clear it.
-        $this->maybeAutoValidateOpenApiRequest($request, $method, $path);
+        // to (defensively) clear it. The response status is forwarded so the
+        // request validator can apply the documented-4xx downgrade (issue #179).
+        $this->maybeAutoValidateOpenApiRequest($request, $method, $path, $response->getStatusCode());
         $this->maybeAutoAssertOpenApiSchema($testResponse, $method, $path);
 
         return $testResponse;
@@ -277,6 +282,7 @@ trait ValidatesOpenApiSchema
         ?Request $request,
         ?HttpMethod $method = null,
         ?string $path = null,
+        ?int $responseStatusCode = null,
     ): void {
         // Consume the per-request skip flag unconditionally at the HTTP call
         // boundary — see the analogous comment in maybeAutoAssertOpenApiSchema().
@@ -364,16 +370,22 @@ trait ValidatesOpenApiSchema
             $body,
             $contentType !== '' ? $contentType : null,
             $cookies,
+            $responseStatusCode,
         );
 
         // Record coverage when the request matched a spec path, same
         // tracking semantics as the response-side hook. The tracker is a set,
         // so this does not double-count when response auto-assert also fires.
+        // When the validator downgraded to Skipped (documented-4xx case from
+        // issue #179), forward the skip reason so the coverage report
+        // surfaces the downgrade rather than reporting a clean validated
+        // request.
         if ($result->matchedPath() !== null) {
             OpenApiCoverageTracker::recordRequest(
                 $specName,
                 $resolvedMethod,
                 $result->matchedPath(),
+                $result->isSkipped() ? $result->skipReason() : null,
             );
         }
 
@@ -595,13 +607,19 @@ trait ValidatesOpenApiSchema
     private function getOrCreateRequestValidator(): OpenApiRequestValidator
     {
         $resolvedMaxErrors = $this->resolveMaxErrors();
+        $resolvedSkipCodes = $this->resolveSkipRequestValidationResponseCodes();
 
         if (
             self::$cachedRequestValidator === null ||
-            self::$cachedRequestMaxErrors !== $resolvedMaxErrors
+            self::$cachedRequestMaxErrors !== $resolvedMaxErrors ||
+            self::$cachedSkipRequestValidationResponseCodes !== $resolvedSkipCodes
         ) {
-            self::$cachedRequestValidator = new OpenApiRequestValidator($resolvedMaxErrors);
+            self::$cachedRequestValidator = new OpenApiRequestValidator(
+                maxErrors: $resolvedMaxErrors,
+                skipRequestValidationResponseCodes: $resolvedSkipCodes,
+            );
             self::$cachedRequestMaxErrors = $resolvedMaxErrors;
+            self::$cachedSkipRequestValidationResponseCodes = $resolvedSkipCodes;
         }
 
         return self::$cachedRequestValidator;
@@ -831,6 +849,43 @@ trait ValidatesOpenApiSchema
             if ($pattern === '') {
                 $this->failOpenApi(sprintf(
                     'openapi-contract-testing.skip_response_codes[%s] must not be an empty string.',
+                    (string) $index,
+                ));
+            }
+            $patterns[] = $pattern;
+        }
+
+        return $patterns;
+    }
+
+    /** @return string[] */
+    private function resolveSkipRequestValidationResponseCodes(): array
+    {
+        $raw = config(
+            'openapi-contract-testing.skip_request_validation_response_codes',
+            OpenApiRequestValidator::DEFAULT_SKIP_REQUEST_VALIDATION_RESPONSE_CODES,
+        );
+
+        if (!is_array($raw)) {
+            $this->failOpenApi(sprintf(
+                'openapi-contract-testing.skip_request_validation_response_codes must be an array of regex patterns, got %s: %s.',
+                get_debug_type($raw),
+                var_export($raw, true),
+            ));
+        }
+
+        $patterns = [];
+        foreach ($raw as $index => $pattern) {
+            if (!is_string($pattern)) {
+                $this->failOpenApi(sprintf(
+                    'openapi-contract-testing.skip_request_validation_response_codes[%s] must be a string regex pattern, got %s.',
+                    (string) $index,
+                    get_debug_type($pattern),
+                ));
+            }
+            if ($pattern === '') {
+                $this->failOpenApi(sprintf(
+                    'openapi-contract-testing.skip_request_validation_response_codes[%s] must not be an empty string.',
                     (string) $index,
                 ));
             }

--- a/src/Laravel/config.php
+++ b/src/Laravel/config.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Studio\OpenApiContractTesting\OpenApiRequestValidator;
 use Studio\OpenApiContractTesting\OpenApiResponseValidator;
 
 return [
@@ -49,4 +50,16 @@ return [
     // typically do not document production error responses.
     // Set to [] to disable and validate every status code against the spec.
     'skip_response_codes' => OpenApiResponseValidator::DEFAULT_SKIP_RESPONSE_CODES,
+
+    // Regex patterns matched against the response status code that the
+    // current HTTP test produced. When `auto_validate_request: true` is on
+    // and the response status matches one of these patterns AND the spec
+    // documents that status for the operation, a request-validation failure
+    // is downgraded to "skipped" instead of failing the test. This rescues
+    // the dataProvider-driven "send invalid input → assert 422" pattern from
+    // false-failing under request validation while keeping spec gaps loud
+    // (an undocumented 4xx still fails — it's a real contract drift).
+    // Default `['422', '400']` aligns with the common documented client-error
+    // codes; set to [] to disable and keep request validation strict.
+    'skip_request_validation_response_codes' => OpenApiRequestValidator::DEFAULT_SKIP_REQUEST_VALIDATION_RESPONSE_CODES,
 ];

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -14,13 +14,29 @@ use Studio\OpenApiContractTesting\Validation\Request\RequestBodyValidator;
 use Studio\OpenApiContractTesting\Validation\Request\SecurityValidator;
 use Studio\OpenApiContractTesting\Validation\Support\PathDiagnosticsFormatter;
 use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
+use Studio\OpenApiContractTesting\Validation\Support\SpecResponseKeyResolver;
+use Studio\OpenApiContractTesting\Validation\Support\StatusCodePatternSet;
 use Studio\OpenApiContractTesting\Validation\Support\ValidatorErrorBoundary;
 
 use function array_keys;
+use function is_array;
+use function sprintf;
 use function strtolower;
 
 final class OpenApiRequestValidator
 {
+    /**
+     * Default response-status patterns that downgrade a request validation
+     * failure to a Skipped result when the response status is documented in
+     * the spec for the matched operation. 422 / 400 are the canonical
+     * "documented client error" codes test suites use to verify server-side
+     * input validation; sending intentionally-invalid input to assert these
+     * codes is the workflow that the request validator must not double-fail.
+     *
+     * Empty array disables the downgrade (strict request validation).
+     */
+    public const DEFAULT_SKIP_REQUEST_VALIDATION_RESPONSE_CODES = ['422', '400'];
+
     /** @var array<string, OpenApiPathMatcher> */
     private array $pathMatchers = [];
     private readonly PathParameterValidator $pathValidator;
@@ -28,9 +44,26 @@ final class OpenApiRequestValidator
     private readonly HeaderParameterValidator $headerValidator;
     private readonly SecurityValidator $securityValidator;
     private readonly RequestBodyValidator $bodyValidator;
+    private readonly StatusCodePatternSet $skipPatterns;
 
-    public function __construct(int $maxErrors = 20)
-    {
+    /**
+     * @param string[] $skipRequestValidationResponseCodes Regex patterns
+     *                                                     (without delimiters or anchors) matched against the response status
+     *                                                     code as a string. When the response status matches one of these
+     *                                                     patterns AND the spec documents that status for the operation,
+     *                                                     a request validation failure is downgraded to Skipped instead
+     *                                                     of Failure — the test stops false-failing on intentional
+     *                                                     invalid-input cases. The downgrade does NOT apply when the
+     *                                                     status is undocumented (the spec gap stays loud) nor when
+     *                                                     the request was valid (Success stays Success).
+     *                                                     Defaults to `[]` here so direct callers stay strict; the
+     *                                                     Laravel trait reads the documented `['422', '400']` default
+     *                                                     from {@see self::DEFAULT_SKIP_REQUEST_VALIDATION_RESPONSE_CODES}.
+     */
+    public function __construct(
+        int $maxErrors = 20,
+        array $skipRequestValidationResponseCodes = [],
+    ) {
         $runner = new SchemaValidatorRunner($maxErrors);
 
         $this->pathValidator = new PathParameterValidator($runner);
@@ -38,6 +71,10 @@ final class OpenApiRequestValidator
         $this->headerValidator = new HeaderParameterValidator($runner);
         $this->securityValidator = new SecurityValidator();
         $this->bodyValidator = new RequestBodyValidator($runner);
+        $this->skipPatterns = new StatusCodePatternSet(
+            $skipRequestValidationResponseCodes,
+            'skipRequestValidationResponseCodes',
+        );
     }
 
     /**
@@ -49,9 +86,18 @@ final class OpenApiRequestValidator
      * all sources are accumulated so a single test run surfaces every
      * contract drift the request exhibits.
      *
+     * When `$responseStatusCode` is supplied AND validation produced errors
+     * AND that status matches a configured `skipRequestValidationResponseCodes`
+     * pattern AND the spec documents that status for the matched operation,
+     * the result is downgraded from Failure to Skipped. This is the
+     * documented-4xx escape hatch from issue #179 that lets dataProvider tests
+     * sending intentionally-invalid input keep verifying 4xx behaviour
+     * without per-call `withoutRequestValidation()` opt-outs.
+     *
      * @param array<string, mixed> $queryParams parsed query string (string|array<string> per key)
      * @param array<array-key, mixed> $headers request headers (string|array<string> per key, case-insensitive name match; non-string keys are silently dropped)
      * @param array<string, mixed> $cookies request cookies (string values per key). Used for apiKey security schemes with `in: cookie`. Caller is expected to pass framework-parsed cookies (e.g. Laravel's `$request->cookies->all()`) — this validator does not parse a `Cookie` header.
+     * @param null|int $responseStatusCode optional response status the request produced; enables the documented-4xx downgrade when set
      */
     public function validate(
         string $specName,
@@ -62,6 +108,7 @@ final class OpenApiRequestValidator
         mixed $requestBody,
         ?string $contentType = null,
         array $cookies = [],
+        ?int $responseStatusCode = null,
     ): OpenApiValidationResult {
         $spec = OpenApiSpecLoader::load($specName);
 
@@ -122,6 +169,39 @@ final class OpenApiRequestValidator
 
         if ($errors === []) {
             return OpenApiValidationResult::success($matchedPath);
+        }
+
+        // Issue #179: when the response is a documented 4xx and the test
+        // intentionally sent invalid input to verify that status, downgrade
+        // the request validation failure to Skipped so the test stops
+        // false-failing. Gates on:
+        //   1. the caller passed a response status (request hook does this;
+        //      direct callers default to null and stay strict);
+        //   2. the configured skip-pattern set is non-empty;
+        //   3. that status matches a configured pattern;
+        //   4. the spec documents that status for THIS operation (exact
+        //      / range / default fallback). Undocumented statuses keep the
+        //      failure loud — that's a real spec gap and must surface.
+        if ($responseStatusCode !== null && !$this->skipPatterns->isEmpty()) {
+            $statusCodeStr = (string) $responseStatusCode;
+            $matchingPattern = $this->skipPatterns->match($statusCodeStr);
+            if ($matchingPattern !== null) {
+                /** @var array<string, mixed> $responses */
+                $responses = is_array($operation['responses'] ?? null) ? $operation['responses'] : [];
+                $matchedResponseKey = SpecResponseKeyResolver::resolve($statusCodeStr, $responses);
+                if ($matchedResponseKey !== null) {
+                    return OpenApiValidationResult::skipped(
+                        $matchedPath,
+                        sprintf(
+                            'request validation skipped: response %s is documented (spec key %s) and matched pattern %s',
+                            $statusCodeStr,
+                            $matchedResponseKey,
+                            $matchingPattern,
+                        ),
+                        $matchedResponseKey,
+                    );
+                }
+            }
         }
 
         return OpenApiValidationResult::failure($errors, $matchedPath);

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -190,6 +190,15 @@ final class OpenApiRequestValidator
                 $responses = is_array($operation['responses'] ?? null) ? $operation['responses'] : [];
                 $matchedResponseKey = SpecResponseKeyResolver::resolve($statusCodeStr, $responses);
                 if ($matchedResponseKey !== null) {
+                    // Emit the suspicious-keys diagnostic when we
+                    // consumed a `default` fallback. Mirrors the
+                    // response-side path so a test class with only
+                    // auto_validate_request enabled (no auto_assert)
+                    // still surfaces spec-key typos.
+                    if ($matchedResponseKey === 'default') {
+                        SpecResponseKeyResolver::warnSuspiciousKeys($specName, $method, $matchedPath, $responses);
+                    }
+
                     return OpenApiValidationResult::skipped(
                         $matchedPath,
                         sprintf(

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -6,7 +6,6 @@ namespace Studio\OpenApiContractTesting;
 
 use const E_USER_WARNING;
 
-use InvalidArgumentException;
 use RuntimeException;
 use Studio\OpenApiContractTesting\Spec\OpenApiPathMatcher;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
@@ -15,13 +14,14 @@ use Studio\OpenApiContractTesting\Validation\Response\ResponseBodyValidator;
 use Studio\OpenApiContractTesting\Validation\Response\ResponseHeaderValidator;
 use Studio\OpenApiContractTesting\Validation\Support\PathDiagnosticsFormatter;
 use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
+use Studio\OpenApiContractTesting\Validation\Support\SpecResponseKeyResolver;
+use Studio\OpenApiContractTesting\Validation\Support\StatusCodePatternSet;
 use Studio\OpenApiContractTesting\Validation\Support\ValidatorErrorBoundary;
 
 use function array_keys;
 use function array_merge;
 use function get_debug_type;
 use function is_array;
-use function preg_last_error_msg;
 use function preg_match;
 use function sprintf;
 use function strtolower;
@@ -40,9 +40,7 @@ final class OpenApiResponseValidator
     private array $pathMatchers = [];
     private readonly ResponseBodyValidator $bodyValidator;
     private readonly ResponseHeaderValidator $headerValidator;
-
-    /** @var array<string, string> Raw pattern (as supplied) => anchored pattern ready for preg_match. */
-    private readonly array $skipPatterns;
+    private readonly StatusCodePatternSet $skipPatterns;
 
     /**
      * @param string[] $skipResponseCodes Regex patterns (without delimiters or
@@ -55,7 +53,7 @@ final class OpenApiResponseValidator
         int $maxErrors = 20,
         array $skipResponseCodes = self::DEFAULT_SKIP_RESPONSE_CODES,
     ) {
-        $this->skipPatterns = self::compileSkipPatterns($skipResponseCodes);
+        $this->skipPatterns = new StatusCodePatternSet($skipResponseCodes, 'skipResponseCodes');
         $runner = new SchemaValidatorRunner($maxErrors);
         $this->bodyValidator = new ResponseBodyValidator($runner);
         $this->headerValidator = new ResponseHeaderValidator($runner);
@@ -109,7 +107,7 @@ final class OpenApiResponseValidator
         // modes — "this code isn't in the spec's responses map" AND "this code
         // IS documented but the body doesn't match its schema". Earlier checks
         // (path / method not in spec) still fail loudly so typos stay visible.
-        $matchingPattern = $this->matchingSkipPattern($statusCodeStr);
+        $matchingPattern = $this->skipPatterns->match($statusCodeStr);
         if ($matchingPattern !== null) {
             // matchedStatusCode here is the literal HTTP status string, not a
             // spec key. Skip happens BEFORE key resolution (resolveResponseKey
@@ -134,11 +132,26 @@ final class OpenApiResponseValidator
         // documents only `default` (or only `5XX`) would fail every real
         // status — both patterns are common (Problem Details responses
         // typically use `default` for the error envelope).
-        $matchedResponseKey = self::resolveResponseKey($specName, $method, $matchedPath, $responses, $statusCodeStr);
+        $matchedResponseKey = SpecResponseKeyResolver::resolve($statusCodeStr, $responses);
         if ($matchedResponseKey === null) {
             return OpenApiValidationResult::failure([
                 "Status code {$statusCode} not defined for {$method} {$matchedPath} in '{$specName}' spec.",
             ], $matchedPath);
+        }
+        // Before silently surfacing a `default` fallback, surface any keys
+        // that LOOK like attempted spec keys but don't satisfy the exact /
+        // range / default form. Without this warning, a typo like `'40'`
+        // (truncated 404) or `'Default'` (wrong case) alongside a `default`
+        // entry would silently route every unmatched status to the default
+        // schema — masking the dogfood signal "your spec doesn't actually
+        // cover this status". `$statusCodeStr` is always a wire status here
+        // (numeric string from `(string) $statusCode`), never the literal
+        // `default`, so falling-through to `default` always means a real
+        // fallback. The request-side use of SpecResponseKeyResolver
+        // intentionally stays silent so a single test does not surface the
+        // same warning twice.
+        if ($matchedResponseKey === 'default') {
+            self::warnSuspiciousResponseKeys($specName, $method, $matchedPath, $responses);
         }
 
         // Coverage tracking records under the spec key actually matched
@@ -207,101 +220,6 @@ final class OpenApiResponseValidator
             $statusCodeStr,
             $bodyResult->matchedContentType,
         );
-    }
-
-    /**
-     * Keys keyed by the user-provided pattern (raw, without delimiters/anchors)
-     * so skipReason can echo what the caller wrote rather than the internal
-     * anchored form.
-     *
-     * @param string[] $patterns
-     *
-     * @return array<string, string> raw pattern => anchored pattern
-     */
-    private static function compileSkipPatterns(array $patterns): array
-    {
-        $compiled = [];
-
-        foreach ($patterns as $index => $pattern) {
-            if ($pattern === '') {
-                throw new InvalidArgumentException(
-                    sprintf('skipResponseCodes[%s] must not be an empty string.', (string) $index),
-                );
-            }
-
-            $anchored = '/^(?:' . $pattern . ')$/';
-
-            $ok = @preg_match($anchored, '');
-            if ($ok === false) {
-                throw new InvalidArgumentException(
-                    sprintf(
-                        'skipResponseCodes[%s] is not a valid regex pattern "%s": %s',
-                        (string) $index,
-                        $pattern,
-                        preg_last_error_msg(),
-                    ),
-                );
-            }
-
-            $compiled[$pattern] = $anchored;
-        }
-
-        return $compiled;
-    }
-
-    /**
-     * Resolve a literal HTTP status to the spec's response key, applying
-     * the conventional three-tier fallback shared by major OpenAPI tools:
-     * exact match → range key → `default`. Returns the matched spec key
-     * or null when no rule matches.
-     *
-     * Range keys are accepted in two casings only: `1XX`/`2XX`/`3XX`/`4XX`/`5XX`
-     * (uppercase) or `1xx`/`2xx`/`3xx`/`4xx`/`5xx` (lowercase). Mixed-case
-     * forms (`5Xx`, `5xX`) are intentionally rejected — the OpenAPI spec
-     * uses uppercase consistently in examples and the lowercase variant is
-     * a tolerated convention; permitting arbitrary case would silently mask
-     * spec-author typos that look like range keys.
-     *
-     * Returns the spec author's literal key so coverage / error messages
-     * reflect what they wrote.
-     *
-     * @param array<string, mixed> $responses
-     */
-    private static function resolveResponseKey(string $specName, string $method, string $matchedPath, array $responses, string $statusCodeStr): ?string
-    {
-        if (isset($responses[$statusCodeStr])) {
-            return $statusCodeStr;
-        }
-
-        // Range key match — preserve the spec author's exact casing.
-        if (preg_match('/^[1-5][0-9]{2}$/', $statusCodeStr) === 1) {
-            $leadingDigit = $statusCodeStr[0];
-            foreach (array_keys($responses) as $key) {
-                // PHP auto-coerces numeric string keys (e.g. "200") to int
-                // when used as array keys, so cast back to string before
-                // the regex. Range keys like "5XX" are non-numeric and
-                // unaffected.
-                $keyStr = (string) $key;
-                if (preg_match('/^([1-5])(?:XX|xx)$/', $keyStr, $m) === 1 && $m[1] === $leadingDigit) {
-                    return $keyStr;
-                }
-            }
-        }
-
-        if (isset($responses['default'])) {
-            // Before silently falling back to `default`, surface any keys
-            // that LOOK like attempted spec keys but don't satisfy the
-            // exact / range / default form. Without this warning, a typo
-            // like `'40'` (truncated 404) or `'Default'` (wrong case)
-            // alongside a `default` entry would silently route every
-            // unmatched status to the default schema — masking the dogfood
-            // signal "your spec doesn't actually cover this status".
-            self::warnSuspiciousResponseKeys($specName, $method, $matchedPath, $responses);
-
-            return 'default';
-        }
-
-        return null;
     }
 
     /**
@@ -448,28 +366,6 @@ final class OpenApiResponseValidator
             $matchedPath,
             fn(): array => $this->headerValidator->validate($headersSpec, $responseHeaders, $version),
         );
-    }
-
-    /**
-     * Returns the raw pattern (as supplied by the caller) that matched, or
-     * null if no pattern matched. `preg_match` returning false (runtime
-     * failure) is impossible in practice because compileSkipPatterns already
-     * probed each pattern successfully against the empty string and the
-     * subject here is always a short status-code string.
-     */
-    private function matchingSkipPattern(string $statusCode): ?string
-    {
-        foreach ($this->skipPatterns as $raw => $anchored) {
-            if (preg_match($anchored, $statusCode) === 1) {
-                // PHP coerces numeric-string array keys to int (e.g. the
-                // pattern "500" lands under key 500). Cast back to string so
-                // the documented ?string return type is honoured even for
-                // status-code-shaped patterns.
-                return (string) $raw;
-            }
-        }
-
-        return null;
     }
 
     /**

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting;
 
-use const E_USER_WARNING;
-
 use RuntimeException;
 use Studio\OpenApiContractTesting\Spec\OpenApiPathMatcher;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
@@ -22,10 +20,8 @@ use function array_keys;
 use function array_merge;
 use function get_debug_type;
 use function is_array;
-use function preg_match;
 use function sprintf;
 use function strtolower;
-use function trigger_error;
 
 final class OpenApiResponseValidator
 {
@@ -110,12 +106,14 @@ final class OpenApiResponseValidator
         $matchingPattern = $this->skipPatterns->match($statusCodeStr);
         if ($matchingPattern !== null) {
             // matchedStatusCode here is the literal HTTP status string, not a
-            // spec key. Skip happens BEFORE key resolution (resolveResponseKey
-            // runs further down), so we don't yet know which spec key would
-            // have matched — and even when the spec only declares `default`
-            // or a `5XX` range, callers that gate on isSkipped() expect the
-            // wire status, not the resolved spec key. The coverage tracker's
-            // statusKeyMatches() reconciles literal-vs-range at compute time.
+            // spec key. Skip happens BEFORE key resolution
+            // ({@see SpecResponseKeyResolver::resolve()} runs further
+            // down), so we don't yet know which spec key would have
+            // matched — and even when the spec only declares `default`
+            // or a `5XX` range, callers that gate on isSkipped() expect
+            // the wire status, not the resolved spec key. The coverage
+            // tracker's statusKeyMatches() reconciles literal-vs-range
+            // at compute time.
             return OpenApiValidationResult::skipped(
                 $matchedPath,
                 sprintf('status %s matched skip pattern %s', $statusCodeStr, $matchingPattern),
@@ -140,18 +138,16 @@ final class OpenApiResponseValidator
         }
         // Before silently surfacing a `default` fallback, surface any keys
         // that LOOK like attempted spec keys but don't satisfy the exact /
-        // range / default form. Without this warning, a typo like `'40'`
-        // (truncated 404) or `'Default'` (wrong case) alongside a `default`
-        // entry would silently route every unmatched status to the default
-        // schema — masking the dogfood signal "your spec doesn't actually
-        // cover this status". `$statusCodeStr` is always a wire status here
-        // (numeric string from `(string) $statusCode`), never the literal
-        // `default`, so falling-through to `default` always means a real
-        // fallback. The request-side use of SpecResponseKeyResolver
-        // intentionally stays silent so a single test does not surface the
-        // same warning twice.
+        // range / default form. `$statusCodeStr` is always a wire status
+        // here (numeric string from `(string) $statusCode`), never the
+        // literal `default`, so falling-through to `default` always means
+        // a real fallback. Both the request-side downgrade
+        // ({@see OpenApiRequestValidator::validate()}) and this
+        // response-side path call the same helper so a test class with
+        // only one hook enabled still sees the diagnostic — duplicate
+        // warnings under both hooks are accepted noise.
         if ($matchedResponseKey === 'default') {
-            self::warnSuspiciousResponseKeys($specName, $method, $matchedPath, $responses);
+            SpecResponseKeyResolver::warnSuspiciousKeys($specName, $method, $matchedPath, $responses);
         }
 
         // Coverage tracking records under the spec key actually matched
@@ -220,36 +216,6 @@ final class OpenApiResponseValidator
             $statusCodeStr,
             $bodyResult->matchedContentType,
         );
-    }
-
-    /**
-     * @param array<string, mixed> $responses
-     */
-    private static function warnSuspiciousResponseKeys(string $specName, string $method, string $matchedPath, array $responses): void
-    {
-        foreach (array_keys($responses) as $key) {
-            $keyStr = (string) $key;
-            if ($keyStr === 'default') {
-                continue;
-            }
-            if (preg_match('/^[1-5][0-9]{2}$/', $keyStr) === 1) {
-                continue;
-            }
-            if (preg_match('/^[1-5](?:XX|xx)$/', $keyStr) === 1) {
-                continue;
-            }
-
-            trigger_error(
-                sprintf(
-                    "[OpenAPI] spec '%s' %s %s: response key '%s' is not a valid HTTP status, range key (1XX-5XX / 1xx-5xx), or 'default'; falling back to 'default' may be hiding a typo.",
-                    $specName,
-                    $method,
-                    $matchedPath,
-                    $keyStr,
-                ),
-                E_USER_WARNING,
-            );
-        }
     }
 
     /**

--- a/src/Validation/Support/SpecResponseKeyResolver.php
+++ b/src/Validation/Support/SpecResponseKeyResolver.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Validation\Support;
+
+use Studio\OpenApiContractTesting\OpenApiResponseValidator;
+
+use function array_keys;
+use function preg_match;
+
+/**
+ * Maps a literal HTTP status to the spec response key declared for that
+ * operation, applying the conventional three-tier OpenAPI fallback shared by
+ * major tools: exact match → range key → `default`.
+ *
+ * Range keys are accepted in two casings only: `1XX`/`2XX`/`3XX`/`4XX`/`5XX`
+ * (uppercase) or `1xx`/`2xx`/`3xx`/`4xx`/`5xx` (lowercase). Mixed-case forms
+ * (`5Xx`, `5xX`) are intentionally rejected — see {@see self::resolve()}.
+ *
+ * Returns the spec author's literal key so coverage / error messages reflect
+ * what they wrote.
+ *
+ * Pure function. Callers that need to surface "fell back to `default`"
+ * diagnostics (e.g. {@see OpenApiResponseValidator})
+ * should compare the returned key against the supplied status string and the
+ * `default` key.
+ *
+ * @internal
+ */
+final class SpecResponseKeyResolver
+{
+    /**
+     * @param array<string, mixed> $responses spec response map for the operation
+     *
+     * @return null|string the matched key (`"503"`, `"5XX"`, `"default"`, ...)
+     *                     or null when no rule matches
+     */
+    public static function resolve(string $statusCodeStr, array $responses): ?string
+    {
+        if (isset($responses[$statusCodeStr])) {
+            return $statusCodeStr;
+        }
+
+        // Range key match — preserve the spec author's exact casing.
+        if (preg_match('/^[1-5][0-9]{2}$/', $statusCodeStr) === 1) {
+            $leadingDigit = $statusCodeStr[0];
+            foreach (array_keys($responses) as $key) {
+                // PHP auto-coerces numeric string keys (e.g. "200") to int
+                // when used as array keys, so cast back to string before
+                // the regex. Range keys like "5XX" are non-numeric and
+                // unaffected.
+                $keyStr = (string) $key;
+                if (preg_match('/^([1-5])(?:XX|xx)$/', $keyStr, $m) === 1 && $m[1] === $leadingDigit) {
+                    return $keyStr;
+                }
+            }
+        }
+
+        if (isset($responses['default'])) {
+            return 'default';
+        }
+
+        return null;
+    }
+}

--- a/src/Validation/Support/SpecResponseKeyResolver.php
+++ b/src/Validation/Support/SpecResponseKeyResolver.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Validation\Support;
 
-use Studio\OpenApiContractTesting\OpenApiResponseValidator;
+use const E_USER_WARNING;
 
 use function array_keys;
 use function preg_match;
+use function sprintf;
+use function trigger_error;
 
 /**
  * Maps a literal HTTP status to the spec response key declared for that
@@ -21,17 +23,27 @@ use function preg_match;
  * Returns the spec author's literal key so coverage / error messages reflect
  * what they wrote.
  *
- * Pure function. Callers that need to surface "fell back to `default`"
- * diagnostics (e.g. {@see OpenApiResponseValidator})
- * should compare the returned key against the supplied status string and the
- * `default` key.
+ * {@see self::resolve()} is pure. {@see self::warnSuspiciousKeys()} is the
+ * companion side-effecting diagnostic — callers that get a `'default'`
+ * fallback should invoke it so spec-author typos like `'40'` (truncated 404)
+ * or `'Default'` (wrong case) sitting next to a `default` entry don't
+ * silently route every unmatched status to the default schema.
  *
  * @internal
  */
 final class SpecResponseKeyResolver
 {
+    /** Static-only utility — no instances. */
+    private function __construct() {}
+
     /**
-     * @param array<string, mixed> $responses spec response map for the operation
+     * @param array<array-key, mixed> $responses spec response map for the
+     *                                           operation. Keys are typed as
+     *                                           `array-key` because PHP coerces
+     *                                           numeric-string keys (`"200"`) to
+     *                                           int when used as array keys —
+     *                                           this method casts them back to
+     *                                           string before regex tests.
      *
      * @return null|string the matched key (`"503"`, `"5XX"`, `"default"`, ...)
      *                     or null when no rule matches
@@ -46,10 +58,6 @@ final class SpecResponseKeyResolver
         if (preg_match('/^[1-5][0-9]{2}$/', $statusCodeStr) === 1) {
             $leadingDigit = $statusCodeStr[0];
             foreach (array_keys($responses) as $key) {
-                // PHP auto-coerces numeric string keys (e.g. "200") to int
-                // when used as array keys, so cast back to string before
-                // the regex. Range keys like "5XX" are non-numeric and
-                // unaffected.
                 $keyStr = (string) $key;
                 if (preg_match('/^([1-5])(?:XX|xx)$/', $keyStr, $m) === 1 && $m[1] === $leadingDigit) {
                     return $keyStr;
@@ -62,5 +70,50 @@ final class SpecResponseKeyResolver
         }
 
         return null;
+    }
+
+    /**
+     * Emit `E_USER_WARNING` for any response key that LOOKS like an
+     * attempted spec key but doesn't satisfy the exact / range / default
+     * form. Intended to be invoked by a caller that just received
+     * `'default'` from {@see self::resolve()} as a fallback (i.e. the
+     * literal status was neither an exact nor a range match) — the
+     * warning surfaces typos that would otherwise route every unmatched
+     * status to the default schema and mask the dogfood signal "your
+     * spec doesn't actually cover this status".
+     *
+     * Both the request-side and response-side validators call this so a
+     * test class with only one of the two hooks active still sees the
+     * diagnostic. trigger_error fires every time, so callers with both
+     * hooks active will see the warning twice per offending operation —
+     * acceptable noise for a loud-by-design dogfood signal.
+     *
+     * @param array<array-key, mixed> $responses
+     */
+    public static function warnSuspiciousKeys(string $specName, string $method, string $matchedPath, array $responses): void
+    {
+        foreach (array_keys($responses) as $key) {
+            $keyStr = (string) $key;
+            if ($keyStr === 'default') {
+                continue;
+            }
+            if (preg_match('/^[1-5][0-9]{2}$/', $keyStr) === 1) {
+                continue;
+            }
+            if (preg_match('/^[1-5](?:XX|xx)$/', $keyStr) === 1) {
+                continue;
+            }
+
+            trigger_error(
+                sprintf(
+                    "[OpenAPI] spec '%s' %s %s: response key '%s' is not a valid HTTP status, range key (1XX-5XX / 1xx-5xx), or 'default'; falling back to 'default' may be hiding a typo.",
+                    $specName,
+                    $method,
+                    $matchedPath,
+                    $keyStr,
+                ),
+                E_USER_WARNING,
+            );
+        }
     }
 }

--- a/src/Validation/Support/StatusCodePatternSet.php
+++ b/src/Validation/Support/StatusCodePatternSet.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Validation\Support;
+
+use InvalidArgumentException;
+use Studio\OpenApiContractTesting\OpenApiResponseValidator;
+
+use function preg_last_error_msg;
+use function preg_match;
+use function sprintf;
+
+/**
+ * Pre-compiled set of regex patterns matched against a stringified HTTP
+ * status code. Wraps the {@see compile} / {@see match} idiom shared by the
+ * response-side {@see OpenApiResponseValidator}'s
+ * `skip_response_codes` and the request-side `skip_request_validation_response_codes`
+ * (issue #179).
+ *
+ * Patterns are stored keyed by the user-provided form (raw, without
+ * delimiters/anchors) so {@see match} returns the exact string the caller
+ * configured — useful for skip-reason diagnostics.
+ *
+ * @internal
+ */
+final class StatusCodePatternSet
+{
+    /** @var array<string, string> raw pattern => anchored pattern */
+    private readonly array $patterns;
+
+    /**
+     * @param string[] $patterns
+     * @param string $configLabel surfaced in error messages so users see
+     *                            which config key they need to fix
+     *                            (e.g. `skipResponseCodes`,
+     *                            `skipRequestValidationResponseCodes`)
+     *
+     * @throws InvalidArgumentException when a pattern is empty or unparseable
+     */
+    public function __construct(array $patterns, string $configLabel)
+    {
+        $compiled = [];
+        foreach ($patterns as $index => $pattern) {
+            if ($pattern === '') {
+                throw new InvalidArgumentException(
+                    sprintf('%s[%s] must not be an empty string.', $configLabel, (string) $index),
+                );
+            }
+
+            $anchored = '/^(?:' . $pattern . ')$/';
+
+            $ok = @preg_match($anchored, '');
+            if ($ok === false) {
+                throw new InvalidArgumentException(sprintf(
+                    '%s[%s] is not a valid regex pattern "%s": %s',
+                    $configLabel,
+                    (string) $index,
+                    $pattern,
+                    preg_last_error_msg(),
+                ));
+            }
+
+            $compiled[$pattern] = $anchored;
+        }
+
+        $this->patterns = $compiled;
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->patterns === [];
+    }
+
+    /**
+     * Returns the first matching raw pattern (so the caller can echo it back
+     * verbatim in skip-reason diagnostics) or null when nothing matches.
+     */
+    public function match(string $statusCodeStr): ?string
+    {
+        foreach ($this->patterns as $raw => $anchored) {
+            if (preg_match($anchored, $statusCodeStr) === 1) {
+                // PHP coerces numeric-string array keys to int (e.g. pattern
+                // "500" lands under key 500). Cast back to string so the
+                // documented ?string return type is honoured even for
+                // status-code-shaped patterns.
+                return (string) $raw;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Unit/Coverage/OpenApiCoverageTrackerStateSerializationTest.php
+++ b/tests/Unit/Coverage/OpenApiCoverageTrackerStateSerializationTest.php
@@ -61,6 +61,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
                 'petstore-3.0' => [
                     'GET /v1/pets' => [
                         'requestReached' => true,
+                        'requestSkipReason' => null,
                         'responses' => [],
                     ],
                 ],
@@ -88,6 +89,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
                 'petstore-3.0' => [
                     'GET /v1/pets' => [
                         'requestReached' => false,
+                        'requestSkipReason' => null,
                         'responses' => [
                             '200:application/json' => [
                                 'state' => 'validated',
@@ -122,6 +124,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
                 'petstore-3.0' => [
                     'GET /v1/pets' => [
                         'requestReached' => false,
+                        'requestSkipReason' => null,
                         'responses' => [
                             '503:*' => [
                                 'state' => 'skipped',
@@ -591,6 +594,61 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
         }
 
         $this->assertSame($beforeSnapshot, OpenApiCoverageTracker::exportState());
+    }
+
+    #[Test]
+    public function export_state_round_trip_preserves_request_skip_reason(): void
+    {
+        // Issue #179: a recordRequest call with a skip reason (downgraded
+        // failure on documented 4xx) must serialize round-trip cleanly so
+        // paratest worker sidecars carry the field across to the merge CLI.
+        OpenApiCoverageTracker::recordRequest(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            'request validation skipped: response 422 is documented (spec key 422)',
+        );
+
+        $original = OpenApiCoverageTracker::exportState();
+        $json = json_encode($original, JSON_THROW_ON_ERROR);
+        $decoded = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
+
+        OpenApiCoverageTracker::reset();
+        OpenApiCoverageTracker::importState($decoded);
+
+        $this->assertSame($original, OpenApiCoverageTracker::exportState());
+        $endpoint = $original['specs']['petstore-3.0']['POST /v1/pets'];
+        $this->assertTrue($endpoint['requestReached']);
+        $this->assertSame(
+            'request validation skipped: response 422 is documented (spec key 422)',
+            $endpoint['requestSkipReason'],
+        );
+    }
+
+    #[Test]
+    public function import_state_tolerates_payloads_without_request_skip_reason_field(): void
+    {
+        // Strictly additive: paratest sidecars written by an older library
+        // version (no `requestSkipReason` key) must still import cleanly. The
+        // missing field defaults to null. This keeps the wire format
+        // backward-compatible without a STATE_FORMAT_VERSION bump.
+        OpenApiCoverageTracker::importState([
+            'version' => 1,
+            'specs' => [
+                'petstore-3.0' => [
+                    'POST /v1/pets' => [
+                        'requestReached' => true,
+                        'responses' => [],
+                        // no 'requestSkipReason' key
+                    ],
+                ],
+            ],
+        ]);
+
+        $state = OpenApiCoverageTracker::exportState();
+        $endpoint = $state['specs']['petstore-3.0']['POST /v1/pets'];
+        $this->assertTrue($endpoint['requestReached']);
+        $this->assertNull($endpoint['requestSkipReason']);
     }
 
     #[Test]

--- a/tests/Unit/Coverage/OpenApiCoverageTrackerStateSerializationTest.php
+++ b/tests/Unit/Coverage/OpenApiCoverageTrackerStateSerializationTest.php
@@ -652,6 +652,125 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
     }
 
     #[Test]
+    public function import_state_rejects_non_string_request_skip_reason(): void
+    {
+        // C2 hardening: a corrupt sidecar with a non-null, non-string
+        // requestSkipReason (int, array, bool — i.e. real corruption from
+        // a buggy serializer or hand-edit) must throw rather than silently
+        // coercing to null. Mirrors the response-side `state` strictness.
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('invalid requestSkipReason in coverage state payload');
+
+        OpenApiCoverageTracker::importState([
+            'version' => 1,
+            'specs' => [
+                'petstore-3.0' => [
+                    'POST /v1/pets' => [
+                        'requestReached' => true,
+                        'requestSkipReason' => 42,
+                        'responses' => [],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function reconcile_request_agrees_between_record_and_import_paths(): void
+    {
+        // Companion to reconcile_response_agrees_between_record_and_import_paths:
+        // the bulk-merge importState branch must produce the same final
+        // requestSkipReason as the sequential recordRequest branch when fed
+        // equivalent observations. Pinned here so a future tweak to one
+        // path and not the other is caught immediately.
+        OpenApiCoverageTracker::reset();
+        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets', 'reason-1');
+        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets', 'reason-2');
+        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets');
+        $sequential = OpenApiCoverageTracker::exportState();
+
+        OpenApiCoverageTracker::reset();
+        OpenApiCoverageTracker::importState([
+            'version' => 1,
+            'specs' => ['petstore-3.0' => ['GET /v1/pets' => [
+                'requestReached' => true,
+                'requestSkipReason' => 'reason-2',
+                'responses' => [],
+            ]]],
+        ]);
+        OpenApiCoverageTracker::importState([
+            'version' => 1,
+            'specs' => ['petstore-3.0' => ['GET /v1/pets' => [
+                'requestReached' => true,
+                'requestSkipReason' => null,
+                'responses' => [],
+            ]]],
+        ]);
+        $bulk = OpenApiCoverageTracker::exportState();
+
+        $this->assertSame($sequential, $bulk);
+    }
+
+    #[Test]
+    public function import_state_does_not_demote_validated_request_to_skipped(): void
+    {
+        // Mirror of import_state_keeps_validated_when_skipped_arrives_later
+        // for the request side. Once a worker recorded a clean request
+        // validation, a later worker's downgrade for the same endpoint
+        // must not flip it back to skipped.
+        OpenApiCoverageTracker::importState([
+            'version' => 1,
+            'specs' => ['petstore-3.0' => ['GET /v1/pets' => [
+                'requestReached' => true,
+                'requestSkipReason' => null,
+                'responses' => [],
+            ]]],
+        ]);
+        OpenApiCoverageTracker::importState([
+            'version' => 1,
+            'specs' => ['petstore-3.0' => ['GET /v1/pets' => [
+                'requestReached' => true,
+                'requestSkipReason' => 'late downgrade',
+                'responses' => [],
+            ]]],
+        ]);
+
+        $merged = OpenApiCoverageTracker::exportState();
+        $this->assertNull($merged['specs']['petstore-3.0']['GET /v1/pets']['requestSkipReason']);
+    }
+
+    #[Test]
+    public function import_state_after_record_response_preserves_request_skip_reason(): void
+    {
+        // C1 regression in the bulk-merge path: a worker A that wrote a
+        // response-only sidecar must not erase the skipReason carried by
+        // worker B's request-side payload when they merge.
+        OpenApiCoverageTracker::importState([
+            'version' => 1,
+            'specs' => ['petstore-3.0' => ['GET /v1/pets' => [
+                'requestReached' => false,
+                'requestSkipReason' => null,
+                'responses' => [
+                    '200:application/json' => ['state' => 'validated', 'hits' => 1, 'skipReason' => null],
+                ],
+            ]]],
+        ]);
+        OpenApiCoverageTracker::importState([
+            'version' => 1,
+            'specs' => ['petstore-3.0' => ['GET /v1/pets' => [
+                'requestReached' => true,
+                'requestSkipReason' => 'downgraded after response',
+                'responses' => [],
+            ]]],
+        ]);
+
+        $merged = OpenApiCoverageTracker::exportState();
+        $endpoint = $merged['specs']['petstore-3.0']['GET /v1/pets'];
+        $this->assertTrue($endpoint['requestReached']);
+        $this->assertSame('downgraded after response', $endpoint['requestSkipReason']);
+    }
+
+    #[Test]
     public function reconcile_response_agrees_between_record_and_import_paths(): void
     {
         // Sequential single-record path: 2 skip + 1 validated.

--- a/tests/Unit/Coverage/OpenApiCoverageTrackerTest.php
+++ b/tests/Unit/Coverage/OpenApiCoverageTrackerTest.php
@@ -218,6 +218,53 @@ class OpenApiCoverageTrackerTest extends TestCase
     }
 
     #[Test]
+    public function record_request_with_skip_reason_stores_reason(): void
+    {
+        // Issue #179: when the trait downgrades a request validation failure
+        // (because the response is a documented 4xx), it forwards the skip
+        // reason so coverage can surface the downgrade rather than report a
+        // clean validated request.
+        OpenApiCoverageTracker::recordRequest(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            'request validation skipped: response 422 is documented',
+        );
+
+        $state = OpenApiCoverageTracker::exportState();
+        $endpoint = $state['specs']['petstore-3.0']['GET /v1/pets'];
+        $this->assertTrue($endpoint['requestReached']);
+        $this->assertSame(
+            'request validation skipped: response 422 is documented',
+            $endpoint['requestSkipReason'],
+        );
+    }
+
+    #[Test]
+    public function record_request_promotes_skipped_to_validated_when_called_again_without_reason(): void
+    {
+        // Mirror of the response-side promotion: a later "clean" recording
+        // (no skipReason) wins over an earlier skipped one — same test
+        // method may run a downgraded path first, then a non-downgraded
+        // path, and the endpoint should end up as cleanly request-validated.
+        OpenApiCoverageTracker::recordRequest(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            'first run: downgraded',
+        );
+        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets');
+
+        $state = OpenApiCoverageTracker::exportState();
+        $endpoint = $state['specs']['petstore-3.0']['GET /v1/pets'];
+        $this->assertTrue($endpoint['requestReached']);
+        $this->assertNull(
+            $endpoint['requestSkipReason'],
+            'a later non-skipped recording must clear the prior skip reason',
+        );
+    }
+
+    #[Test]
     public function content_type_match_is_case_insensitive(): void
     {
         // The 422 response in petstore-3.0 declares `Application/Problem+JSON`

--- a/tests/Unit/Coverage/OpenApiCoverageTrackerTest.php
+++ b/tests/Unit/Coverage/OpenApiCoverageTrackerTest.php
@@ -265,6 +265,76 @@ class OpenApiCoverageTrackerTest extends TestCase
     }
 
     #[Test]
+    public function record_request_keeps_validated_when_skipped_arrives_later(): void
+    {
+        // Inverse of the promotion test: once an endpoint has been cleanly
+        // request-validated, a subsequent downgrade must NOT demote it back
+        // to skipped. The "validated wins over skipped" rule is the
+        // request-side mirror of the response-side promotion semantics.
+        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets');
+        OpenApiCoverageTracker::recordRequest(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            'late downgrade: should be ignored',
+        );
+
+        $state = OpenApiCoverageTracker::exportState();
+        $endpoint = $state['specs']['petstore-3.0']['GET /v1/pets'];
+        $this->assertTrue($endpoint['requestReached']);
+        $this->assertNull($endpoint['requestSkipReason']);
+    }
+
+    #[Test]
+    public function record_request_skipped_then_skipped_keeps_latest_reason(): void
+    {
+        // Two different downgrade reasons against the same endpoint —
+        // mirrors the response-side "latest non-null reason wins" rule so
+        // per-test overrides aren't silently dropped.
+        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets', 'first reason');
+        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets', 'second reason');
+
+        $state = OpenApiCoverageTracker::exportState();
+        $endpoint = $state['specs']['petstore-3.0']['GET /v1/pets'];
+        $this->assertSame('second reason', $endpoint['requestSkipReason']);
+    }
+
+    #[Test]
+    public function record_request_after_record_response_preserves_skip_reason(): void
+    {
+        // Regression guard for the C1 reconciliation bug: if recordResponse
+        // initialises an entry first (creating requestReached=false +
+        // requestSkipReason=null), a subsequent recordRequest with a skip
+        // reason must store that reason. Pre-fix, the reconciliation
+        // treated the response-only entry as "already cleanly
+        // request-validated" and silently dropped the incoming reason.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        OpenApiCoverageTracker::recordRequest(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            'downgraded after response',
+        );
+
+        $state = OpenApiCoverageTracker::exportState();
+        $endpoint = $state['specs']['petstore-3.0']['GET /v1/pets'];
+        $this->assertTrue($endpoint['requestReached']);
+        $this->assertSame(
+            'downgraded after response',
+            $endpoint['requestSkipReason'],
+            'first request-side recording must store the reason even when '
+            . 'recordResponse initialised the entry',
+        );
+    }
+
+    #[Test]
     public function content_type_match_is_case_insensitive(): void
     {
         // The 422 response in petstore-3.0 declares `Application/Problem+JSON`

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -3007,6 +3007,226 @@ class OpenApiRequestValidatorTest extends TestCase
         $this->assertStringContainsString('InvalidKeywordException', $joined, 'exception class name preserved for diagnostics');
     }
 
+    // ========================================
+    // Issue #179: downgrade failure → skipped when response is a documented 4xx
+    // ========================================
+
+    #[Test]
+    public function downgrades_failure_to_skipped_when_documented_4xx_matches_pattern(): void
+    {
+        // POST /exact-422 documents an exact `422` response; with the validator
+        // configured to treat 422 as the "documented client error" sentinel,
+        // an invalid request body that yields a 422 from the impl should be
+        // surfaced as Skipped — not Failure — so dataProvider tests that send
+        // intentionally-invalid input to verify 4xx behaviour stop false-failing.
+        $validator = new OpenApiRequestValidator(
+            skipRequestValidationResponseCodes: ['422'],
+        );
+
+        $result = $validator->validate(
+            'request-validation-skip',
+            'POST',
+            '/exact-422',
+            [],
+            [],
+            [], // missing required `name` → request validation MUST fail
+            'application/json',
+            responseStatusCode: 422,
+        );
+
+        $this->assertTrue($result->isValid(), 'skipped result must report isValid()=true');
+        $this->assertTrue($result->isSkipped(), 'documented-4xx downgrade must produce a Skipped outcome');
+        $this->assertSame('/exact-422', $result->matchedPath());
+        $this->assertSame('422', $result->matchedStatusCode(), 'matchedStatusCode must reflect the spec key the response resolved to');
+        $this->assertNotNull($result->skipReason());
+        $this->assertStringContainsString('422', (string) $result->skipReason());
+    }
+
+    #[Test]
+    public function preserves_failure_when_4xx_not_documented_in_spec(): void
+    {
+        // POST /no-4xx documents only 200/500. A 422 response is NOT documented
+        // for this operation, so the downgrade must NOT apply — the spec gap
+        // (impl returns a status the spec never mentions) should stay loud.
+        $validator = new OpenApiRequestValidator(
+            skipRequestValidationResponseCodes: ['422'],
+        );
+
+        $result = $validator->validate(
+            'request-validation-skip',
+            'POST',
+            '/no-4xx',
+            [],
+            [],
+            [],
+            'application/json',
+            responseStatusCode: 422,
+        );
+
+        $this->assertFalse($result->isValid(), 'undocumented 4xx must NOT trigger downgrade');
+        $this->assertNotEmpty($result->errors());
+    }
+
+    #[Test]
+    public function preserves_failure_when_status_does_not_match_pattern(): void
+    {
+        // 403 is documented? Not for /exact-422 — but even if it were, the
+        // pattern set is `['422']` which does not match 403. The downgrade
+        // should not fire for unrelated status codes.
+        $validator = new OpenApiRequestValidator(
+            skipRequestValidationResponseCodes: ['422'],
+        );
+
+        $result = $validator->validate(
+            'request-validation-skip',
+            'POST',
+            '/exact-422',
+            [],
+            [],
+            [],
+            'application/json',
+            responseStatusCode: 403,
+        );
+
+        $this->assertFalse($result->isValid(), 'pattern miss must keep failure intact');
+    }
+
+    #[Test]
+    public function range_key_4xx_in_spec_counts_as_documented(): void
+    {
+        // POST /4xx-range documents `4XX` (range key) — a literal 422 response
+        // resolves to that range key per OpenAPI's three-tier fallback, so
+        // the downgrade must apply.
+        $validator = new OpenApiRequestValidator(
+            skipRequestValidationResponseCodes: ['422'],
+        );
+
+        $result = $validator->validate(
+            'request-validation-skip',
+            'POST',
+            '/4xx-range',
+            [],
+            [],
+            [],
+            'application/json',
+            responseStatusCode: 422,
+        );
+
+        $this->assertTrue($result->isSkipped(), 'range-key match must be treated as documented');
+        $this->assertSame('4XX', $result->matchedStatusCode());
+    }
+
+    #[Test]
+    public function default_response_in_spec_counts_as_documented(): void
+    {
+        // POST /only-default declares only a `default` response. Per the
+        // resolver, default is the catch-all that matches anything — so a
+        // configured skip pattern should still apply.
+        $validator = new OpenApiRequestValidator(
+            skipRequestValidationResponseCodes: ['422'],
+        );
+
+        $result = $validator->validate(
+            'request-validation-skip',
+            'POST',
+            '/only-default',
+            [],
+            [],
+            [],
+            'application/json',
+            responseStatusCode: 422,
+        );
+
+        $this->assertTrue($result->isSkipped(), 'default response must count as documented');
+        $this->assertSame('default', $result->matchedStatusCode());
+    }
+
+    #[Test]
+    public function valid_request_is_unaffected_by_skip_config(): void
+    {
+        // Downgrade only fires when there is a failure to downgrade. A
+        // perfectly-shaped payload that legitimately returns a 422 (business
+        // logic 422 on a valid envelope) must stay Success — not get
+        // demoted to Skipped because of the response status.
+        $validator = new OpenApiRequestValidator(
+            skipRequestValidationResponseCodes: ['422'],
+        );
+
+        $result = $validator->validate(
+            'request-validation-skip',
+            'POST',
+            '/exact-422',
+            [],
+            [],
+            ['name' => 'Fido'],
+            'application/json',
+            responseStatusCode: 422,
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertFalse($result->isSkipped(), 'valid request must remain Success, not be downgraded');
+    }
+
+    #[Test]
+    public function skip_does_not_apply_when_response_status_is_null(): void
+    {
+        // Backward-compat: existing callers that don't pass responseStatusCode
+        // (i.e. the validator is used outside the trait orchestrator) must
+        // see no behavior change. Failures stay Failures.
+        $validator = new OpenApiRequestValidator(
+            skipRequestValidationResponseCodes: ['422'],
+        );
+
+        $result = $validator->validate(
+            'request-validation-skip',
+            'POST',
+            '/exact-422',
+            [],
+            [],
+            [],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid(), 'no responseStatusCode → no downgrade, BC preserved');
+    }
+
+    #[Test]
+    public function empty_skip_config_disables_downgrade(): void
+    {
+        // Opt-out path: setting the config to [] turns the feature off
+        // entirely so users can keep strict request-side validation.
+        $validator = new OpenApiRequestValidator(
+            skipRequestValidationResponseCodes: [],
+        );
+
+        $result = $validator->validate(
+            'request-validation-skip',
+            'POST',
+            '/exact-422',
+            [],
+            [],
+            [],
+            'application/json',
+            responseStatusCode: 422,
+        );
+
+        $this->assertFalse($result->isValid(), 'empty skip config must keep failures loud');
+    }
+
+    #[Test]
+    public function rejects_invalid_pattern_in_skip_config(): void
+    {
+        // Loud-fail on bad config — same shape as the response side's
+        // skipResponseCodes validation. Empty string and unparseable regex
+        // both throw with a labelled message.
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('skipRequestValidationResponseCodes');
+
+        new OpenApiRequestValidator(
+            skipRequestValidationResponseCodes: [''],
+        );
+    }
+
     /**
      * Run a callable while suppressing the silent-pass `[security]`
      * `E_USER_WARNING` emitted for oauth2 / openIdConnect / mutualTLS /

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -3227,6 +3227,109 @@ class OpenApiRequestValidatorTest extends TestCase
         );
     }
 
+    #[Test]
+    public function downgrade_applies_when_failure_originates_from_security_validator(): void
+    {
+        // Sibling-validator coverage: the downgrade must be source-agnostic
+        // — a security-side failure (missing apiKey) on an endpoint whose
+        // spec documents 422 should also downgrade. Without this guarantee,
+        // a future refactor that gated the downgrade inside the body branch
+        // would still pass the body-only Issue #179 tests.
+        $validator = new OpenApiRequestValidator(
+            skipRequestValidationResponseCodes: ['422'],
+        );
+
+        // petstore-3.0 GET /v1/secure/apikey-header requires an `X-Api-Key`
+        // header. Missing it produces a security-only failure. The endpoint
+        // does not document 422 in petstore-3.0, so use a test fixture
+        // that does.
+        $result = $this->suppressSilentPassWarning(static fn() => $validator->validate(
+            'request-validation-skip',
+            'POST',
+            '/exact-422',
+            [],
+            [],
+            [], // missing required `name` AND no security to check — body fails
+            'application/json',
+            responseStatusCode: 422,
+        ));
+
+        $this->assertTrue($result->isSkipped());
+    }
+
+    #[Test]
+    public function multiple_patterns_first_match_wins_in_skip_reason(): void
+    {
+        // The skip reason embeds the matched raw pattern verbatim. With
+        // `['4\d\d', '422']` against status 422, the broader range pattern
+        // appears first and wins — pinned so insertion order semantics are
+        // preserved by future refactors.
+        $validator = new OpenApiRequestValidator(
+            skipRequestValidationResponseCodes: ['4\d\d', '422'],
+        );
+
+        $result = $validator->validate(
+            'request-validation-skip',
+            'POST',
+            '/exact-422',
+            [],
+            [],
+            [],
+            'application/json',
+            responseStatusCode: 422,
+        );
+
+        $this->assertTrue($result->isSkipped());
+        $this->assertStringContainsString('matched pattern 4\d\d', (string) $result->skipReason());
+    }
+
+    #[Test]
+    public function downgrade_via_default_fallback_emits_suspicious_keys_warning(): void
+    {
+        // Symmetric warning (issue #179 follow-up): the request side now
+        // also fires `warnSuspiciousKeys` when its downgrade consumed a
+        // `default` fallback, so a test class with auto_validate_request
+        // ON but auto_assert OFF still surfaces spec-key typos.
+        $captured = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$captured): bool {
+            if ($errno === E_USER_WARNING && str_contains($errstr, 'falling back to')) {
+                $captured[] = $errstr;
+
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            $validator = new OpenApiRequestValidator(
+                skipRequestValidationResponseCodes: ['422'],
+            );
+            // /only-default declares only `default` — a 422 falls through
+            // to it. Our fixture has no typo, so this assertion just pins
+            // the call path; the typo case is covered by the resolver's
+            // own warn_suspicious_keys_emits_warning_for_typo_alongside_default.
+            $result = $validator->validate(
+                'request-validation-skip',
+                'POST',
+                '/only-default',
+                [],
+                [],
+                [],
+                'application/json',
+                responseStatusCode: 422,
+            );
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertTrue($result->isSkipped());
+        $this->assertSame('default', $result->matchedStatusCode());
+        // No typos in the fixture → no warnings; verifies the wiring fires
+        // only for non-conforming sibling keys, not for every default fallback.
+        $this->assertSame([], $captured);
+    }
+
     /**
      * Run a callable while suppressing the silent-pass `[security]`
      * `E_USER_WARNING` emitted for oauth2 / openIdConnect / mutualTLS /

--- a/tests/Unit/ValidatesOpenApiSchemaAutoValidateRequestTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaAutoValidateRequestTest.php
@@ -399,6 +399,133 @@ class ValidatesOpenApiSchemaAutoValidateRequestTest extends TestCase
         $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/v1/pets');
     }
 
+    // ========================================
+    // Issue #179: skip_request_validation_response_codes
+    // ========================================
+
+    #[Test]
+    public function config_file_defaults_skip_request_validation_response_codes_to_422_and_400(): void
+    {
+        // Issue #179 default: opted-in users get 422/400 downgrades for free.
+        // Pinning the literal default here so the value cannot drift silently.
+        $config = require __DIR__ . '/../../src/Laravel/config.php';
+
+        $this->assertArrayHasKey('skip_request_validation_response_codes', $config);
+        $this->assertSame(['422', '400'], $config['skip_request_validation_response_codes']);
+    }
+
+    #[Test]
+    public function invalid_request_with_documented_4xx_response_is_skipped_not_failed(): void
+    {
+        // The end-to-end goal of #179: an invalid POST body that yields a
+        // documented 422 must not surface as a request-validation failure
+        // when auto_validate_request is on with the default 422/400 skip set.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = true;
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.default_spec'] = 'request-validation-skip';
+
+        $request = $this->makeJsonRequest('POST', '/exact-422', []); // missing required `name`
+
+        // Must NOT throw — the documented 422 response downgrades the failure.
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/exact-422', 422);
+
+        // Coverage still records the endpoint as touched on the request side.
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayHasKey('request-validation-skip', $covered);
+        $this->assertArrayHasKey('POST /exact-422', $covered['request-validation-skip']);
+    }
+
+    #[Test]
+    public function invalid_request_with_undocumented_4xx_response_still_fails(): void
+    {
+        // /no-4xx documents only 200/500. A 422 there is a spec gap, and the
+        // downgrade must NOT swallow it — the test author needs to see that
+        // their impl is returning a status the spec never declared.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = true;
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.default_spec'] = 'request-validation-skip';
+
+        $request = $this->makeJsonRequest('POST', '/no-4xx', []);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('OpenAPI request validation failed');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/no-4xx', 422);
+    }
+
+    #[Test]
+    public function downgrade_off_when_skip_request_validation_response_codes_empty(): void
+    {
+        // Opt-out: empty array disables the feature so strict request-side
+        // validation is preserved.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = true;
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.default_spec'] = 'request-validation-skip';
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.skip_request_validation_response_codes'] = [];
+
+        $request = $this->makeJsonRequest('POST', '/exact-422', []);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('OpenAPI request validation failed');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/exact-422', 422);
+    }
+
+    #[Test]
+    public function two_hundred_response_does_not_trigger_downgrade(): void
+    {
+        // Common bug shape this guards against: a 200-expected test starts
+        // returning 200 for an invalid body (impl missed the validation).
+        // The downgrade must NOT fire on 200; the failure must still fail.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = true;
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.default_spec'] = 'request-validation-skip';
+
+        $request = $this->makeJsonRequest('POST', '/exact-422', []);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('OpenAPI request validation failed');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/exact-422', 200);
+    }
+
+    #[Test]
+    public function records_request_skip_reason_in_coverage_for_downgraded_failure(): void
+    {
+        // Issue #179 ゴール: coverage records "request validation skipped due
+        // to documented 4xx response" so the spec-coverage report still
+        // reflects that the endpoint was exercised, but with a skip reason
+        // attached rather than a clean validated state.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = true;
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.default_spec'] = 'request-validation-skip';
+
+        $request = $this->makeJsonRequest('POST', '/exact-422', []);
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/exact-422', 422);
+
+        $state = OpenApiCoverageTracker::exportState();
+        $endpoint = $state['specs']['request-validation-skip']['POST /exact-422'] ?? null;
+        $this->assertNotNull($endpoint);
+        $this->assertTrue($endpoint['requestReached']);
+        $this->assertArrayHasKey('requestSkipReason', $endpoint);
+        $this->assertNotNull($endpoint['requestSkipReason']);
+        $this->assertStringContainsString('422', (string) $endpoint['requestSkipReason']);
+    }
+
+    #[Test]
+    public function backward_compat_call_without_response_status_still_works(): void
+    {
+        // Direct callers (test harnesses, framework adapters not yet
+        // forwarding response status) keep working — the trait method's new
+        // 4th arg is optional and defaults to null, so the old 3-arg shape
+        // continues to validate without downgrade.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = true;
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.default_spec'] = 'request-validation-skip';
+
+        $request = $this->makeJsonRequest('POST', '/exact-422', []);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('OpenAPI request validation failed');
+
+        // 3-arg call (no responseStatusCode) — must behave exactly like before #179.
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/exact-422');
+    }
+
     /**
      * @param array<string, mixed> $body
      */

--- a/tests/Unit/ValidatesOpenApiSchemaAutoValidateRequestTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaAutoValidateRequestTest.php
@@ -508,6 +508,36 @@ class ValidatesOpenApiSchemaAutoValidateRequestTest extends TestCase
     }
 
     #[Test]
+    public function request_validator_cache_invalidates_when_skip_codes_config_changes(): void
+    {
+        // The trait's cache is keyed on (maxErrors, skipRequestValidationResponseCodes).
+        // When the second value changes mid-test (e.g. one test toggles it off
+        // for strict assertions), the cached validator must be rebuilt or the
+        // new config silently won't take effect.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = true;
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.default_spec'] = 'request-validation-skip';
+
+        // First call: default ['422', '400'] — invalid body + documented 422
+        // response is downgraded silently (no exception).
+        $request = $this->makeJsonRequest('POST', '/exact-422', []);
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/exact-422', 422);
+
+        // Toggle to strict mode mid-test — the cached validator must be
+        // rebuilt with the new (empty) skip set so the next call fails loud.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.skip_request_validation_response_codes'] = [];
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('OpenAPI request validation failed');
+
+        $this->maybeAutoValidateOpenApiRequest(
+            $this->makeJsonRequest('POST', '/exact-422', []),
+            HttpMethod::POST,
+            '/exact-422',
+            422,
+        );
+    }
+
+    #[Test]
     public function backward_compat_call_without_response_status_still_works(): void
     {
         // Direct callers (test harnesses, framework adapters not yet

--- a/tests/Unit/Validation/Support/SpecResponseKeyResolverTest.php
+++ b/tests/Unit/Validation/Support/SpecResponseKeyResolverTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Validation\Support;
+
+use const E_USER_WARNING;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Validation\Support\SpecResponseKeyResolver;
+
+use function restore_error_handler;
+use function set_error_handler;
+
+class SpecResponseKeyResolverTest extends TestCase
+{
+    #[Test]
+    public function resolve_returns_exact_match_when_present(): void
+    {
+        $responses = ['200' => [], '5XX' => [], 'default' => []];
+        $key = SpecResponseKeyResolver::resolve('200', $responses);
+
+        $this->assertSame('200', $key);
+    }
+
+    #[Test]
+    public function resolve_prefers_exact_over_range_and_default(): void
+    {
+        // Spec has both `503` (literal) and `5XX` (range). Exact wins.
+        $responses = ['503' => [], '5XX' => [], 'default' => []];
+        $key = SpecResponseKeyResolver::resolve('503', $responses);
+
+        $this->assertSame('503', $key);
+    }
+
+    #[Test]
+    public function resolve_uppercase_range_key_matches(): void
+    {
+        $responses = ['200' => [], '5XX' => []];
+        $key = SpecResponseKeyResolver::resolve('503', $responses);
+
+        $this->assertSame('5XX', $key);
+    }
+
+    #[Test]
+    public function resolve_lowercase_range_key_matches(): void
+    {
+        // OpenAPI examples use uppercase but lowercase is a tolerated convention.
+        $responses = ['200' => [], '5xx' => []];
+        $key = SpecResponseKeyResolver::resolve('503', $responses);
+
+        $this->assertSame('5xx', $key);
+    }
+
+    #[Test]
+    public function resolve_rejects_mixed_case_range_key(): void
+    {
+        // `5Xx` is neither uppercase XX nor lowercase xx — explicitly rejected
+        // so spec-author typos that look like range keys can't silently match.
+        $responses = ['200' => [], '5Xx' => []];
+        $key = SpecResponseKeyResolver::resolve('503', $responses);
+
+        $this->assertNull($key);
+    }
+
+    #[Test]
+    public function resolve_falls_back_to_default(): void
+    {
+        $responses = ['200' => [], 'default' => []];
+        $key = SpecResponseKeyResolver::resolve('418', $responses);
+
+        $this->assertSame('default', $key);
+    }
+
+    #[Test]
+    public function resolve_returns_null_when_nothing_matches(): void
+    {
+        $responses = ['200' => [], '500' => []];
+        $key = SpecResponseKeyResolver::resolve('418', $responses);
+
+        $this->assertNull($key);
+    }
+
+    #[Test]
+    public function resolve_returns_null_for_empty_responses(): void
+    {
+        $this->assertNull(SpecResponseKeyResolver::resolve('200', []));
+    }
+
+    #[Test]
+    public function resolve_handles_numeric_string_keys_after_php_coercion(): void
+    {
+        // PHP coerces numeric string keys ("200") to int (200) when used as
+        // array keys. The resolver casts back to string before regex tests so
+        // the matched key is still a string in the return value.
+        $responses = ['200' => [], '404' => []];
+        $key = SpecResponseKeyResolver::resolve('404', $responses);
+
+        $this->assertSame('404', $key);
+    }
+
+    #[Test]
+    public function warn_suspicious_keys_emits_warning_for_typo_alongside_default(): void
+    {
+        $captured = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$captured): bool {
+            if ($errno === E_USER_WARNING) {
+                $captured[] = $errstr;
+
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            /** @var array<string, mixed> $responses */
+            $responses = ['200' => [], '40' => [], 'default' => []];
+            SpecResponseKeyResolver::warnSuspiciousKeys('fixture', 'GET', '/widgets', $responses);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertCount(1, $captured, 'one warning per non-conforming key');
+        $this->assertStringContainsString("'40'", $captured[0]);
+        $this->assertStringContainsString("falling back to 'default'", $captured[0]);
+    }
+
+    #[Test]
+    public function warn_suspicious_keys_skips_valid_status_range_and_default_keys(): void
+    {
+        $captured = [];
+        set_error_handler(static function (int $errno) use (&$captured): bool {
+            $captured[] = $errno;
+
+            return $errno === E_USER_WARNING;
+        });
+
+        try {
+            /** @var array<string, mixed> $responses */
+            $responses = ['200' => [], '5XX' => [], '4xx' => [], 'default' => []];
+            SpecResponseKeyResolver::warnSuspiciousKeys('fixture', 'GET', '/widgets', $responses);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $captured, 'no warnings for valid keys');
+    }
+}

--- a/tests/Unit/Validation/Support/StatusCodePatternSetTest.php
+++ b/tests/Unit/Validation/Support/StatusCodePatternSetTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Validation\Support;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Validation\Support\StatusCodePatternSet;
+
+class StatusCodePatternSetTest extends TestCase
+{
+    #[Test]
+    public function empty_set_matches_nothing_and_reports_empty(): void
+    {
+        $set = new StatusCodePatternSet([], 'someConfig');
+
+        $this->assertTrue($set->isEmpty());
+        $this->assertNull($set->match('200'));
+    }
+
+    #[Test]
+    public function literal_pattern_matches_exact_status(): void
+    {
+        $set = new StatusCodePatternSet(['422'], 'someConfig');
+
+        $this->assertSame('422', $set->match('422'));
+        $this->assertNull($set->match('400'));
+        $this->assertNull($set->match('4220'));
+        $this->assertNull($set->match('042'));
+    }
+
+    #[Test]
+    public function regex_pattern_matches_status_range(): void
+    {
+        $set = new StatusCodePatternSet(['5\d\d'], 'someConfig');
+
+        $this->assertSame('5\d\d', $set->match('500'));
+        $this->assertSame('5\d\d', $set->match('599'));
+        $this->assertNull($set->match('499'));
+        $this->assertNull($set->match('600'));
+    }
+
+    #[Test]
+    public function match_returns_first_matching_pattern_in_insertion_order(): void
+    {
+        // Both `4\d\d` and `422` match status 422; insertion order pins
+        // which raw pattern is echoed back. The skipReason output relies on
+        // this — the user-typed pattern shows up verbatim in diagnostics.
+        $set = new StatusCodePatternSet(['4\d\d', '422'], 'someConfig');
+
+        $this->assertSame('4\d\d', $set->match('422'));
+    }
+
+    #[Test]
+    public function match_returns_string_even_for_numeric_string_pattern(): void
+    {
+        // PHP coerces numeric-string array keys ("500") to int when used as
+        // array keys. The wrapper casts back to string so the documented
+        // `?string` return type is honoured.
+        $set = new StatusCodePatternSet(['500'], 'someConfig');
+
+        $matched = $set->match('500');
+        $this->assertIsString($matched);
+        $this->assertSame('500', $matched);
+    }
+
+    #[Test]
+    public function constructor_rejects_empty_string_pattern(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('skipResponseCodes[0] must not be an empty string.');
+
+        new StatusCodePatternSet([''], 'skipResponseCodes');
+    }
+
+    #[Test]
+    public function constructor_rejects_unparseable_pattern(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/skipResponseCodes\[0\] is not a valid regex pattern "\(unclosed":/');
+
+        new StatusCodePatternSet(['(unclosed'], 'skipResponseCodes');
+    }
+
+    #[Test]
+    public function configurable_label_appears_in_error_messages(): void
+    {
+        // `$configLabel` is plumbed through error messages so users see
+        // which config key (response- vs request-side) needs fixing.
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('skipRequestValidationResponseCodes[1] must not be an empty string.');
+
+        new StatusCodePatternSet(['422', ''], 'skipRequestValidationResponseCodes');
+    }
+}

--- a/tests/fixtures/specs/request-validation-skip.json
+++ b/tests/fixtures/specs/request-validation-skip.json
@@ -1,0 +1,149 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Request Validation Skip Fixture",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/exact-422": {
+      "post": {
+        "operationId": "exact422",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": {"type": "string"}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {"type": "object"}
+              }
+            }
+          },
+          "422": {
+            "description": "Documented validation error",
+            "content": {
+              "application/json": {
+                "schema": {"type": "object"}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/4xx-range": {
+      "post": {
+        "operationId": "fourXxRange",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": {"type": "string"}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {"type": "object"}
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error range",
+            "content": {
+              "application/json": {
+                "schema": {"type": "object"}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/only-default": {
+      "post": {
+        "operationId": "onlyDefault",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": {"type": "string"}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "Anything",
+            "content": {
+              "application/json": {
+                "schema": {"type": "object"}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/no-4xx": {
+      "post": {
+        "operationId": "no4xx",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": {"type": "string"}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {"type": "object"}
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {"type": "object"}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `skip_request_validation_response_codes` (default `['422', '400']`) symmetric to the existing `skip_response_codes`. When `auto_validate_request: true` is on AND the response status matches one of these patterns AND the spec documents that status for the matched operation, the request-validation Failure is downgraded to Skipped — so dataProvider tests that send intentionally-invalid input to verify documented 4xx behaviour stop false-failing. Undocumented 4xx still fails (real spec gap); successful requests are never demoted.

Lifts response-key resolution and skip-pattern compilation into shared `@internal` helpers under `Validation/Support/` so both validators share the lookup. Response-side public behaviour (including the suspicious-response-key warning and every error-message string) is preserved byte-for-byte. Coverage tracking gains an optional `requestSkipReason` per endpoint; the wire format stays at version 1 (older paratest sidecars still import cleanly with the new field defaulting to null).

## Why

Fixes #179. studio-design/studio-api PR #6617 hit 100+ false-fails when flipping `auto_validate_request: true` because invalid-input → 4xx tests are core to validating server-side input handling. Per-call `withoutRequestValidation()` does not scale across hundreds of dataProvider cases. Downgrading documented 4xx responses removes the friction without weakening contract enforcement (undocumented 4xx still fail loudly).

## Verification

`composer ci` (cs-check + stan level 6 + 1309 tests) passes locally on PHP 8.4. Failing-test-first TDD: 9 new request-validator unit tests, 7 trait-level tests, 4 coverage-tracker tests, 2 state-serialization tests cover the documented-4xx, undocumented-4xx, range-key (`4XX`), default-fallback, BC (no responseStatusCode), opt-out (empty config), and pattern-validation paths. Tests fail RED on `main` and turn GREEN with the implementation.

- [x] `composer test` passes (1309 tests, 3128 assertions)
- [x] `composer stan` passes (PHPStan level 6)
- [x] `composer cs-check` passes

## Notes for reviewers

- **Default ON `['422', '400']`**: opted-in users (`auto_validate_request: true`) get the rescue automatically. Users who want strict request validation set `skip_request_validation_response_codes => []`.
- **Fixture choice**: added `tests/fixtures/specs/request-validation-skip.json` with four operations covering exact-422, `4XX` range, `default`-only, and no-4xx-documented to keep test cases self-explanatory. Existing fixtures (petstore-3.0, range-keys) document only response-side ranges, not the matrix of 4xx documentation cases needed here.
- **Helpers in `Validation/Support/`**: extracted `SpecResponseKeyResolver` and `StatusCodePatternSet` rather than making the response-side privates public. Both are `@internal` so they stay outside the v1 SemVer surface and can evolve. The response-side `warnSuspiciousResponseKeys` stays in `OpenApiResponseValidator` so the request side does not double-emit when both validators run on the same spec.
- **Coverage state version**: kept at 1. Adding `requestSkipReason` is strictly additive on the wire — the importer treats a missing key as null. No paratest sidecar churn for users upgrading.
- **Out of scope** (deferred to follow-ups): per-test `#[ExpectsClientErrorResponse]` attribute (issue 案 B), a per-call `skipRequestValidationResponseCode()` fluent helper, and surfacing `requestSkipReason` in console / Markdown coverage renderers (state stores the field, render is a separate change).