### PR TITLE
refactor(pest): consolidate supported HttpMethod list rendering

### DIFF
--- a/src/HttpMethod.php
+++ b/src/HttpMethod.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting;
 
+use function array_map;
+use function implode;
+
 enum HttpMethod: string
 {
     case GET = 'GET';
@@ -11,4 +14,18 @@ enum HttpMethod: string
     case PUT = 'PUT';
     case PATCH = 'PATCH';
     case DELETE = 'DELETE';
+
+    /**
+     * Comma-separated list of supported method values for use in error
+     * messages (e.g. "Allowed: GET, POST, PUT, PATCH, DELETE").
+     *
+     * Centralised so the Pest dispatcher and the Laravel trait error
+     * surfaces stay in sync when a new case is added to the enum.
+     *
+     * @internal Used by the Pest plugin and the Laravel ValidatesOpenApiSchema trait.
+     */
+    public static function listOfValues(): string
+    {
+        return implode(', ', array_map(static fn(self $m): string => $m->value, self::cases()));
+    }
 }

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -33,12 +33,10 @@ use Symfony\Component\HttpFoundation\Response;
 use WeakMap;
 
 use function array_key_first;
-use function array_map;
 use function array_merge;
 use function filter_var;
 use function fwrite;
 use function get_debug_type;
-use function implode;
 use function is_array;
 use function is_int;
 use function is_numeric;
@@ -199,7 +197,7 @@ trait ValidatesOpenApiSchema
                 'toMatchOpenApiRequestSchema received a Request with unrecognised HTTP method %s. '
                 . 'Supported methods: %s.',
                 var_export($request->getMethod(), true),
-                implode(', ', array_map(static fn(HttpMethod $m): string => $m->value, HttpMethod::cases())),
+                HttpMethod::listOfValues(),
             ));
         }
 

--- a/src/Pest/Expectations.php
+++ b/src/Pest/Expectations.php
@@ -13,8 +13,6 @@ use Symfony\Component\HttpFoundation\Request;
 
 use function function_exists;
 use function get_debug_type;
-use function implode;
-use function in_array;
 use function method_exists;
 use function sprintf;
 use function strtoupper;
@@ -178,22 +176,10 @@ final class Expectations
                 '%s() received unsupported method: %s. Allowed: %s.',
                 $expectationName,
                 $method,
-                self::supportedMethodList(),
+                HttpMethod::listOfValues(),
             ));
         }
 
         return $resolved;
-    }
-
-    private static function supportedMethodList(): string
-    {
-        $names = [];
-        foreach (HttpMethod::cases() as $case) {
-            if (!in_array($case->value, $names, true)) {
-                $names[] = $case->value;
-            }
-        }
-
-        return implode(', ', $names);
     }
 }


### PR DESCRIPTION
## Summary

Adds \`HttpMethod::listOfValues(): string\` and replaces the two independent renderings of the supported-method comma-separated string in \`src/Pest/Expectations.php\` and \`src/Laravel/ValidatesOpenApiSchema.php\` with calls to it. Drops the dead \`in_array\` dedup that the Pest dispatcher carried.

## Why

Closes #195. Filed from PR #193 review (silent-failure S3 / code-reviewer Suggestion 2). The two renderings produced identical output today (\`'GET, POST, PUT, PATCH, DELETE'\`), but a sixth case added to \`HttpMethod\` would silently require updating both error messages — easy to forget. One source of truth eliminates the drift.

## Verification

- \`composer ci\` (cs-check + stan + 1347 PHPUnit tests): green
- \`cd examples/pest && vendor/bin/pest\`: 5 passed (10 assertions)
- \`composer test:pest\` (with Pest 3 + PHPUnit 11 temp install): 10 passed (28 assertions)

- [x] \`composer test\` passes
- [x] \`composer stan\` passes
- [x] \`composer cs-check\` passes

## Notes for reviewers

- **\`HttpMethod::listOfValues()\` is marked \`@internal\`.** It exists for the Pest plugin and the Laravel trait error surfaces; downstream consumers shouldn't depend on it.
- **No SemVer concern.** \`HttpMethod\` is a public enum, but adding a static method is a minor-version-compatible addition.
- **Behaviour preserved.** Both call sites continue to produce \`'GET, POST, PUT, PATCH, DELETE'\` today; the test surface that pins error messages (PluginLoadsTest, ExpectationsTest, the integration tests for the Laravel request bridge) is untouched and green.
- **\`in_array\` dedup removal is safe.** PHP backed enum cases are unique by language guarantee.