### PR TITLE
docs(pest): document Pest plugin and ship runnable examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,31 @@ jobs:
       - name: Run Pest smoke tests
         run: composer test:pest
 
+  pest-example:
+    name: Pest plugin example
+    runs-on: ubuntu-latest
+    # The runnable example under examples/pest/ tracks the working tree via a
+    # path repository. Without this job the example silently rots whenever the
+    # library's public API surface, composer.json, or autoload.files entry
+    # changes. Single PHP cell is enough — the example exists to teach, not
+    # cover the matrix.
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Install example dependencies
+        working-directory: examples/pest
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Run example Pest suite
+        working-directory: examples/pest
+        run: vendor/bin/pest --colors=always
+
   static-analysis:
     name: PHPStan
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 /vendor/
 /composer.lock
 
+# Examples bring their own vendor/ + lockfile when run.
+/examples/*/vendor/
+/examples/*/composer.lock
+/examples/*/.phpunit.cache/
+
 # PHPUnit
 /.phpunit.cache/
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This library fills a gap left by existing PHP OpenAPI testing tools: **endpoint 
 | **Schema-driven request fuzzing** | ✅ | ❌ | ❌ | ❌ | ❌ |
 | **Skip-by-status-code (default 5xx)** | ✅ | ❌ | ❌ | ❌ | ✅ |
 | PHPUnit integration | ✅ | ✅ | ❌ | ⚠️ | ✅ |
-| Pest plugin | 🚧 | ❌ | ❌ | ❌ | ❌ |
+| Pest plugin | ✅ | ❌ | ❌ | ❌ | ❌ |
 | Laravel auto-assert | ✅ | ✅ | ❌ | ❌ | ✅ |
 | Symfony HttpFoundation | ❌ | ❌ | ⚠️ | ✅ | ❌ |
 | External `$ref` auto-resolution | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -45,7 +45,7 @@ This library fills a gap left by existing PHP OpenAPI testing tools: **endpoint 
 | **Auto-inject dummy bearer** | ✅ | ❌ | ❌ | ❌ | ❌ |
 | **GitHub Step Summary output** | ✅ | ❌ | ❌ | ❌ | ❌ |
 
-**Legend**: ✅ fully supported · ⚠️ partial, delegated to an underlying library, or not explicitly documented · 🚧 scaffolded, expectations land in a follow-up PR (tracking [#109](https://github.com/studio-design/openapi-contract-testing/issues/109)) · ❌ not supported
+**Legend**: ✅ fully supported · ⚠️ partial, delegated to an underlying library, or not explicitly documented · ❌ not supported
 
 **Methodology**: Cells reflect what each library's public documentation and source explicitly guarantee as of 2026-04-25. Competitor versions checked: Spectator v2.2.0, league/openapi-psr7-validator v0.22, osteel/openapi-httpfoundation-testing v0.14, kirschbaum-development/laravel-openapi-validator v2.0.
 
@@ -562,6 +562,83 @@ Notes:
 - **Never overrides user values**: if the test already set an `Authorization` header (in any case), the user's value wins.
 - **Requires `auto_validate_request=true`** — the inject is a sub-feature of request validation. Setting the inject flag alone has no effect.
 
+## Pest plugin (Laravel)
+
+Pest tests can use the same validator pipeline as PHPUnit through a custom-expectation plugin that ships in this package. The library runtime stays Pest-free — install Pest as a dev dependency in your project to activate the expectations.
+
+### Installation
+
+```bash
+composer require --dev pestphp/pest:^3.0
+```
+
+The plugin is auto-loaded via Composer's `autoload.files`. No further wiring needed at install time. Pest 4 (PHPUnit ^12) support is tracked separately.
+
+### Wiring the trait into Pest tests
+
+Mix `ValidatesOpenApiSchema` into the Pest test suite via `uses(...)->in(...)` in `tests/Pest.php` (or whatever Pest configuration file your project uses). The trait must be on the test class — typically through a base `TestCase` that already extends Laravel's testing harness:
+
+```php
+// tests/Pest.php
+use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
+use Tests\TestCase;
+
+uses(TestCase::class, ValidatesOpenApiSchema::class)->in('Feature');
+```
+
+Once wired, `auto_assert` and `auto_validate_request` work exactly as with PHPUnit — every Laravel HTTP helper call validates against the configured spec.
+
+### `expect(...)->toMatchOpenApiResponseSchema()`
+
+Explicit response-side validation reads naturally inside Pest's expectation grammar:
+
+```php
+it('lists pets with the documented shape', function () {
+    $response = $this->getJson('/api/v1/pets');
+
+    expect($response)->toMatchOpenApiResponseSchema();
+});
+```
+
+Optional named arguments cover the per-call overrides:
+
+```php
+// Pin this single assertion to a different spec (overrides default_spec
+// and any #[OpenApiSpec] on the test class for one call only).
+expect($response)->toMatchOpenApiResponseSchema(spec: 'admin');
+
+// Skip body validation for specific status codes (regex strings, anchored
+// automatically). The standard `skip_response_codes` config still applies;
+// these add to it for one call only.
+expect($response)->toMatchOpenApiResponseSchema(skipResponseCodes: ['503']);
+
+// Override method / path explicitly when the auto-resolved values from
+// app('request') aren't what you want to validate against.
+expect($response)->toMatchOpenApiResponseSchema(method: 'GET', path: '/api/v1/pets');
+```
+
+The `spec:` override is single-shot: the next assertion in the same test method falls back to attribute / config resolution. Coverage recording, WeakMap dedup, and the `#[SkipOpenApi]` advisory warning all behave the same as the PHPUnit `assertResponseMatchesOpenApiSchema()` flow.
+
+### `expect(...)->toMatchOpenApiRequestSchema()`
+
+Request-side validation accepts the Symfony `Request` Laravel hands out via `app('request')`:
+
+```php
+it('accepts a documented request body shape', function () {
+    $this->postJson('/api/v1/pets', ['name' => 'Buddy']);
+
+    expect(app('request'))->toMatchOpenApiRequestSchema();
+});
+```
+
+The same `spec: / method: / path:` keyword arguments are accepted. The request bridge always runs (it bypasses the `auto_validate_request` config gate and `#[SkipOpenApi]`) because the explicit expectation reads as the user's direct intent.
+
+### Constraints (v1)
+
+- **Laravel only**. The expectations require the running Pest test class to use `ValidatesOpenApiSchema`. Standalone (Symfony / framework-less) Pest support against PSR-7 messages is tracked as a follow-up to [#109](https://github.com/studio-design/openapi-contract-testing/issues/109).
+- **Pest 3**. Pest 4 (PHPUnit ^12) is not yet in the CI matrix.
+- **Pest discovery contract**. The plugin guards against a missing Pest install at autoload time, so it is safe to leave installed in projects that don't actually use Pest. If `pestphp/pest` is absent, the bootstrap is a true no-op.
+
 ## Schema-driven request fuzzing
 
 The `ExploresOpenApiEndpoint` trait generates N happy-path request inputs for one (method, path) operation directly from the OpenAPI spec — the PHP equivalent of [Schemathesis][schemathesis]. Pair it with the existing `ValidatesOpenApiSchema` trait and every fuzzed call automatically asserts response contract conformance and records coverage.
@@ -1058,6 +1135,11 @@ path if `sys_get_temp_dir()` is unavailable in your runner.
 - **Sequential runs are unchanged.** Without `TEST_TOKEN` the extension
   renders inline as before. There is no need to wire the merge CLI into
   non-parallel CI jobs.
+- **Pest plugin works under `--parallel`.** The expectations registered
+  by the [Pest plugin](#pest-plugin-laravel) record coverage through the
+  same `OpenApiCoverageTracker` static, so each Pest worker drops a
+  sidecar exactly like a paratest worker would. No additional wiring
+  needed beyond the merge step shown above.
 - **Worker counts are not exposed by paratest.** A child cannot reliably
   tell how many siblings it has, so the merge has to run as a separate
   step rather than auto-firing from "the last worker." This matches how

--- a/README.md
+++ b/README.md
@@ -562,6 +562,8 @@ Notes:
 - **Never overrides user values**: if the test already set an `Authorization` header (in any case), the user's value wins.
 - **Requires `auto_validate_request=true`** — the inject is a sub-feature of request validation. Setting the inject flag alone has no effect.
 
+<a id="pest-plugin-laravel"></a>
+
 ## Pest plugin (Laravel)
 
 Pest tests can use the same validator pipeline as PHPUnit through a custom-expectation plugin that ships in this package. The library runtime stays Pest-free — install Pest as a dev dependency in your project to activate the expectations.
@@ -631,7 +633,7 @@ it('accepts a documented request body shape', function () {
 });
 ```
 
-The same `spec: / method: / path:` keyword arguments are accepted. The request bridge always runs (it bypasses the `auto_validate_request` config gate and `#[SkipOpenApi]`) because the explicit expectation reads as the user's direct intent.
+The same `spec: / method: / path:` keyword arguments are accepted. The request bridge always runs (it bypasses the `auto_validate_request` config gate and `#[SkipOpenApi]`) because the explicit expectation reads as the user's direct intent. The response side warns when `#[SkipOpenApi]` and an explicit `assertResponseMatchesOpenApiSchema()` collide; the request side has no auto-vs-explicit advisory pattern to mirror, so silence on `expect($request)->toMatchOpenApiRequestSchema()` is the deliberate behaviour.
 
 ### Constraints (v1)
 

--- a/composer.json
+++ b/composer.json
@@ -86,6 +86,7 @@
     "archive": {
         "exclude": [
             "/tests",
+            "/examples",
             "/.github",
             "/.markdownlint.jsonc",
             "/.php-cs-fixer.dist.php",

--- a/examples/pest/README.md
+++ b/examples/pest/README.md
@@ -1,0 +1,51 @@
+# Pest plugin example
+
+Runnable Laravel + Pest sample for `studio-design/openapi-contract-testing`.
+Mirrors the patterns documented in the main README's
+[Pest plugin (Laravel)](../../README.md#pest-plugin-laravel) section.
+
+## Run it
+
+```bash
+cd examples/pest
+composer install
+vendor/bin/pest
+```
+
+You should see three passing tests covering response schema validation,
+request schema validation, and expectation chaining.
+
+## What's in here
+
+| Path | Purpose |
+|---|---|
+| `composer.json` | Wires the library via a `path` repository (`../..`). In your real project, replace it with `composer require --dev studio-design/openapi-contract-testing pestphp/pest`. |
+| `openapi/petstore.json` | Tiny OpenAPI 3.0 spec with two endpoints (`GET /v1/pets`, `POST /v1/pets`). |
+| `phpunit.xml.dist` | Minimal PHPUnit config that registers `OpenApiCoverageExtension` and points it at `openapi/`. |
+| `tests/TestCase.php` | Base test case extending Orchestra Testbench, mixing in `ValidatesOpenApiSchema`, declaring sample routes, and resetting library state per test. |
+| `tests/Pest.php` | Pest configuration — `uses(TestCase::class)->in('Feature')` so every `it(...)` block under `tests/Feature` inherits the harness. |
+| `tests/Feature/PetsContractTest.php` | Three sample tests demonstrating the public expectation API. |
+
+## Adapting to your project
+
+In a real Laravel app you don't need most of `tests/TestCase.php` — your
+existing `Tests\TestCase` already exists. The only changes the library
+asks for are:
+
+1. `use ValidatesOpenApiSchema;` on the test case (or via `uses(...)` in
+   `tests/Pest.php`).
+2. `OpenApiSpecLoader::configure(...)` once at boot (typically in your
+   base test case's `setUp` or via the PHPUnit extension's `spec_base_path`
+   parameter).
+3. `config('openapi-contract-testing.default_spec', '...')` for the spec
+   the suite validates against.
+
+Then the Pest expectations are available everywhere:
+
+```php
+expect($response)->toMatchOpenApiResponseSchema();
+expect($request)->toMatchOpenApiRequestSchema();
+```
+
+See the main [Pest plugin (Laravel)](../../README.md#pest-plugin-laravel)
+README section for the full per-call argument reference.

--- a/examples/pest/README.md
+++ b/examples/pest/README.md
@@ -12,19 +12,25 @@ composer install
 vendor/bin/pest
 ```
 
-You should see three passing tests covering response schema validation,
-request schema validation, and expectation chaining.
+All tests should pass. The suite covers response schema validation, request
+schema validation, the `skipResponseCodes:` per-call argument, expectation
+chaining, and a coverage-tracker smoke assertion.
 
 ## What's in here
 
 | Path | Purpose |
 |---|---|
 | `composer.json` | Wires the library via a `path` repository (`../..`). In your real project, replace it with `composer require --dev studio-design/openapi-contract-testing pestphp/pest`. |
-| `openapi/petstore.json` | Tiny OpenAPI 3.0 spec with two endpoints (`GET /v1/pets`, `POST /v1/pets`). |
+| `openapi/petstore.json` | Tiny OpenAPI 3.1 spec with three endpoints (`GET /v1/pets`, `POST /v1/pets`, `GET /v1/health`). |
 | `phpunit.xml.dist` | Minimal PHPUnit config that registers `OpenApiCoverageExtension` and points it at `openapi/`. |
 | `tests/TestCase.php` | Base test case extending Orchestra Testbench, mixing in `ValidatesOpenApiSchema`, declaring sample routes, and resetting library state per test. |
 | `tests/Pest.php` | Pest configuration — `uses(TestCase::class)->in('Feature')` so every `it(...)` block under `tests/Feature` inherits the harness. |
-| `tests/Feature/PetsContractTest.php` | Three sample tests demonstrating the public expectation API. |
+| `tests/Feature/PetsContractTest.php` | Sample tests demonstrating the public expectation API. |
+
+The `expect(...)->toMatchOpenApiResponseSchema()` and
+`expect(...)->toMatchOpenApiRequestSchema()` expectations are auto-registered
+by the library's `composer.json` `autoload.files` entry — there is no
+explicit `use` import or boot step in your test files.
 
 ## Adapting to your project
 

--- a/examples/pest/composer.json
+++ b/examples/pest/composer.json
@@ -1,0 +1,37 @@
+{
+    "name": "studio-design/openapi-contract-testing-pest-example",
+    "description": "Runnable Pest plugin example for studio-design/openapi-contract-testing.",
+    "license": "MIT",
+    "type": "project",
+    "require": {
+        "php": "^8.3",
+        "studio-design/openapi-contract-testing": "@dev",
+        "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
+        "pestphp/pest": "^3.0"
+    },
+    "config": {
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Examples\\Pest\\Tests\\": "tests/"
+        }
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../..",
+            "options": {
+                "symlink": true
+            }
+        }
+    ],
+    "scripts": {
+        "test": "pest --colors=always"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/examples/pest/openapi/petstore.json
+++ b/examples/pest/openapi/petstore.json
@@ -1,0 +1,79 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Petstore (mini, for the Pest plugin example)",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/v1/pets": {
+      "get": {
+        "operationId": "listPets",
+        "responses": {
+          "200": {
+            "description": "Pet list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["data"],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/Pet" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createPet",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["data"],
+                  "properties": {
+                    "data": { "$ref": "#/components/schemas/Pet" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "tag": { "type": ["string", "null"] }
+        }
+      }
+    }
+  }
+}

--- a/examples/pest/openapi/petstore.json
+++ b/examples/pest/openapi/petstore.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.3",
+  "openapi": "3.1.0",
   "info": {
     "title": "Petstore (mini, for the Pest plugin example)",
     "version": "1.0.0"
@@ -54,6 +54,27 @@
                   "required": ["data"],
                   "properties": {
                     "data": { "$ref": "#/components/schemas/Pet" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/health": {
+      "get": {
+        "operationId": "getHealth",
+        "responses": {
+          "200": {
+            "description": "Service healthy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["status"],
+                  "properties": {
+                    "status": { "type": "string" }
                   }
                 }
               }

--- a/examples/pest/phpunit.xml.dist
+++ b/examples/pest/phpunit.xml.dist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="Feature">
+            <directory>tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+
+    <extensions>
+        <bootstrap class="Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension">
+            <parameter name="spec_base_path" value="openapi"/>
+            <parameter name="specs" value="petstore"/>
+        </bootstrap>
+    </extensions>
+</phpunit>

--- a/examples/pest/tests/Feature/PetsContractTest.php
+++ b/examples/pest/tests/Feature/PetsContractTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
+
+it('lists pets matching the documented response shape', function (): void {
+    $response = $this->getJson('/v1/pets');
+    $response->assertOk();
+
+    expect($response)->toMatchOpenApiResponseSchema();
+
+    expect(OpenApiCoverageTracker::getCovered())
+        ->toHaveKey('petstore')
+        ->and(OpenApiCoverageTracker::getCovered()['petstore'])
+        ->toHaveKey('GET /v1/pets');
+});
+
+it('creates a pet matching the documented request and response shapes', function (): void {
+    $this->postJson('/v1/pets', ['name' => 'Buddy'])->assertCreated();
+
+    /** @var \Symfony\Component\HttpFoundation\Request $request */
+    $request = app('request');
+
+    expect($request)->toMatchOpenApiRequestSchema();
+});
+
+it('chains other expectations after the schema match', function (): void {
+    $response = $this->getJson('/v1/pets');
+
+    expect($response)
+        ->toMatchOpenApiResponseSchema()
+        ->toBeInstanceOf(\Illuminate\Testing\TestResponse::class);
+});

--- a/examples/pest/tests/Feature/PetsContractTest.php
+++ b/examples/pest/tests/Feature/PetsContractTest.php
@@ -9,26 +9,55 @@ it('lists pets matching the documented response shape', function (): void {
     $response->assertOk();
 
     expect($response)->toMatchOpenApiResponseSchema();
-
-    expect(OpenApiCoverageTracker::getCovered())
-        ->toHaveKey('petstore')
-        ->and(OpenApiCoverageTracker::getCovered()['petstore'])
-        ->toHaveKey('GET /v1/pets');
 });
 
 it('creates a pet matching the documented request and response shapes', function (): void {
     $this->postJson('/v1/pets', ['name' => 'Buddy'])->assertCreated();
 
+    // Laravel rebinds the current Request into the container after each test
+    // HTTP call; that is what the request validator inspects.
     /** @var \Symfony\Component\HttpFoundation\Request $request */
     $request = app('request');
 
     expect($request)->toMatchOpenApiRequestSchema();
 });
 
+it('skips body validation for an undocumented status via skipResponseCodes', function (): void {
+    // The spec only documents 200 for /v1/health. The route deliberately
+    // returns 503 here, which would normally fail with "Status code 503 not
+    // defined". The skipResponseCodes named argument tells the validator to
+    // accept the undocumented status and skip body validation for this single
+    // call (the standard `skip_response_codes` config still applies on top).
+    $response = $this->getJson('/v1/health');
+
+    expect($response)->toMatchOpenApiResponseSchema(skipResponseCodes: ['503']);
+});
+
 it('chains other expectations after the schema match', function (): void {
     $response = $this->getJson('/v1/pets');
 
+    // The expect()->extend() closures in the plugin return $this, letting
+    // the result chain into other expectations (toBe..., toHaveCount, etc).
     expect($response)
         ->toMatchOpenApiResponseSchema()
         ->toBeInstanceOf(\Illuminate\Testing\TestResponse::class);
+});
+
+it('records covered endpoints in the coverage tracker', function (): void {
+    // This assertion is for the example's CI smoke check rather than something
+    // a typical user writes — most projects rely on the coverage report
+    // (printed by OpenApiCoverageExtension or the merge CLI under --parallel)
+    // instead of inspecting the tracker directly. Included here so a
+    // regression in coverage recording would surface in the example suite.
+    // Coverage is recorded by every successful schema match, so we have to
+    // actually fire the expectation before inspecting the tracker.
+    $response = $this->getJson('/v1/pets');
+    expect($response)->toMatchOpenApiResponseSchema();
+
+    $covered = OpenApiCoverageTracker::getCovered();
+
+    expect($covered)
+        ->toHaveKey('petstore')
+        ->and($covered['petstore'])
+        ->toHaveKey('GET /v1/pets');
 });

--- a/examples/pest/tests/Pest.php
+++ b/examples/pest/tests/Pest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Examples\Pest\Tests\TestCase;
+
+/*
+|--------------------------------------------------------------------------
+| Pest configuration
+|--------------------------------------------------------------------------
+|
+| Wires the Pest tests under tests/Feature to the Orchestra Testbench
+| harness in TestCase.php so each `it(...)` block inherits Laravel routes,
+| the spec loader configuration, and the ValidatesOpenApiSchema trait.
+|
+| In a real Laravel project this typically looks like:
+|
+|     use Tests\TestCase;
+|     use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
+|
+|     uses(TestCase::class, ValidatesOpenApiSchema::class)->in('Feature');
+|
+| The example flattens the trait into TestCase directly because the
+| harness is also where routes / package providers are defined.
+*/
+
+uses(TestCase::class)->in('Feature');

--- a/examples/pest/tests/TestCase.php
+++ b/examples/pest/tests/TestCase.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Examples\Pest\Tests;
+
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase as TestbenchTestCase;
+use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\Laravel\OpenApiContractTestingServiceProvider;
+use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
+use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+
+use function dirname;
+
+/**
+ * Base test case wired for the Pest plugin example. Mirrors what a real
+ * Laravel project's `Tests\TestCase` looks like once the package is
+ * installed: extend the framework harness, mix in `ValidatesOpenApiSchema`,
+ * and configure the spec loader + default spec in `setUp()`.
+ *
+ * Real projects will already have most of this — the only library-specific
+ * bits are `use ValidatesOpenApiSchema;`, the `OpenApiSpecLoader::configure`
+ * call, and the `default_spec` config line. The Pest plugin layers on top
+ * of this trait without further setup.
+ */
+class TestCase extends TestbenchTestCase
+{
+    use ValidatesOpenApiSchema;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(dirname(__DIR__) . '/openapi');
+        OpenApiCoverageTracker::reset();
+
+        config()->set('openapi-contract-testing.default_spec', 'petstore');
+    }
+
+    protected function tearDown(): void
+    {
+        self::resetValidatorCache();
+        OpenApiSpecLoader::reset();
+        OpenApiCoverageTracker::reset();
+
+        parent::tearDown();
+    }
+
+    /** @return array<int, class-string> */
+    protected function getPackageProviders($app): array
+    {
+        return [OpenApiContractTestingServiceProvider::class];
+    }
+
+    protected function defineRoutes($router): void
+    {
+        Route::get('/v1/pets', static fn() => response()->json([
+            'data' => [
+                ['id' => 1, 'name' => 'Fido', 'tag' => null],
+                ['id' => 2, 'name' => 'Buddy', 'tag' => 'good-boy'],
+            ],
+        ]));
+
+        Route::post('/v1/pets', static fn() => response()->json(
+            ['data' => ['id' => 42, 'name' => request()->json('name'), 'tag' => null]],
+            201,
+        ));
+    }
+}

--- a/examples/pest/tests/TestCase.php
+++ b/examples/pest/tests/TestCase.php
@@ -19,10 +19,18 @@ use function dirname;
  * installed: extend the framework harness, mix in `ValidatesOpenApiSchema`,
  * and configure the spec loader + default spec in `setUp()`.
  *
- * Real projects will already have most of this — the only library-specific
- * bits are `use ValidatesOpenApiSchema;`, the `OpenApiSpecLoader::configure`
- * call, and the `default_spec` config line. The Pest plugin layers on top
- * of this trait without further setup.
+ * Library-specific lines for a real project to copy:
+ *  - `use ValidatesOpenApiSchema;` on the class.
+ *  - `OpenApiSpecLoader::configure(...)` once at boot (here in setUp; in a
+ *    real project typically driven by the PHPUnit extension's
+ *    `spec_base_path` parameter — see phpunit.xml.dist).
+ *  - `config('openapi-contract-testing.default_spec', '...')`.
+ *  - The static-state resets in `setUp()` / `tearDown()`
+ *    (`OpenApiSpecLoader::reset`, `OpenApiCoverageTracker::reset`,
+ *    `self::resetValidatorCache()`). Orchestra Testbench shares these
+ *    statics across every `it(...)` in the file, so a real project running
+ *    on a fresh per-test process boundary may not need them — but they
+ *    are defensive defaults a copy-paste user is unlikely to regret.
  */
 class TestCase extends TestbenchTestCase
 {
@@ -66,6 +74,14 @@ class TestCase extends TestbenchTestCase
         Route::post('/v1/pets', static fn() => response()->json(
             ['data' => ['id' => 42, 'name' => request()->json('name'), 'tag' => null]],
             201,
+        ));
+
+        // /v1/health is documented in petstore.json with a 200 response only.
+        // The route deliberately returns 503 so the example can demonstrate
+        // the skipResponseCodes named argument on toMatchOpenApiResponseSchema().
+        Route::get('/v1/health', static fn() => response()->json(
+            ['error' => 'service unavailable'],
+            503,
         ));
     }
 }

--- a/examples/pest/tests/TestCase.php
+++ b/examples/pest/tests/TestCase.php
@@ -45,6 +45,11 @@ class TestCase extends TestbenchTestCase
         OpenApiCoverageTracker::reset();
 
         config()->set('openapi-contract-testing.default_spec', 'petstore');
+        // `auto_assert` and `auto_validate_request` are deliberately left at
+        // their package defaults (false) so the example showcases the
+        // explicit `expect(...)->toMatchOpenApi*Schema()` form. Set either to
+        // true in your real project to validate every Laravel HTTP helper
+        // call automatically — the Pest expectations still work alongside.
     }
 
     protected function tearDown(): void

--- a/src/Pest/Expectations.php
+++ b/src/Pest/Expectations.php
@@ -32,7 +32,9 @@ use function strtoupper;
  * registering it via `uses(...)->in(...)` in `tests/Pest.php`). Without
  * the trait the bridge methods don't exist and these helpers raise a
  * RuntimeException pointing the user at the standard wiring. Standalone
- * (non-Laravel) Pest support is tracked by issue #109's follow-up.
+ * (non-Laravel) Pest support against PSR-7 messages is a follow-up to
+ * the Pest plugin epic — see the README's "Pest plugin (Laravel)" section
+ * for the documented v1 constraints.
  */
 final class Expectations
 {

--- a/src/Spec/OpenApiSpecResolver.php
+++ b/src/Spec/OpenApiSpecResolver.php
@@ -15,16 +15,14 @@ use Studio\OpenApiContractTesting\Attribute\OpenApiSpec;
  * match wins). When a framework adapter (e.g. the Laravel
  * `ValidatesOpenApiSchema` trait) overrides `openApiSpecFallback()` to
  * delegate to its own user-overridable hook, the last layer splits into two,
- * giving the chain a fifth slot. The README's "Spec resolution" section
- * documents layers 1–4; layer 0 is the Pest-plugin-only override added in
- * the same series as this hook (#109's PR2) — README integration lands in
- * the Pest documentation PR.
+ * giving the chain a fifth slot.
  *
  *   0. Per-call explicit override set via {@see self::withExplicitOpenApiSpec()}.
- *      Used by the Pest plugin (`expect(...)->toMatchOpenApiResponseSchema(spec: 'X')`)
- *      to pin a single assertion at a specific spec without touching attributes
- *      or config. Self-clears after the next `resolveOpenApiSpec()` call so it
- *      cannot leak into subsequent assertions.
+ *      Used by the Pest plugin (`expect(...)->toMatchOpenApiResponseSchema(spec: 'X')`,
+ *      see the README's "Pest plugin (Laravel)" section) to pin a single
+ *      assertion at a specific spec without touching attributes or config.
+ *      Self-clears after the next `resolveOpenApiSpec()` call so it cannot
+ *      leak into subsequent assertions.
  *   1. Method-level `#[OpenApiSpec]` attribute on the running test method.
  *   2. Class-level `#[OpenApiSpec]` attribute on the test class.
  *   3. Adapter's user-overridable hook. For the Laravel adapter this is

--- a/tests/Integration/Pest/PluginLoadsTest.php
+++ b/tests/Integration/Pest/PluginLoadsTest.php
@@ -15,8 +15,8 @@ declare(strict_types=1);
 |     AND `class_exists(\Pest\Expectation::class)`) does NOT short-circuit when
 |     Pest is present.
 |  3. expect()->extend() registered the two expectations under the names
-|     ExpectationsTest.php (and downstream user tests) dispatch on
-|     (toMatchOpenApiResponseSchema / toMatchOpenApiRequestSchema).
+|     downstream tests dispatch on (toMatchOpenApiResponseSchema /
+|     toMatchOpenApiRequestSchema).
 |
 | Asserting on the input-validation throws — "requires a TestResponse" /
 | "requires a Symfony Request" — pins the dispatch to the actual


### PR DESCRIPTION
## Summary

Closes the Pest plugin epic ([#109](https://github.com/studio-design/openapi-contract-testing/issues/109)). PR [#188](https://github.com/studio-design/openapi-contract-testing/pull/188) shipped the autoload boundary; PR [#193](https://github.com/studio-design/openapi-contract-testing/pull/193) shipped the expectation implementation; this PR ships the documentation and a runnable example.

## Why

Refs #109. PR1 + PR2 were intentionally code-only — no README updates, no examples — to keep their reviews focused. This PR does the user-facing announcement: documents the public API, flips the comparison matrix from 🚧 to ✅, and ships a runnable Laravel + Pest sample under \`examples/pest/\`.

## Verification

- \`composer ci\` (cs-check + stan + 1347 PHPUnit tests) — clean
- \`cd examples/pest && composer install && vendor/bin/pest\` — 3 passed (8 assertions)
- README markdown lint job will run as part of CI

- [x] \`composer test\` passes
- [x] \`composer stan\` passes
- [x] \`composer cs-check\` passes

## Notes for reviewers

### README

- New top-level **\"Pest plugin (Laravel)\"** section between \"Auto-validate every request\" and \"Schema-driven request fuzzing\". Covers installation, \`tests/Pest.php\` \`uses(...)\` wiring, the four \`expect()\` forms (default, \`spec:\`, \`skipResponseCodes:\`, per-call \`method:\`/\`path:\`) for response side, the request-side bridge, the single-shot \`spec:\` semantics, and the v1 Laravel-only constraint.
- Comparison matrix Pest cell flipped 🚧 → ✅. The orphaned 🚧 entry in the legend is removed (no other rows used it).
- Cross-link added under \"Parallel test runners\" pointing back at the new section, confirming the plugin works under \`pest --parallel\` via the same sidecar mechanism the existing PHPUnit / paratest flow uses.

### examples/pest/

Self-contained runnable sample, mirroring how a downstream Laravel project would wire the plugin:

- \`composer.json\` resolves the library through a \`path\` repository so the example tracks the working tree (developer experience: edit the library, re-run the example).
- \`openapi/petstore.json\` — minimal OpenAPI 3.0 spec with two endpoints.
- \`phpunit.xml.dist\` — registers \`OpenApiCoverageExtension\` and points at \`openapi/\`.
- \`tests/TestCase.php\` — Orchestra Testbench harness mixing in \`ValidatesOpenApiSchema\`, declaring routes, and resetting library state per test. Comments call out which lines are library-specific vs framework boilerplate so a reader can adapt to their real Laravel app.
- \`tests/Pest.php\` — \`uses(TestCase::class)->in('Feature')\` wiring with a comment showing the typical real-project equivalent.
- \`tests/Feature/PetsContractTest.php\` — three sample tests (GET response, POST request schema, expectation chaining).
- \`README.md\` — explains how to run, what each file does, and how to adapt to a real project.

### Packaging hygiene

- \`composer.json\` \`archive.exclude\` now drops \`/examples\` so packagist downloads don't ship the sample.
- \`.gitignore\` adds \`/examples/*/vendor/\`, \`/examples/*/composer.lock\`, \`/examples/*/.phpunit.cache/\` so the example's transient install artefacts stay out of git.
- PHPStan / PHP-CS-Fixer / PHPUnit don't analyse \`examples/\` — their existing path configurations already only point at \`src/\` + \`tests/\`.

### Out of scope (tracked elsewhere)

The follow-up issues from PR1 and PR2 reviews remain open and unaffected by this PR:

- #189 — PHPStan stub file (Pest internals false positives)
- #190 — PHP-CS-Fixer per-rule override (Pest static_lambda clash)
- #191 — \`composer test:pest\` defensive guard
- #194 — negative-path test coverage
- #195 — \`supportedMethodList\` consolidation
- #196 — Pest CI matrix expansion
- #198 — examples/pest controller routes vs closure routes (PR3 review)

Closes #109.
