### PR TITLE
chore(test:pest): defensive guard for missing Pest install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,10 @@
     },
     "scripts": {
         "test": "phpunit",
-        "test:pest": "pest --colors=always tests/Integration/Pest",
+        "test:pest": [
+            "@php scripts/check-pest.php",
+            "pest --colors=always tests/Integration/Pest"
+        ],
         "stan": "phpstan analyse",
         "cs": "php-cs-fixer fix",
         "cs-check": "php-cs-fixer fix --dry-run --diff",
@@ -87,6 +90,7 @@
         "exclude": [
             "/tests",
             "/examples",
+            "/scripts",
             "/.github",
             "/.markdownlint.jsonc",
             "/.php-cs-fixer.dist.php",

--- a/scripts/check-pest.php
+++ b/scripts/check-pest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Composer-script guard invoked before `composer test:pest`.
+ *
+ * Pest is intentionally not listed in require-dev because Pest 3 requires
+ * PHPUnit ^11 — incompatible with the PHPUnit ^12 / ^13 cells of the main
+ * test matrix. So a fresh `composer install` does NOT bring Pest in.
+ *
+ * Without this guard, `composer test:pest` against a Pest-free vendor/
+ * fails with "sh: pest: command not found" (exit 127) — technically
+ * loud, but a contributor seeing it has to know which command to run
+ * to fix it. This script catches the missing binary up front and prints
+ * the exact install command instead.
+ */
+
+if (is_file(__DIR__ . '/../vendor/bin/pest')) {
+    exit(0);
+}
+
+fwrite(
+    STDERR,
+    "\nERROR: vendor/bin/pest not found.\n"
+    . "\n"
+    . "composer test:pest requires Pest 3+. Install it with:\n"
+    . "  composer require --dev pestphp/pest:^3.0\n"
+    . "\n"
+    . "Pest is intentionally not in require-dev because Pest 3 conflicts\n"
+    . "with PHPUnit ^12 / ^13 from the mainline test matrix.\n"
+    . "\n",
+);
+
+exit(1);


### PR DESCRIPTION
## Summary

Adds \`scripts/check-pest.php\` as a composer-script guard invoked before the actual \`pest\` call. When \`vendor/bin/pest\` is missing, it prints an actionable error pointing at the install command and exits non-zero — replacing the bare \`sh: pest: command not found\` (exit 127) that contributors used to see.

## Why

Closes #191. Filed from PR #188 review (silent-failure S-3). \`composer test:pest\` was technically loud on a Pest-free vendor (exit 127) but the failure mode wasn't actionable — a first-time contributor had to know that Pest is intentionally not in \`require-dev\` (it conflicts with PHPUnit ^12 / ^13 in the mainline matrix) and had to look up the install command.

## Verification

Tested both branches locally:

- **Pest absent** (\`composer install\` baseline):
  \`\`\`
  $ composer test:pest
  ERROR: vendor/bin/pest not found.

  composer test:pest requires Pest 3+. Install it with:
    composer require --dev pestphp/pest:^3.0

  Pest is intentionally not in require-dev because Pest 3 conflicts
  with PHPUnit ^12 / ^13 from the mainline test matrix.
  \`\`\`
  Exit code 1 (clean fail, script chain stops).

- **Pest installed** (after \`composer require --dev pestphp/pest:^3.0\`): 10 passed (28 assertions). Guard exits 0 silently and Pest runs as before.

- \`composer ci\` (cs-check + stan + 1347 PHPUnit tests): green.

- [x] \`composer test\` passes
- [x] \`composer stan\` passes
- [x] \`composer cs-check\` passes

## Notes for reviewers

- **Bin script over inline \`@php -r\`.** Inline composer scripts via \`@php -r\` get gnarly with quoting (cmd.exe vs bash differ on quote handling), and the resulting JSON is unreadable. A small bin script is cross-platform and self-documenting.
- **\`scripts/\` directory added to \`archive.exclude\`** so the helper doesn't ship in packagist downloads. PHPStan paths and PHP-CS-Fixer Finder are scoped to \`src/\` + \`tests/\`, so no exclusion needed there.
- **No bin/ entry.** \`bin/openapi-coverage-merge\` is user-facing (downstream consumers run it). The Pest guard is purely for the package's own composer scripts.