### PR TITLE
ci(release-please): use GitHub App token to trigger required checks

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,16 +5,22 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release-please:
     name: Release please
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
+        with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

Switch the release-please workflow from the default `GITHUB_TOKEN` to a GitHub App token so the PRs it opens fire downstream `pull_request` workflows. Without this, the 12 required CI checks stay stuck on "Expected — Waiting for status to be reported" and release PRs are unmergeable.

## Why

GitHub intentionally suppresses workflow triggers for events caused by the default `GITHUB_TOKEN` (recursion guard — see [docs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow)). Using a GitHub App token (or PAT) restores normal event firing. The same App token pattern is already in use in `studio-auth`'s release-please workflow.

## Changes

- Add `actions/create-github-app-token@v3` step using `secrets.CI_APP_ID` / `secrets.CI_APP_PRIVATE_KEY` (org-level secrets, already present)
- Pass the generated token to `googleapis/release-please-action` via `token:`
- Bump `release-please-action` v4 → v5 (only breaking change: node24 runtime — `ubuntu-latest` already has it)
- Tighten workflow `permissions:` to `{}` since the App token now carries the required `contents: write` / `pull-requests: write` scopes
- Both actions are SHA-pinned (matching studio-auth's hardening style)

## Verification

- The current open release-please PR (#181) was opened before this change and will not retroactively get CI runs. release-please will regenerate the PR on the next `main` push, at which point the 12 required checks should run automatically.

## Related

- Mirrors the workflow in `studio-design/studio-auth` (`.github/workflows/release-please.yml`)