### PR TITLE
feat(phpunit): add AssertsNoEnumDrift trait for PHPUnit-aware enum drift assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,6 +735,44 @@ EnumDriftAsserter::assertNoDrift([NotificationCodeEnum::class], failOnDrift: fal
 
 The asserter then fires one `E_USER_WARNING` containing the full drift report (every drifting binding aggregated into a single message) instead of throwing — `failOnWarning="true"` in `phpunit.xml` will still fail the run, but explicit warning suppressors will not. For programmatic access without the global error channel, use `detectAll()` (see below) and inspect the returned `EnumDriftReport[]` directly.
 
+### `AssertsNoEnumDrift` — PHPUnit trait
+
+`EnumDriftAsserter::assertNoDrift()` works on a throw-on-failure / return-void-on-success contract, so PHPUnit never sees the call as a real assertion. Under PHPUnit 13's default `beStrictAboutTestsThatDoNotTestAnything=true`, drift tests that pass get flagged risky:
+
+```
+There was 1 risky test:
+1) Tests\Unit\EnumDriftTest::no_drift
+This test did not perform any assertions
+```
+
+The `AssertsNoEnumDrift` trait wraps the same comparison and bumps PHPUnit's assertion counter on success — drop it into any `TestCase`:
+
+```php
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\PHPUnit\AssertsNoEnumDrift;
+
+class EnumDriftTest extends TestCase
+{
+    use AssertsNoEnumDrift;
+
+    #[Test]
+    public function no_drift(): void
+    {
+        $this->assertNoEnumDrift([
+            \App\Enums\StatusEnum::class,
+            \App\Enums\RoleEnum::class,
+        ]);
+    }
+}
+```
+
+Failures throw `PHPUnit\Framework\AssertionFailedError` with the same `[OpenAPI Enum Drift] FATAL` block as the static asserter, routed through `Assert::fail()` so PHPUnit's diff-aware reporter picks it up. Stack frames inside this library are filtered out so the failure points at the consumer's test line.
+
+Misconfiguration (`EnumBindingException` — missing `#[BoundToOpenApiEnum]`, spec file not found, malformed JSON, etc.) is **not** wrapped — it bubbles unchanged so the structured `$reason`/`$enumFqcn`/`$specPath` properties stay accessible to downstream tooling.
+
+The static `EnumDriftAsserter::assertNoDrift()` is unchanged. Non-PHPUnit consumers (dedicated drift CI scripts that catch `EnumDriftException` directly) keep working as before.
+
 ### `detectAll()` — inspection without throwing
 
 For dashboards or custom CI summaries that need every report (clean and drifting):

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -35,3 +35,14 @@ parameters:
         # SkipOpenApiResolver and OpenApiSpecResolver call it to resolve the
         # current test method name for attribute lookup.
         - '#Call to internal method PHPUnit\\Framework\\TestCase::name\(\)#'
+        # `TestCase::numberOfAssertionsPerformed()` is PHPUnit's public-but-
+        # @internal-tagged accessor for the in-test assertion counter. We use
+        # it in AssertsNoEnumDriftTest to pin the trait's "increment by 1 per
+        # call" contract — there is no public replacement.
+        - '#Call to internal method PHPUnit\\Framework\\TestCase::numberOfAssertionsPerformed\(\)#'
+        # `TestCase::addToAssertionCount()` is the documented hook for
+        # framework-level helpers (PHPUnit's own ValidatesOpenApiSchema-style
+        # traits, Pest's expectation API) to register assertions performed via
+        # custom paths. Marked @internal upstream but no replacement exists.
+        # AssertsNoEnumDrift uses it for exactly this purpose.
+        - '#Call to internal method PHPUnit\\Framework\\TestCase::addToAssertionCount\(\)#'

--- a/src/Internal/StackTraceFilter.php
+++ b/src/Internal/StackTraceFilter.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Studio\OpenApiContractTesting\Laravel\Internal;
+namespace Studio\OpenApiContractTesting\Internal;
 
 use Error;
 use Exception;
@@ -10,7 +10,6 @@ use PHPUnit\Framework\AssertionFailedError;
 use ReflectionException;
 use ReflectionProperty;
 
-use function array_values;
 use function is_string;
 use function str_contains;
 use function str_replace;
@@ -120,7 +119,7 @@ final class StackTraceFilter
             }
         }
 
-        return array_values($kept);
+        return $kept;
     }
 
     private static function traceProperty(): ReflectionProperty

--- a/src/Internal/StackTraceFilter.php
+++ b/src/Internal/StackTraceFilter.php
@@ -15,9 +15,11 @@ use function str_contains;
 use function str_replace;
 
 /**
- * Trims this library's own + Laravel test-concern frames out of an
- * assertion-failure trace so a contract-test failure points at the
- * user's test line, not at vendor code.
+ * Trims this library's own frames (and known framework testing-concern
+ * frames) out of an assertion-failure trace so a contract-test failure
+ * points at the user's test line, not at vendor code. Consumed by the
+ * Laravel traits (`ValidatesOpenApiSchema`, `ExploresOpenApiEndpoint`)
+ * and the PHPUnit trait (`AssertsNoEnumDrift`).
  *
  * @internal Not part of the package's public API. Do not use from user code.
  */
@@ -25,13 +27,14 @@ final class StackTraceFilter
 {
     /**
      * Frame `file` substrings (forward-slash form) that mark frames as
-     * library/framework noise and should be dropped from the trace.
+     * library/framework noise and should be dropped from the trace. Each
+     * `/openapi-contract-testing/src/<Subdir>/` entry covers path-repo /
+     * monorepo dev installs where the vendor prefix is absent; the list
+     * mirrors the actual source subdirectories below.
      *
-     * - `studio-design/openapi-contract-testing/src/` covers the composer-installed location.
-     * - `openapi-contract-testing/src/Laravel/`, `…/src/Internal/`, `…/src/PHPUnit/`
-     *   cover path-repo / monorepo dev installs where the vendor prefix is absent.
-     * - The two Laravel entries cover the testing concerns that always sit
-     *   between the trait hook and the user test method.
+     * The two `Illuminate/` entries cover the Laravel testing concerns
+     * that sit between a Laravel trait's hook and the user test method;
+     * they are inert (no-op) on the PHPUnit-only `AssertsNoEnumDrift` path.
      *
      * PHPUnit's own internal frames (Assert, Constraint, TestCase) are
      * filtered by PHPUnit's stack-trace formatter when the default result

--- a/src/Laravel/ExploresOpenApiEndpoint.php
+++ b/src/Laravel/ExploresOpenApiEndpoint.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\AssertionFailedError;
 use RuntimeException;
 use Studio\OpenApiContractTesting\Fuzz\ExplorationCases;
 use Studio\OpenApiContractTesting\Fuzz\OpenApiEndpointExplorer;
-use Studio\OpenApiContractTesting\Laravel\Internal\StackTraceFilter;
+use Studio\OpenApiContractTesting\Internal\StackTraceFilter;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecResolver;
 
 use function is_string;

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -19,7 +19,7 @@ use RuntimeException;
 use Studio\OpenApiContractTesting\Attribute\SkipOpenApi;
 use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\HttpMethod;
-use Studio\OpenApiContractTesting\Laravel\Internal\StackTraceFilter;
+use Studio\OpenApiContractTesting\Internal\StackTraceFilter;
 use Studio\OpenApiContractTesting\OpenApiRequestValidator;
 use Studio\OpenApiContractTesting\OpenApiResponseValidator;
 use Studio\OpenApiContractTesting\SkipOpenApiResolver;

--- a/src/PHPUnit/AssertsNoEnumDrift.php
+++ b/src/PHPUnit/AssertsNoEnumDrift.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\PHPUnit;
+
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\AssertionFailedError;
+use Studio\OpenApiContractTesting\Internal\StackTraceFilter;
+use Studio\OpenApiContractTesting\Schema\EnumDriftAsserter;
+use Studio\OpenApiContractTesting\Schema\EnumDriftReport;
+
+use function array_filter;
+use function array_values;
+
+/**
+ * PHPUnit-aware shim over {@see EnumDriftAsserter}.
+ *
+ * `EnumDriftAsserter::assertNoDrift()` is framework-agnostic — it throws on
+ * failure and returns void on success, which means PHPUnit's bookkeeping
+ * never sees it and tests that "passed" get marked risky under
+ * `beStrictAboutTestsThatDoNotTestAnything=true` (PHPUnit 13 default).
+ *
+ * This trait wraps the same comparison through `Assert::fail()` and bumps
+ * the assertion counter so passing drift tests stay green. The static
+ * `assertNoDrift()` API is unchanged; non-PHPUnit drift CI scripts can
+ * keep using it.
+ *
+ * Misconfiguration (`EnumBindingException`) is intentionally NOT routed
+ * through `Assert::fail()` — a missing `#[BoundToOpenApiEnum]` or
+ * unreadable spec file is a setup error, not a drift signal, and callers
+ * want the structured exception properties (`$reason`, `$enumFqcn`,
+ * `$specPath`) preserved.
+ */
+trait AssertsNoEnumDrift
+{
+    /**
+     * @param list<class-string> $enumFqcns
+     */
+    public function assertNoEnumDrift(array $enumFqcns): void
+    {
+        $reports = EnumDriftAsserter::detectAll($enumFqcns);
+        $drifting = array_values(array_filter(
+            $reports,
+            static fn(EnumDriftReport $report): bool => $report->hasDrift(),
+        ));
+
+        if ($drifting === []) {
+            $this->addToAssertionCount(1);
+
+            return;
+        }
+
+        try {
+            Assert::fail(EnumDriftAsserter::renderMessage($drifting, failOnDrift: true));
+        } catch (AssertionFailedError $e) {
+            StackTraceFilter::rethrowWithCleanTrace($e);
+        }
+    }
+}

--- a/src/PHPUnit/AssertsNoEnumDrift.php
+++ b/src/PHPUnit/AssertsNoEnumDrift.php
@@ -18,8 +18,9 @@ use function array_values;
  *
  * `EnumDriftAsserter::assertNoDrift()` is framework-agnostic — it throws on
  * failure and returns void on success, which means PHPUnit's bookkeeping
- * never sees it and tests that "passed" get marked risky under
- * `beStrictAboutTestsThatDoNotTestAnything=true` (PHPUnit 13 default).
+ * never sees it and tests that "passed" get marked risky whenever
+ * `beStrictAboutTestsThatDoNotTestAnything=true` (the PHPUnit 13 default;
+ * opt-in on earlier majors).
  *
  * This trait wraps the same comparison through `Assert::fail()` and bumps
  * the assertion counter so passing drift tests stay green. The static

--- a/tests/Unit/Internal/StackTraceFilterTest.php
+++ b/tests/Unit/Internal/StackTraceFilterTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Studio\OpenApiContractTesting\Tests\Unit\Laravel\Internal;
+namespace Studio\OpenApiContractTesting\Tests\Unit\Internal;
 
 use Exception;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
-use Studio\OpenApiContractTesting\Laravel\Internal\StackTraceFilter;
+use Studio\OpenApiContractTesting\Internal\StackTraceFilter;
 
 use function array_column;
 use function array_keys;

--- a/tests/Unit/PHPUnit/AssertsNoEnumDriftTest.php
+++ b/tests/Unit/PHPUnit/AssertsNoEnumDriftTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\PHPUnit;
+
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Exception\EnumBindingException;
+use Studio\OpenApiContractTesting\Exception\EnumBindingReason;
+use Studio\OpenApiContractTesting\PHPUnit\AssertsNoEnumDrift;
+use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\Tests\Unit\Schema\Fixture\MatchingEnum;
+use Studio\OpenApiContractTesting\Tests\Unit\Schema\Fixture\NotAnEnum;
+use Studio\OpenApiContractTesting\Tests\Unit\Schema\Fixture\PhpExtraEnum;
+use Studio\OpenApiContractTesting\Tests\Unit\Schema\Fixture\SpecExtraEnum;
+
+use function array_column;
+use function str_contains;
+use function str_replace;
+
+class AssertsNoEnumDriftTest extends TestCase
+{
+    use AssertsNoEnumDrift;
+
+    private const SPEC_BASE_PATH = __DIR__ . '/../../fixtures/specs';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(self::SPEC_BASE_PATH);
+    }
+
+    protected function tearDown(): void
+    {
+        OpenApiSpecLoader::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function clean_enum_increments_assertion_count_by_one(): void
+    {
+        $before = $this->numberOfAssertionsPerformed();
+
+        $this->assertNoEnumDrift([MatchingEnum::class]);
+
+        // Exactly one assertion was credited — that is the whole point of
+        // the trait. The follow-up assertSame() does NOT skew the delta
+        // because we capture both anchor values before it executes.
+        $after = $this->numberOfAssertionsPerformed();
+        $this->assertSame($before + 1, $after);
+    }
+
+    #[Test]
+    public function clean_input_with_multiple_enums_still_credits_one_assertion(): void
+    {
+        // The trait's contract is "one logical assertion per call",
+        // not "one per enum checked". This pins that decision so a future
+        // refactor cannot drift it without an explicit test change.
+        $before = $this->numberOfAssertionsPerformed();
+
+        $this->assertNoEnumDrift([MatchingEnum::class, MatchingEnum::class]);
+
+        $after = $this->numberOfAssertionsPerformed();
+        $this->assertSame($before + 1, $after);
+    }
+
+    #[Test]
+    public function php_only_drift_fails_with_assertion_failed_error(): void
+    {
+        try {
+            $this->assertNoEnumDrift([PhpExtraEnum::class]);
+            $this->fail('expected AssertionFailedError');
+        } catch (AssertionFailedError $e) {
+            $message = $e->getMessage();
+            $this->assertStringContainsString('[OpenAPI Enum Drift] FATAL', $message);
+            $this->assertStringContainsString('1 enum binding(s) drift', $message);
+            $this->assertStringContainsString('PHP-only', $message);
+            $this->assertStringContainsString('blue', $message);
+        }
+    }
+
+    #[Test]
+    public function spec_only_drift_fails_with_assertion_failed_error(): void
+    {
+        try {
+            $this->assertNoEnumDrift([SpecExtraEnum::class]);
+            $this->fail('expected AssertionFailedError');
+        } catch (AssertionFailedError $e) {
+            $message = $e->getMessage();
+            $this->assertStringContainsString('Spec-only', $message);
+            $this->assertStringContainsString('yellow', $message);
+        }
+    }
+
+    #[Test]
+    public function mixed_input_reports_only_drifting_enums(): void
+    {
+        try {
+            $this->assertNoEnumDrift([MatchingEnum::class, PhpExtraEnum::class]);
+            $this->fail('expected AssertionFailedError');
+        } catch (AssertionFailedError $e) {
+            $message = $e->getMessage();
+            // Only the drifting enum should appear in the rendered block —
+            // clean enums are filtered out so the diagnostic stays signal-only.
+            $this->assertStringContainsString('1 enum binding(s) drift', $message);
+            $this->assertStringContainsString(PhpExtraEnum::class, $message);
+            $this->assertStringNotContainsString(MatchingEnum::class, $message);
+        }
+    }
+
+    #[Test]
+    public function misconfigured_enum_bubbles_enum_binding_exception(): void
+    {
+        // Misconfiguration is a setup error, not a drift assertion failure.
+        // The trait must NOT wrap this in an AssertionFailedError — letting
+        // EnumBindingException propagate preserves the structured $reason +
+        // $enumFqcn properties that downstream tooling relies on.
+        try {
+            $this->assertNoEnumDrift([NotAnEnum::class]);
+            $this->fail('expected EnumBindingException');
+        } catch (EnumBindingException $e) {
+            $this->assertSame(EnumBindingReason::TargetIsNotEnum, $e->reason);
+            $this->assertSame(NotAnEnum::class, $e->enumFqcn);
+        }
+    }
+
+    #[Test]
+    public function failure_trace_strips_library_frames(): void
+    {
+        // The trait routes failures through StackTraceFilter so consumers
+        // see their own test line at the top of the trace rather than this
+        // library's internals. Verify the trait's own file is not in the
+        // filtered frames.
+        try {
+            $this->assertNoEnumDrift([PhpExtraEnum::class]);
+            $this->fail('expected AssertionFailedError');
+        } catch (AssertionFailedError $e) {
+            $files = array_column($e->getTrace(), 'file');
+            foreach ($files as $file) {
+                $normalized = str_replace('\\', '/', $file);
+                $this->assertFalse(
+                    str_contains($normalized, '/src/PHPUnit/AssertsNoEnumDrift.php'),
+                    'StackTraceFilter should drop frames inside the trait file, got: ' . $normalized,
+                );
+            }
+        }
+    }
+}

--- a/tests/Unit/PHPUnit/AssertsNoEnumDriftTest.php
+++ b/tests/Unit/PHPUnit/AssertsNoEnumDriftTest.php
@@ -11,6 +11,7 @@ use Studio\OpenApiContractTesting\Exception\EnumBindingException;
 use Studio\OpenApiContractTesting\Exception\EnumBindingReason;
 use Studio\OpenApiContractTesting\PHPUnit\AssertsNoEnumDrift;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\Tests\Unit\Schema\Fixture\IntegerBackedEnum;
 use Studio\OpenApiContractTesting\Tests\Unit\Schema\Fixture\MatchingEnum;
 use Studio\OpenApiContractTesting\Tests\Unit\Schema\Fixture\NotAnEnum;
 use Studio\OpenApiContractTesting\Tests\Unit\Schema\Fixture\PhpExtraEnum;
@@ -57,14 +58,31 @@ class AssertsNoEnumDriftTest extends TestCase
     public function clean_input_with_multiple_enums_still_credits_one_assertion(): void
     {
         // The trait's contract is "one logical assertion per call",
-        // not "one per enum checked". This pins that decision so a future
-        // refactor cannot drift it without an explicit test change.
+        // not "one per enum checked". Two distinct clean fixtures pin
+        // that decision so a future refactor (per-enum counting, fqcn
+        // deduplication, etc.) cannot drift it without an explicit
+        // test change.
         $before = $this->numberOfAssertionsPerformed();
 
-        $this->assertNoEnumDrift([MatchingEnum::class, MatchingEnum::class]);
+        $this->assertNoEnumDrift([MatchingEnum::class, IntegerBackedEnum::class]);
 
         $after = $this->numberOfAssertionsPerformed();
         $this->assertSame($before + 1, $after);
+    }
+
+    #[Test]
+    public function two_consecutive_calls_each_credit_an_assertion(): void
+    {
+        // Fan-in counterpart to the multi-enum test: two separate calls
+        // must each increment the counter, so a future memoization /
+        // short-circuit on subsequent invocations would be caught.
+        $before = $this->numberOfAssertionsPerformed();
+
+        $this->assertNoEnumDrift([MatchingEnum::class]);
+        $this->assertNoEnumDrift([IntegerBackedEnum::class]);
+
+        $after = $this->numberOfAssertionsPerformed();
+        $this->assertSame($before + 2, $after);
     }
 
     #[Test]
@@ -138,6 +156,13 @@ class AssertsNoEnumDriftTest extends TestCase
             $this->assertNoEnumDrift([PhpExtraEnum::class]);
             $this->fail('expected AssertionFailedError');
         } catch (AssertionFailedError $e) {
+            // Disambiguate from the inner $this->fail() sentinel: if a
+            // future regression makes assertNoEnumDrift silently return,
+            // the sentinel would still throw and pass an unrelated trace
+            // through every check below. Insist on the rendered drift
+            // block first.
+            $this->assertStringContainsString('[OpenAPI Enum Drift]', $e->getMessage());
+
             $files = array_column($e->getTrace(), 'file');
             foreach ($files as $file) {
                 $normalized = str_replace('\\', '/', $file);

--- a/tests/Unit/ValidatesOpenApiSchemaStackTraceTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaStackTraceTest.php
@@ -41,7 +41,8 @@ class ValidatesOpenApiSchemaStackTraceTest extends TestCase
         ];
 
         $traitFile = (new ReflectionClass(ValidatesOpenApiSchema::class))->getFileName();
-        // The trait + the StackTraceFilter helper both sit under src/Laravel/.
+        // The trait sits under src/Laravel/ — its directory is the only one
+        // we need to detect for "library frames" in this Laravel-specific test.
         // Deriving the directory at runtime keeps the assertions robust against
         // CI checkout paths that don't happen to contain the literal string
         // "/openapi-contract-testing/src/Laravel/".


### PR DESCRIPTION
## Summary

Adds `Studio\OpenApiContractTesting\PHPUnit\AssertsNoEnumDrift` — a PHPUnit trait that wraps `EnumDriftAsserter` so enum-drift tests integrate with PHPUnit's assertion counting and stop getting flagged risky under PHPUnit 13's strict mode.

Also moves the `@internal` `StackTraceFilter` helper from `src/Laravel/Internal/` to `src/Internal/` so the new PHPUnit-namespaced trait does not have to import from a Laravel-namespaced internal helper. The class already listed the new path in its own `DROP_PATTERNS`.

## Why

Fixes #185.

`EnumDriftAsserter::assertNoDrift()` is framework-agnostic — throws on failure, returns void on success — so PHPUnit's bookkeeping never sees it. Under `beStrictAboutTestsThatDoNotTestAnything=true` (PHPUnit 13 default), drift tests that pass get marked risky:

```
There was 1 risky test:
1) Tests\Unit\EnumDriftTest::no_drift
This test did not perform any assertions
```

Consumers currently fall back to one of three workarounds: `expectNotToPerformAssertions()`, manual `addToAssertionCount(1)`, or hand-rolled `detectAll + assertSame`. None are clean.

After this PR:

```php
class EnumDriftTest extends TestCase
{
    use AssertsNoEnumDrift;

    #[Test]
    public function no_drift(): void
    {
        $this->assertNoEnumDrift([StatusEnum::class, RoleEnum::class]);
    }
}
```

The static `EnumDriftAsserter::assertNoDrift()` API is unchanged. Non-PHPUnit drift CI scripts catching `EnumDriftException` directly keep working as before.

## Verification

- TDD: wrote `tests/Unit/PHPUnit/AssertsNoEnumDriftTest.php` first, confirmed they fail with "Trait not found", then implemented the trait.
- Test cases cover the issue's acceptance criteria:
  - clean enum → assertion count increments by 1 (single + multiple-enum inputs)
  - PHP-only drift / Spec-only drift → `AssertionFailedError` with the expected diff message
  - mixed clean + drifting input → only drifting enum appears in the rendered block
  - misconfigured enum → `EnumBindingException` bubbles unchanged (preserves `$reason`/`$enumFqcn`)
  - failure-path stack trace → frames inside `src/PHPUnit/AssertsNoEnumDrift.php` are filtered out
- Verified the moved `StackTraceFilter` + `ValidatesOpenApiSchema` + full Laravel test suite still pass.
- Full suite: 1346 tests, 3213 assertions, all green.

- [x] `composer test` passes
- [x] `composer stan` passes
- [x] `composer cs-check` passes

## Notes for reviewers

- `StackTraceFilter` was `@internal` and its own `DROP_PATTERNS` already covered `/openapi-contract-testing/src/Internal/` (line 48 pre-move) — the move keeps the helper framework-neutral without breaking any documented surface. Both call sites (`ValidatesOpenApiSchema`, `ExploresOpenApiEndpoint`) updated.
- Moving `StackTraceFilter` out of the PHPStan-excluded `src/Laravel/` exposed a pre-existing redundant `array_values()` on a list — fixed inline as part of the move.
- Two PHPStan `ignoreErrors` entries added for `TestCase::numberOfAssertionsPerformed()` (used in the new test to pin the "increment by 1 per call" contract) and `TestCase::addToAssertionCount()` (used in the trait for exactly its documented purpose). Both are `@internal` upstream with no public replacement.
- Trait method's failure path goes through `Assert::fail()` then `StackTraceFilter::rethrowWithCleanTrace()`, matching the pattern used by `ValidatesOpenApiSchema::failOpenApi()`. Misconfiguration is intentionally NOT routed through `Assert::fail()`.