### PR TITLE
ci(pest): expand pest job matrix to PHP 8.3 + 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,21 +59,31 @@ jobs:
         run: vendor/bin/phpunit
 
   pest:
-    name: Pest plugin smoke
+    name: Pest plugin smoke (PHP ${{ matrix.php }})
     runs-on: ubuntu-latest
-    # Pest 3 requires PHPUnit ^11; mainline matrix also runs PHPUnit 12/13
-    # for which Pest has no compatible major yet. Keeping this job on the
-    # PHPUnit 11 floor isolates the Pest plugin without forcing the rest of
-    # the matrix to drop newer PHPUnit versions. Pest is added on demand
-    # rather than to require-dev so the regular composer install used by
-    # the matrix above stays Pest-free.
+    # Pest 3 requires PHPUnit ^11; the mainline matrix also runs PHPUnit
+    # 12/13 for which Pest has no compatible major yet. Keeping this job on
+    # the PHPUnit 11 floor isolates the Pest plugin without forcing the rest
+    # of the matrix to drop newer PHPUnit versions. Pest is added on demand
+    # rather than to require-dev so the regular composer install used by the
+    # matrix above stays Pest-free.
+    #
+    # The 2-cell matrix (PHP 8.3 + 8.4) catches PHP-version regressions on
+    # the Pest internals the dispatcher depends on (HigherOrderTapProxy,
+    # PendingCalls\TestCall, dynamic property access). PHP 8.2 is excluded
+    # because Pest 3 dropped PHP 8.2 support around v3.5; bumping the upper
+    # Pest version (Pest 4 / PHPUnit ^12) is tracked separately.
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.3', '8.4']
     steps:
       - uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: ${{ matrix.php }}
           coverage: none
 
       - name: Install dependencies (with Pest 3)


### PR DESCRIPTION
## Summary

Converts the existing single-cell \`pest:\` CI job into a 2-cell matrix (PHP 8.3 + PHP 8.4, both with PHPUnit ^11 + Pest ^3).

## Why

Closes #196. Filed from PR #193 review (test-analyzer #11). The Pest plugin dispatcher in \`src/Pest/Expectations.php\` depends on Pest internals (\`Pest\Support\HigherOrderTapProxy::\$target\`, \`Pest\PendingCalls\TestCall\`, dynamic property access on the proxy) that aren't stability-frozen across PHP minor versions. The single-cell job catches PHP 8.3 regressions only; PHP 8.4 changes in dynamic property access semantics or Pest internals would slip through.

## Verification

- Workflow YAML structure validated locally (matrix block parses).
- The actual matrix run will be visible on this PR — both cells should pass with the existing \`composer test:pest\` smoke (10 it() blocks across PluginLoadsTest + ExpectationsTest).

- [x] \`composer test\` passes (untouched — workflow change only)
- [x] \`composer stan\` passes (untouched)
- [x] \`composer cs-check\` passes (untouched)

## Notes for reviewers

- **PHP 8.2 stays out** — Pest 3 dropped PHP 8.2 support around v3.5. Adding it would force a Pest version pin we don't need; PHP 8.2 is still covered by the mainline matrix where Pest is absent.
- **Pest 4 (PHPUnit ^12) deferred** — that's a larger move (Pest 4 changes dispatcher behaviour around \`HigherOrderTapProxy\` per upstream changelog) and would need its own scoping issue.
- Matrix cells run in parallel; total wall-clock is unchanged.