### PR TITLE
feat(coverage): add JUnit XML output for CI dashboard integration

### DIFF
--- a/docs/samples/coverage.junit.xml
+++ b/docs/samples/coverage.junit.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="openapi-contract-coverage" time="0" tests="6" failures="2" skipped="1">
+  <testsuite name="petstore" time="0" tests="6" failures="2" skipped="1">
+    <testcase classname="openapi.coverage.petstore" name="GET /v1/pets [200 application/json]" time="0">
+      <system-out>hits=12 operationId=listPets</system-out>
+    </testcase>
+    <testcase classname="openapi.coverage.petstore" name="POST /v1/pets [201 application/json]" time="0">
+      <system-out>hits=3 operationId=createPet</system-out>
+    </testcase>
+    <testcase classname="openapi.coverage.petstore" name="POST /v1/pets [422 application/problem+json]" time="0">
+      <failure type="UncoveredResponse" message="Response 422 application/problem+json on POST /v1/pets not exercised by any test"/>
+      <system-out>hits=0 operationId=createPet</system-out>
+    </testcase>
+    <testcase classname="openapi.coverage.petstore" name="POST /v1/pets [unexpected 418 application/json]" time="0">
+      <failure type="UnexpectedObservation" message="Observed 418 application/json on POST /v1/pets but spec declares no such response"/>
+      <system-out>hits=0 operationId=createPet</system-out>
+    </testcase>
+    <testcase classname="openapi.coverage.petstore" name="DELETE /v1/pets/{petId} [204 *]" time="0">
+      <system-out>hits=1 operationId=deletePet</system-out>
+    </testcase>
+    <testcase classname="openapi.coverage.petstore" name="DELETE /v1/pets/{petId} [503 application/json]" time="0">
+      <skipped message="status 503 matched skip pattern 5\d\d"/>
+      <system-out>hits=1 operationId=deletePet</system-out>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/src/Coverage/CoverageMergeCommand.php
+++ b/src/Coverage/CoverageMergeCommand.php
@@ -52,6 +52,7 @@ use function unlink;
  *     specs?: list<string>,
  *     strip_prefixes?: list<string>,
  *     output_file?: string,
+ *     junit_output?: string,
  *     github_step_summary?: string,
  *     console_output?: string,
  *     cleanup?: bool,
@@ -160,6 +161,8 @@ final class CoverageMergeCommand
               --sidecar-dir=<path>          Worker sidecar directory. Defaults to
                                             sys_get_temp_dir()/openapi-coverage-sidecars.
               --output-file=<path>          Markdown report output path.
+              --junit-output=<path>         JUnit XML report output path (for CI dashboards
+                                            like GitLab CI test reports, Jenkins, SonarQube).
               --github-step-summary=<path>  Append Markdown report to this file (also
                                             consults GITHUB_STEP_SUMMARY env var).
               --console-output=<mode>       default | all | uncovered_only.
@@ -202,6 +205,9 @@ final class CoverageMergeCommand
         $stripPrefixes = $options['strip_prefixes'] ?? [];
         $outputFile = isset($options['output_file']) && $options['output_file'] !== ''
             ? $this->absolutise($options['output_file'])
+            : null;
+        $junitOutput = isset($options['junit_output']) && $options['junit_output'] !== ''
+            ? $this->absolutise($options['junit_output'])
             : null;
         $githubSummaryPath = isset($options['github_step_summary']) && $options['github_step_summary'] !== ''
             ? $options['github_step_summary']
@@ -300,7 +306,7 @@ final class CoverageMergeCommand
 
         $this->writeStdout(ConsoleCoverageRenderer::render($results, $consoleOutput));
 
-        $writeFailures = $this->writeReports($results, $outputFile);
+        $writeFailures = $this->writeReports($results, $outputFile, $junitOutput);
         $this->appendGithubStepSummary($results, $githubSummaryPath);
 
         $thresholdFailure = $this->evaluateThresholdGate($results, $minEndpointPct, $minResponsePct, $minStrict);
@@ -323,11 +329,11 @@ final class CoverageMergeCommand
      *
      * @return int Number of format outputs that failed to write
      */
-    private function writeReports(array $results, ?string $outputFile): int
+    private function writeReports(array $results, ?string $outputFile, ?string $junitOutput): int
     {
         $writeFailures = 0;
 
-        foreach ($this->buildReportEntries($outputFile) as $entry) {
+        foreach ($this->buildReportEntries($outputFile, $junitOutput) as $entry) {
             if ($entry['outputFile'] === null) {
                 continue;
             }
@@ -360,13 +366,18 @@ final class CoverageMergeCommand
      *
      * @return list<CoverageReportEntry>
      */
-    private function buildReportEntries(?string $outputFile): array
+    private function buildReportEntries(?string $outputFile, ?string $junitOutput): array
     {
         return [
             [
                 'label' => 'Markdown',
                 'renderer' => static fn(array $r): string => MarkdownCoverageRenderer::render($r),
                 'outputFile' => $outputFile,
+            ],
+            [
+                'label' => 'JUnit XML',
+                'renderer' => static fn(array $r): string => JUnitCoverageRenderer::render($r),
+                'outputFile' => $junitOutput,
             ],
         ];
     }

--- a/src/Coverage/InvalidCoverageOutputPathException.php
+++ b/src/Coverage/InvalidCoverageOutputPathException.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Coverage;
+
+use RuntimeException;
+use Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension;
+use Throwable;
+
+/**
+ * Thrown by {@see OpenApiCoverageExtension} when an output-file path parameter
+ * (currently `junit_output`; reusable for additional formats added under #116)
+ * is set but invalid — empty/whitespace value, or a parent directory that
+ * does not exist / is not writable.
+ *
+ * Distinct from {@see InvalidThresholdConfigurationException} because the
+ * failure mode is filesystem misconfiguration, not a threshold typo. Distinct
+ * from a generic SPL `InvalidArgumentException` so `bootstrap()` can catch
+ * exactly this case without swallowing unrelated argument errors raised
+ * deeper in the call graph (e.g. from spec loading or path matching).
+ */
+final class InvalidCoverageOutputPathException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $parameterName,
+        string $message,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/src/Coverage/JUnitCoverageRenderer.php
+++ b/src/Coverage/JUnitCoverageRenderer.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Coverage;
+
+use DOMDocument;
+use DOMElement;
+
+use function implode;
+use function sprintf;
+
+/**
+ * Render coverage results as a JUnit XML document for CI dashboards (GitLab,
+ * Jenkins, SonarQube, Bitrise, CircleCI test-report tabs).
+ *
+ * Mapping from coverage state to JUnit elements:
+ *  - {@see ResponseCoverageState::Validated}: `<testcase>` with no child element (CI green)
+ *  - {@see ResponseCoverageState::Skipped}:   `<testcase>` with `<skipped>` (CI yellow)
+ *  - {@see ResponseCoverageState::Uncovered}: `<testcase>` with `<failure type="UncoveredResponse">` (CI red)
+ *  - Endpoint with no spec response definitions: one synthetic `<testcase>` with `<skipped>`
+ *  - Unexpected observation (status / content-type not in spec): `<testcase>` with `<failure type="UnexpectedObservation">`
+ *
+ * Structural decisions documented in issue #116 plan:
+ *  - Wrap in `<testsuites>` root even for one spec (Jenkins-strict parsers reject bare `<testsuite>`).
+ *  - `classname="openapi.coverage.{specName}"` for SonarQube tree-view compatibility.
+ *  - Emit `time="0"` on every element (some parsers throw without it).
+ *  - Build via {@see DOMDocument} so attribute / text escaping is automatic.
+ *
+ * @phpstan-import-type CoverageResult from OpenApiCoverageTracker
+ * @phpstan-import-type EndpointSummary from OpenApiCoverageTracker
+ * @phpstan-import-type ResponseRow from OpenApiCoverageTracker
+ */
+final class JUnitCoverageRenderer
+{
+    private const ROOT_NAME = 'openapi-contract-coverage';
+    private const CLASSNAME_PREFIX = 'openapi.coverage.';
+
+    /**
+     * @param array<string, CoverageResult> $results
+     */
+    public static function render(array $results): string
+    {
+        if ($results === []) {
+            return '';
+        }
+
+        $doc = new DOMDocument('1.0', 'UTF-8');
+        $doc->formatOutput = true;
+
+        $root = $doc->createElement('testsuites');
+        $root->setAttribute('name', self::ROOT_NAME);
+        $root->setAttribute('time', '0');
+        $doc->appendChild($root);
+
+        $totalTests = 0;
+        $totalFailures = 0;
+        $totalSkipped = 0;
+
+        foreach ($results as $specName => $result) {
+            [$suite, $suiteTests, $suiteFailures, $suiteSkipped] = self::renderSpec($doc, $specName, $result);
+            $root->appendChild($suite);
+
+            $totalTests += $suiteTests;
+            $totalFailures += $suiteFailures;
+            $totalSkipped += $suiteSkipped;
+        }
+
+        $root->setAttribute('tests', (string) $totalTests);
+        $root->setAttribute('failures', (string) $totalFailures);
+        $root->setAttribute('skipped', (string) $totalSkipped);
+
+        return (string) $doc->saveXML();
+    }
+
+    /**
+     * @param CoverageResult $result
+     *
+     * @return array{0: DOMElement, 1: int, 2: int, 3: int} {suite element, tests, failures, skipped}
+     */
+    private static function renderSpec(DOMDocument $doc, string $specName, array $result): array
+    {
+        $suite = $doc->createElement('testsuite');
+        $suite->setAttribute('name', $specName);
+        $suite->setAttribute('time', '0');
+
+        $classname = self::CLASSNAME_PREFIX . $specName;
+        $tests = 0;
+        $failures = 0;
+        $skipped = 0;
+
+        foreach ($result['endpoints'] as $endpoint) {
+            foreach (self::renderEndpoint($doc, $classname, $endpoint) as $entry) {
+                /** @var array{element: DOMElement, isFailure: bool, isSkipped: bool} $entry */
+                $suite->appendChild($entry['element']);
+                $tests++;
+                if ($entry['isFailure']) {
+                    $failures++;
+                }
+                if ($entry['isSkipped']) {
+                    $skipped++;
+                }
+            }
+        }
+
+        $suite->setAttribute('tests', (string) $tests);
+        $suite->setAttribute('failures', (string) $failures);
+        $suite->setAttribute('skipped', (string) $skipped);
+
+        return [$suite, $tests, $failures, $skipped];
+    }
+
+    /**
+     * Build a list of `<testcase>` elements for a single endpoint. Always
+     * returns at least one element so the per-spec count stays meaningful
+     * even for endpoints with no declared responses.
+     *
+     * @param EndpointSummary $endpoint
+     *
+     * @return list<array{element: DOMElement, isFailure: bool, isSkipped: bool}>
+     */
+    private static function renderEndpoint(DOMDocument $doc, string $classname, array $endpoint): array
+    {
+        $cases = [];
+
+        foreach ($endpoint['responses'] as $row) {
+            $cases[] = self::renderResponseCase($doc, $classname, $endpoint, $row);
+        }
+
+        foreach ($endpoint['unexpectedObservations'] as $obs) {
+            $cases[] = self::renderUnexpectedCase($doc, $classname, $endpoint, $obs);
+        }
+
+        if ($cases === []) {
+            // No declared responses and no unexpected observations — emit one
+            // synthetic <skipped> so the endpoint still contributes to the
+            // testsuite count and "structural gap" stays visible in CI.
+            $cases[] = self::renderSyntheticCase($doc, $classname, $endpoint);
+        }
+
+        return $cases;
+    }
+
+    /**
+     * @param EndpointSummary $endpoint
+     * @param ResponseRow $row
+     *
+     * @return array{element: DOMElement, isFailure: bool, isSkipped: bool}
+     */
+    private static function renderResponseCase(
+        DOMDocument $doc,
+        string $classname,
+        array $endpoint,
+        array $row,
+    ): array {
+        $name = sprintf(
+            '%s [%s %s]',
+            $endpoint['endpoint'],
+            $row['statusKey'],
+            $row['contentTypeKey'],
+        );
+        $tc = self::baseTestcase($doc, $classname, $name);
+
+        $isFailure = false;
+        $isSkipped = false;
+
+        switch ($row['state']) {
+            case ResponseCoverageState::Validated:
+                // green — no child element
+                break;
+            case ResponseCoverageState::Skipped:
+                $skipEl = $doc->createElement('skipped');
+                $skipEl->setAttribute('message', $row['skipReason'] ?? 'skipped');
+                $tc->appendChild($skipEl);
+                $isSkipped = true;
+                break;
+            case ResponseCoverageState::Uncovered:
+                $failEl = $doc->createElement('failure');
+                $failEl->setAttribute('type', 'UncoveredResponse');
+                $failEl->setAttribute('message', sprintf(
+                    'Response %s %s on %s not exercised by any test',
+                    $row['statusKey'],
+                    $row['contentTypeKey'],
+                    $endpoint['endpoint'],
+                ));
+                $tc->appendChild($failEl);
+                $isFailure = true;
+                break;
+        }
+
+        self::appendSystemOut($doc, $tc, $endpoint, $row['hits']);
+
+        return ['element' => $tc, 'isFailure' => $isFailure, 'isSkipped' => $isSkipped];
+    }
+
+    /**
+     * @param EndpointSummary $endpoint
+     * @param array{statusKey: string, contentTypeKey: string} $obs
+     *
+     * @return array{element: DOMElement, isFailure: bool, isSkipped: bool}
+     */
+    private static function renderUnexpectedCase(
+        DOMDocument $doc,
+        string $classname,
+        array $endpoint,
+        array $obs,
+    ): array {
+        $name = sprintf(
+            '%s [unexpected %s %s]',
+            $endpoint['endpoint'],
+            $obs['statusKey'],
+            $obs['contentTypeKey'],
+        );
+        $tc = self::baseTestcase($doc, $classname, $name);
+
+        $failEl = $doc->createElement('failure');
+        $failEl->setAttribute('type', 'UnexpectedObservation');
+        $failEl->setAttribute('message', sprintf(
+            'Observed %s %s on %s but spec declares no such response',
+            $obs['statusKey'],
+            $obs['contentTypeKey'],
+            $endpoint['endpoint'],
+        ));
+        $tc->appendChild($failEl);
+
+        self::appendSystemOut($doc, $tc, $endpoint, hits: 0);
+
+        return ['element' => $tc, 'isFailure' => true, 'isSkipped' => false];
+    }
+
+    /**
+     * @param EndpointSummary $endpoint
+     *
+     * @return array{element: DOMElement, isFailure: bool, isSkipped: bool}
+     */
+    private static function renderSyntheticCase(DOMDocument $doc, string $classname, array $endpoint): array
+    {
+        $tc = self::baseTestcase($doc, $classname, $endpoint['endpoint']);
+
+        $skipEl = $doc->createElement('skipped');
+        $skipEl->setAttribute(
+            'message',
+            $endpoint['requestReached']
+                ? 'request reached, but spec has no response definitions'
+                : 'no response definitions in spec; no observations recorded',
+        );
+        $tc->appendChild($skipEl);
+
+        self::appendSystemOut($doc, $tc, $endpoint, hits: 0);
+
+        return ['element' => $tc, 'isFailure' => false, 'isSkipped' => true];
+    }
+
+    private static function baseTestcase(DOMDocument $doc, string $classname, string $name): DOMElement
+    {
+        $tc = $doc->createElement('testcase');
+        $tc->setAttribute('classname', $classname);
+        $tc->setAttribute('name', $name);
+        $tc->setAttribute('time', '0');
+
+        return $tc;
+    }
+
+    /**
+     * @param EndpointSummary $endpoint
+     */
+    private static function appendSystemOut(DOMDocument $doc, DOMElement $tc, array $endpoint, int $hits): void
+    {
+        $parts = [sprintf('hits=%d', $hits)];
+        if ($endpoint['operationId'] !== null) {
+            $parts[] = sprintf('operationId=%s', $endpoint['operationId']);
+        }
+
+        $sysOut = $doc->createElement('system-out');
+        $sysOut->appendChild($doc->createTextNode(implode(' ', $parts)));
+        $tc->appendChild($sysOut);
+    }
+}

--- a/src/Coverage/JUnitCoverageRenderer.php
+++ b/src/Coverage/JUnitCoverageRenderer.php
@@ -6,6 +6,7 @@ namespace Studio\OpenApiContractTesting\Coverage;
 
 use DOMDocument;
 use DOMElement;
+use RuntimeException;
 
 use function implode;
 use function sprintf;
@@ -18,14 +19,19 @@ use function sprintf;
  *  - {@see ResponseCoverageState::Validated}: `<testcase>` with no child element (CI green)
  *  - {@see ResponseCoverageState::Skipped}:   `<testcase>` with `<skipped>` (CI yellow)
  *  - {@see ResponseCoverageState::Uncovered}: `<testcase>` with `<failure type="UncoveredResponse">` (CI red)
- *  - Endpoint with no spec response definitions: one synthetic `<testcase>` with `<skipped>`
  *  - Unexpected observation (status / content-type not in spec): `<testcase>` with `<failure type="UnexpectedObservation">`
+ *  - Endpoint with neither declared responses nor unexpected observations recorded:
+ *    one synthetic `<testcase>` with `<skipped>` so the structural gap stays visible
+ *    in CI dashboards instead of the endpoint disappearing entirely.
  *
  * Structural decisions documented in issue #116 plan:
- *  - Wrap in `<testsuites>` root even for one spec (Jenkins-strict parsers reject bare `<testsuite>`).
+ *  - Wrap in `<testsuites>` root even for one spec (some Jenkins-strict
+ *    parsers and CI integrations reject a bare `<testsuite>` at root).
  *  - `classname="openapi.coverage.{specName}"` for SonarQube tree-view compatibility.
- *  - Emit `time="0"` on every element (some parsers throw without it).
- *  - Build via {@see DOMDocument} so attribute / text escaping is automatic.
+ *  - Emit `time="0"` on every element (some parsers warn or refuse to parse
+ *    a `<testcase>` / `<testsuite>` without a `time` attribute).
+ *  - Build via {@see DOMDocument} so attribute / text escaping is automatic —
+ *    avoids the entire class of hand-rolled-concat XML bugs.
  *
  * @phpstan-import-type CoverageResult from OpenApiCoverageTracker
  * @phpstan-import-type EndpointSummary from OpenApiCoverageTracker
@@ -70,7 +76,17 @@ final class JUnitCoverageRenderer
         $root->setAttribute('failures', (string) $totalFailures);
         $root->setAttribute('skipped', (string) $totalSkipped);
 
-        return (string) $doc->saveXML();
+        $xml = $doc->saveXML();
+        if ($xml === false) {
+            // saveXML() rarely fails for the elements we build (no entities, no
+            // XSLT, no surrogate halves reach createTextNode under normal
+            // tracker output), but the empty-string fallback would be a silent
+            // CI dashboard regression. Surface the failure so the dispatch
+            // loop's existing write-failure handling can report it.
+            throw new RuntimeException('Failed to serialize JUnit XML document');
+        }
+
+        return $xml;
     }
 
     /**
@@ -132,9 +148,9 @@ final class JUnitCoverageRenderer
         }
 
         if ($cases === []) {
-            // No declared responses and no unexpected observations — emit one
-            // synthetic <skipped> so the endpoint still contributes to the
-            // testsuite count and "structural gap" stays visible in CI.
+            // Without this, an endpoint that declares no responses and saw no
+            // unexpected observations would disappear from JUnit entirely —
+            // CI dashboards would silently under-report the spec surface.
             $cases[] = self::renderSyntheticCase($doc, $classname, $endpoint);
         }
 

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -301,7 +301,11 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
 
             $rendered = ($entry['renderer'])($results);
 
-            if (file_put_contents($entry['outputFile'], $rendered) === false) {
+            // Suppress PHP warning on failure — we surface the error via the
+            // WARNING stderr line below, and the raw PHP warning is redundant
+            // noise that breaks `beStrictAboutOutputDuringTests` test runs.
+            // Mirrors the CLI dispatch loop's @ suppression.
+            if (@file_put_contents($entry['outputFile'], $rendered) === false) {
                 $this->writeStderr(sprintf(
                     "[OpenAPI Coverage] WARNING: Failed to write %s report to %s\n",
                     $entry['label'],
@@ -355,7 +359,8 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         }
 
         $markdown = MarkdownCoverageRenderer::render($results);
-        $written = file_put_contents($this->githubSummaryPath, $markdown . "\n", FILE_APPEND);
+        // Same @ rationale as writeReports().
+        $written = @file_put_contents($this->githubSummaryPath, $markdown . "\n", FILE_APPEND);
 
         if ($written === false) {
             $this->writeStderr("[OpenAPI Coverage] WARNING: Failed to append Markdown report to GITHUB_STEP_SUMMARY ({$this->githubSummaryPath})\n");

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -14,6 +14,7 @@ use Studio\OpenApiContractTesting\Coverage\ConsoleCoverageRenderer;
 use Studio\OpenApiContractTesting\Coverage\CoverageMergeCommand;
 use Studio\OpenApiContractTesting\Coverage\CoverageSidecarWriter;
 use Studio\OpenApiContractTesting\Coverage\CoverageThresholdEvaluator;
+use Studio\OpenApiContractTesting\Coverage\JUnitCoverageRenderer;
 use Studio\OpenApiContractTesting\Coverage\MarkdownCoverageRenderer;
 use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecException;
@@ -63,6 +64,7 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         private ?float $minResponseCoverage = null,
         private bool $minCoverageStrict = false,
         private mixed $exitHandler = null,
+        private ?string $junitOutput = null,
     ) {}
 
     /** @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter */
@@ -328,6 +330,11 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
                 'label' => 'Markdown',
                 'renderer' => static fn(array $r): string => MarkdownCoverageRenderer::render($r),
                 'outputFile' => $this->outputFile,
+            ],
+            [
+                'label' => 'JUnit XML',
+                'renderer' => static fn(array $r): string => JUnitCoverageRenderer::render($r),
+                'outputFile' => $this->junitOutput,
             ],
         ];
     }

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -8,6 +8,7 @@ use const FILE_APPEND;
 use const PHP_EOL;
 use const STDERR;
 
+use InvalidArgumentException;
 use PHPUnit\Runner\Extension\Extension;
 use PHPUnit\Runner\Extension\Facade;
 use PHPUnit\Runner\Extension\ParameterCollection;
@@ -26,6 +27,7 @@ use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 use function array_filter;
 use function array_map;
 use function array_values;
+use function dirname;
 use function explode;
 use function fflush;
 use function file_put_contents;
@@ -34,7 +36,9 @@ use function getcwd;
 use function getenv;
 use function implode;
 use function in_array;
+use function is_dir;
 use function is_numeric;
+use function is_writable;
 use function sprintf;
 use function str_starts_with;
 use function sys_get_temp_dir;
@@ -87,7 +91,7 @@ final class OpenApiCoverageExtension implements Extension
     {
         try {
             $this->setupExtension($facade, $parameters, getenv('GITHUB_STEP_SUMMARY') ?: null);
-        } catch (EnumBindingException|EnumDriftException|InvalidOpenApiSpecException|InvalidThresholdConfigurationException|SpecFileNotFoundException) {
+        } catch (EnumBindingException|EnumDriftException|InvalidArgumentException|InvalidOpenApiSpecException|InvalidThresholdConfigurationException|SpecFileNotFoundException) {
             // setupExtension() has already written a FATAL line to stderr and
             // (if GITHUB_STEP_SUMMARY is set) appended a fatal block to it.
             // PHPUnit's ExtensionBootstrapper::bootstrap() wraps this call in
@@ -186,6 +190,8 @@ final class OpenApiCoverageExtension implements Extension
             }
         }
 
+        $junitOutput = self::resolveOutputPathParameter($parameters, 'junit_output', $githubSummaryPath);
+
         $consoleOutput = ConsoleOutput::resolve(
             $parameters->has('console_output') ? $parameters->get('console_output') : null,
         );
@@ -217,6 +223,7 @@ final class OpenApiCoverageExtension implements Extension
             minEndpointCoverage: $minEndpointCoverage,
             minResponseCoverage: $minResponseCoverage,
             minCoverageStrict: $minCoverageStrict,
+            junitOutput: $junitOutput,
         ));
     }
 
@@ -272,6 +279,58 @@ final class OpenApiCoverageExtension implements Extension
 
         if (!str_starts_with($raw, '/')) {
             $raw = getcwd() . '/' . $raw;
+        }
+
+        return $raw;
+    }
+
+    /**
+     * Read an optional output-file path parameter (used by `junit_output` and
+     * the JSON / HTML formats added in follow-up work tracked in #116). Empty
+     * or whitespace-only values are FATAL — silently dropping the parameter
+     * would defeat the fail-loud-on-misconfiguration policy this extension
+     * enforces. Parent directory writability is checked here so the failure
+     * surfaces at bootstrap rather than as a runtime WARN after tests ran.
+     *
+     * Returns the absolutised path or `null` when the parameter is absent.
+     */
+    private static function resolveOutputPathParameter(
+        ParameterCollection $parameters,
+        string $name,
+        ?string $githubSummaryPath,
+    ): ?string {
+        if (!$parameters->has($name)) {
+            return null;
+        }
+
+        $raw = trim($parameters->get($name));
+        if ($raw === '') {
+            $reason = sprintf(
+                '%s is set but empty. Either provide an output file path or remove the parameter.',
+                $name,
+            );
+            self::writeStderr("[OpenAPI Coverage] FATAL: {$reason}\n");
+            self::appendGithubStepSummaryFatalBlock($githubSummaryPath, $name, $reason);
+
+            throw new InvalidArgumentException($reason);
+        }
+
+        if (!str_starts_with($raw, '/')) {
+            $raw = getcwd() . '/' . $raw;
+        }
+
+        $parentDir = dirname($raw);
+        if (!is_dir($parentDir) || !is_writable($parentDir)) {
+            $reason = sprintf(
+                '%s=%s: parent directory %s does not exist or is not writable.',
+                $name,
+                $raw,
+                $parentDir,
+            );
+            self::writeStderr("[OpenAPI Coverage] FATAL: {$reason}\n");
+            self::appendGithubStepSummaryFatalBlock($githubSummaryPath, $name, $reason);
+
+            throw new InvalidArgumentException($reason);
         }
 
         return $raw;

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -8,11 +8,11 @@ use const FILE_APPEND;
 use const PHP_EOL;
 use const STDERR;
 
-use InvalidArgumentException;
 use PHPUnit\Runner\Extension\Extension;
 use PHPUnit\Runner\Extension\Facade;
 use PHPUnit\Runner\Extension\ParameterCollection;
 use PHPUnit\TextUI\Configuration\Configuration;
+use Studio\OpenApiContractTesting\Coverage\InvalidCoverageOutputPathException;
 use Studio\OpenApiContractTesting\Coverage\InvalidThresholdConfigurationException;
 use Studio\OpenApiContractTesting\Exception\EnumBindingException;
 use Studio\OpenApiContractTesting\Exception\EnumBindingReason;
@@ -91,7 +91,7 @@ final class OpenApiCoverageExtension implements Extension
     {
         try {
             $this->setupExtension($facade, $parameters, getenv('GITHUB_STEP_SUMMARY') ?: null);
-        } catch (EnumBindingException|EnumDriftException|InvalidArgumentException|InvalidOpenApiSpecException|InvalidThresholdConfigurationException|SpecFileNotFoundException) {
+        } catch (EnumBindingException|EnumDriftException|InvalidCoverageOutputPathException|InvalidOpenApiSpecException|InvalidThresholdConfigurationException|SpecFileNotFoundException) {
             // setupExtension() has already written a FATAL line to stderr and
             // (if GITHUB_STEP_SUMMARY is set) appended a fatal block to it.
             // PHPUnit's ExtensionBootstrapper::bootstrap() wraps this call in
@@ -285,12 +285,18 @@ final class OpenApiCoverageExtension implements Extension
     }
 
     /**
-     * Read an optional output-file path parameter (used by `junit_output` and
-     * the JSON / HTML formats added in follow-up work tracked in #116). Empty
-     * or whitespace-only values are FATAL — silently dropping the parameter
-     * would defeat the fail-loud-on-misconfiguration policy this extension
-     * enforces. Parent directory writability is checked here so the failure
-     * surfaces at bootstrap rather than as a runtime WARN after tests ran.
+     * Generic helper for output-file-path parameters (currently `junit_output`;
+     * reusable for other formats added under #116). Empty or whitespace-only
+     * values are FATAL — silently dropping the parameter would defeat the
+     * fail-loud-on-misconfiguration policy this extension enforces. Parent
+     * directory writability is checked here so misconfigurations surface at
+     * bootstrap rather than as a runtime WARN after tests ran.
+     *
+     * Note the bootstrap-vs-runtime severity asymmetry: the parent-dir check
+     * here hard-fails the run, but a `dirname()` that disappears mid-run will
+     * trip the dispatch loop's existing `file_put_contents() === false` branch,
+     * which only emits a WARN in subscriber mode (FATAL+exit in the merge CLI).
+     * Don't read "validated at bootstrap" as "guaranteed at write".
      *
      * Returns the absolutised path or `null` when the parameter is absent.
      */
@@ -312,7 +318,7 @@ final class OpenApiCoverageExtension implements Extension
             self::writeStderr("[OpenAPI Coverage] FATAL: {$reason}\n");
             self::appendGithubStepSummaryFatalBlock($githubSummaryPath, $name, $reason);
 
-            throw new InvalidArgumentException($reason);
+            throw new InvalidCoverageOutputPathException($name, $reason);
         }
 
         if (!str_starts_with($raw, '/')) {
@@ -330,7 +336,7 @@ final class OpenApiCoverageExtension implements Extension
             self::writeStderr("[OpenAPI Coverage] FATAL: {$reason}\n");
             self::appendGithubStepSummaryFatalBlock($githubSummaryPath, $name, $reason);
 
-            throw new InvalidArgumentException($reason);
+            throw new InvalidCoverageOutputPathException($name, $reason);
         }
 
         return $raw;

--- a/tests/Unit/Coverage/CoverageMergeCommandTest.php
+++ b/tests/Unit/Coverage/CoverageMergeCommandTest.php
@@ -272,6 +272,7 @@ class CoverageMergeCommandTest extends TestCase
             '--strip-prefixes=/api',
             '--sidecar-dir=/tmp/sidecars',
             '--output-file=/tmp/cov.md',
+            '--junit-output=/tmp/cov.junit.xml',
             '--no-cleanup',
         ]);
 
@@ -280,7 +281,46 @@ class CoverageMergeCommandTest extends TestCase
         $this->assertSame(['/api'], $opts['strip_prefixes']);
         $this->assertSame('/tmp/sidecars', $opts['sidecar_dir']);
         $this->assertSame('/tmp/cov.md', $opts['output_file']);
+        $this->assertSame('/tmp/cov.junit.xml', $opts['junit_output']);
         $this->assertFalse($opts['cleanup']);
+    }
+
+    #[Test]
+    public function writes_junit_xml_to_configured_path(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        $junitPath = dirname($this->sidecarDir) . '/coverage.junit.xml';
+
+        $command = new CoverageMergeCommand(stdoutWriter: static fn(string $msg): null => null);
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'output_file' => $this->outputFile,
+            'junit_output' => $junitPath,
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertFileExists($junitPath);
+        $this->assertFileExists($this->outputFile, 'Markdown output should still be written when JUnit is enabled');
+
+        $junitContents = (string) file_get_contents($junitPath);
+        $this->assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"', $junitContents);
+        $this->assertStringContainsString('<testsuites', $junitContents);
+        $this->assertStringContainsString('openapi.coverage.petstore-3.0', $junitContents);
+        $this->assertStringContainsString('GET /v1/pets [200 application/json]', $junitContents);
+
+        @unlink($junitPath);
     }
 
     #[Test]

--- a/tests/Unit/Coverage/CoverageMergeCommandTest.php
+++ b/tests/Unit/Coverage/CoverageMergeCommandTest.php
@@ -286,6 +286,43 @@ class CoverageMergeCommandTest extends TestCase
     }
 
     #[Test]
+    public function exits_one_when_junit_output_write_fails(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        // /proc/0 is unwritable on Linux and nonexistent on macOS — file_put_contents fails closed.
+        $unwritable = '/proc/0/forbidden/coverage.junit.xml';
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            stdoutWriter: static fn(string $msg): null => null,
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'junit_output' => $unwritable,
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('FATAL', $stderr);
+        $this->assertStringContainsString('JUnit XML', $stderr);
+    }
+
+    #[Test]
     public function writes_junit_xml_to_configured_path(): void
     {
         OpenApiCoverageTracker::recordResponse(

--- a/tests/Unit/Coverage/JUnitCoverageRendererTest.php
+++ b/tests/Unit/Coverage/JUnitCoverageRendererTest.php
@@ -1,0 +1,433 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Coverage;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use SimpleXMLElement;
+use Studio\OpenApiContractTesting\Coverage\EndpointCoverageState;
+use Studio\OpenApiContractTesting\Coverage\JUnitCoverageRenderer;
+use Studio\OpenApiContractTesting\Coverage\ResponseCoverageState;
+
+use function explode;
+use function simplexml_load_string;
+
+class JUnitCoverageRendererTest extends TestCase
+{
+    #[Test]
+    public function render_returns_empty_string_for_empty_results(): void
+    {
+        $this->assertSame('', JUnitCoverageRenderer::render([]));
+    }
+
+    #[Test]
+    public function render_validated_response_emits_testcase_without_failure(): void
+    {
+        $xml = $this->renderOne(
+            'front',
+            self::endpoint('GET /v1/pets', 'all-covered', requestReached: true, operationId: 'listPets', responses: [
+                self::row('200', 'application/json', 'validated', hits: 3),
+            ], coveredResponseCount: 1, totalResponseCount: 1),
+            endpointTotal: 1,
+            endpointFullyCovered: 1,
+            responseTotal: 1,
+            responseCovered: 1,
+        );
+
+        $sx = $this->parse($xml);
+        $testcases = $sx->xpath('//testcase');
+        $this->assertCount(1, $testcases);
+
+        $tc = $testcases[0];
+        $this->assertSame('openapi.coverage.front', (string) $tc['classname']);
+        $this->assertSame('GET /v1/pets [200 application/json]', (string) $tc['name']);
+        $this->assertSame('0', (string) $tc['time']);
+        $this->assertSame([], $tc->xpath('failure') ?: []);
+        $this->assertSame([], $tc->xpath('skipped') ?: []);
+    }
+
+    #[Test]
+    public function render_uncovered_response_emits_failure_element(): void
+    {
+        $xml = $this->renderOne(
+            'front',
+            self::endpoint('GET /v1/health', 'uncovered', responses: [
+                self::row('200', 'application/json', 'uncovered'),
+            ], totalResponseCount: 1),
+            endpointTotal: 1,
+            endpointUncovered: 1,
+            responseTotal: 1,
+            responseUncovered: 1,
+        );
+
+        $sx = $this->parse($xml);
+        $failures = $sx->xpath('//testcase/failure');
+        $this->assertNotEmpty($failures);
+        $this->assertSame('UncoveredResponse', (string) $failures[0]['type']);
+        $this->assertStringContainsString('200 application/json', (string) $failures[0]['message']);
+        $this->assertStringContainsString('GET /v1/health', (string) $failures[0]['message']);
+    }
+
+    #[Test]
+    public function render_skipped_response_emits_skipped_element_with_reason(): void
+    {
+        $xml = $this->renderOne(
+            'front',
+            self::endpoint('DELETE /v1/pets/{petId}', 'partial', responses: [
+                self::row(
+                    '503',
+                    'application/json',
+                    'skipped',
+                    hits: 1,
+                    skipReason: 'status 503 matched skip pattern 5\d\d',
+                ),
+            ], skippedResponseCount: 1, totalResponseCount: 1),
+            endpointTotal: 1,
+            endpointPartial: 1,
+            responseTotal: 1,
+            responseSkipped: 1,
+        );
+
+        $sx = $this->parse($xml);
+        $skipped = $sx->xpath('//testcase/skipped');
+        $this->assertNotEmpty($skipped);
+        $this->assertStringContainsString('5\d\d', (string) $skipped[0]['message']);
+    }
+
+    #[Test]
+    public function render_endpoint_with_no_response_definitions_emits_synthetic_skipped(): void
+    {
+        $xml = $this->renderOne(
+            'front',
+            self::endpoint('GET /v1/health', 'request-only', requestReached: true),
+            endpointTotal: 1,
+            endpointRequestOnly: 1,
+        );
+
+        $sx = $this->parse($xml);
+        $testcases = $sx->xpath('//testcase');
+        $this->assertCount(1, $testcases);
+        $skipped = $testcases[0]->xpath('skipped');
+        $this->assertNotEmpty($skipped);
+        $this->assertStringContainsString('no response definitions', (string) $skipped[0]['message']);
+    }
+
+    #[Test]
+    public function render_unexpected_observation_emits_failure_testcase(): void
+    {
+        $xml = $this->renderOne(
+            'front',
+            self::endpoint('POST /v1/pets', 'partial', responses: [
+                self::row('201', 'application/json', 'validated', hits: 1),
+            ], coveredResponseCount: 1, totalResponseCount: 1, unexpectedObservations: [
+                ['statusKey' => '418', 'contentTypeKey' => 'application/json'],
+            ]),
+            endpointTotal: 1,
+            endpointFullyCovered: 1,
+            responseTotal: 1,
+            responseCovered: 1,
+        );
+
+        $sx = $this->parse($xml);
+        $failures = $sx->xpath('//testcase/failure[@type="UnexpectedObservation"]');
+        $this->assertNotEmpty($failures);
+        $this->assertStringContainsString('418', (string) $failures[0]['message']);
+    }
+
+    #[Test]
+    public function render_includes_hits_and_operation_id_in_system_out(): void
+    {
+        $xml = $this->renderOne(
+            'front',
+            self::endpoint('GET /v1/pets', 'all-covered', requestReached: true, operationId: 'listPets', responses: [
+                self::row('200', 'application/json', 'validated', hits: 7),
+            ], coveredResponseCount: 1, totalResponseCount: 1),
+            endpointTotal: 1,
+            endpointFullyCovered: 1,
+            responseTotal: 1,
+            responseCovered: 1,
+        );
+
+        $sx = $this->parse($xml);
+        $systemOut = $sx->xpath('//testcase/system-out');
+        $this->assertNotEmpty($systemOut);
+        $text = (string) $systemOut[0];
+        $this->assertStringContainsString('hits=7', $text);
+        $this->assertStringContainsString('operationId=listPets', $text);
+    }
+
+    #[Test]
+    public function render_omits_operation_id_when_missing(): void
+    {
+        $xml = $this->renderOne(
+            'front',
+            self::endpoint('GET /v1/pets', 'all-covered', requestReached: true, responses: [
+                self::row('200', 'application/json', 'validated', hits: 2),
+            ], coveredResponseCount: 1, totalResponseCount: 1),
+            endpointTotal: 1,
+            endpointFullyCovered: 1,
+            responseTotal: 1,
+            responseCovered: 1,
+        );
+
+        $sx = $this->parse($xml);
+        $systemOut = $sx->xpath('//testcase/system-out');
+        $this->assertNotEmpty($systemOut);
+        $this->assertStringNotContainsString('operationId=', (string) $systemOut[0]);
+    }
+
+    #[Test]
+    public function render_uses_dotted_classname_for_sonarqube_compat(): void
+    {
+        $xml = $this->renderOne(
+            'pet-store',
+            self::endpoint('GET /v1/pets', 'all-covered', requestReached: true, responses: [
+                self::row('200', 'application/json', 'validated', hits: 1),
+            ], coveredResponseCount: 1, totalResponseCount: 1),
+            endpointTotal: 1,
+            endpointFullyCovered: 1,
+            responseTotal: 1,
+            responseCovered: 1,
+        );
+
+        $sx = $this->parse($xml);
+        $tc = $sx->xpath('//testcase')[0];
+        $this->assertSame('openapi.coverage.pet-store', (string) $tc['classname']);
+    }
+
+    #[Test]
+    public function render_wraps_in_testsuites_root_with_time_zero(): void
+    {
+        $xml = $this->renderOne(
+            'front',
+            self::endpoint('GET /v1/pets', 'all-covered', requestReached: true, responses: [
+                self::row('200', 'application/json', 'validated', hits: 1),
+            ], coveredResponseCount: 1, totalResponseCount: 1),
+            endpointTotal: 1,
+            endpointFullyCovered: 1,
+            responseTotal: 1,
+            responseCovered: 1,
+        );
+
+        $sx = $this->parse($xml);
+        $this->assertSame('testsuites', $sx->getName());
+        $this->assertSame('openapi-contract-coverage', (string) $sx['name']);
+        $this->assertSame('0', (string) $sx['time']);
+
+        $suite = $sx->xpath('testsuite')[0];
+        $this->assertSame('front', (string) $suite['name']);
+        $this->assertSame('0', (string) $suite['time']);
+
+        $tc = $sx->xpath('//testcase')[0];
+        $this->assertSame('0', (string) $tc['time']);
+    }
+
+    #[Test]
+    public function render_aggregates_counts_at_testsuites_and_testsuite_level(): void
+    {
+        $results = [
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v1/pets', 'all-covered', requestReached: true, responses: [
+                        self::row('200', 'application/json', 'validated', hits: 1),
+                    ], coveredResponseCount: 1, totalResponseCount: 1),
+                    self::endpoint('POST /v1/pets', 'partial', responses: [
+                        self::row('201', 'application/json', 'validated', hits: 1),
+                        self::row('422', 'application/problem+json', 'uncovered'),
+                    ], coveredResponseCount: 1, totalResponseCount: 2),
+                    self::endpoint('DELETE /v1/pets/{id}', 'partial', responses: [
+                        self::row('204', 'application/json', 'skipped', hits: 1, skipReason: 'manual skip'),
+                    ], skippedResponseCount: 1, totalResponseCount: 1),
+                ],
+                endpointTotal: 3,
+                endpointFullyCovered: 1,
+                endpointPartial: 2,
+                responseTotal: 4,
+                responseCovered: 2,
+                responseSkipped: 1,
+                responseUncovered: 1,
+            ),
+        ];
+
+        $xml = JUnitCoverageRenderer::render($results);
+        $sx = $this->parse($xml);
+
+        $this->assertSame('4', (string) $sx['tests']);
+        $this->assertSame('1', (string) $sx['failures']);
+        $this->assertSame('1', (string) $sx['skipped']);
+
+        $suite = $sx->xpath('testsuite')[0];
+        $this->assertSame('4', (string) $suite['tests']);
+        $this->assertSame('1', (string) $suite['failures']);
+        $this->assertSame('1', (string) $suite['skipped']);
+    }
+
+    #[Test]
+    public function render_xml_escapes_special_characters_in_attributes(): void
+    {
+        $xml = $this->renderOne(
+            'front',
+            self::endpoint('GET /v1/items<&"\'', 'uncovered', responses: [
+                self::row('200', 'application/json', 'uncovered'),
+            ], totalResponseCount: 1),
+            endpointTotal: 1,
+            endpointUncovered: 1,
+            responseTotal: 1,
+            responseUncovered: 1,
+        );
+
+        // Round-trip via SimpleXML proves the document is well-formed.
+        $sx = $this->parse($xml);
+        $tc = $sx->xpath('//testcase')[0];
+        $this->assertStringContainsString('<&"\'', (string) $tc['name']);
+    }
+
+    #[Test]
+    public function render_includes_xml_declaration_and_utf8_encoding(): void
+    {
+        $xml = $this->renderOne(
+            'front',
+            self::endpoint('GET /v1/pets', 'all-covered', requestReached: true, responses: [
+                self::row('200', 'application/json', 'validated', hits: 1),
+            ], coveredResponseCount: 1, totalResponseCount: 1),
+            endpointTotal: 1,
+            endpointFullyCovered: 1,
+            responseTotal: 1,
+            responseCovered: 1,
+        );
+
+        $this->assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"', $xml);
+    }
+
+    /**
+     * @param list<array{endpoint: string, method: string, path: string, operationId: ?string, state: EndpointCoverageState, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}> $endpoints
+     *
+     * @return array{endpoints: list<array{endpoint: string, method: string, path: string, operationId: ?string, state: EndpointCoverageState, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}>, endpointTotal: int, endpointFullyCovered: int, endpointPartial: int, endpointUncovered: int, endpointRequestOnly: int, responseTotal: int, responseCovered: int, responseSkipped: int, responseUncovered: int}
+     */
+    private static function coverage(
+        array $endpoints,
+        int $endpointTotal = 0,
+        int $endpointFullyCovered = 0,
+        int $endpointPartial = 0,
+        int $endpointUncovered = 0,
+        int $endpointRequestOnly = 0,
+        int $responseTotal = 0,
+        int $responseCovered = 0,
+        int $responseSkipped = 0,
+        int $responseUncovered = 0,
+    ): array {
+        return [
+            'endpoints' => $endpoints,
+            'endpointTotal' => $endpointTotal,
+            'endpointFullyCovered' => $endpointFullyCovered,
+            'endpointPartial' => $endpointPartial,
+            'endpointUncovered' => $endpointUncovered,
+            'endpointRequestOnly' => $endpointRequestOnly,
+            'responseTotal' => $responseTotal,
+            'responseCovered' => $responseCovered,
+            'responseSkipped' => $responseSkipped,
+            'responseUncovered' => $responseUncovered,
+        ];
+    }
+
+    /**
+     * @param list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}> $responses
+     * @param list<array{statusKey: string, contentTypeKey: string}> $unexpectedObservations
+     *
+     * @return array{endpoint: string, method: string, path: string, operationId: ?string, state: EndpointCoverageState, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}
+     */
+    private static function endpoint(
+        string $endpoint,
+        string $state,
+        bool $requestReached = false,
+        ?string $operationId = null,
+        array $responses = [],
+        int $coveredResponseCount = 0,
+        int $skippedResponseCount = 0,
+        int $totalResponseCount = 0,
+        array $unexpectedObservations = [],
+    ): array {
+        [$method, $path] = explode(' ', $endpoint, 2);
+
+        return [
+            'endpoint' => $endpoint,
+            'method' => $method,
+            'path' => $path,
+            'operationId' => $operationId,
+            'state' => EndpointCoverageState::from($state),
+            'requestReached' => $requestReached,
+            'responses' => $responses,
+            'coveredResponseCount' => $coveredResponseCount,
+            'skippedResponseCount' => $skippedResponseCount,
+            'totalResponseCount' => $totalResponseCount,
+            'unexpectedObservations' => $unexpectedObservations,
+        ];
+    }
+
+    /**
+     * @return array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}
+     */
+    private static function row(
+        string $statusKey,
+        string $contentTypeKey,
+        string $state,
+        int $hits = 0,
+        ?string $skipReason = null,
+    ): array {
+        return [
+            'statusKey' => $statusKey,
+            'contentTypeKey' => $contentTypeKey,
+            'state' => ResponseCoverageState::from($state),
+            'hits' => $hits,
+            'skipReason' => $skipReason,
+        ];
+    }
+
+    /**
+     * Convenience: render a single-endpoint coverage result for a single spec.
+     *
+     * @param array<string, mixed> $endpoint
+     */
+    private function renderOne(
+        string $specName,
+        array $endpoint,
+        int $endpointTotal = 0,
+        int $endpointFullyCovered = 0,
+        int $endpointPartial = 0,
+        int $endpointUncovered = 0,
+        int $endpointRequestOnly = 0,
+        int $responseTotal = 0,
+        int $responseCovered = 0,
+        int $responseSkipped = 0,
+        int $responseUncovered = 0,
+    ): string {
+        $results = [
+            $specName => self::coverage(
+                endpoints: [$endpoint],
+                endpointTotal: $endpointTotal,
+                endpointFullyCovered: $endpointFullyCovered,
+                endpointPartial: $endpointPartial,
+                endpointUncovered: $endpointUncovered,
+                endpointRequestOnly: $endpointRequestOnly,
+                responseTotal: $responseTotal,
+                responseCovered: $responseCovered,
+                responseSkipped: $responseSkipped,
+                responseUncovered: $responseUncovered,
+            ),
+        ];
+
+        return JUnitCoverageRenderer::render($results);
+    }
+
+    private function parse(string $xml): SimpleXMLElement
+    {
+        $sx = simplexml_load_string($xml);
+        if ($sx === false) {
+            $this->fail('Rendered XML is not parseable: ' . $xml);
+        }
+
+        return $sx;
+    }
+}

--- a/tests/Unit/Coverage/JUnitCoverageRendererTest.php
+++ b/tests/Unit/Coverage/JUnitCoverageRendererTest.php
@@ -64,7 +64,7 @@ class JUnitCoverageRendererTest extends TestCase
 
         $sx = $this->parse($xml);
         $failures = $sx->xpath('//testcase/failure');
-        $this->assertNotEmpty($failures);
+        $this->assertCount(1, $failures);
         $this->assertSame('UncoveredResponse', (string) $failures[0]['type']);
         $this->assertStringContainsString('200 application/json', (string) $failures[0]['message']);
         $this->assertStringContainsString('GET /v1/health', (string) $failures[0]['message']);
@@ -92,7 +92,7 @@ class JUnitCoverageRendererTest extends TestCase
 
         $sx = $this->parse($xml);
         $skipped = $sx->xpath('//testcase/skipped');
-        $this->assertNotEmpty($skipped);
+        $this->assertCount(1, $skipped);
         $this->assertStringContainsString('5\d\d', (string) $skipped[0]['message']);
     }
 
@@ -110,7 +110,7 @@ class JUnitCoverageRendererTest extends TestCase
         $testcases = $sx->xpath('//testcase');
         $this->assertCount(1, $testcases);
         $skipped = $testcases[0]->xpath('skipped');
-        $this->assertNotEmpty($skipped);
+        $this->assertCount(1, $skipped);
         $this->assertStringContainsString('no response definitions', (string) $skipped[0]['message']);
     }
 
@@ -132,7 +132,7 @@ class JUnitCoverageRendererTest extends TestCase
 
         $sx = $this->parse($xml);
         $failures = $sx->xpath('//testcase/failure[@type="UnexpectedObservation"]');
-        $this->assertNotEmpty($failures);
+        $this->assertCount(1, $failures);
         $this->assertStringContainsString('418', (string) $failures[0]['message']);
     }
 
@@ -152,7 +152,7 @@ class JUnitCoverageRendererTest extends TestCase
 
         $sx = $this->parse($xml);
         $systemOut = $sx->xpath('//testcase/system-out');
-        $this->assertNotEmpty($systemOut);
+        $this->assertCount(1, $systemOut);
         $text = (string) $systemOut[0];
         $this->assertStringContainsString('hits=7', $text);
         $this->assertStringContainsString('operationId=listPets', $text);
@@ -174,7 +174,7 @@ class JUnitCoverageRendererTest extends TestCase
 
         $sx = $this->parse($xml);
         $systemOut = $sx->xpath('//testcase/system-out');
-        $this->assertNotEmpty($systemOut);
+        $this->assertCount(1, $systemOut);
         $this->assertStringNotContainsString('operationId=', (string) $systemOut[0]);
     }
 

--- a/tests/Unit/PHPUnit/CoverageReportSubscriberWorkerModeTest.php
+++ b/tests/Unit/PHPUnit/CoverageReportSubscriberWorkerModeTest.php
@@ -98,6 +98,7 @@ class CoverageReportSubscriberWorkerModeTest extends TestCase
             consoleOutput: ConsoleOutput::DEFAULT,
             githubSummaryPath: null,
             sidecarDir: $this->tmpDir,
+            junitOutput: $this->tmpDir . '/coverage.junit.xml',
         );
 
         ob_start();
@@ -106,6 +107,10 @@ class CoverageReportSubscriberWorkerModeTest extends TestCase
 
         $this->assertSame('', $stdout, 'worker mode must not emit console output');
         $this->assertFileDoesNotExist($this->tmpDir . '/coverage-report.md', 'worker mode must not write output_file');
+        $this->assertFileDoesNotExist(
+            $this->tmpDir . '/coverage.junit.xml',
+            'worker mode must not write junit_output (merge CLI is the canonical paratest renderer)',
+        );
 
         $loaded = CoverageSidecarReader::readDir($this->tmpDir);
         $this->assertCount(1, $loaded);
@@ -168,6 +173,87 @@ class CoverageReportSubscriberWorkerModeTest extends TestCase
         $this->assertNotSame('', $stdout, 'sequential mode must render to stdout');
         $this->assertFileExists($outputFile, 'sequential mode must write output_file');
         $this->assertSame([], CoverageSidecarReader::readDir($this->tmpDir));
+    }
+
+    #[Test]
+    public function sequential_mode_writes_junit_output_when_configured(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        mkdir($this->tmpDir, 0o755, recursive: true);
+        $junitPath = $this->tmpDir . '/coverage.junit.xml';
+
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            sidecarDir: $this->tmpDir,
+            junitOutput: $junitPath,
+        );
+
+        ob_start();
+        $subscriber->notify($this->fakeExecutionFinished());
+        ob_get_clean();
+
+        $this->assertFileExists($junitPath, 'sequential mode must write junit_output when configured');
+        $contents = (string) file_get_contents($junitPath);
+        $this->assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"', $contents);
+        $this->assertStringContainsString('<testsuites', $contents);
+        $this->assertStringContainsString('openapi.coverage.petstore-3.0', $contents);
+    }
+
+    #[Test]
+    public function sequential_mode_warns_and_continues_when_junit_write_fails(): void
+    {
+        // Severity asymmetry from PR #206: a subscriber-side write failure
+        // emits a WARN and keeps going (no exit). The merge CLI's contract is
+        // FATAL+exit-1 (pinned by CoverageMergeCommandTest). This test pins
+        // the subscriber half so the asymmetry can't drift unnoticed.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        mkdir($this->tmpDir, 0o755, recursive: true);
+        // Unwritable target — parent dir exists check passes (we are not
+        // exercising the bootstrap-time gate), but the actual write will fail
+        // because the path is a directory rather than a regular file.
+        $junitPath = $this->tmpDir . '/coverage.junit.xml';
+        mkdir($junitPath, 0o755, recursive: true);
+
+        $stderrLog = '';
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            stderrWriter: static function (string $msg) use (&$stderrLog): void {
+                $stderrLog .= $msg;
+            },
+            sidecarDir: $this->tmpDir,
+            junitOutput: $junitPath,
+        );
+
+        ob_start();
+        $subscriber->notify($this->fakeExecutionFinished());
+        ob_get_clean();
+
+        @rmdir($junitPath);
+
+        $this->assertStringContainsString('WARNING', $stderrLog);
+        $this->assertStringContainsString('JUnit XML', $stderrLog);
     }
 
     #[Test]

--- a/tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php
+++ b/tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php
@@ -9,6 +9,7 @@ use const E_USER_WARNING;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\Extension\ParameterCollection;
+use Studio\OpenApiContractTesting\Coverage\InvalidCoverageOutputPathException;
 use Studio\OpenApiContractTesting\Coverage\InvalidThresholdConfigurationException;
 use Studio\OpenApiContractTesting\Exception\EnumBindingException;
 use Studio\OpenApiContractTesting\Exception\EnumBindingReason;
@@ -884,6 +885,54 @@ class OpenApiCoverageExtensionTest extends TestCase
         $this->expectException(EnumDriftException::class);
 
         $extension->setupExtension(null, $parameters, null);
+    }
+
+    #[Test]
+    public function bootstrap_fatal_when_junit_output_is_empty(): void
+    {
+        // <parameter name="junit_output" value=""/> would otherwise coerce to
+        // getcwd() and silently overwrite a directory listing as a file.
+        // Mirror the enum_spec_base_path policy: empty → FATAL.
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'junit_output' => '',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+            $this->fail('expected InvalidCoverageOutputPathException');
+        } catch (InvalidCoverageOutputPathException $e) {
+            $this->assertSame('junit_output', $e->parameterName);
+            $this->assertStringContainsString('empty', $e->getMessage());
+        }
+
+        $this->assertStringContainsString('FATAL', $this->readStderr());
+    }
+
+    #[Test]
+    public function bootstrap_fatal_when_junit_output_parent_dir_not_writable(): void
+    {
+        // Surface the misconfiguration at bootstrap rather than as a runtime
+        // file_put_contents() WARN after every test ran. /proc/0 does not
+        // exist on macOS and is unwritable on Linux — fails closed either way.
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'junit_output' => '/proc/0/nonexistent/coverage.junit.xml',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+            $this->fail('expected InvalidCoverageOutputPathException');
+        } catch (InvalidCoverageOutputPathException $e) {
+            $this->assertSame('junit_output', $e->parameterName);
+            $this->assertStringContainsString('not writable', $e->getMessage());
+        }
+
+        $this->assertStringContainsString('FATAL', $this->readStderr());
     }
 
     private function readStderr(): string


### PR DESCRIPTION
## Summary

Adds the second format in the #116 series: `JUnitCoverageRenderer` plus `junit_output` (PHPUnit Extension) and `--junit-output` (merge CLI) wired through the dispatch foundation from #206.

After this PR, users can pin a `<parameter name="junit_output" value="build/coverage.junit.xml"/>` (or pass `--junit-output=build/coverage.junit.xml`) and consume contract test coverage in GitLab CI test reports, Jenkins, SonarQube, Bitrise, CircleCI test-report tabs, etc.

## Why

Markdown / Console / GITHUB_STEP_SUMMARY were the only output channels, which limited adoption to GitHub Actions users. JUnit XML is the lingua franca for non-GitHub CI dashboards and is a prerequisite for enterprise adoption (epic:dx, priority:medium).

Plan (and Cobertura's intentional omission) approved in #206.

## Coverage state → JUnit element mapping

| State | Element | CI Color |
|-------|---------|----------|
| Validated | `<testcase>` with no child | Green |
| Skipped | `<testcase>` with `<skipped>` (skip reason in `message`) | Yellow |
| Uncovered | `<testcase>` with `<failure type="UncoveredResponse">` | Red |
| Unexpected observation | extra `<testcase>` with `<failure type="UnexpectedObservation">` | Red |
| Endpoint with no spec responses | synthetic `<testcase>` with `<skipped>` | Yellow |

`hits` + `operationId` surface via `<system-out>`.

## Structural choices

- Wrap in `<testsuites>` root even with one spec (Jenkins-strict parsers reject bare `<testsuite>`).
- `classname="openapi.coverage.{specName}"` so SonarQube's tree view groups sensibly.
- Emit `time="0"` on every element (some parsers throw without it).
- Build via `DOMDocument` so attribute/text escaping is automatic — no string concatenation.

## Verification

- [x] `composer test` — 1361 tests / 3263 assertions pass (13 new for the renderer, 1 new CLI integration test, 1 parseArgv test updated)
- [x] `composer stan` — clean, level 6
- [x] `composer cs-check` — clean for the primary config

Pre-existing on `main`, unrelated to this PR: the Pest-specific `.php-cs-fixer.pest.dist.php` config still flags `static fn ()` (space) in two test files (`tests/Integration/Pest/MissingTraitTest.php`, `tests/Integration/Pest/ExpectationsTest.php`). Same finding flagged on #206.

## Notes for reviewers

- Worker mode (`TEST_TOKEN` set) automatically ignores `junit_output` because the subscriber early-returns from `notify()` before `buildReportEntries()` is reached. The merge CLI is the canonical renderer surface for paratest, and it accepts `--junit-output`.
- Multi-format simultaneous output works: setting `output_file` + `junit_output` writes both independently. A failure on one entry emits the appropriate severity (WARN in subscriber, FATAL in CLI) and does not block the other.
- Parameter validation mirrors `resolveEnumSpecBasePathParameter`: empty/whitespace → FATAL, parent directory must exist and be writable (`is_writable(dirname($path))`). The new `resolveOutputPathParameter()` helper is generic so JSON/HTML follow-ups will reuse it.
- Sample output committed at `docs/samples/coverage.junit.xml`.
- Round-trip parsing via `simplexml_load_string()` is used as a well-formedness smoke test instead of XSD validation (Jenkins and Apache Ant XSDs diverge on which is canonical — discussed in plan).
- No `CHANGELOG.md` edit (managed by release-please).

## Follow-up

- PR 3 (JSON renderer) — next in the #116 chain
- PR 4 (HTML renderer)

Refs #116. Stacks on #206.