### PR TITLE
test(pest): negative-path coverage for plugin dispatch

### DIFF
--- a/tests/Integration/Pest/ExpectationsTest.php
+++ b/tests/Integration/Pest/ExpectationsTest.php
@@ -131,3 +131,44 @@ it('chains expectations after the schema match', function (): void {
         ->toMatchOpenApiResponseSchema()
         ->toBeInstanceOf(\Illuminate\Testing\TestResponse::class);
 });
+
+/*
+|--------------------------------------------------------------------------
+| Negative-path coverage
+|--------------------------------------------------------------------------
+|
+| Pin the dispatch's input-validation error paths so a future rewording or
+| accidental removal of a guard surfaces in CI rather than at downstream
+| user reports. The "missing trait" path lives in MissingTraitTest.php
+| because it requires a test class WITHOUT ValidatesOpenApiSchema and the
+| harness here always provides it.
+*/
+
+it('rejects unsupported HTTP methods on toMatchOpenApiResponseSchema', function (): void {
+    $response = $this->get('/v1/pets');
+
+    expect(static fn () => expect($response)->toMatchOpenApiResponseSchema(method: 'CONNECT'))
+        ->toThrow(\RuntimeException::class, 'received unsupported method: CONNECT');
+});
+
+it('round-trips lowercase HTTP method strings via strtoupper', function (): void {
+    // Removing the strtoupper in resolveHttpMethod would silently break the
+    // (probably common) case where users write `method: 'get'`. Pin it.
+    $response = $this->get('/v1/pets');
+    $response->assertOk();
+
+    expect($response)->toMatchOpenApiResponseSchema(method: 'get');
+});
+
+it('fails loudly when spec: is an empty string', function (): void {
+    // Layer-0 explicit override accepts the empty string as a valid value
+    // (it short-circuits resolution to ''), then assertResponseMatchesOpenApiSchema
+    // surfaces the standard "openApiSpec() must return a non-empty spec name"
+    // error from the trait. Real footgun for users null-coalescing optional
+    // config; pin the current behaviour so a future change doesn't silently
+    // shift the surface.
+    $response = $this->get('/v1/pets');
+
+    expect(static fn () => expect($response)->toMatchOpenApiResponseSchema(spec: ''))
+        ->toThrow(AssertionFailedError::class, 'openApiSpec() must return a non-empty spec name');
+});

--- a/tests/Integration/Pest/MissingTraitTest.php
+++ b/tests/Integration/Pest/MissingTraitTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Response;
+use Illuminate\Testing\TestResponse;
+
+/*
+|--------------------------------------------------------------------------
+| "Missing trait" dispatch path
+|--------------------------------------------------------------------------
+|
+| Exercises Expectations::resolveTestCase()'s `method_exists` guard — the
+| user-facing message that fires when a Pest test class is missing the
+| ValidatesOpenApiSchema trait. The other Pest tests inherit the trait
+| through PestLaravelTestCase, which short-circuits this guard, so this
+| file deliberately stays outside the global `uses(PestLaravelTestCase::class)`
+| binding declared in tests/Pest.php.
+|
+| The guard is the most common misconfiguration surface for new Pest plugin
+| users — get the wiring wrong in tests/Pest.php and this is the message
+| pointing them at the fix. Worth pinning so a future rewording doesn't
+| silently regress its actionability.
+*/
+
+it('errors with guidance when test class lacks ValidatesOpenApiSchema', function (): void {
+    // Construct a TestResponse synthetically — we do NOT have Laravel booted
+    // here, so $this->get() / $this->postJson() / app('request') aren't
+    // available. The dispatch only needs the type-validation guard
+    // (instanceof TestResponse) to pass, then it lands on
+    // resolveTestCase()'s method_exists check, which is what we're pinning.
+    $response = new TestResponse(new Response('{"data":[]}', 200, ['Content-Type' => 'application/json']));
+
+    expect(static fn () => expect($response)->toMatchOpenApiResponseSchema())
+        ->toThrow(
+            \RuntimeException::class,
+            'requires the test class',
+        );
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -20,4 +20,13 @@ use Studio\OpenApiContractTesting\Tests\Helpers\PestLaravelTestCase;
 | filter directories — the script's path argument already does.
 */
 
-uses(PestLaravelTestCase::class)->in('Integration/Pest');
+// Bind the Orchestra Testbench harness explicitly to the Laravel-flavoured
+// test files. NegativePathsTest covers boundary errors that can be triggered
+// without booting Laravel, and MissingTraitTest deliberately runs against
+// vanilla PHPUnit\Framework\TestCase to exercise the dispatch's "missing
+// trait" guidance message — both are excluded so they don't pick up the
+// trait that would short-circuit those checks.
+uses(PestLaravelTestCase::class)->in(
+    'Integration/Pest/PluginLoadsTest.php',
+    'Integration/Pest/ExpectationsTest.php',
+);


### PR DESCRIPTION
## Summary

Adds 4 \`it(...)\` blocks pinning the Pest plugin dispatch's input-validation error paths. Each test would catch a regression where a guard is rewritten or removed; without them the failure mode is a downstream user reporting a confusing exception.

## Why

Closes #194. Filed from PR #193 review (test-analyzer #1, #3, #4, #6). The dispatch in \`src/Pest/Expectations.php\` raises four classes of \`RuntimeException\` for input misuse — supported method validation, empty spec, missing trait, lowercase method. Happy-path coverage was complete in PR #193; the unhappy paths slipped through.

## Verification

- \`composer test:pest\` (Pest 3 + PHPUnit 11 temp install): **14 passed (37 assertions)** — up from 10 / 28 in main.
- \`composer ci\` (cs-check + stan + 1347 PHPUnit tests): green.

- [x] \`composer test\` passes
- [x] \`composer stan\` passes
- [x] \`composer cs-check\` passes

## Notes for reviewers

### What's covered

| Path | Test | Pinned behaviour |
|---|---|---|
| Unsupported method (\`'CONNECT'\`) | ExpectationsTest | \`Expectations::resolveHttpMethod\` throws with "received unsupported method: CONNECT" |
| Lowercase method (\`'get'\`) round-trip | ExpectationsTest | \`strtoupper\` lets \`'get'\` resolve to \`HttpMethod::GET\` (regression guard) |
| \`spec: ''\` empty string | ExpectationsTest | Layer-0 override accepts \`''\`, falls through to \`assertResponseMatchesOpenApiSchema\` standard "openApiSpec() must return a non-empty spec name" error |
| Test class lacks \`ValidatesOpenApiSchema\` | **MissingTraitTest** (new file) | \`resolveTestCase()\` \`method_exists\` guard throws with "requires the test class to use the trait" |

### MissingTraitTest setup

The "trait missing" path needs a test class WITHOUT the trait. The other Pest tests inherit it through \`PestLaravelTestCase\`, which short-circuits the guard. To exercise the real path:

- \`tests/Pest.php\` now lists the trait-bound files explicitly (\`PluginLoadsTest.php\`, \`ExpectationsTest.php\`) instead of binding to the whole \`Integration/Pest/\` directory. New files default to vanilla \`PHPUnit\\Framework\\TestCase\` unless explicitly bound.
- \`MissingTraitTest\` constructs a \`TestResponse\` synthetically (no Laravel boot needed — only the dispatch's \`method_exists\` check fires before the trait would normally take over).

### Future-proofing

If new files are added under \`tests/Integration/Pest/\` later, contributors will need to either (a) add them to the explicit list in \`tests/Pest.php\` or (b) leave them out if they're standalone. The list-vs-glob trade-off is documented inline.