### PR TITLE
docs(examples/pest): note closure-vs-controller route choice

### DIFF
--- a/examples/pest/tests/TestCase.php
+++ b/examples/pest/tests/TestCase.php
@@ -69,6 +69,12 @@ class TestCase extends TestbenchTestCase
 
     protected function defineRoutes($router): void
     {
+        // Closure routes keep the example focused. In your real Laravel
+        // project these would typically be controller actions:
+        //   Route::get('/v1/pets', [PetController::class, 'index']);
+        // The library validates the response after Laravel dispatches —
+        // independent of how the route resolved — so the contract tests
+        // look identical either way.
         Route::get('/v1/pets', static fn() => response()->json([
             'data' => [
                 ['id' => 1, 'name' => 'Fido', 'tag' => null],


### PR DESCRIPTION
## Summary

Adds a 6-line header comment to `defineRoutes()` in `examples/pest/tests/TestCase.php` pointing readers at the controller-route form a real Laravel app would use. The closures stay — they keep the example focused on the library API — but the comment removes the "wait, where would I put my real controller?" friction a first-time reader hits.

## Why

Closes #198. Filed from the PR #197 review (test-analyzer S3): the closure routes are perfectly fine for teaching the library, but the example silently models a routing style most Laravel apps don't use.

## Verification

- \`cd examples/pest && vendor/bin/pest\`: 5 passed (10 assertions)

- [x] \`composer test\` passes (untouched — no library code changed)
- [x] \`composer stan\` passes (untouched)
- [x] \`composer cs-check\` passes (untouched)

## Notes for reviewers

Picked Option A from the issue (inline comment) over Option B (full controller class scaffold) because the example's value is the `expect(...)->toMatchOpenApi*Schema()` calls, not the routing layer. A controller class would add boilerplate that doesn't teach the library and would force the harness to wire namespaces / autoload-dev entries that real projects already have.