### PR TITLE
refactor(pest): replace PHPStan excludePaths with Pest stub file

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,25 +15,28 @@ parameters:
     paths:
         - src
         - tests
+    # Pest is intentionally not in require-dev (Pest 3 conflicts with the
+    # PHPUnit ^12 / ^13 cells of the matrix). Without this stub PHPStan
+    # would surface "unknown class" / "unknown function" errors on every
+    # Pest-flavoured file. The stub declares Pest\Expectation, the
+    # HigherOrderTapProxy / TestCall wrappers, and the global
+    # expect()/test()/it()/uses() functions with just enough type
+    # information for the type-sensitive static dispatch in
+    # src/Pest/Expectations.php to analyse cleanly (the file is no longer
+    # excluded from analysis).
+    scanFiles:
+        - stubs/pest.stub
     excludePaths:
         - src/Laravel
-        # Pest plugin code references Pest classes (`Pest\Expectation`,
-        # `Pest\Support\HigherOrderTapProxy`) and the global `expect()` /
-        # `test()` functions, none of which are available unless the
-        # downstream consumer installs `pestphp/pest`. The static-analysis
-        # job uses the default require-dev (Pest-free), so analysing these
-        # files would surface false positives. The runtime guards
-        # (function_exists + class_exists checks in Autoload.php; trait
-        # method_exists check in Expectations.php) make the symbols safe to
-        # reference at load time. The Pest bootstrap and integration tests
-        # are excluded for the same reason — they reference Pest globals
-        # PHPStan cannot resolve without Pest installed.
-        #
-        # Issue #189 tracks replacing these exclusions with a Pest stub
-        # file so PHPStan can analyse the closure signatures and the
-        # `$this->value` access inside expect()->extend() callbacks.
+        # Pest's `expect()->extend()` and `it(...)` rebind `$this` to the
+        # Expectation / TestCase instance at runtime — a pattern PHPStan
+        # cannot follow statically. Every $this access inside those
+        # closures would surface as "Undefined variable: $this". The
+        # Autoload file and the Pest test files are excluded for that
+        # reason; the type-sensitive dispatch logic lives in
+        # src/Pest/Expectations.php (not excluded) which the stub now
+        # makes analysable.
         - src/Pest/Autoload.php
-        - src/Pest/Expectations.php
         - tests/Pest.php
         - tests/Integration/Pest
         # EnumScanner fixture dir holds intentionally-unused trait/abstract

--- a/src/Pest/Expectations.php
+++ b/src/Pest/Expectations.php
@@ -124,7 +124,6 @@ final class Expectations
             ));
         }
 
-        /** @var object $testCase */
         $testCase = test();
         if ($testCase instanceof HigherOrderTapProxy) {
             /** @var object $testCase */

--- a/stubs/pest.stub
+++ b/stubs/pest.stub
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * PHPStan stub for the Pest plugin's runtime dependencies.
+ *
+ * The Pest plugin under src/Pest/ and the Pest tests under
+ * tests/Integration/Pest/ reference Pest classes and global functions
+ * (Pest\Expectation, expect(), test(), it(), uses(), HigherOrderTapProxy,
+ * PendingCalls\TestCall). Pest is intentionally absent from require-dev
+ * — Pest 3 conflicts with PHPUnit ^12 / ^13 from the mainline test
+ * matrix — so the static-analysis CI job has no real Pest classes
+ * available and would otherwise surface false "unknown class / function"
+ * errors on every Pest-flavoured file.
+ *
+ * This stub gives PHPStan just enough type information to analyse the
+ * dispatch closures, `$this->value` access inside expect()->extend()
+ * callbacks, and the `instanceof HigherOrderTapProxy` / `TestCall`
+ * unwrap branches. Method bodies are intentionally empty — runtime
+ * behaviour is provided by Pest itself when it's installed.
+ *
+ * Loaded via `parameters.scanFiles` in phpstan.neon.dist so PHPStan
+ * picks up the class / function declarations without analysing them.
+ *
+ * Closes #189.
+ */
+
+namespace Pest {
+    final class Expectation
+    {
+        public mixed $value;
+
+        public function extend(string $name, \Closure $expectation): void
+        {
+        }
+
+        public function toThrow(string|\Throwable $exception, ?string $exceptionMessage = null): self
+        {
+        }
+
+        public function toBeInstanceOf(string $class): self
+        {
+        }
+
+        public function toHaveKey(string $key): self
+        {
+        }
+
+        public function toBe(mixed $expected): self
+        {
+        }
+
+        public function toBeNull(): self
+        {
+        }
+
+        public function and(mixed $value = null): self
+        {
+        }
+
+        public function not(): self
+        {
+        }
+
+        public function __get(string $name): self
+        {
+        }
+    }
+}
+
+namespace Pest\Support {
+    /**
+     * Wraps the running TestCase so user code can write `test()->skip(...)`.
+     */
+    final class HigherOrderTapProxy
+    {
+        public mixed $target;
+    }
+}
+
+namespace Pest\PendingCalls {
+    /**
+     * Returned by `test()` when a description is supplied.
+     */
+    final class TestCall
+    {
+    }
+}
+
+namespace {
+    function expect(mixed $value = null): \Pest\Expectation
+    {
+    }
+
+    function test(?string $description = null, ?\Closure $closure = null): \Pest\Expectation|\Pest\PendingCalls\TestCall|\Pest\Support\HigherOrderTapProxy
+    {
+    }
+
+    function it(string $description, ?\Closure $closure = null): \Pest\PendingCalls\TestCall
+    {
+    }
+
+    function uses(string ...$classAndTraits): \Pest\PendingCalls\TestCall
+    {
+    }
+
+    function beforeEach(?\Closure $closure = null): \Pest\PendingCalls\TestCall
+    {
+    }
+
+    function afterEach(?\Closure $closure = null): \Pest\PendingCalls\TestCall
+    {
+    }
+}


### PR DESCRIPTION
## Summary

Adds \`stubs/pest.stub\` declaring the Pest classes and global functions referenced by the plugin code, wires it into \`phpstan.neon.dist\` via \`parameters.scanFiles\`, and reduces the Pest exclusion set so \`src/Pest/Expectations.php\` is now analysed.

## Why

Closes #189. PR #188 review (silent-failure I-4) flagged that excluding the Pest plugin code from PHPStan silently loses analysis on type-sensitive dispatch logic — a future drift in \`HttpMethod::tryFrom\` chain, \`HigherOrderTapProxy::\$target\` access, or instanceof unwrap order would only surface at runtime. The stub replaces "no analysis" with "analysis backed by typed declarations."

## What changed

| File | Now analysed? | Why |
|---|---|---|
| \`src/Pest/Expectations.php\` | **Yes** (was excluded) | All references resolve via the stub. The redundant \`@var object \$testCase\` is dropped — the stub provides a precise union type for \`test()\`. |
| \`src/Pest/Autoload.php\` | Still excluded | \`expect()->extend()\` rebinds \`\$this\` to the Expectation instance at runtime; PHPStan can't follow that. The file is purely procedural registration. |
| \`tests/Integration/Pest/\` | Still excluded | \`it(...)\` callbacks have the same \`\$this\` rebinding issue against the TestCase. |
| \`tests/Pest.php\` | Still excluded | Same reason. |

## Verification

- \`composer ci\` (cs-check + stan + 1347 PHPUnit tests): green
- \`composer stan\` specifically: **No errors** (was 4-49 errors at various stages of debugging the stub)
- \`composer test:pest\` (Pest 3 + PHPUnit 11 temp install): 10 passed (28 assertions)
- \`cd examples/pest && vendor/bin/pest\`: 5 passed (10 assertions)

- [x] \`composer test\` passes
- [x] \`composer stan\` passes
- [x] \`composer cs-check\` passes

## Notes for reviewers

- **\`scanFiles\` over \`stubFiles\`.** PHPStan's \`stubFiles\` are designed to OVERRIDE existing class declarations (i.e. patch incorrect types in real third-party libraries). Pest is missing entirely from the static-analysis env, not just incorrectly typed — so \`scanFiles\` (which makes PHPStan parse a file for declarations without analysing it) is the right choice. Verified via \`vendor/bin/phpstan dump-parameters | grep pest.stub\` showing the stub loaded.
- **Bracketed namespaces are mandatory** for the global function declarations in this stub. PHP rejects mixing bracketed and non-bracketed namespaces in one file with a fatal error; learned the hard way during stub iteration.
- **Stub coverage is intentionally minimal.** It declares only the Pest API surface this plugin actually touches. Adding methods is cheap when needed; carrying a "complete" Pest API would just be drift bait.
- **\`@var object\` removal.** The stub now types \`test()\` as \`Pest\Expectation|Pest\PendingCalls\TestCall|Pest\Support\HigherOrderTapProxy\`, which is strictly more specific than \`object\`. PHPStan's \`varTag.nativeType\` rule (under bleedingEdge) flags the now-redundant annotation.