### PR TITLE
revert: ci(release-please): use GitHub App token to trigger required checks (#183)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,22 +5,16 @@ on:
     branches:
       - main
 
-permissions: {}
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   release-please:
     name: Release please
     runs-on: ubuntu-latest
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+      - uses: googleapis/release-please-action@v4
         with:
-          app-id: ${{ secrets.CI_APP_ID }}
-          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
-
-      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
-        with:
-          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

Reverts #183. Restores the release-please workflow to the default `GITHUB_TOKEN` flow so version tags / GitHub Releases get created again.

## Why

PR #183 changed `release-please.yml` to authenticate via a GitHub App token (`secrets.CI_APP_ID` / `secrets.CI_APP_PRIVATE_KEY`). Those secrets are **not configured** in this repository, so every release-please workflow run since #183 merged has failed at the "Generate GitHub App token" step:

```
Error: The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string.
```

The most visible symptom: the release PR #181 (`chore(main): release 1.3.0`) merged successfully — main was bumped to `1.3.0` in `.release-please-manifest.json` and `CHANGELOG.md` — but the post-merge release-please run failed, so **no `v1.3.0` git tag and no GitHub Release were ever created**.

## After this PR merges

Releases will be created by release-please using the default `GITHUB_TOKEN` again, which restores the v0.x → v1.2.0 working state.

There are two leftover items to handle separately:

1. **v1.3.0 tag/release**: main is already at 1.3.0 but the tag is missing. We may need to either (a) create `v1.3.0` manually at `5bcc094` (the release-please merge commit), or (b) let release-please open a fresh release PR. I'll handle this as a follow-up depending on what release-please does after this PR lands.
2. **The original problem #183 was solving** (status checks not retriggered when release-please merges its own PR) is back. To re-address it, we need to provision `CI_APP_ID` / `CI_APP_PRIVATE_KEY` first, then re-apply the App-token approach in a follow-up PR.

## Test plan

- [x] `release-please.yml` matches the pre-#183 content (default token, no App token step)
- [ ] CI passes on this PR
- [ ] After merge: confirm release-please workflow runs successfully on the push to main