### PR TITLE
refactor(coverage): extract callable-list dispatch for report writers

### DIFF
--- a/src/Coverage/CoverageMergeCommand.php
+++ b/src/Coverage/CoverageMergeCommand.php
@@ -43,6 +43,13 @@ use function unlink;
  * lives here as a class so it can be unit-tested without spawning a
  * subprocess.
  *
+ * @phpstan-import-type CoverageResult from OpenApiCoverageTracker
+ *
+ * @phpstan-type CoverageReportEntry array{
+ *     label: string,
+ *     renderer: callable(array<string, CoverageResult>): string,
+ *     outputFile: ?string,
+ * }
  * @phpstan-type MergeOptions array{
  *     sidecar_dir?: string,
  *     spec_base_path?: string,
@@ -297,21 +304,8 @@ final class CoverageMergeCommand
 
         $this->writeStdout(ConsoleCoverageRenderer::render($results, $consoleOutput));
 
-        $writeFailures = 0;
-        if ($outputFile !== null || $githubSummaryPath !== null) {
-            $markdown = MarkdownCoverageRenderer::render($results);
-
-            // Suppress PHP warning on failure — we surface the error
-            // ourselves via stderr + exit code so the warning is redundant
-            // noise that breaks `beStrictAboutOutputDuringTests` test runs.
-            if ($outputFile !== null && @file_put_contents($outputFile, $markdown) === false) {
-                $this->writeStderr(sprintf("[OpenAPI Coverage] FATAL: Failed to write Markdown report to %s\n", $outputFile));
-                $writeFailures++;
-            }
-            if ($githubSummaryPath !== null && @file_put_contents($githubSummaryPath, $markdown . "\n", FILE_APPEND) === false) {
-                $this->writeStderr(sprintf("[OpenAPI Coverage] WARNING: Failed to append Markdown report to GITHUB_STEP_SUMMARY (%s)\n", $githubSummaryPath));
-            }
-        }
+        $writeFailures = $this->writeReports($results, $outputFile);
+        $this->appendGithubStepSummary($results, $githubSummaryPath);
 
         $thresholdFailure = $this->evaluateThresholdGate($results, $minEndpointPct, $minResponsePct, $minStrict);
 
@@ -320,6 +314,85 @@ final class CoverageMergeCommand
         }
 
         return $writeFailures > 0 || $thresholdFailure ? 1 : 0;
+    }
+
+    /**
+     * Dispatch each configured renderer to its output target. Per-entry write
+     * failures emit a FATAL line and bump the counter the caller turns into a
+     * non-zero exit — broken format paths must not silently disappear in CI.
+     *
+     * @param array<string, CoverageResult> $results
+     *
+     * @return int Number of format outputs that failed to write
+     */
+    private function writeReports(array $results, ?string $outputFile): int
+    {
+        $writeFailures = 0;
+
+        foreach ($this->buildReportEntries($outputFile) as $entry) {
+            if ($entry['outputFile'] === null) {
+                continue;
+            }
+
+            $rendered = ($entry['renderer'])($results);
+
+            // Suppress PHP warning on failure — we surface the error
+            // ourselves via stderr + exit code so the warning is redundant
+            // noise that breaks `beStrictAboutOutputDuringTests` test runs.
+            if (@file_put_contents($entry['outputFile'], $rendered) === false) {
+                $this->writeStderr(sprintf(
+                    "[OpenAPI Coverage] FATAL: Failed to write %s report to %s\n",
+                    $entry['label'],
+                    $entry['outputFile'],
+                ));
+                $writeFailures++;
+            }
+        }
+
+        return $writeFailures;
+    }
+
+    /**
+     * Renderer dispatch table. PR 2/3/4 (issue #116) append JUnit XML, JSON,
+     * and HTML entries here; the loop in writeReports() does not need to
+     * change. The merge CLI mirrors {@see CoverageReportSubscriber} so adding
+     * a format means touching both dispatchers identically.
+     *
+     * @return list<CoverageReportEntry>
+     */
+    private function buildReportEntries(?string $outputFile): array
+    {
+        return [
+            [
+                'label' => 'Markdown',
+                'renderer' => static fn(array $r): string => MarkdownCoverageRenderer::render($r),
+                'outputFile' => $outputFile,
+            ],
+        ];
+    }
+
+    /**
+     * GITHUB_STEP_SUMMARY is Markdown-only by design — the file is a single
+     * shared sink that GitHub consumes as Markdown, so JUnit/JSON/HTML do not
+     * get appended here. A failure here is non-fatal: the merge CLI's exit
+     * code stays driven by the primary output writes.
+     *
+     * @param array<string, CoverageResult> $results
+     */
+    private function appendGithubStepSummary(array $results, ?string $githubSummaryPath): void
+    {
+        if ($githubSummaryPath === null) {
+            return;
+        }
+
+        $markdown = MarkdownCoverageRenderer::render($results);
+
+        if (@file_put_contents($githubSummaryPath, $markdown . "\n", FILE_APPEND) === false) {
+            $this->writeStderr(sprintf(
+                "[OpenAPI Coverage] WARNING: Failed to append Markdown report to GITHUB_STEP_SUMMARY (%s)\n",
+                $githubSummaryPath,
+            ));
+        }
     }
 
     /**

--- a/src/Coverage/CoverageMergeCommand.php
+++ b/src/Coverage/CoverageMergeCommand.php
@@ -44,12 +44,8 @@ use function unlink;
  * subprocess.
  *
  * @phpstan-import-type CoverageResult from OpenApiCoverageTracker
+ * @phpstan-import-type CoverageReportEntry from OpenApiCoverageTracker
  *
- * @phpstan-type CoverageReportEntry array{
- *     label: string,
- *     renderer: callable(array<string, CoverageResult>): string,
- *     outputFile: ?string,
- * }
  * @phpstan-type MergeOptions array{
  *     sidecar_dir?: string,
  *     spec_base_path?: string,
@@ -318,8 +314,10 @@ final class CoverageMergeCommand
 
     /**
      * Dispatch each configured renderer to its output target. Per-entry write
-     * failures emit a FATAL line and bump the counter the caller turns into a
-     * non-zero exit — broken format paths must not silently disappear in CI.
+     * failures emit a FATAL line, bump the counter the caller turns into a
+     * non-zero exit, and continue to the next entry — one format's broken
+     * path must not suppress the others or block the threshold gate that
+     * runs after this.
      *
      * @param array<string, CoverageResult> $results
      *
@@ -353,10 +351,12 @@ final class CoverageMergeCommand
     }
 
     /**
-     * Renderer dispatch table. PR 2/3/4 (issue #116) append JUnit XML, JSON,
-     * and HTML entries here; the loop in writeReports() does not need to
-     * change. The merge CLI mirrors {@see CoverageReportSubscriber} so adding
-     * a format means touching both dispatchers identically.
+     * Renderer dispatch table. Follow-up work tracked in #116 appends JUnit
+     * XML, JSON, and HTML entries here; the loop in {@see self::writeReports()}
+     * does not need to change. The PHPUnit subscriber keeps a parallel table
+     * in {@see CoverageReportSubscriber},
+     * so any new format must be added to both in lockstep — note the severity
+     * asymmetry (subscriber warns; CLI counts failures toward exit code).
      *
      * @return list<CoverageReportEntry>
      */

--- a/src/Coverage/OpenApiCoverageTracker.php
+++ b/src/Coverage/OpenApiCoverageTracker.php
@@ -79,6 +79,11 @@ use function usort;
  *         responses: array<string, array{state: string, hits: int, skipReason: ?string}>,
  *     }>>,
  * }
+ * @phpstan-type CoverageReportEntry array{
+ *     label: string,
+ *     renderer: callable(array<string, CoverageResult>): string,
+ *     outputFile: ?string,
+ * }
  */
 final class OpenApiCoverageTracker
 {

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -29,6 +29,12 @@ use function trim;
 /**
  * @phpstan-import-type CoverageResult from OpenApiCoverageTracker
  *
+ * @phpstan-type CoverageReportEntry array{
+ *     label: string,
+ *     renderer: callable(array<string, CoverageResult>): string,
+ *     outputFile: ?string,
+ * }
+ *
  * @internal Not part of the package's public API. Do not use from user code.
  */
 final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscriber
@@ -92,9 +98,7 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
 
         echo ConsoleCoverageRenderer::render($results, $this->consoleOutput);
 
-        if ($this->outputFile !== null || $this->githubSummaryPath !== null) {
-            $this->writeMarkdownReport($results);
-        }
+        $this->writeReports($results);
 
         $this->evaluateThresholdGate($results);
     }
@@ -282,26 +286,67 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
     }
 
     /**
+     * Dispatch each configured renderer to its output target. Per-entry write
+     * failures emit a WARNING and continue — one format's broken path must not
+     * suppress the others or block the threshold gate that runs after this.
+     *
+     * GITHUB_STEP_SUMMARY is Markdown-only by design and handled separately.
+     *
      * @param array<string, CoverageResult> $results
      */
-    private function writeMarkdownReport(array $results): void
+    private function writeReports(array $results): void
     {
-        $markdown = MarkdownCoverageRenderer::render($results);
+        foreach ($this->buildReportEntries() as $entry) {
+            if ($entry['outputFile'] === null) {
+                continue;
+            }
 
-        if ($this->outputFile !== null) {
-            $written = file_put_contents($this->outputFile, $markdown);
+            $rendered = ($entry['renderer'])($results);
 
-            if ($written === false) {
-                $this->writeStderr("[OpenAPI Coverage] WARNING: Failed to write Markdown report to {$this->outputFile}\n");
+            if (file_put_contents($entry['outputFile'], $rendered) === false) {
+                $this->writeStderr(sprintf(
+                    "[OpenAPI Coverage] WARNING: Failed to write %s report to %s\n",
+                    $entry['label'],
+                    $entry['outputFile'],
+                ));
             }
         }
 
-        if ($this->githubSummaryPath !== null) {
-            $written = file_put_contents($this->githubSummaryPath, $markdown . "\n", FILE_APPEND);
+        $this->appendGithubStepSummary($results);
+    }
 
-            if ($written === false) {
-                $this->writeStderr("[OpenAPI Coverage] WARNING: Failed to append Markdown report to GITHUB_STEP_SUMMARY ({$this->githubSummaryPath})\n");
-            }
+    /**
+     * Renderer dispatch table. PR 2/3/4 (issue #116) append JUnit XML, JSON,
+     * and HTML entries here; the loop in writeReports() does not need to
+     * change.
+     *
+     * @return list<CoverageReportEntry>
+     */
+    private function buildReportEntries(): array
+    {
+        return [
+            [
+                'label' => 'Markdown',
+                'renderer' => static fn(array $r): string => MarkdownCoverageRenderer::render($r),
+                'outputFile' => $this->outputFile,
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, CoverageResult> $results
+     */
+    private function appendGithubStepSummary(array $results): void
+    {
+        if ($this->githubSummaryPath === null) {
+            return;
+        }
+
+        $markdown = MarkdownCoverageRenderer::render($results);
+        $written = file_put_contents($this->githubSummaryPath, $markdown . "\n", FILE_APPEND);
+
+        if ($written === false) {
+            $this->writeStderr("[OpenAPI Coverage] WARNING: Failed to append Markdown report to GITHUB_STEP_SUMMARY ({$this->githubSummaryPath})\n");
         }
     }
 }

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -11,6 +11,7 @@ use PHPUnit\Event\TestRunner\ExecutionFinished;
 use PHPUnit\Event\TestRunner\ExecutionFinishedSubscriber;
 use RuntimeException;
 use Studio\OpenApiContractTesting\Coverage\ConsoleCoverageRenderer;
+use Studio\OpenApiContractTesting\Coverage\CoverageMergeCommand;
 use Studio\OpenApiContractTesting\Coverage\CoverageSidecarWriter;
 use Studio\OpenApiContractTesting\Coverage\CoverageThresholdEvaluator;
 use Studio\OpenApiContractTesting\Coverage\MarkdownCoverageRenderer;
@@ -28,12 +29,7 @@ use function trim;
 
 /**
  * @phpstan-import-type CoverageResult from OpenApiCoverageTracker
- *
- * @phpstan-type CoverageReportEntry array{
- *     label: string,
- *     renderer: callable(array<string, CoverageResult>): string,
- *     outputFile: ?string,
- * }
+ * @phpstan-import-type CoverageReportEntry from OpenApiCoverageTracker
  *
  * @internal Not part of the package's public API. Do not use from user code.
  */
@@ -316,9 +312,12 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
     }
 
     /**
-     * Renderer dispatch table. PR 2/3/4 (issue #116) append JUnit XML, JSON,
-     * and HTML entries here; the loop in writeReports() does not need to
-     * change.
+     * Renderer dispatch table. Follow-up work tracked in #116 appends JUnit
+     * XML, JSON, and HTML entries here; the loop in {@see self::writeReports()}
+     * does not need to change. The merge CLI keeps a parallel table in
+     * {@see CoverageMergeCommand}, so
+     * any new format must be added to both in lockstep — note the severity
+     * asymmetry (subscriber warns; CLI counts failures toward exit code).
      *
      * @return list<CoverageReportEntry>
      */
@@ -334,6 +333,12 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
     }
 
     /**
+     * GITHUB_STEP_SUMMARY is Markdown-only by design — the file is a single
+     * shared sink that GitHub consumes as Markdown, so additional output
+     * formats do not get appended here. Failures emit a WARNING and do not
+     * affect any exit code (the subscriber has no exit gate of its own for
+     * this path).
+     *
      * @param array<string, CoverageResult> $results
      */
     private function appendGithubStepSummary(array $results): void


### PR DESCRIPTION
## Summary

Foundation refactor for #116. Splits the "render → `file_put_contents`" path in `CoverageReportSubscriber` and `CoverageMergeCommand` into a small dispatch table (`buildReportEntries()` + `writeReports()` + `appendGithubStepSummary()`) so subsequent PRs can append JUnit XML / JSON / HTML entries without touching the loop.

## Why

#116 adds JUnit XML / JSON / HTML coverage output to broaden CI dashboard integration (GitLab, Jenkins, SonarQube, Bitrise). Plumbing four new formats into two existing call sites with copy-pasted `if ... file_put_contents` blocks would compound complexity. This PR is the dispatch-shape refactor only — no new format, no new parameter, no behaviour change for users.

Cobertura is deliberately out of scope (semantic mismatch with code-coverage tooling); will re-evaluate if demand surfaces.

## Verification

- [x] `composer test` passes (1347 tests / 3217 assertions)
- [x] `composer stan` passes (level 6, 190 files)
- [x] `composer cs-check` passes for the primary config

Pre-existing on `main` and unrelated to this PR: the Pest-specific `.php-cs-fixer.pest.dist.php` config flags `static fn ()` (space) vs `static fn()` (no space) in `tests/Integration/Pest/MissingTraitTest.php` and `tests/Integration/Pest/ExpectationsTest.php`. Reproducible by checking out `main` and running `composer cs-check`. Worth a follow-up but out of scope here.

## Notes for reviewers

- Subscriber preserves WARN-and-continue semantics on Markdown write failure (no exit-code change).
- Merge CLI preserves the FATAL-and-bump-`$writeFailures` semantics for the primary `--output-file` path → still exits 1 on write failure (covered by `CoverageMergeCommandTest::exits_one_when_output_file_write_fails`).
- `GITHUB_STEP_SUMMARY` stays Markdown-only and is handled outside the dispatch loop because the file is a single GitHub-consumed sink.
- New `@phpstan-type CoverageReportEntry` is declared in both files (subscriber and merge command) rather than shared, since both classes are `@internal` and the loop bodies differ slightly (WARN vs FATAL severity). Will revisit if a third consumer appears.
- Subsequent PRs in the #116 chain: JUnit XML → JSON → HTML, each adds a renderer + extension parameter + CLI flag + tests + sample.