### PR TITLE
feat(pest): implement toMatchOpenApiResponseSchema / toMatchOpenApiRequestSchema

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,17 +17,23 @@ parameters:
         - tests
     excludePaths:
         - src/Laravel
-        # Pest plugin entrypoint references the Pest\Expectation class and the
-        # global `expect()` function, neither of which is available unless the
-        # downstream consumer installs `pestphp/pest`. The static-analysis job
-        # uses the default require-dev (Pest-free), so analysing this file
-        # would surface false positives. The runtime guard inside the file
-        # (function_exists + class_exists check) makes the symbols safe to
-        # reference at load time. The Pest test bootstrap and integration
-        # tests are excluded for the same reason — once PR2 populates them
-        # with `uses(...)`, `it(...)`, `expect(...)` they will reference Pest
-        # globals that PHPStan cannot resolve without Pest installed.
+        # Pest plugin code references Pest classes (`Pest\Expectation`,
+        # `Pest\Support\HigherOrderTapProxy`) and the global `expect()` /
+        # `test()` functions, none of which are available unless the
+        # downstream consumer installs `pestphp/pest`. The static-analysis
+        # job uses the default require-dev (Pest-free), so analysing these
+        # files would surface false positives. The runtime guards
+        # (function_exists + class_exists checks in Autoload.php; trait
+        # method_exists check in Expectations.php) make the symbols safe to
+        # reference at load time. The Pest bootstrap and integration tests
+        # are excluded for the same reason — they reference Pest globals
+        # PHPStan cannot resolve without Pest installed.
+        #
+        # Issue #189 tracks replacing these exclusions with a Pest stub
+        # file so PHPStan can analyse the closure signatures and the
+        # `$this->value` access inside expect()->extend() callbacks.
         - src/Pest/Autoload.php
+        - src/Pest/Expectations.php
         - tests/Pest.php
         - tests/Integration/Pest
         # EnumScanner fixture dir holds intentionally-unused trait/abstract

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -148,19 +148,36 @@ trait ValidatesOpenApiSchema
         ?string $path = null,
         array $extraSkipResponseCodes = [],
     ): void {
-        if ($spec !== null) {
-            $this->withExplicitOpenApiSpec($spec);
+        if ($spec === null) {
+            $this->assertResponseMatchesOpenApiSchema($response, $method, $path, $extraSkipResponseCodes);
+
+            return;
         }
-        $this->assertResponseMatchesOpenApiSchema($response, $method, $path, $extraSkipResponseCodes);
+
+        // try/finally guards against the override leaking into the next
+        // assertion if assertResponseMatchesOpenApiSchema throws BEFORE
+        // resolveOpenApiSpec consumes the override. The resolver also
+        // self-clears on read, so the finally is a no-op on the success
+        // path — it only matters when an early throw catches the override
+        // mid-flight.
+        $this->withExplicitOpenApiSpec($spec);
+
+        try {
+            $this->assertResponseMatchesOpenApiSchema($response, $method, $path, $extraSkipResponseCodes);
+        } finally {
+            $this->withExplicitOpenApiSpec(null);
+        }
     }
 
     /**
      * Public bridge for the Pest expectation `expect($request)->toMatchOpenApiRequestSchema()`.
      * Always runs (bypasses the `auto_validate_request` config gate) because
-     * the user explicitly opted in by writing the expectation. `#[SkipOpenApi]`
-     * is also bypassed for the same reason — the explicit call wins, mirroring
-     * the response-side {@see self::assertResponseMatchesOpenApiSchema()}
-     * convention.
+     * the user explicitly opted in by writing the expectation. The
+     * `#[SkipOpenApi]` attribute is NOT consulted here — the request side has
+     * no auto-vs-explicit advisory pattern to mirror (unlike the response
+     * side, where `assertResponseMatchesOpenApiSchema()` warns when both
+     * signals are present), so silence on the explicit request bridge is
+     * the deliberate behaviour, not a bug.
      *
      * @internal Pest plugin only — see src/Pest/Expectations.php.
      */
@@ -170,10 +187,12 @@ trait ValidatesOpenApiSchema
         ?HttpMethod $method = null,
         ?string $path = null,
     ): void {
-        if ($spec !== null) {
-            $this->withExplicitOpenApiSpec($spec);
-        }
-
+        // Coerce the HTTP method BEFORE setting the explicit spec override.
+        // failOpenApi() throws AssertionFailedError, which a downstream test
+        // can intentionally catch (`expect(static fn () => ...)->toThrow(...)`).
+        // If the override were already set, the leak would carry into the
+        // next assertion in the same test method — exactly the invariant
+        // the resolver's single-shot consumption is meant to prevent.
         $resolvedMethod = $method ?? HttpMethod::tryFrom(strtoupper($request->getMethod()));
         if ($resolvedMethod === null) {
             $this->failOpenApi(sprintf(
@@ -184,7 +203,23 @@ trait ValidatesOpenApiSchema
             ));
         }
 
-        $this->runRequestAssertion($request, $resolvedMethod, $path, null);
+        if ($spec === null) {
+            $this->runRequestAssertion($request, $resolvedMethod, $path, null);
+
+            return;
+        }
+
+        // Same try/finally rationale as runOpenApiResponseAssertion above —
+        // protects the override against an early throw in runRequestAssertion
+        // (e.g. failOpenApi from an empty spec name) that would otherwise
+        // leak into the next assertion in the same test method.
+        $this->withExplicitOpenApiSpec($spec);
+
+        try {
+            $this->runRequestAssertion($request, $resolvedMethod, $path, null);
+        } finally {
+            $this->withExplicitOpenApiSpec(null);
+        }
     }
 
     /**

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -33,10 +33,12 @@ use Symfony\Component\HttpFoundation\Response;
 use WeakMap;
 
 use function array_key_first;
+use function array_map;
 use function array_merge;
 use function filter_var;
 use function fwrite;
 use function get_debug_type;
+use function implode;
 use function is_array;
 use function is_int;
 use function is_numeric;
@@ -126,6 +128,63 @@ trait ValidatesOpenApiSchema
         self::$cachedSkipRequestValidationResponseCodes = null;
         self::$cachedSecuritySchemeIntrospector = null;
         self::$validatedResponses = null;
+    }
+
+    /**
+     * Public bridge for the Pest expectation `expect($response)->toMatchOpenApiResponseSchema()`.
+     * Forwards to the existing protected {@see self::assertResponseMatchesOpenApiSchema()}
+     * so dedup, skip-codes merging, and coverage recording are shared verbatim
+     * with PHPUnit usage. When `$spec` is non-null, pins this single assertion
+     * to that spec via {@see OpenApiSpecResolver::withExplicitOpenApiSpec()}.
+     *
+     * @internal Pest plugin only — see src/Pest/Expectations.php.
+     *
+     * @param string[] $extraSkipResponseCodes
+     */
+    public function runOpenApiResponseAssertion(
+        TestResponse $response,
+        ?string $spec = null,
+        ?HttpMethod $method = null,
+        ?string $path = null,
+        array $extraSkipResponseCodes = [],
+    ): void {
+        if ($spec !== null) {
+            $this->withExplicitOpenApiSpec($spec);
+        }
+        $this->assertResponseMatchesOpenApiSchema($response, $method, $path, $extraSkipResponseCodes);
+    }
+
+    /**
+     * Public bridge for the Pest expectation `expect($request)->toMatchOpenApiRequestSchema()`.
+     * Always runs (bypasses the `auto_validate_request` config gate) because
+     * the user explicitly opted in by writing the expectation. `#[SkipOpenApi]`
+     * is also bypassed for the same reason — the explicit call wins, mirroring
+     * the response-side {@see self::assertResponseMatchesOpenApiSchema()}
+     * convention.
+     *
+     * @internal Pest plugin only — see src/Pest/Expectations.php.
+     */
+    public function runOpenApiRequestAssertion(
+        Request $request,
+        ?string $spec = null,
+        ?HttpMethod $method = null,
+        ?string $path = null,
+    ): void {
+        if ($spec !== null) {
+            $this->withExplicitOpenApiSpec($spec);
+        }
+
+        $resolvedMethod = $method ?? HttpMethod::tryFrom(strtoupper($request->getMethod()));
+        if ($resolvedMethod === null) {
+            $this->failOpenApi(sprintf(
+                'toMatchOpenApiRequestSchema received a Request with unrecognised HTTP method %s. '
+                . 'Supported methods: %s.',
+                var_export($request->getMethod(), true),
+                implode(', ', array_map(static fn(HttpMethod $m): string => $m->value, HttpMethod::cases())),
+            ));
+        }
+
+        $this->runRequestAssertion($request, $resolvedMethod, $path, null);
     }
 
     /**
@@ -309,91 +368,7 @@ trait ValidatesOpenApiSchema
             return;
         }
 
-        $specName = $this->resolveOpenApiSpec();
-        if ($specName === '') {
-            $this->failOpenApi(
-                'openApiSpec() must return a non-empty spec name, but an empty string was returned. '
-                . 'Either add #[OpenApiSpec(\'your-spec\')] to your test class or method, '
-                . 'override openApiSpec() in your test class, or set the "default_spec" key '
-                . 'in config/openapi-contract-testing.php.',
-            );
-        }
-
-        $resolvedMethod = $method->value;
-        $resolvedPath = $path ?? $request->getPathInfo();
-
-        /** @var array<string, mixed> $queryParams */
-        $queryParams = $request->query->all();
-        /** @var array<string, array<int, null|string>> $headers */
-        $headers = $request->headers->all();
-        /** @var array<string, mixed> $cookies */
-        $cookies = $request->cookies->all();
-        $rawContentType = $request->headers->get('Content-Type');
-        $contentType = is_string($rawContentType) ? $rawContentType : '';
-
-        $body = $this->extractRequestBody($request, $contentType);
-
-        foreach ($this->resolveAutoInjectCredentials($specName, $resolvedMethod, $resolvedPath, $headers, $cookies, $queryParams) as $credential) {
-            if ($credential['kind'] === 'bearer') {
-                // Lower-case the key so it round-trips through
-                // HeaderNormalizer::normalize() the same way Symfony's
-                // already-lowercased header bag does.
-                $headers['authorization'] = ['Bearer ' . self::DUMMY_BEARER_TOKEN];
-
-                continue;
-            }
-
-            $name = $credential['name'];
-            switch ($credential['in']) {
-                case 'header':
-                    $headers[strtolower($name)] = [self::DUMMY_API_KEY_VALUE];
-
-                    break;
-                case 'cookie':
-                    $cookies[$name] = self::DUMMY_API_KEY_VALUE;
-
-                    break;
-                case 'query':
-                    $queryParams[$name] = self::DUMMY_API_KEY_VALUE;
-
-                    break;
-            }
-        }
-
-        $validator = $this->getOrCreateRequestValidator();
-        $result = $validator->validate(
-            $specName,
-            $resolvedMethod,
-            $resolvedPath,
-            $queryParams,
-            $headers,
-            $body,
-            $contentType !== '' ? $contentType : null,
-            $cookies,
-            $responseStatusCode,
-        );
-
-        // Record coverage when the request matched a spec path, same
-        // tracking semantics as the response-side hook. The tracker is a set,
-        // so this does not double-count when response auto-assert also fires.
-        // When the validator downgraded to Skipped (documented-4xx case from
-        // issue #179), forward the skip reason so the coverage report
-        // surfaces the downgrade rather than reporting a clean validated
-        // request.
-        if ($result->matchedPath() !== null) {
-            OpenApiCoverageTracker::recordRequest(
-                $specName,
-                $resolvedMethod,
-                $result->matchedPath(),
-                $result->isSkipped() ? $result->skipReason() : null,
-            );
-        }
-
-        $this->assertOpenApi(
-            $result->isValid(),
-            "OpenAPI request validation failed for {$resolvedMethod} {$resolvedPath} (spec: {$specName}):\n"
-            . $result->errorMessage(),
-        );
+        $this->runRequestAssertion($request, $method, $path, $responseStatusCode);
     }
 
     protected function maybeAutoAssertOpenApiSchema(
@@ -602,6 +577,107 @@ trait ValidatesOpenApiSchema
         }
 
         return is_string($value) && $value !== '';
+    }
+
+    /**
+     * Run request schema validation against a Request, recording coverage and
+     * asserting the outcome. Callers gate on auto-validate config / skip
+     * flags / `#[SkipOpenApi]` themselves; this method always runs.
+     *
+     * Shared implementation for the auto-validate hook and the explicit
+     * `runOpenApiRequestAssertion()` public bridge.
+     */
+    private function runRequestAssertion(
+        Request $request,
+        HttpMethod $method,
+        ?string $path,
+        ?int $responseStatusCode,
+    ): void {
+        $specName = $this->resolveOpenApiSpec();
+        if ($specName === '') {
+            $this->failOpenApi(
+                'openApiSpec() must return a non-empty spec name, but an empty string was returned. '
+                . 'Either add #[OpenApiSpec(\'your-spec\')] to your test class or method, '
+                . 'override openApiSpec() in your test class, or set the "default_spec" key '
+                . 'in config/openapi-contract-testing.php.',
+            );
+        }
+
+        $resolvedMethod = $method->value;
+        $resolvedPath = $path ?? $request->getPathInfo();
+
+        /** @var array<string, mixed> $queryParams */
+        $queryParams = $request->query->all();
+        /** @var array<string, array<int, null|string>> $headers */
+        $headers = $request->headers->all();
+        /** @var array<string, mixed> $cookies */
+        $cookies = $request->cookies->all();
+        $rawContentType = $request->headers->get('Content-Type');
+        $contentType = is_string($rawContentType) ? $rawContentType : '';
+
+        $body = $this->extractRequestBody($request, $contentType);
+
+        foreach ($this->resolveAutoInjectCredentials($specName, $resolvedMethod, $resolvedPath, $headers, $cookies, $queryParams) as $credential) {
+            if ($credential['kind'] === 'bearer') {
+                // Lower-case the key so it round-trips through
+                // HeaderNormalizer::normalize() the same way Symfony's
+                // already-lowercased header bag does.
+                $headers['authorization'] = ['Bearer ' . self::DUMMY_BEARER_TOKEN];
+
+                continue;
+            }
+
+            $name = $credential['name'];
+            switch ($credential['in']) {
+                case 'header':
+                    $headers[strtolower($name)] = [self::DUMMY_API_KEY_VALUE];
+
+                    break;
+                case 'cookie':
+                    $cookies[$name] = self::DUMMY_API_KEY_VALUE;
+
+                    break;
+                case 'query':
+                    $queryParams[$name] = self::DUMMY_API_KEY_VALUE;
+
+                    break;
+            }
+        }
+
+        $validator = $this->getOrCreateRequestValidator();
+        $result = $validator->validate(
+            $specName,
+            $resolvedMethod,
+            $resolvedPath,
+            $queryParams,
+            $headers,
+            $body,
+            $contentType !== '' ? $contentType : null,
+            $cookies,
+            $responseStatusCode,
+        );
+
+        // Record coverage when the request matched a spec path, same
+        // tracking semantics as the response-side hook. The tracker is a set,
+        // so this does not double-count when response auto-assert also fires.
+        // When the validator downgraded to Skipped (documented-4xx case from
+        // issue #179), forward the skip reason so the coverage report
+        // surfaces the downgrade rather than reporting a clean validated
+        // request.
+        if ($result->matchedPath() !== null) {
+            OpenApiCoverageTracker::recordRequest(
+                $specName,
+                $resolvedMethod,
+                $result->matchedPath(),
+                $result->isSkipped() ? $result->skipReason() : null,
+            );
+        }
+
+        $this->assertOpenApi(
+            $result->isValid(),
+            "OpenAPI request validation failed for {$resolvedMethod} {$resolvedPath} (spec: {$specName}):\n"
+            . $result->errorMessage(),
+        );
     }
 
     private function getOrCreateRequestValidator(): OpenApiRequestValidator

--- a/src/Pest/Expectations.php
+++ b/src/Pest/Expectations.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio\OpenApiContractTesting\Pest;
 
 use Illuminate\Testing\TestResponse;
+use Pest\PendingCalls\TestCall;
 use Pest\Support\HigherOrderTapProxy;
 use RuntimeException;
 use Studio\OpenApiContractTesting\HttpMethod;
@@ -98,11 +99,20 @@ final class Expectations
      * test class is missing the `ValidatesOpenApiSchema` trait — almost
      * always a `tests/Pest.php` `uses(...)` misconfiguration.
      *
-     * Pest can wrap the current TestCase in a `HigherOrderTapProxy` when
-     * `test()` is called from inside an `expect()->extend()` closure (the
-     * proxy lets method chaining feel natural in test bodies). We unwrap
-     * it so `method_exists()` checks land on the real TestCase rather than
-     * the proxy, which intentionally exposes only `__call` / `__get`.
+     * Pest's `test()` returns `HigherOrderTapProxy` whenever called with no
+     * description argument while a TestCase is active — the proxy forwards
+     * to the underlying TestCase via `__call` / `__get` so user code can
+     * write `test()->skip(...)` or `test()->throws(...)`. We unwrap it
+     * here because `method_exists()` against the proxy would resolve the
+     * proxy's `__call` rather than the real bridge method, returning
+     * false unconditionally.
+     *
+     * Pest can also return a `Pest\PendingCalls\TestCall` when `test()` is
+     * resolved before any `it(...)` body has been entered (e.g., from a
+     * dataset closure or `beforeEach` initialiser). The TestCall has its
+     * own method surface and would surface as the misleading "missing
+     * trait" message; we detect it explicitly and report the actual
+     * environmental cause instead.
      */
     private static function resolveTestCase(string $expectationName): object
     {
@@ -119,6 +129,17 @@ final class Expectations
         if ($testCase instanceof HigherOrderTapProxy) {
             /** @var object $testCase */
             $testCase = $testCase->target;
+        }
+
+        if ($testCase instanceof TestCall) {
+            throw new RuntimeException(sprintf(
+                '%s() must be called from inside an it(...) / test(...) body. '
+                . '`test()` returned a pending TestCall, which means no PHPUnit '
+                . 'TestCase is currently executing (most often this happens when '
+                . 'the expectation is invoked from a dataset closure or beforeEach '
+                . 'initialiser before any test body has been entered).',
+                $expectationName,
+            ));
         }
 
         $bridge = $expectationName === 'toMatchOpenApiResponseSchema'

--- a/src/Pest/Expectations.php
+++ b/src/Pest/Expectations.php
@@ -4,29 +4,37 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Pest;
 
+use Illuminate\Testing\TestResponse;
+use Pest\Support\HigherOrderTapProxy;
 use RuntimeException;
+use Studio\OpenApiContractTesting\HttpMethod;
+use Symfony\Component\HttpFoundation\Request;
 
+use function function_exists;
+use function get_debug_type;
+use function implode;
+use function in_array;
+use function method_exists;
 use function sprintf;
+use function strtoupper;
 
 /**
  * Static dispatch target for the Pest custom expectations registered in
  * {@see Autoload.php}. Centralising the implementation here (rather than
- * inlining it inside the closure) gives us a real call site that PHPStan
- * and PHPUnit-driven Pest tests can introspect, and lets PR2 land the real
- * validator orchestration without touching the autoload boundary.
+ * inlining it inside the closure) gives PHPStan and PHPUnit-driven tests a
+ * real call site to introspect, and isolates the autoload boundary from
+ * the validator orchestration.
  *
- * The methods are stubs in PR1 — they intentionally throw so the smoke
- * test in `tests/Integration/Pest/PluginLoadsTest.php` can prove that
- * (a) the autoload entrypoint registered the expectation under the
- * expected name and (b) the dispatch reaches this class. PR2 replaces
- * the throw with the real `OpenApiResponseValidator` /
- * `OpenApiRequestValidator` orchestration and the `ValidatesOpenApiSchema`
- * public bridge call.
+ * The dispatch contract: the running Pest test class must use the
+ * `Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema` trait
+ * (typically by extending a base `TestCase` that already does, then
+ * registering it via `uses(...)->in(...)` in `tests/Pest.php`). Without
+ * the trait the bridge methods don't exist and these helpers raise a
+ * RuntimeException pointing the user at the standard wiring. Standalone
+ * (non-Laravel) Pest support is tracked by issue #109's follow-up.
  */
 final class Expectations
 {
-    public const NOT_IMPLEMENTED_URL = 'https://github.com/studio-design/openapi-contract-testing/issues/109';
-
     /**
      * @param string[] $skipResponseCodes
      */
@@ -37,7 +45,25 @@ final class Expectations
         ?string $path,
         array $skipResponseCodes,
     ): void {
-        throw new RuntimeException(self::notImplementedMessage(__METHOD__));
+        if (!$value instanceof TestResponse) {
+            throw new RuntimeException(sprintf(
+                'expect(...)->toMatchOpenApiResponseSchema() requires a %s, got %s. '
+                . 'Standalone (non-Laravel) Pest support is tracked separately.',
+                TestResponse::class,
+                get_debug_type($value),
+            ));
+        }
+
+        $testCase = self::resolveTestCase('toMatchOpenApiResponseSchema');
+        $resolvedMethod = self::resolveHttpMethod($method, 'toMatchOpenApiResponseSchema');
+
+        $testCase->runOpenApiResponseAssertion(
+            $value,
+            $spec,
+            $resolvedMethod,
+            $path,
+            $skipResponseCodes,
+        );
     }
 
     public static function matchRequest(
@@ -46,21 +72,105 @@ final class Expectations
         ?string $method,
         ?string $path,
     ): void {
-        throw new RuntimeException(self::notImplementedMessage(__METHOD__));
+        if (!$value instanceof Request) {
+            throw new RuntimeException(sprintf(
+                'expect(...)->toMatchOpenApiRequestSchema() requires a %s, got %s. '
+                . 'In a Laravel test the current request is available via app(\'request\').',
+                Request::class,
+                get_debug_type($value),
+            ));
+        }
+
+        $testCase = self::resolveTestCase('toMatchOpenApiRequestSchema');
+        $resolvedMethod = self::resolveHttpMethod($method, 'toMatchOpenApiRequestSchema');
+
+        $testCase->runOpenApiRequestAssertion(
+            $value,
+            $spec,
+            $resolvedMethod,
+            $path,
+        );
     }
 
     /**
-     * Build the stub error message identifying which dispatch was hit.
-     * Carrying __METHOD__ lets a clipped CI log still pinpoint matchResponse
-     * vs matchRequest. The constant URL is the single source of truth for
-     * the tracking issue so PR2 only deletes call sites, not literals.
+     * Locate the running Pest TestCase via the global `test()` helper and
+     * verify it carries the public bridge methods. Failing here means the
+     * test class is missing the `ValidatesOpenApiSchema` trait — almost
+     * always a `tests/Pest.php` `uses(...)` misconfiguration.
+     *
+     * Pest can wrap the current TestCase in a `HigherOrderTapProxy` when
+     * `test()` is called from inside an `expect()->extend()` closure (the
+     * proxy lets method chaining feel natural in test bodies). We unwrap
+     * it so `method_exists()` checks land on the real TestCase rather than
+     * the proxy, which intentionally exposes only `__call` / `__get`.
      */
-    private static function notImplementedMessage(string $method): string
+    private static function resolveTestCase(string $expectationName): object
     {
-        return sprintf(
-            'The Pest plugin entrypoint loaded, but %s lands in PR2. See %s.',
-            $method,
-            self::NOT_IMPLEMENTED_URL,
-        );
+        if (!function_exists('test')) {
+            throw new RuntimeException(sprintf(
+                '%s() was invoked outside a Pest test run (`test()` global is undefined). '
+                . 'Custom expectations only run when the Pest CLI is the entrypoint.',
+                $expectationName,
+            ));
+        }
+
+        /** @var object $testCase */
+        $testCase = test();
+        if ($testCase instanceof HigherOrderTapProxy) {
+            /** @var object $testCase */
+            $testCase = $testCase->target;
+        }
+
+        $bridge = $expectationName === 'toMatchOpenApiResponseSchema'
+            ? 'runOpenApiResponseAssertion'
+            : 'runOpenApiRequestAssertion';
+        if (!method_exists($testCase, $bridge)) {
+            throw new RuntimeException(sprintf(
+                '%s() requires the test class (%s) to use the %s trait. '
+                . 'Add `uses(\Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema::class)->in(...)` '
+                . 'to tests/Pest.php, or extend a base TestCase that already uses the trait.',
+                $expectationName,
+                $testCase::class,
+                'Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema',
+            ));
+        }
+
+        return $testCase;
+    }
+
+    /**
+     * Coerce the optional method string to the trait's HttpMethod enum.
+     * Null passes through (the trait then auto-resolves from the current
+     * request); anything else must be one of the supported verbs.
+     */
+    private static function resolveHttpMethod(?string $method, string $expectationName): ?HttpMethod
+    {
+        if ($method === null) {
+            return null;
+        }
+
+        $resolved = HttpMethod::tryFrom(strtoupper($method));
+        if ($resolved === null) {
+            throw new RuntimeException(sprintf(
+                '%s() received unsupported method: %s. Allowed: %s.',
+                $expectationName,
+                $method,
+                self::supportedMethodList(),
+            ));
+        }
+
+        return $resolved;
+    }
+
+    private static function supportedMethodList(): string
+    {
+        $names = [];
+        foreach (HttpMethod::cases() as $case) {
+            if (!in_array($case->value, $names, true)) {
+                $names[] = $case->value;
+            }
+        }
+
+        return implode(', ', $names);
     }
 }

--- a/src/Spec/OpenApiSpecResolver.php
+++ b/src/Spec/OpenApiSpecResolver.php
@@ -11,11 +11,14 @@ use Studio\OpenApiContractTesting\Attribute\OpenApiSpec;
 /**
  * Resolves which OpenAPI spec name a test case should validate against.
  *
- * The resolver itself evaluates four layers (highest first; first non-null
+ * The resolver evaluates the layers below (highest first; first non-null
  * match wins). When a framework adapter (e.g. the Laravel
  * `ValidatesOpenApiSchema` trait) overrides `openApiSpecFallback()` to
- * delegate to its own user-overridable hook, the last layer splits into two —
- * producing the five-layer priority documented in README:
+ * delegate to its own user-overridable hook, the last layer splits into two,
+ * giving the chain a fifth slot. The README's "Spec resolution" section
+ * documents layers 1–4; layer 0 is the Pest-plugin-only override added in
+ * the same series as this hook (#109's PR2) — README integration lands in
+ * the Pest documentation PR.
  *
  *   0. Per-call explicit override set via {@see self::withExplicitOpenApiSpec()}.
  *      Used by the Pest plugin (`expect(...)->toMatchOpenApiResponseSchema(spec: 'X')`)
@@ -32,7 +35,7 @@ use Studio\OpenApiContractTesting\Attribute\OpenApiSpec;
  *      trait's own `openApiSpec()` implementation when not overridden.
  *
  * Adapters that don't override `openApiSpecFallback()` collapse layers 3 and 4
- * into a single fallback.
+ * into a single fallback (so the resolution chain becomes 0, 1, 2, fallback).
  *
  * Attribute layers return the attribute's raw `name` as-is. `#[OpenApiSpec('')]`
  * is still "set" and short-circuits resolution to the empty string — the

--- a/src/Spec/OpenApiSpecResolver.php
+++ b/src/Spec/OpenApiSpecResolver.php
@@ -11,12 +11,17 @@ use Studio\OpenApiContractTesting\Attribute\OpenApiSpec;
 /**
  * Resolves which OpenAPI spec name a test case should validate against.
  *
- * The resolver itself evaluates three layers. When a framework adapter (e.g.
- * the Laravel `ValidatesOpenApiSchema` trait) overrides `openApiSpecFallback()`
- * to delegate to its own user-overridable hook, the last layer splits into
- * two — producing the four-layer priority documented in README (highest first;
- * first match wins):
+ * The resolver itself evaluates four layers (highest first; first non-null
+ * match wins). When a framework adapter (e.g. the Laravel
+ * `ValidatesOpenApiSchema` trait) overrides `openApiSpecFallback()` to
+ * delegate to its own user-overridable hook, the last layer splits into two —
+ * producing the five-layer priority documented in README:
  *
+ *   0. Per-call explicit override set via {@see self::withExplicitOpenApiSpec()}.
+ *      Used by the Pest plugin (`expect(...)->toMatchOpenApiResponseSchema(spec: 'X')`)
+ *      to pin a single assertion at a specific spec without touching attributes
+ *      or config. Self-clears after the next `resolveOpenApiSpec()` call so it
+ *      cannot leak into subsequent assertions.
  *   1. Method-level `#[OpenApiSpec]` attribute on the running test method.
  *   2. Class-level `#[OpenApiSpec]` attribute on the test class.
  *   3. Adapter's user-overridable hook. For the Laravel adapter this is
@@ -27,7 +32,7 @@ use Studio\OpenApiContractTesting\Attribute\OpenApiSpec;
  *      trait's own `openApiSpec()` implementation when not overridden.
  *
  * Adapters that don't override `openApiSpecFallback()` collapse layers 3 and 4
- * into a single fallback and remain three-layer.
+ * into a single fallback.
  *
  * Attribute layers return the attribute's raw `name` as-is. `#[OpenApiSpec('')]`
  * is still "set" and short-circuits resolution to the empty string — the
@@ -36,6 +41,26 @@ use Studio\OpenApiContractTesting\Attribute\OpenApiSpec;
  */
 trait OpenApiSpecResolver
 {
+    /**
+     * Per-assertion explicit spec set by callers that need to bypass the
+     * attribute / fallback chain (Pest plugin's `spec:` argument). Consumed
+     * once by `resolveOpenApiSpec()` so the value cannot leak into the next
+     * assertion in the same test method.
+     */
+    private ?string $explicitOpenApiSpec = null;
+
+    /**
+     * Pin the next `resolveOpenApiSpec()` call to a specific spec, bypassing
+     * attribute and fallback resolution. Used by the Pest expectation
+     * dispatcher to honour the `spec:` argument. Pass `null` to clear.
+     *
+     * @internal Pest plugin / framework adapters only.
+     */
+    public function withExplicitOpenApiSpec(?string $spec): void
+    {
+        $this->explicitOpenApiSpec = $spec;
+    }
+
     protected function openApiSpecFallback(): string
     {
         return '';
@@ -43,6 +68,14 @@ trait OpenApiSpecResolver
 
     private function resolveOpenApiSpec(): string
     {
+        // 0. Per-call explicit override (consumed once).
+        if ($this->explicitOpenApiSpec !== null) {
+            $spec = $this->explicitOpenApiSpec;
+            $this->explicitOpenApiSpec = null;
+
+            return $spec;
+        }
+
         // 1. Method-level #[OpenApiSpec] attribute
         $methodName = $this->name(); // @phpstan-ignore method.notFound
         $refMethod = new ReflectionMethod($this, $methodName);

--- a/tests/Helpers/PestLaravelTestCase.php
+++ b/tests/Helpers/PestLaravelTestCase.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Helpers;
+
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\Laravel\OpenApiContractTestingServiceProvider;
+use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
+use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+
+use function dirname;
+
+/**
+ * Orchestra Testbench harness used by `tests/Integration/Pest/ExpectationsTest.php`.
+ * Mirrors `tests/Integration/Laravel/AutoAssertIntegrationTest` minus the
+ * PHPUnit `#[Test]` attribute layer — Pest binds tests via `uses(...)->in()`
+ * and reuses the routes/spec config defined here for every `it(...)` block.
+ *
+ * Lives under `tests/Helpers/` so it stays outside Pest's discovery path
+ * (`pest tests/Integration/Pest`) and outside the PHPUnit Integration suite.
+ * Both runners reach it via PSR-4 instead.
+ */
+class PestLaravelTestCase extends TestCase
+{
+    use ValidatesOpenApiSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(dirname(__DIR__) . '/fixtures/specs');
+        OpenApiCoverageTracker::reset();
+        config()->set('openapi-contract-testing.default_spec', 'petstore-3.0');
+    }
+
+    protected function tearDown(): void
+    {
+        self::resetValidatorCache();
+        OpenApiSpecLoader::reset();
+        OpenApiCoverageTracker::reset();
+        parent::tearDown();
+    }
+
+    /** @return array<int, class-string> */
+    protected function getPackageProviders($app): array
+    {
+        return [OpenApiContractTestingServiceProvider::class];
+    }
+
+    protected function defineRoutes($router): void
+    {
+        Route::get('/v1/pets', static function () {
+            $bad = request()->query('bad') === '1';
+
+            return response()->json(
+                $bad
+                    ? ['wrong_key' => 'value']
+                    : ['data' => [['id' => 1, 'name' => 'Fido', 'tag' => null]]],
+            );
+        });
+
+        Route::post('/v1/pets', static fn() => response()->json(
+            ['data' => ['id' => 42, 'name' => 'Buddy', 'tag' => null]],
+            201,
+        ));
+
+        Route::get('/v1/health', static fn() => response()->json(
+            ['error' => 'service unavailable'],
+            503,
+        ));
+    }
+}

--- a/tests/Integration/Pest/ExpectationsTest.php
+++ b/tests/Integration/Pest/ExpectationsTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\AssertionFailedError;
+use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
+
+/*
+|--------------------------------------------------------------------------
+| Pest expectation integration
+|--------------------------------------------------------------------------
+|
+| Exercises the Pest plugin's `toMatchOpenApiResponseSchema` /
+| `toMatchOpenApiRequestSchema` end-to-end through Orchestra Testbench
+| (configured by `tests/Helpers/PestLaravelTestCase` and wired in
+| `tests/Pest.php`). Each `it(...)` boots a fresh Laravel app and resets
+| the coverage tracker, so test ordering is irrelevant.
+|
+| The companion `PluginLoadsTest.php` proves only that the autoload
+| boundary is wired. This file proves the dispatch actually runs the
+| existing OpenApiResponseValidator / OpenApiRequestValidator pipeline.
+*/
+
+it('validates a matching response against the default spec', function (): void {
+    $response = $this->get('/v1/pets');
+    $response->assertOk();
+
+    expect($response)->toMatchOpenApiResponseSchema();
+
+    $covered = OpenApiCoverageTracker::getCovered();
+    expect($covered)
+        ->toHaveKey('petstore-3.0')
+        ->and($covered['petstore-3.0'])
+        ->toHaveKey('GET /v1/pets');
+});
+
+it('fails when the response does not match the schema', function (): void {
+    $response = $this->get('/v1/pets?bad=1');
+
+    expect(static fn () => expect($response)->toMatchOpenApiResponseSchema())
+        ->toThrow(AssertionFailedError::class, 'OpenAPI schema validation failed');
+});
+
+it('honours the spec: argument as a per-call override', function (): void {
+    $response = $this->get('/v1/pets');
+    $response->assertOk();
+
+    expect($response)->toMatchOpenApiResponseSchema(spec: 'petstore-3.1');
+
+    $covered = OpenApiCoverageTracker::getCovered();
+    expect($covered)->toHaveKey('petstore-3.1')
+        ->and($covered)->not->toHaveKey('petstore-3.0');
+});
+
+it('honours the skipResponseCodes argument for per-call skip', function (): void {
+    // /v1/health returns 503; the spec only documents 200, so a strict
+    // assertion would fail with "Status code 503 not defined". Passing
+    // skipResponseCodes turns that into a skip rather than a failure.
+    $response = $this->get('/v1/health');
+
+    expect($response)->toMatchOpenApiResponseSchema(skipResponseCodes: ['503']);
+});
+
+it('validates a matching request via toMatchOpenApiRequestSchema', function (): void {
+    $this->postJson('/v1/pets', ['name' => 'Buddy']);
+
+    /** @var \Symfony\Component\HttpFoundation\Request $request */
+    $request = app('request');
+
+    expect($request)->toMatchOpenApiRequestSchema();
+
+    $covered = OpenApiCoverageTracker::getCovered();
+    expect($covered)
+        ->toHaveKey('petstore-3.0')
+        ->and($covered['petstore-3.0'])
+        ->toHaveKey('POST /v1/pets');
+});
+
+it('does not double-record coverage when explicit assert follows auto-assert', function (): void {
+    config()->set('openapi-contract-testing.auto_assert', true);
+
+    $response = $this->get('/v1/pets');
+
+    // auto-assert already validated this response and recorded its hit.
+    // The explicit expect() is a WeakMap-deduped no-op — coverage hits
+    // for GET /v1/pets / 200 must remain at 1.
+    expect($response)->toMatchOpenApiResponseSchema();
+
+    $coverage = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
+    $endpoint = null;
+    foreach ($coverage['endpoints'] as $candidate) {
+        if ($candidate['endpoint'] === 'GET /v1/pets') {
+            $endpoint = $candidate;
+
+            break;
+        }
+    }
+    expect($endpoint)->not->toBeNull();
+    $hits = $endpoint['responses'][0]['hits'] ?? -1;
+    expect($hits)->toBe(1);
+});
+
+it('chains expectations after the schema match', function (): void {
+    $response = $this->get('/v1/pets');
+
+    // Returning $this from the closure (verified at registration in
+    // PluginLoadsTest) lets the result chain into other expectations.
+    expect($response)
+        ->toMatchOpenApiResponseSchema()
+        ->toBeInstanceOf(\Illuminate\Testing\TestResponse::class);
+});

--- a/tests/Integration/Pest/ExpectationsTest.php
+++ b/tests/Integration/Pest/ExpectationsTest.php
@@ -52,6 +52,26 @@ it('honours the spec: argument as a per-call override', function (): void {
         ->and($covered)->not->toHaveKey('petstore-3.0');
 });
 
+it('clears the per-call spec override after a single assertion', function (): void {
+    // Pin the documented "self-clears after the next resolveOpenApiSpec()
+    // call" invariant: one explicit `spec:` followed by an implicit call must
+    // route to the configured default, not the previous override. Removing the
+    // single-shot reset in OpenApiSpecResolver, or losing the try/finally
+    // guard in the trait bridges, would let petstore-3.1 leak into the
+    // second assertion and this test would fail.
+    $first = $this->get('/v1/pets');
+    expect($first)->toMatchOpenApiResponseSchema(spec: 'petstore-3.1');
+
+    $second = $this->get('/v1/pets');
+    expect($second)->toMatchOpenApiResponseSchema();
+
+    $covered = OpenApiCoverageTracker::getCovered();
+    expect($covered)
+        ->toHaveKey('petstore-3.1')
+        ->and($covered)
+        ->toHaveKey('petstore-3.0');
+});
+
 it('honours the skipResponseCodes argument for per-call skip', function (): void {
     // /v1/health returns 503; the spec only documents 200, so a strict
     // assertion would fail with "Status code 503 not defined". Passing
@@ -103,8 +123,10 @@ it('does not double-record coverage when explicit assert follows auto-assert', f
 it('chains expectations after the schema match', function (): void {
     $response = $this->get('/v1/pets');
 
-    // Returning $this from the closure (verified at registration in
-    // PluginLoadsTest) lets the result chain into other expectations.
+    // The `expect()->extend()` closures in src/Pest/Autoload.php return $this,
+    // letting the result chain into other expectations. PluginLoadsTest only
+    // proves the closures are registered; this assertion proves they actually
+    // return the Expectation instance.
     expect($response)
         ->toMatchOpenApiResponseSchema()
         ->toBeInstanceOf(\Illuminate\Testing\TestResponse::class);

--- a/tests/Integration/Pest/PluginLoadsTest.php
+++ b/tests/Integration/Pest/PluginLoadsTest.php
@@ -11,8 +11,9 @@ declare(strict_types=1);
 |
 |  1. composer.json `autoload.files` actually loads `src/Pest/Autoload.php`
 |     when the Pest binary boots.
-|  2. The `function_exists('expect') || class_exists(\Pest\Expectation::class)`
-|     guard does NOT short-circuit when Pest is present.
+|  2. The two-symbol guard in src/Pest/Autoload.php (`function_exists('expect')`
+|     AND `class_exists(\Pest\Expectation::class)`) does NOT short-circuit when
+|     Pest is present.
 |  3. expect()->extend() registered the two expectations under the names
 |     ExpectationsTest.php (and downstream user tests) dispatch on
 |     (toMatchOpenApiResponseSchema / toMatchOpenApiRequestSchema).

--- a/tests/Integration/Pest/PluginLoadsTest.php
+++ b/tests/Integration/Pest/PluginLoadsTest.php
@@ -7,46 +7,36 @@ declare(strict_types=1);
 | Pest plugin smoke test
 |--------------------------------------------------------------------------
 |
-| Proves three things at once:
+| Proves the autoload boundary stays wired:
 |
 |  1. composer.json `autoload.files` actually loads `src/Pest/Autoload.php`
 |     when the Pest binary boots.
-|  2. The class_exists(\Pest\Expectation::class) guard short-circuits on
-|     missing Pest, but does NOT short-circuit when Pest is present.
-|  3. expect()->extend() registered the two expectations under the
-|     names the PR2 implementation will dispatch on
+|  2. The `function_exists('expect') || class_exists(\Pest\Expectation::class)`
+|     guard does NOT short-circuit when Pest is present.
+|  3. expect()->extend() registered the two expectations under the names
+|     ExpectationsTest.php (and downstream user tests) dispatch on
 |     (toMatchOpenApiResponseSchema / toMatchOpenApiRequestSchema).
-|     The README documents these names in PR3.
 |
-| PR1 ships the dispatch stubs in
-| Studio\OpenApiContractTesting\Pest\Expectations as throwing
-| RuntimeExceptions, so "the autoload entrypoint is wired correctly" is
-| provable by asserting the throw lands here. PR2 will replace those stubs
-| with the real validator orchestration and these asserts will move to
-| checking the validation outcome instead.
+| Asserting on the input-validation throws — "requires a TestResponse" /
+| "requires a Symfony Request" — pins the dispatch to the actual
+| Studio\OpenApiContractTesting\Pest\Expectations class. A wrong
+| expectation name would surface as a different exception type
+| (BadMethodCallException) and fail the test.
+|
+| Behavioural coverage of the validator orchestration lives in
+| ExpectationsTest.php; this file only guards the registration boundary.
 |
 | The closures below are intentionally not `static` — Pest binds $this on
 | each test callback and rejects static closures. The file is excluded
 | from PHP-CS-Fixer's `static_lambda` rule via `.php-cs-fixer.dist.php`.
 */
 
-// Pin the substring to the dispatch FQCN ("...::matchResponse" /
-// "...::matchRequest") rather than the bare token 'PR2'. That asserts the
-// throw originated from *this* codebase's stub for *this* method, not just
-// any RuntimeException Pest might raise on a wrong expectation name.
-
 it('registers the toMatchOpenApiResponseSchema expectation', function (): void {
     expect(static fn () => expect(null)->toMatchOpenApiResponseSchema())
-        ->toThrow(
-            \RuntimeException::class,
-            \Studio\OpenApiContractTesting\Pest\Expectations::class . '::matchResponse',
-        );
+        ->toThrow(\RuntimeException::class, 'requires a Illuminate\Testing\TestResponse');
 });
 
 it('registers the toMatchOpenApiRequestSchema expectation', function (): void {
     expect(static fn () => expect(null)->toMatchOpenApiRequestSchema())
-        ->toThrow(
-            \RuntimeException::class,
-            \Studio\OpenApiContractTesting\Pest\Expectations::class . '::matchRequest',
-        );
+        ->toThrow(\RuntimeException::class, 'requires a Symfony\Component\HttpFoundation\Request');
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,18 +2,22 @@
 
 declare(strict_types=1);
 
+use Studio\OpenApiContractTesting\Tests\Helpers\PestLaravelTestCase;
+
 /*
 |--------------------------------------------------------------------------
 | Pest configuration
 |--------------------------------------------------------------------------
 |
-| Loaded by the Pest CLI before any tests run. PR1 keeps it intentionally
-| empty: the smoke test is self-contained and the wider Pest test surface
-| (Laravel auto-assert wiring, expectations against TestResponse) lands
-| in PR2, which will populate `uses(...)->in('Integration/Pest')` and
-| friends here.
+| Loaded by the Pest CLI before any tests run. Wires the Pest tests under
+| tests/Integration/Pest/ to the Orchestra Testbench harness in
+| tests/Helpers/PestLaravelTestCase.php so each `it(...)` block inherits
+| Laravel routes, the spec base path, and the ValidatesOpenApiSchema trait
+| (via the base class).
 |
 | `composer test:pest` runs `pest --colors=always tests/Integration/Pest`
 | (the path is baked into the script), so this file does not need to
 | filter directories — the script's path argument already does.
 */
+
+uses(PestLaravelTestCase::class)->in('Integration/Pest');


### PR DESCRIPTION
## Summary

Replaces the PR #188 stubs with real validator orchestration. Pest tests under a Laravel base class that uses `ValidatesOpenApiSchema` can now write `expect(\$response)->toMatchOpenApiResponseSchema()` / `toMatchOpenApiRequestSchema()` and get the same dedup, attribute resolution, skip-codes merging, and coverage recording the existing PHPUnit pipeline provides.

## Why

Refs #109. PR #188 wired the autoload boundary; this PR makes the expectations actually do something. The third PR will document them in the README and ship `examples/`.

## Verification

- `composer ci` (cs-check + stan + 1347 PHPUnit tests) green on Pest-free `composer install` (mirrors the static-analysis job)
- `composer test:pest` (Pest 3 + PHPUnit 11 temp env locally) — 9 passed (24 assertions)
  - 7 expectation scenarios in `tests/Integration/Pest/ExpectationsTest.php`
  - 2 carried-over smoke tests in `PluginLoadsTest.php` (now assert the new input-validation throws)

- [x] \`composer test\` passes
- [x] \`composer stan\` passes
- [x] \`composer cs-check\` passes

## Notes for reviewers

### Public API additions (SemVer-minor)

- \`ValidatesOpenApiSchema::runOpenApiResponseAssertion(TestResponse, ?string \$spec, ?HttpMethod, ?string \$path, array \$extraSkipResponseCodes)\` — public bridge for \`toMatchOpenApiResponseSchema()\`
- \`ValidatesOpenApiSchema::runOpenApiRequestAssertion(Request, ?string \$spec, ?HttpMethod, ?string \$path)\` — public bridge for \`toMatchOpenApiRequestSchema()\`. Bypasses \`auto_validate_request\` and \`#[SkipOpenApi]\` (the user explicitly opted in by writing the expectation; mirrors the response side).
- \`OpenApiSpecResolver::withExplicitOpenApiSpec(?string \$spec)\` — single-shot per-call override consumed by \`resolveOpenApiSpec()\`. New layer 0 in the resolver, above the existing 1–4. Self-clears so it cannot leak into the next assertion.

All three are marked \`@internal\` ("Pest plugin only") so consumers don't accidentally rely on them outside the plugin's dispatch.

### Refactor

\`maybeAutoValidateOpenApiRequest()\` now delegates its post-skip-flag-check body to a new private \`runRequestAssertion()\`. The auto-validate path keeps its config gating; the new public bridge calls \`runRequestAssertion()\` directly, always running. Behaviour preserved — the existing \`AutoValidateRequestIntegrationTest\` is untouched and green.

### Pest TestCase resolution

\`Expectations::resolveTestCase()\` calls \`test()\` and unwraps \`Pest\Support\HigherOrderTapProxy\` if present. Pest can return the proxy when \`test()\` is invoked from inside an \`expect()->extend()\` closure (the proxy enables fluent method chaining in test bodies). Without the unwrap, \`method_exists()\` checks land on the proxy instead of the real TestCase and fail.

### Static analysis

\`src/Pest/Expectations.php\` is added to \`phpstan.neon.dist\` \`excludePaths\` because it now references \`Pest\Support\HigherOrderTapProxy\` (only available with Pest installed). Same rationale as the PR #188 \`Autoload.php\` exclusion. Replacing both with a Pest stub file is tracked in #189.

### Test infrastructure

- \`tests/Helpers/PestLaravelTestCase.php\` (new) — Orchestra Testbench harness mirroring \`tests/Integration/Laravel/AutoAssertIntegrationTest\` minus the PHPUnit \`#[Test]\` attribute layer. Lives under \`tests/Helpers/\` so it stays outside Pest's discovery path and the PHPUnit Integration suite.
- \`tests/Pest.php\` — now wires \`uses(PestLaravelTestCase::class)->in('Integration/Pest')\` so each \`it(...)\` block under \`tests/Integration/Pest\` inherits the harness.
- \`tests/Integration/Pest/ExpectationsTest.php\` (new) — 7 scenarios covering happy path, failure, per-call overrides, request-side bridge, dedup, chaining.

### Out of scope (deferred)

- Standalone (non-Laravel) Pest support — \`expect()\` against PSR-7 messages without a Laravel test case. Not in #109's PR2 charter.
- README \`Pest plugin (Laravel)\` section + \`examples/pest/\` directory — those land in PR3 along with the matrix flip 🚧 → ✅.

## Follow-up issues (deferred from review)

- #194 — test(pest): negative-path coverage for plugin dispatch (test-analyzer #1, #3, #4, #6)
- #195 — refactor(pest): consolidate supported HttpMethod list rendering (silent-failure S3 / code-reviewer Suggestion 2)
- #196 — ci(pest): expand pest job matrix to include PHP 8.4 (test-analyzer #11)
