### PR TITLE
feat(coverage): add JSON output for machine-readable coverage reports

### DIFF
--- a/docs/coverage-json-schema.md
+++ b/docs/coverage-json-schema.md
@@ -1,0 +1,100 @@
+# Coverage JSON Schema
+
+`studio-design/openapi-contract-testing` can emit machine-readable coverage
+output via the `json_output` PHPUnit Extension parameter or the
+`--json-output` flag on `openapi-coverage-merge`. This page documents the
+schema so downstream consumers (custom dashboards, contract-coverage
+analytics, scripted gating) can rely on a stable shape.
+
+A sample document is committed at [`samples/coverage.json`](samples/coverage.json).
+
+## Top level
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `schema_version` | `integer` | Bumped on incompatible structural changes. The current version is `1`. Consumers SHOULD reject unknown values. |
+| `generated_at` | `string` | ISO-8601 timestamp (`DateTimeImmutable::ATOM`) for when the document was rendered. |
+| `tool` | `object` | `{ "name": "studio-design/openapi-contract-testing", "version": "<composer version or 'unknown'>" }`. Useful for downstream consumers diagnosing format drift. |
+| `aggregate` | `object` | Rollup across every spec in the document. Lets consumers read one "total" without re-summing. See [aggregate fields](#aggregate-fields). |
+| `specs` | `object` | Keyed by spec name. Each value is `{ "aggregates": …, "endpoints": [...] }`. |
+
+## Aggregate fields
+
+The same shape is used for `aggregate` (top-level) and `specs.<name>.aggregates`
+(per-spec).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `endpoint_total` | `integer` | Total declared `(method, path)` endpoints in the spec(s). |
+| `endpoint_fully_covered` | `integer` | Endpoints where every declared `(status, content-type)` response pair was validated. |
+| `endpoint_partial` | `integer` | Endpoints where at least one response was validated and at least one was not. |
+| `endpoint_uncovered` | `integer` | Endpoints with no validated responses and no skipped responses. |
+| `endpoint_request_only` | `integer` | Endpoints where a request reached the endpoint but no response definitions matched (request-only observations). |
+| `response_total` | `integer` | Total declared `(status, content-type)` pairs. |
+| `response_covered` | `integer` | Pairs validated by at least one test. |
+| `response_skipped` | `integer` | Pairs reconciled to a skip (e.g. a status matched a configured skip pattern). |
+| `response_uncovered` | `integer` | Pairs with no observation. |
+
+## Endpoint
+
+Each entry in `specs.<name>.endpoints` has this shape:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `endpoint` | `string` | `"{METHOD} {path}"`, e.g. `"GET /v1/pets"`. |
+| `method` | `string` | HTTP method, uppercase. |
+| `path` | `string` | Spec path template (e.g. `/v1/pets/{petId}`), not a concrete request path. |
+| `operation_id` | `string \| null` | OpenAPI `operationId` if declared. |
+| `endpoint_state` | `string` | One of `"all-covered"`, `"partial"`, `"uncovered"`, `"request-only"`. Namespaced (not just `"state"`) to avoid value-string collision with `response_state`. |
+| `request_reached` | `boolean` | Whether a request hook fired for this endpoint during the run. |
+| `responses` | `array` | Per `(status, content-type)` rows. See [Response row](#response-row). |
+| `covered_response_count` | `integer` | Convenience count: how many of `responses` reached state `"validated"`. |
+| `skipped_response_count` | `integer` | How many of `responses` reached state `"skipped"`. |
+| `total_response_count` | `integer` | Length of `responses` — included for ergonomics so consumers do not have to count. |
+| `unexpected_observations` | `array` | Observations whose `(status, content-type)` pair is not declared in the spec. See [Unexpected observation](#unexpected-observation). |
+
+### Response row
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status_key` | `string` | Literal HTTP status (`"200"`) or spec range key (`"5XX"`, `"default"`). |
+| `content_type_key` | `string` | The spec's original-cased media-type key (e.g. `"application/json"`), or the wildcard sentinel `"*"` for "any / no content-type". |
+| `response_state` | `string` | One of `"validated"`, `"skipped"`, `"uncovered"`. Namespaced as above. |
+| `hits` | `integer` | Monotonic count of observations recorded for this pair across the run. |
+| `skip_reason` | `string \| null` | Latest non-null skip reason, when `response_state` is `"skipped"`. |
+
+### Unexpected observation
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status_key` | `string` | The literal status observed. |
+| `content_type_key` | `string` | The literal content-type observed. |
+
+## Compatibility policy
+
+- Additive changes (new fields, new enum values for `endpoint_state` / `response_state`) keep `schema_version` at `1`.
+- Removals, renames, or shape changes bump `schema_version`.
+- The wire format used by paratest worker sidecars is **separate** from this schema (it lives at `Coverage/OpenApiCoverageTracker::exportState()` and is versioned independently via `STATE_FORMAT_VERSION`). Do not consume sidecar payloads as if they were `json_output`; they have a different shape (no `operation_id`, no derived states, no `unexpected_observations`).
+
+## Generating the file
+
+PHPUnit Extension:
+
+```xml
+<extensions>
+  <bootstrap class="Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension">
+    <parameter name="spec_base_path" value="openapi" />
+    <parameter name="json_output" value="build/coverage.json" />
+  </bootstrap>
+</extensions>
+```
+
+Paratest merge CLI:
+
+```bash
+vendor/bin/openapi-coverage-merge \
+  --spec-base-path=openapi \
+  --json-output=build/coverage.json
+```
+
+Multiple format outputs are independent: setting `output_file`, `junit_output`, and `json_output` simultaneously writes all three. A write failure on one does not block the others; severity follows the existing convention (subscriber WARN, CLI FATAL+exit 1).

--- a/docs/coverage-json-schema.md
+++ b/docs/coverage-json-schema.md
@@ -14,7 +14,7 @@ A sample document is committed at [`samples/coverage.json`](samples/coverage.jso
 |-------|------|-------------|
 | `schema_version` | `integer` | Bumped on incompatible structural changes. The current version is `1`. Consumers SHOULD reject unknown values. |
 | `generated_at` | `string` | ISO-8601 timestamp (`DateTimeImmutable::ATOM`) for when the document was rendered. |
-| `tool` | `object` | `{ "name": "studio-design/openapi-contract-testing", "version": "<composer version or 'unknown'>" }`. Useful for downstream consumers diagnosing format drift. |
+| `tool` | `object` | `{ "name": "studio-design/openapi-contract-testing", "version": "<composer version or 'unknown'>" }`. Useful for downstream consumers diagnosing format drift. `"unknown"` is emitted when Composer's `InstalledVersions` metadata is unavailable (e.g. running from a vendored checkout without `composer install`, or `replace`d in a parent project); the field is always a string so downstream JSON schema validators do not need a nullable type. |
 | `aggregate` | `object` | Rollup across every spec in the document. Lets consumers read one "total" without re-summing. See [aggregate fields](#aggregate-fields). |
 | `specs` | `object` | Keyed by spec name. Each value is `{ "aggregates": …, "endpoints": [...] }`. |
 

--- a/docs/samples/coverage.json
+++ b/docs/samples/coverage.json
@@ -1,0 +1,90 @@
+{
+    "schema_version": 1,
+    "generated_at": "2026-05-11T12:34:56+00:00",
+    "tool": {
+        "name": "studio-design/openapi-contract-testing",
+        "version": "dev-main"
+    },
+    "aggregate": {
+        "endpoint_total": 2,
+        "endpoint_fully_covered": 1,
+        "endpoint_partial": 1,
+        "endpoint_uncovered": 0,
+        "endpoint_request_only": 0,
+        "response_total": 3,
+        "response_covered": 2,
+        "response_skipped": 0,
+        "response_uncovered": 1
+    },
+    "specs": {
+        "petstore": {
+            "aggregates": {
+                "endpoint_total": 2,
+                "endpoint_fully_covered": 1,
+                "endpoint_partial": 1,
+                "endpoint_uncovered": 0,
+                "endpoint_request_only": 0,
+                "response_total": 3,
+                "response_covered": 2,
+                "response_skipped": 0,
+                "response_uncovered": 1
+            },
+            "endpoints": [
+                {
+                    "endpoint": "GET /v1/pets",
+                    "method": "GET",
+                    "path": "/v1/pets",
+                    "operation_id": "listPets",
+                    "endpoint_state": "all-covered",
+                    "request_reached": true,
+                    "responses": [
+                        {
+                            "status_key": "200",
+                            "content_type_key": "application/json",
+                            "response_state": "validated",
+                            "hits": 12,
+                            "skip_reason": null
+                        }
+                    ],
+                    "covered_response_count": 1,
+                    "skipped_response_count": 0,
+                    "total_response_count": 1,
+                    "unexpected_observations": []
+                },
+                {
+                    "endpoint": "POST /v1/pets",
+                    "method": "POST",
+                    "path": "/v1/pets",
+                    "operation_id": "createPet",
+                    "endpoint_state": "partial",
+                    "request_reached": true,
+                    "responses": [
+                        {
+                            "status_key": "201",
+                            "content_type_key": "application/json",
+                            "response_state": "validated",
+                            "hits": 3,
+                            "skip_reason": null
+                        },
+                        {
+                            "status_key": "422",
+                            "content_type_key": "application/problem+json",
+                            "response_state": "uncovered",
+                            "hits": 0,
+                            "skip_reason": null
+                        }
+                    ],
+                    "covered_response_count": 1,
+                    "skipped_response_count": 0,
+                    "total_response_count": 2,
+                    "unexpected_observations": [
+                        {
+                            "status_key": "418",
+                            "content_type_key": "application/json"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/src/Coverage/CoverageMergeCommand.php
+++ b/src/Coverage/CoverageMergeCommand.php
@@ -53,6 +53,7 @@ use function unlink;
  *     strip_prefixes?: list<string>,
  *     output_file?: string,
  *     junit_output?: string,
+ *     json_output?: string,
  *     github_step_summary?: string,
  *     console_output?: string,
  *     cleanup?: bool,
@@ -163,6 +164,8 @@ final class CoverageMergeCommand
               --output-file=<path>          Markdown report output path.
               --junit-output=<path>         JUnit XML report output path (for CI dashboards
                                             like GitLab CI test reports, Jenkins, SonarQube).
+              --json-output=<path>          JSON report output path (machine-readable; see
+                                            docs/coverage-json-schema.md for the schema).
               --github-step-summary=<path>  Append Markdown report to this file (also
                                             consults GITHUB_STEP_SUMMARY env var).
               --console-output=<mode>       default | all | uncovered_only.
@@ -208,6 +211,9 @@ final class CoverageMergeCommand
             : null;
         $junitOutput = isset($options['junit_output']) && $options['junit_output'] !== ''
             ? $this->absolutise($options['junit_output'])
+            : null;
+        $jsonOutput = isset($options['json_output']) && $options['json_output'] !== ''
+            ? $this->absolutise($options['json_output'])
             : null;
         $githubSummaryPath = isset($options['github_step_summary']) && $options['github_step_summary'] !== ''
             ? $options['github_step_summary']
@@ -306,7 +312,7 @@ final class CoverageMergeCommand
 
         $this->writeStdout(ConsoleCoverageRenderer::render($results, $consoleOutput));
 
-        $writeFailures = $this->writeReports($results, $outputFile, $junitOutput);
+        $writeFailures = $this->writeReports($results, $outputFile, $junitOutput, $jsonOutput);
         $this->appendGithubStepSummary($results, $githubSummaryPath);
 
         $thresholdFailure = $this->evaluateThresholdGate($results, $minEndpointPct, $minResponsePct, $minStrict);
@@ -329,11 +335,11 @@ final class CoverageMergeCommand
      *
      * @return int Number of format outputs that failed to write
      */
-    private function writeReports(array $results, ?string $outputFile, ?string $junitOutput): int
+    private function writeReports(array $results, ?string $outputFile, ?string $junitOutput, ?string $jsonOutput): int
     {
         $writeFailures = 0;
 
-        foreach ($this->buildReportEntries($outputFile, $junitOutput) as $entry) {
+        foreach ($this->buildReportEntries($outputFile, $junitOutput, $jsonOutput) as $entry) {
             if ($entry['outputFile'] === null) {
                 continue;
             }
@@ -366,7 +372,7 @@ final class CoverageMergeCommand
      *
      * @return list<CoverageReportEntry>
      */
-    private function buildReportEntries(?string $outputFile, ?string $junitOutput): array
+    private function buildReportEntries(?string $outputFile, ?string $junitOutput, ?string $jsonOutput): array
     {
         return [
             [
@@ -378,6 +384,11 @@ final class CoverageMergeCommand
                 'label' => 'JUnit XML',
                 'renderer' => static fn(array $r): string => JUnitCoverageRenderer::render($r),
                 'outputFile' => $junitOutput,
+            ],
+            [
+                'label' => 'JSON',
+                'renderer' => static fn(array $r): string => JsonCoverageRenderer::render($r),
+                'outputFile' => $jsonOutput,
             ],
         ];
     }

--- a/src/Coverage/CoverageMergeCommand.php
+++ b/src/Coverage/CoverageMergeCommand.php
@@ -14,6 +14,7 @@ use Studio\OpenApiContractTesting\PHPUnit\ConsoleOutput;
 use Studio\OpenApiContractTesting\PHPUnit\CoverageReportSubscriber;
 use Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+use Throwable;
 
 use function array_filter;
 use function array_map;
@@ -30,6 +31,7 @@ use function sprintf;
 use function str_contains;
 use function str_replace;
 use function str_starts_with;
+use function strlen;
 use function substr;
 use function unlink;
 
@@ -344,16 +346,45 @@ final class CoverageMergeCommand
                 continue;
             }
 
-            $rendered = ($entry['renderer'])($results);
+            try {
+                $rendered = ($entry['renderer'])($results);
+            } catch (Throwable $e) {
+                $this->writeStderr(sprintf(
+                    "[OpenAPI Coverage] FATAL: Failed to render %s report: %s\n",
+                    $entry['label'],
+                    $e->getMessage(),
+                ));
+                $writeFailures++;
+
+                continue;
+            }
 
             // Suppress PHP warning on failure — we surface the error
             // ourselves via stderr + exit code so the warning is redundant
             // noise that breaks `beStrictAboutOutputDuringTests` test runs.
-            if (@file_put_contents($entry['outputFile'], $rendered) === false) {
+            $bytes = @file_put_contents($entry['outputFile'], $rendered);
+            if ($bytes === false) {
                 $this->writeStderr(sprintf(
                     "[OpenAPI Coverage] FATAL: Failed to write %s report to %s\n",
                     $entry['label'],
                     $entry['outputFile'],
+                ));
+                $writeFailures++;
+
+                continue;
+            }
+
+            $expected = strlen($rendered);
+            if ($bytes !== $expected) {
+                // Partial write — disk full / quota exceeded mid-write leaves
+                // a truncated file. Surface explicitly so downstream consumers
+                // don't parse half a document several CI steps later.
+                $this->writeStderr(sprintf(
+                    "[OpenAPI Coverage] FATAL: Truncated %s report at %s (%d of %d bytes written)\n",
+                    $entry['label'],
+                    $entry['outputFile'],
+                    $bytes,
+                    $expected,
                 ));
                 $writeFailures++;
             }
@@ -363,12 +394,11 @@ final class CoverageMergeCommand
     }
 
     /**
-     * Renderer dispatch table. Follow-up work tracked in #116 appends JUnit
-     * XML, JSON, and HTML entries here; the loop in {@see self::writeReports()}
-     * does not need to change. The PHPUnit subscriber keeps a parallel table
-     * in {@see CoverageReportSubscriber},
-     * so any new format must be added to both in lockstep — note the severity
-     * asymmetry (subscriber warns; CLI counts failures toward exit code).
+     * Renderer dispatch table. Adding a new format here does not require
+     * changes to the loop in {@see self::writeReports()}. The PHPUnit subscriber
+     * keeps a parallel table in {@see CoverageReportSubscriber}, so any new
+     * format must be added to both in lockstep — note the severity asymmetry
+     * (subscriber warns; CLI counts failures toward exit code).
      *
      * @return list<CoverageReportEntry>
      */

--- a/src/Coverage/JsonCoverageRenderer.php
+++ b/src/Coverage/JsonCoverageRenderer.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Coverage;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+
+use Composer\InstalledVersions;
+use DateTimeImmutable;
+use OutOfBoundsException;
+use RuntimeException;
+
+use function json_encode;
+
+/**
+ * Render coverage results as a JSON document for downstream consumers
+ * (custom dashboards, contract-coverage analytics, scripted gating).
+ *
+ * Shape mirrors the computed {@see CoverageResult} array (not the paratest
+ * sidecar wire format) — fields are snake_case, enum values surface as
+ * strings, and the two state enums get distinct namespaced field names
+ * (`endpoint_state` / `response_state`) to avoid value-string collisions
+ * (e.g. `"uncovered"` exists in both enums).
+ *
+ * Top-level shape:
+ *  - `schema_version`: int, bumped on incompatible structural changes
+ *  - `generated_at`: ISO-8601 timestamp
+ *  - `tool`: `{ name, version }` for downstream consumers diagnosing drift
+ *  - `aggregate`: rollup across all specs (lets consumers read one "total"
+ *    without re-summing)
+ *  - `specs`: per-spec `{ aggregates, endpoints }`
+ *
+ * See `docs/coverage-json-schema.md` for the full field reference.
+ *
+ * @phpstan-import-type CoverageResult from OpenApiCoverageTracker
+ * @phpstan-import-type EndpointSummary from OpenApiCoverageTracker
+ * @phpstan-import-type ResponseRow from OpenApiCoverageTracker
+ */
+final class JsonCoverageRenderer
+{
+    public const SCHEMA_VERSION = 1;
+    private const TOOL_NAME = 'studio-design/openapi-contract-testing';
+
+    /**
+     * @param array<string, CoverageResult> $results
+     * @param null|DateTimeImmutable $generatedAt Test seam for the timestamp.
+     *                                            Defaults to "now" in production.
+     */
+    public static function render(array $results, ?DateTimeImmutable $generatedAt = null): string
+    {
+        if ($results === []) {
+            return '';
+        }
+
+        $payload = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'generated_at' => ($generatedAt ?? new DateTimeImmutable())->format(DateTimeImmutable::ATOM),
+            'tool' => [
+                'name' => self::TOOL_NAME,
+                'version' => self::resolveToolVersion(),
+            ],
+            'aggregate' => self::aggregate($results),
+            'specs' => self::serialiseSpecs($results),
+        ];
+
+        $encoded = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if ($encoded === false) {
+            // Unreachable for the tracker's output (no resources, no NAN, no
+            // unsupported types) but surface a clear error instead of an
+            // empty file if the upstream shape changes unexpectedly.
+            throw new RuntimeException('Failed to encode coverage results as JSON');
+        }
+
+        return $encoded . "\n";
+    }
+
+    /**
+     * @param array<string, CoverageResult> $results
+     *
+     * @return array<string, int>
+     */
+    private static function aggregate(array $results): array
+    {
+        $totals = [
+            'endpoint_total' => 0,
+            'endpoint_fully_covered' => 0,
+            'endpoint_partial' => 0,
+            'endpoint_uncovered' => 0,
+            'endpoint_request_only' => 0,
+            'response_total' => 0,
+            'response_covered' => 0,
+            'response_skipped' => 0,
+            'response_uncovered' => 0,
+        ];
+
+        foreach ($results as $result) {
+            $totals['endpoint_total'] += $result['endpointTotal'];
+            $totals['endpoint_fully_covered'] += $result['endpointFullyCovered'];
+            $totals['endpoint_partial'] += $result['endpointPartial'];
+            $totals['endpoint_uncovered'] += $result['endpointUncovered'];
+            $totals['endpoint_request_only'] += $result['endpointRequestOnly'];
+            $totals['response_total'] += $result['responseTotal'];
+            $totals['response_covered'] += $result['responseCovered'];
+            $totals['response_skipped'] += $result['responseSkipped'];
+            $totals['response_uncovered'] += $result['responseUncovered'];
+        }
+
+        return $totals;
+    }
+
+    /**
+     * @param array<string, CoverageResult> $results
+     *
+     * @return array<string, array{aggregates: array<string, int>, endpoints: list<array<string, mixed>>}>
+     */
+    private static function serialiseSpecs(array $results): array
+    {
+        $specs = [];
+        foreach ($results as $specName => $result) {
+            $specs[$specName] = [
+                'aggregates' => self::aggregate([$specName => $result]),
+                'endpoints' => self::serialiseEndpoints($result['endpoints']),
+            ];
+        }
+
+        return $specs;
+    }
+
+    /**
+     * @param list<EndpointSummary> $endpoints
+     *
+     * @return list<array<string, mixed>>
+     */
+    private static function serialiseEndpoints(array $endpoints): array
+    {
+        $rows = [];
+        foreach ($endpoints as $endpoint) {
+            $rows[] = [
+                'endpoint' => $endpoint['endpoint'],
+                'method' => $endpoint['method'],
+                'path' => $endpoint['path'],
+                'operation_id' => $endpoint['operationId'],
+                'endpoint_state' => $endpoint['state']->value,
+                'request_reached' => $endpoint['requestReached'],
+                'responses' => self::serialiseResponses($endpoint['responses']),
+                'covered_response_count' => $endpoint['coveredResponseCount'],
+                'skipped_response_count' => $endpoint['skippedResponseCount'],
+                'total_response_count' => $endpoint['totalResponseCount'],
+                'unexpected_observations' => self::serialiseUnexpected($endpoint['unexpectedObservations']),
+            ];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param list<ResponseRow> $responses
+     *
+     * @return list<array{status_key: string, content_type_key: string, response_state: string, hits: int, skip_reason: ?string}>
+     */
+    private static function serialiseResponses(array $responses): array
+    {
+        $rows = [];
+        foreach ($responses as $row) {
+            $rows[] = [
+                'status_key' => $row['statusKey'],
+                'content_type_key' => $row['contentTypeKey'],
+                'response_state' => $row['state']->value,
+                'hits' => $row['hits'],
+                'skip_reason' => $row['skipReason'],
+            ];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param list<array{statusKey: string, contentTypeKey: string}> $observations
+     *
+     * @return list<array{status_key: string, content_type_key: string}>
+     */
+    private static function serialiseUnexpected(array $observations): array
+    {
+        $rows = [];
+        foreach ($observations as $obs) {
+            $rows[] = [
+                'status_key' => $obs['statusKey'],
+                'content_type_key' => $obs['contentTypeKey'],
+            ];
+        }
+
+        return $rows;
+    }
+
+    private static function resolveToolVersion(): string
+    {
+        try {
+            $version = InstalledVersions::getVersion(self::TOOL_NAME);
+        } catch (OutOfBoundsException) {
+            // Package metadata unavailable — e.g. running from a vendored
+            // checkout without composer install. The schema requires a
+            // string, so surface an explicit sentinel rather than null.
+            return 'unknown';
+        }
+
+        return $version ?? 'unknown';
+    }
+}

--- a/src/Coverage/JsonCoverageRenderer.php
+++ b/src/Coverage/JsonCoverageRenderer.php
@@ -10,10 +10,12 @@ use const JSON_UNESCAPED_UNICODE;
 
 use Composer\InstalledVersions;
 use DateTimeImmutable;
-use OutOfBoundsException;
 use RuntimeException;
+use Throwable;
 
 use function json_encode;
+use function json_last_error_msg;
+use function sprintf;
 
 /**
  * Render coverage results as a JSON document for downstream consumers
@@ -38,6 +40,46 @@ use function json_encode;
  * @phpstan-import-type CoverageResult from OpenApiCoverageTracker
  * @phpstan-import-type EndpointSummary from OpenApiCoverageTracker
  * @phpstan-import-type ResponseRow from OpenApiCoverageTracker
+ *
+ * @phpstan-type JsonAggregate array{
+ *     endpoint_total: int,
+ *     endpoint_fully_covered: int,
+ *     endpoint_partial: int,
+ *     endpoint_uncovered: int,
+ *     endpoint_request_only: int,
+ *     response_total: int,
+ *     response_covered: int,
+ *     response_skipped: int,
+ *     response_uncovered: int,
+ * }
+ * @phpstan-type JsonResponseRow array{
+ *     status_key: string,
+ *     content_type_key: string,
+ *     response_state: string,
+ *     hits: int,
+ *     skip_reason: ?string,
+ * }
+ * @phpstan-type JsonUnexpected array{
+ *     status_key: string,
+ *     content_type_key: string,
+ * }
+ * @phpstan-type JsonEndpoint array{
+ *     endpoint: string,
+ *     method: string,
+ *     path: string,
+ *     operation_id: ?string,
+ *     endpoint_state: string,
+ *     request_reached: bool,
+ *     responses: list<JsonResponseRow>,
+ *     covered_response_count: int,
+ *     skipped_response_count: int,
+ *     total_response_count: int,
+ *     unexpected_observations: list<JsonUnexpected>,
+ * }
+ * @phpstan-type JsonSpec array{
+ *     aggregates: JsonAggregate,
+ *     endpoints: list<JsonEndpoint>,
+ * }
  */
 final class JsonCoverageRenderer
 {
@@ -46,8 +88,12 @@ final class JsonCoverageRenderer
 
     /**
      * @param array<string, CoverageResult> $results
-     * @param null|DateTimeImmutable $generatedAt Test seam for the timestamp.
-     *                                            Defaults to "now" in production.
+     * @param null|DateTimeImmutable $generatedAt Override the document timestamp.
+     *                                            Defaults to the current time.
+     *
+     * @return string Empty string when `$results` is empty so callers can
+     *                short-circuit a no-coverage run; otherwise a pretty-printed
+     *                JSON document terminated by a single `"\n"`.
      */
     public static function render(array $results, ?DateTimeImmutable $generatedAt = null): string
     {
@@ -71,7 +117,10 @@ final class JsonCoverageRenderer
             // Unreachable for the tracker's output (no resources, no NAN, no
             // unsupported types) but surface a clear error instead of an
             // empty file if the upstream shape changes unexpectedly.
-            throw new RuntimeException('Failed to encode coverage results as JSON');
+            throw new RuntimeException(sprintf(
+                'Failed to encode coverage results as JSON: %s',
+                json_last_error_msg(),
+            ));
         }
 
         return $encoded . "\n";
@@ -80,7 +129,7 @@ final class JsonCoverageRenderer
     /**
      * @param array<string, CoverageResult> $results
      *
-     * @return array<string, int>
+     * @return JsonAggregate
      */
     private static function aggregate(array $results): array
     {
@@ -114,7 +163,7 @@ final class JsonCoverageRenderer
     /**
      * @param array<string, CoverageResult> $results
      *
-     * @return array<string, array{aggregates: array<string, int>, endpoints: list<array<string, mixed>>}>
+     * @return array<string, JsonSpec>
      */
     private static function serialiseSpecs(array $results): array
     {
@@ -132,7 +181,7 @@ final class JsonCoverageRenderer
     /**
      * @param list<EndpointSummary> $endpoints
      *
-     * @return list<array<string, mixed>>
+     * @return list<JsonEndpoint>
      */
     private static function serialiseEndpoints(array $endpoints): array
     {
@@ -195,14 +244,20 @@ final class JsonCoverageRenderer
         return $rows;
     }
 
+    /**
+     * Resolve the running tool version. The field is cosmetic — any failure
+     * here must never abort the report, so the catch is intentionally broad:
+     * `OutOfBoundsException` is the documented Composer 2.x "package not
+     * installed" path, but corrupted `installed.php`, Composer 1.x/2.x metadata
+     * mismatches, or stripped vendor directories can surface as other throwables.
+     * Silent by design — `'unknown'` is the documented sentinel and the schema
+     * forbids null, so emitting a string is enough.
+     */
     private static function resolveToolVersion(): string
     {
         try {
             $version = InstalledVersions::getVersion(self::TOOL_NAME);
-        } catch (OutOfBoundsException) {
-            // Package metadata unavailable — e.g. running from a vendored
-            // checkout without composer install. The schema requires a
-            // string, so surface an explicit sentinel rather than null.
+        } catch (Throwable) {
             return 'unknown';
         }
 

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -14,6 +14,7 @@ use Studio\OpenApiContractTesting\Coverage\ConsoleCoverageRenderer;
 use Studio\OpenApiContractTesting\Coverage\CoverageMergeCommand;
 use Studio\OpenApiContractTesting\Coverage\CoverageSidecarWriter;
 use Studio\OpenApiContractTesting\Coverage\CoverageThresholdEvaluator;
+use Studio\OpenApiContractTesting\Coverage\JsonCoverageRenderer;
 use Studio\OpenApiContractTesting\Coverage\JUnitCoverageRenderer;
 use Studio\OpenApiContractTesting\Coverage\MarkdownCoverageRenderer;
 use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
@@ -65,6 +66,7 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         private bool $minCoverageStrict = false,
         private mixed $exitHandler = null,
         private ?string $junitOutput = null,
+        private ?string $jsonOutput = null,
     ) {}
 
     /** @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter */
@@ -339,6 +341,11 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
                 'label' => 'JUnit XML',
                 'renderer' => static fn(array $r): string => JUnitCoverageRenderer::render($r),
                 'outputFile' => $this->junitOutput,
+            ],
+            [
+                'label' => 'JSON',
+                'renderer' => static fn(array $r): string => JsonCoverageRenderer::render($r),
+                'outputFile' => $this->jsonOutput,
             ],
         ];
     }

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -21,12 +21,14 @@ use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\Exception\SpecFileNotFoundException;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+use Throwable;
 
 use function fflush;
 use function file_put_contents;
 use function getenv;
 use function is_callable;
 use function sprintf;
+use function strlen;
 use function trim;
 
 /**
@@ -286,9 +288,10 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
     }
 
     /**
-     * Dispatch each configured renderer to its output target. Per-entry write
-     * failures emit a WARNING and continue — one format's broken path must not
-     * suppress the others or block the threshold gate that runs after this.
+     * Dispatch each configured renderer to its output target. Per-entry render
+     * or write failures emit a WARNING and continue — one format's broken path
+     * must not suppress the others or block the threshold gate that runs after
+     * this.
      *
      * GITHUB_STEP_SUMMARY is Markdown-only by design and handled separately.
      *
@@ -301,17 +304,44 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
                 continue;
             }
 
-            $rendered = ($entry['renderer'])($results);
+            try {
+                $rendered = ($entry['renderer'])($results);
+            } catch (Throwable $e) {
+                $this->writeStderr(sprintf(
+                    "[OpenAPI Coverage] WARNING: Failed to render %s report: %s\n",
+                    $entry['label'],
+                    $e->getMessage(),
+                ));
+
+                continue;
+            }
 
             // Suppress PHP warning on failure — we surface the error via the
             // WARNING stderr line below, and the raw PHP warning is redundant
             // noise that breaks `beStrictAboutOutputDuringTests` test runs.
             // Mirrors the CLI dispatch loop's @ suppression.
-            if (@file_put_contents($entry['outputFile'], $rendered) === false) {
+            $bytes = @file_put_contents($entry['outputFile'], $rendered);
+            if ($bytes === false) {
                 $this->writeStderr(sprintf(
                     "[OpenAPI Coverage] WARNING: Failed to write %s report to %s\n",
                     $entry['label'],
                     $entry['outputFile'],
+                ));
+
+                continue;
+            }
+
+            $expected = strlen($rendered);
+            if ($bytes !== $expected) {
+                // Partial write — disk full / quota exceeded mid-write leaves
+                // a truncated file. Surface explicitly so consumers don't
+                // parse half a document several CI steps later.
+                $this->writeStderr(sprintf(
+                    "[OpenAPI Coverage] WARNING: Truncated %s report at %s (%d of %d bytes written)\n",
+                    $entry['label'],
+                    $entry['outputFile'],
+                    $bytes,
+                    $expected,
                 ));
             }
         }
@@ -320,12 +350,11 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
     }
 
     /**
-     * Renderer dispatch table. Follow-up work tracked in #116 appends JUnit
-     * XML, JSON, and HTML entries here; the loop in {@see self::writeReports()}
-     * does not need to change. The merge CLI keeps a parallel table in
-     * {@see CoverageMergeCommand}, so
-     * any new format must be added to both in lockstep — note the severity
-     * asymmetry (subscriber warns; CLI counts failures toward exit code).
+     * Renderer dispatch table. Adding a new format here does not require
+     * changes to the loop in {@see self::writeReports()}. The merge CLI keeps
+     * a parallel table in {@see CoverageMergeCommand}, so any new format must
+     * be added to both in lockstep — note the severity asymmetry (subscriber
+     * warns; CLI counts failures toward exit code).
      *
      * @return list<CoverageReportEntry>
      */

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -191,6 +191,7 @@ final class OpenApiCoverageExtension implements Extension
         }
 
         $junitOutput = self::resolveOutputPathParameter($parameters, 'junit_output', $githubSummaryPath);
+        $jsonOutput = self::resolveOutputPathParameter($parameters, 'json_output', $githubSummaryPath);
 
         $consoleOutput = ConsoleOutput::resolve(
             $parameters->has('console_output') ? $parameters->get('console_output') : null,
@@ -224,6 +225,7 @@ final class OpenApiCoverageExtension implements Extension
             minResponseCoverage: $minResponseCoverage,
             minCoverageStrict: $minCoverageStrict,
             junitOutput: $junitOutput,
+            jsonOutput: $jsonOutput,
         ));
     }
 

--- a/tests/Unit/Coverage/CoverageMergeCommandTest.php
+++ b/tests/Unit/Coverage/CoverageMergeCommandTest.php
@@ -17,6 +17,7 @@ use function file_get_contents;
 use function file_put_contents;
 use function glob;
 use function is_dir;
+use function json_decode;
 use function mkdir;
 use function rmdir;
 use function substr_count;
@@ -273,6 +274,7 @@ class CoverageMergeCommandTest extends TestCase
             '--sidecar-dir=/tmp/sidecars',
             '--output-file=/tmp/cov.md',
             '--junit-output=/tmp/cov.junit.xml',
+            '--json-output=/tmp/cov.json',
             '--no-cleanup',
         ]);
 
@@ -282,6 +284,7 @@ class CoverageMergeCommandTest extends TestCase
         $this->assertSame('/tmp/sidecars', $opts['sidecar_dir']);
         $this->assertSame('/tmp/cov.md', $opts['output_file']);
         $this->assertSame('/tmp/cov.junit.xml', $opts['junit_output']);
+        $this->assertSame('/tmp/cov.json', $opts['json_output']);
         $this->assertFalse($opts['cleanup']);
     }
 
@@ -320,6 +323,78 @@ class CoverageMergeCommandTest extends TestCase
         $this->assertSame(1, $exit);
         $this->assertStringContainsString('FATAL', $stderr);
         $this->assertStringContainsString('JUnit XML', $stderr);
+    }
+
+    #[Test]
+    public function writes_json_to_configured_path(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        $jsonPath = dirname($this->sidecarDir) . '/coverage.json';
+
+        $command = new CoverageMergeCommand(stdoutWriter: static fn(string $msg): null => null);
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'json_output' => $jsonPath,
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertFileExists($jsonPath);
+
+        $decoded = json_decode((string) file_get_contents($jsonPath), true);
+        $this->assertIsArray($decoded);
+        $this->assertSame(1, $decoded['schema_version']);
+        $this->assertSame('studio-design/openapi-contract-testing', $decoded['tool']['name']);
+        $this->assertArrayHasKey('petstore-3.0', $decoded['specs']);
+
+        @unlink($jsonPath);
+    }
+
+    #[Test]
+    public function exits_one_when_json_output_write_fails(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        $unwritable = '/proc/0/forbidden/coverage.json';
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            stdoutWriter: static fn(string $msg): null => null,
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'json_output' => $unwritable,
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('FATAL', $stderr);
+        $this->assertStringContainsString('JSON', $stderr);
     }
 
     #[Test]

--- a/tests/Unit/Coverage/JsonCoverageRendererTest.php
+++ b/tests/Unit/Coverage/JsonCoverageRendererTest.php
@@ -1,0 +1,383 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Coverage;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Coverage\EndpointCoverageState;
+use Studio\OpenApiContractTesting\Coverage\JsonCoverageRenderer;
+use Studio\OpenApiContractTesting\Coverage\ResponseCoverageState;
+
+use function explode;
+use function is_array;
+use function json_decode;
+
+class JsonCoverageRendererTest extends TestCase
+{
+    private const FIXED_TIMESTAMP = '2026-05-11T12:34:56+00:00';
+
+    #[Test]
+    public function render_returns_empty_string_for_empty_results(): void
+    {
+        $this->assertSame('', JsonCoverageRenderer::render([]));
+    }
+
+    #[Test]
+    public function render_emits_schema_version_and_generated_at(): void
+    {
+        $payload = $this->decode($this->renderOneValidated());
+
+        $this->assertSame(1, $payload['schema_version']);
+        $this->assertSame(self::FIXED_TIMESTAMP, $payload['generated_at']);
+    }
+
+    #[Test]
+    public function render_emits_tool_metadata(): void
+    {
+        $payload = $this->decode($this->renderOneValidated());
+
+        $this->assertArrayHasKey('tool', $payload);
+        $this->assertSame('studio-design/openapi-contract-testing', $payload['tool']['name']);
+        $this->assertIsString($payload['tool']['version']);
+        $this->assertNotSame('', $payload['tool']['version']);
+    }
+
+    #[Test]
+    public function render_emits_top_level_aggregate_rolled_across_specs(): void
+    {
+        // Two specs, each with one fully-covered endpoint and one uncovered
+        // endpoint — top-level aggregate must sum across both, not echo one.
+        $results = [
+            'spec-a' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /a/pets', 'all-covered', responses: [
+                        self::row('200', 'application/json', 'validated', hits: 1),
+                    ], coveredResponseCount: 1, totalResponseCount: 1),
+                    self::endpoint('GET /a/health', 'uncovered', responses: [
+                        self::row('200', 'application/json', 'uncovered'),
+                    ], totalResponseCount: 1),
+                ],
+                endpointTotal: 2,
+                endpointFullyCovered: 1,
+                endpointUncovered: 1,
+                responseTotal: 2,
+                responseCovered: 1,
+                responseUncovered: 1,
+            ),
+            'spec-b' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /b/widgets', 'all-covered', responses: [
+                        self::row('200', 'application/json', 'validated', hits: 1),
+                    ], coveredResponseCount: 1, totalResponseCount: 1),
+                ],
+                endpointTotal: 1,
+                endpointFullyCovered: 1,
+                responseTotal: 1,
+                responseCovered: 1,
+            ),
+        ];
+
+        $payload = $this->decode(JsonCoverageRenderer::render($results, $this->fixedNow()));
+
+        $this->assertSame(3, $payload['aggregate']['endpoint_total']);
+        $this->assertSame(2, $payload['aggregate']['endpoint_fully_covered']);
+        $this->assertSame(1, $payload['aggregate']['endpoint_uncovered']);
+        $this->assertSame(3, $payload['aggregate']['response_total']);
+        $this->assertSame(2, $payload['aggregate']['response_covered']);
+        $this->assertSame(1, $payload['aggregate']['response_uncovered']);
+    }
+
+    #[Test]
+    public function render_emits_per_spec_aggregates_and_endpoints(): void
+    {
+        $payload = $this->decode($this->renderOneValidated());
+
+        $this->assertArrayHasKey('specs', $payload);
+        $this->assertArrayHasKey('front', $payload['specs']);
+        $this->assertSame(1, $payload['specs']['front']['aggregates']['endpoint_fully_covered']);
+        $this->assertCount(1, $payload['specs']['front']['endpoints']);
+
+        $endpoint = $payload['specs']['front']['endpoints'][0];
+        $this->assertSame('GET /v1/pets', $endpoint['endpoint']);
+        $this->assertSame('GET', $endpoint['method']);
+        $this->assertSame('/v1/pets', $endpoint['path']);
+        $this->assertSame('listPets', $endpoint['operation_id']);
+        $this->assertSame('all-covered', $endpoint['endpoint_state']);
+        $this->assertTrue($endpoint['request_reached']);
+    }
+
+    #[Test]
+    public function render_serialises_response_state_as_string_value(): void
+    {
+        $payload = $this->decode($this->renderOneValidated());
+        $row = $payload['specs']['front']['endpoints'][0]['responses'][0];
+
+        $this->assertSame('200', $row['status_key']);
+        $this->assertSame('application/json', $row['content_type_key']);
+        $this->assertSame('validated', $row['response_state']);
+        $this->assertSame(3, $row['hits']);
+        $this->assertNull($row['skip_reason']);
+    }
+
+    #[Test]
+    public function render_namespaces_state_fields_to_avoid_enum_value_collision(): void
+    {
+        // EndpointCoverageState and ResponseCoverageState share value-string
+        // namespaces (e.g. "uncovered" exists in both). Each enum's value
+        // must surface under a distinct field name so consumers can read
+        // them unambiguously.
+        $payload = $this->decode($this->renderOneValidated());
+        $endpoint = $payload['specs']['front']['endpoints'][0];
+
+        $this->assertArrayHasKey('endpoint_state', $endpoint);
+        $this->assertArrayNotHasKey('state', $endpoint);
+        $this->assertArrayHasKey('response_state', $endpoint['responses'][0]);
+        $this->assertArrayNotHasKey('state', $endpoint['responses'][0]);
+    }
+
+    #[Test]
+    public function render_includes_skip_reason_when_present(): void
+    {
+        $results = [
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('DELETE /v1/pets/{petId}', 'partial', responses: [
+                        self::row(
+                            '503',
+                            'application/json',
+                            'skipped',
+                            hits: 1,
+                            skipReason: 'status 503 matched skip pattern 5\d\d',
+                        ),
+                    ], skippedResponseCount: 1, totalResponseCount: 1),
+                ],
+                endpointTotal: 1,
+                endpointPartial: 1,
+                responseTotal: 1,
+                responseSkipped: 1,
+            ),
+        ];
+
+        $payload = $this->decode(JsonCoverageRenderer::render($results, $this->fixedNow()));
+        $row = $payload['specs']['front']['endpoints'][0]['responses'][0];
+
+        $this->assertSame('skipped', $row['response_state']);
+        $this->assertSame('status 503 matched skip pattern 5\d\d', $row['skip_reason']);
+    }
+
+    #[Test]
+    public function render_includes_unexpected_observations(): void
+    {
+        $results = [
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('POST /v1/pets', 'partial', responses: [
+                        self::row('201', 'application/json', 'validated', hits: 1),
+                    ], coveredResponseCount: 1, totalResponseCount: 1, unexpectedObservations: [
+                        ['statusKey' => '418', 'contentTypeKey' => 'application/json'],
+                    ]),
+                ],
+                endpointTotal: 1,
+                endpointFullyCovered: 1,
+                responseTotal: 1,
+                responseCovered: 1,
+            ),
+        ];
+
+        $payload = $this->decode(JsonCoverageRenderer::render($results, $this->fixedNow()));
+        $endpoint = $payload['specs']['front']['endpoints'][0];
+
+        $this->assertCount(1, $endpoint['unexpected_observations']);
+        $this->assertSame('418', $endpoint['unexpected_observations'][0]['status_key']);
+        $this->assertSame('application/json', $endpoint['unexpected_observations'][0]['content_type_key']);
+    }
+
+    #[Test]
+    public function render_omits_null_operation_id_field_value_but_keeps_key(): void
+    {
+        $results = [
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v1/pets', 'all-covered', requestReached: true, responses: [
+                        self::row('200', 'application/json', 'validated', hits: 1),
+                    ], coveredResponseCount: 1, totalResponseCount: 1),
+                ],
+                endpointTotal: 1,
+                endpointFullyCovered: 1,
+                responseTotal: 1,
+                responseCovered: 1,
+            ),
+        ];
+
+        $payload = $this->decode(JsonCoverageRenderer::render($results, $this->fixedNow()));
+        $endpoint = $payload['specs']['front']['endpoints'][0];
+
+        $this->assertArrayHasKey('operation_id', $endpoint);
+        $this->assertNull($endpoint['operation_id']);
+    }
+
+    #[Test]
+    public function render_pretty_prints_with_trailing_newline(): void
+    {
+        // CI consumers often `jq` over the file; pretty-printed JSON is
+        // strictly redundant for jq but matches user expectations for a
+        // human-readable artifact. Trailing newline keeps `cat`/POSIX text
+        // tools happy.
+        $output = $this->renderOneValidated();
+
+        $this->assertStringContainsString("\n", $output);
+        $this->assertStringEndsWith("\n", $output);
+    }
+
+    #[Test]
+    public function render_uses_default_now_when_generated_at_not_passed(): void
+    {
+        $output = JsonCoverageRenderer::render($this->oneSpecResults());
+        $payload = $this->decode($output);
+
+        // Don't assert exact timestamp; verify it parses as ISO-8601 and is
+        // close to current time so we don't depend on clock injection here.
+        $parsed = DateTimeImmutable::createFromFormat(DateTimeImmutable::ATOM, $payload['generated_at']);
+        $this->assertNotFalse($parsed);
+    }
+
+    /**
+     * @param list<array{endpoint: string, method: string, path: string, operationId: ?string, state: EndpointCoverageState, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}> $endpoints
+     *
+     * @return array{endpoints: list<array{endpoint: string, method: string, path: string, operationId: ?string, state: EndpointCoverageState, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}>, endpointTotal: int, endpointFullyCovered: int, endpointPartial: int, endpointUncovered: int, endpointRequestOnly: int, responseTotal: int, responseCovered: int, responseSkipped: int, responseUncovered: int}
+     */
+    private static function coverage(
+        array $endpoints,
+        int $endpointTotal = 0,
+        int $endpointFullyCovered = 0,
+        int $endpointPartial = 0,
+        int $endpointUncovered = 0,
+        int $endpointRequestOnly = 0,
+        int $responseTotal = 0,
+        int $responseCovered = 0,
+        int $responseSkipped = 0,
+        int $responseUncovered = 0,
+    ): array {
+        return [
+            'endpoints' => $endpoints,
+            'endpointTotal' => $endpointTotal,
+            'endpointFullyCovered' => $endpointFullyCovered,
+            'endpointPartial' => $endpointPartial,
+            'endpointUncovered' => $endpointUncovered,
+            'endpointRequestOnly' => $endpointRequestOnly,
+            'responseTotal' => $responseTotal,
+            'responseCovered' => $responseCovered,
+            'responseSkipped' => $responseSkipped,
+            'responseUncovered' => $responseUncovered,
+        ];
+    }
+
+    /**
+     * @param list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}> $responses
+     * @param list<array{statusKey: string, contentTypeKey: string}> $unexpectedObservations
+     *
+     * @return array{endpoint: string, method: string, path: string, operationId: ?string, state: EndpointCoverageState, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}
+     */
+    private static function endpoint(
+        string $endpoint,
+        string $state,
+        bool $requestReached = false,
+        ?string $operationId = null,
+        array $responses = [],
+        int $coveredResponseCount = 0,
+        int $skippedResponseCount = 0,
+        int $totalResponseCount = 0,
+        array $unexpectedObservations = [],
+    ): array {
+        [$method, $path] = explode(' ', $endpoint, 2);
+
+        return [
+            'endpoint' => $endpoint,
+            'method' => $method,
+            'path' => $path,
+            'operationId' => $operationId,
+            'state' => EndpointCoverageState::from($state),
+            'requestReached' => $requestReached,
+            'responses' => $responses,
+            'coveredResponseCount' => $coveredResponseCount,
+            'skippedResponseCount' => $skippedResponseCount,
+            'totalResponseCount' => $totalResponseCount,
+            'unexpectedObservations' => $unexpectedObservations,
+        ];
+    }
+
+    /**
+     * @return array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}
+     */
+    private static function row(
+        string $statusKey,
+        string $contentTypeKey,
+        string $state,
+        int $hits = 0,
+        ?string $skipReason = null,
+    ): array {
+        return [
+            'statusKey' => $statusKey,
+            'contentTypeKey' => $contentTypeKey,
+            'state' => ResponseCoverageState::from($state),
+            'hits' => $hits,
+            'skipReason' => $skipReason,
+        ];
+    }
+
+    private function renderOneValidated(): string
+    {
+        return JsonCoverageRenderer::render($this->oneSpecResults(), $this->fixedNow());
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function oneSpecResults(): array
+    {
+        return [
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint(
+                        'GET /v1/pets',
+                        'all-covered',
+                        requestReached: true,
+                        operationId: 'listPets',
+                        responses: [
+                            self::row('200', 'application/json', 'validated', hits: 3),
+                        ],
+                        coveredResponseCount: 1,
+                        totalResponseCount: 1,
+                    ),
+                ],
+                endpointTotal: 1,
+                endpointFullyCovered: 1,
+                responseTotal: 1,
+                responseCovered: 1,
+            ),
+        ];
+    }
+
+    private function fixedNow(): DateTimeImmutable
+    {
+        return new DateTimeImmutable(self::FIXED_TIMESTAMP, new DateTimeZone('UTC'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(string $json): array
+    {
+        $decoded = json_decode($json, true);
+        if (!is_array($decoded)) {
+            $this->fail('Renderer did not produce a decodable JSON object: ' . $json);
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+}

--- a/tests/Unit/Coverage/JsonCoverageRendererTest.php
+++ b/tests/Unit/Coverage/JsonCoverageRendererTest.php
@@ -12,6 +12,7 @@ use Studio\OpenApiContractTesting\Coverage\EndpointCoverageState;
 use Studio\OpenApiContractTesting\Coverage\JsonCoverageRenderer;
 use Studio\OpenApiContractTesting\Coverage\ResponseCoverageState;
 
+use function array_keys;
 use function explode;
 use function is_array;
 use function json_decode;
@@ -243,6 +244,112 @@ class JsonCoverageRendererTest extends TestCase
         // close to current time so we don't depend on clock injection here.
         $parsed = DateTimeImmutable::createFromFormat(DateTimeImmutable::ATOM, $payload['generated_at']);
         $this->assertNotFalse($parsed);
+    }
+
+    #[Test]
+    public function render_serialises_request_only_endpoint_state(): void
+    {
+        // RequestOnly represents endpoints that received traffic but reconciled
+        // only to unexpected observations. Pin the enum value-string so a
+        // regression in the enum value or in $endpoint['state']->value would
+        // surface here rather than as a silent schema drift.
+        $results = [
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint(
+                        'POST /v1/pets',
+                        'request-only',
+                        requestReached: true,
+                        responses: [
+                            self::row('201', 'application/json', 'uncovered'),
+                        ],
+                        totalResponseCount: 1,
+                        unexpectedObservations: [
+                            ['statusKey' => '418', 'contentTypeKey' => 'application/json'],
+                        ],
+                    ),
+                ],
+                endpointTotal: 1,
+                endpointRequestOnly: 1,
+                responseTotal: 1,
+                responseUncovered: 1,
+            ),
+        ];
+
+        $payload = $this->decode(JsonCoverageRenderer::render($results, $this->fixedNow()));
+
+        $this->assertSame('request-only', $payload['specs']['front']['endpoints'][0]['endpoint_state']);
+    }
+
+    #[Test]
+    public function render_emits_unescaped_slashes_in_paths(): void
+    {
+        // JSON_UNESCAPED_SLASHES is part of the documented output contract.
+        // The raw string assertion catches a regression that drops the flag
+        // (decoded values look identical, so this is the only sound pin).
+        $output = $this->renderOneValidated();
+
+        $this->assertStringContainsString('"/v1/pets"', $output);
+        $this->assertStringNotContainsString('\/v1\/pets', $output);
+    }
+
+    #[Test]
+    public function render_emits_unescaped_unicode_in_skip_reasons(): void
+    {
+        // JSON_UNESCAPED_UNICODE keeps non-ASCII content readable for human
+        // consumers and downstream tools that don't decode \uXXXX sequences
+        // back to UTF-8.
+        $results = [
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('DELETE /v1/pets/{petId}', 'partial', responses: [
+                        self::row(
+                            '503',
+                            'application/json',
+                            'skipped',
+                            hits: 1,
+                            skipReason: 'ステータス 503 はスキップ対象です',
+                        ),
+                    ], skippedResponseCount: 1, totalResponseCount: 1),
+                ],
+                endpointTotal: 1,
+                endpointPartial: 1,
+                responseTotal: 1,
+                responseSkipped: 1,
+            ),
+        ];
+
+        $output = JsonCoverageRenderer::render($results, $this->fixedNow());
+
+        // Raw UTF-8 must round-trip through the output verbatim. The negative
+        // assertion catches a regression that drops JSON_UNESCAPED_UNICODE
+        // (which would surface \uXXXX escapes instead of the original chars).
+        $this->assertStringContainsString('ステータス 503 はスキップ対象です', $output);
+        $this->assertStringNotContainsString('\\u', $output);
+    }
+
+    #[Test]
+    public function render_aggregate_has_documented_nine_field_shape(): void
+    {
+        // Shape-pin against docs/coverage-json-schema.md. A regression that
+        // adds a field without bumping schema_version, or drops a documented
+        // field, surfaces here.
+        $payload = $this->decode($this->renderOneValidated());
+
+        $expectedKeys = [
+            'endpoint_total',
+            'endpoint_fully_covered',
+            'endpoint_partial',
+            'endpoint_uncovered',
+            'endpoint_request_only',
+            'response_total',
+            'response_covered',
+            'response_skipped',
+            'response_uncovered',
+        ];
+
+        $this->assertSame($expectedKeys, array_keys($payload['aggregate']));
+        $this->assertSame($expectedKeys, array_keys($payload['specs']['front']['aggregates']));
     }
 
     /**

--- a/tests/Unit/PHPUnit/CoverageReportSubscriberWorkerModeTest.php
+++ b/tests/Unit/PHPUnit/CoverageReportSubscriberWorkerModeTest.php
@@ -297,6 +297,48 @@ class CoverageReportSubscriberWorkerModeTest extends TestCase
     }
 
     #[Test]
+    public function sequential_mode_warns_and_continues_when_json_write_fails(): void
+    {
+        // Parity with sequential_mode_warns_and_continues_when_junit_write_fails
+        // — the JSON dispatch path must obey the same WARN-and-continue
+        // contract so the asymmetry is consistent across all formats.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        mkdir($this->tmpDir, 0o755, recursive: true);
+        $jsonPath = $this->tmpDir . '/coverage.json';
+        mkdir($jsonPath, 0o755, recursive: true);
+
+        $stderrLog = '';
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            stderrWriter: static function (string $msg) use (&$stderrLog): void {
+                $stderrLog .= $msg;
+            },
+            sidecarDir: $this->tmpDir,
+            jsonOutput: $jsonPath,
+        );
+
+        ob_start();
+        $subscriber->notify($this->fakeExecutionFinished());
+        ob_get_clean();
+
+        @rmdir($jsonPath);
+
+        $this->assertStringContainsString('WARNING', $stderrLog);
+        $this->assertStringContainsString('JSON', $stderrLog);
+    }
+
+    #[Test]
     public function worker_mode_keeps_running_when_sidecar_write_fails(): void
     {
         // The contract assertion that triggered notify() must never be

--- a/tests/Unit/PHPUnit/CoverageReportSubscriberWorkerModeTest.php
+++ b/tests/Unit/PHPUnit/CoverageReportSubscriberWorkerModeTest.php
@@ -99,6 +99,7 @@ class CoverageReportSubscriberWorkerModeTest extends TestCase
             githubSummaryPath: null,
             sidecarDir: $this->tmpDir,
             junitOutput: $this->tmpDir . '/coverage.junit.xml',
+            jsonOutput: $this->tmpDir . '/coverage.json',
         );
 
         ob_start();
@@ -110,6 +111,10 @@ class CoverageReportSubscriberWorkerModeTest extends TestCase
         $this->assertFileDoesNotExist(
             $this->tmpDir . '/coverage.junit.xml',
             'worker mode must not write junit_output (merge CLI is the canonical paratest renderer)',
+        );
+        $this->assertFileDoesNotExist(
+            $this->tmpDir . '/coverage.json',
+            'worker mode must not write json_output (merge CLI is the canonical paratest renderer)',
         );
 
         $loaded = CoverageSidecarReader::readDir($this->tmpDir);
@@ -208,6 +213,41 @@ class CoverageReportSubscriberWorkerModeTest extends TestCase
         $this->assertStringStartsWith('<?xml version="1.0" encoding="UTF-8"', $contents);
         $this->assertStringContainsString('<testsuites', $contents);
         $this->assertStringContainsString('openapi.coverage.petstore-3.0', $contents);
+    }
+
+    #[Test]
+    public function sequential_mode_writes_json_output_when_configured(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        mkdir($this->tmpDir, 0o755, recursive: true);
+        $jsonPath = $this->tmpDir . '/coverage.json';
+
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            sidecarDir: $this->tmpDir,
+            jsonOutput: $jsonPath,
+        );
+
+        ob_start();
+        $subscriber->notify($this->fakeExecutionFinished());
+        ob_get_clean();
+
+        $this->assertFileExists($jsonPath, 'sequential mode must write json_output when configured');
+        $decoded = json_decode((string) file_get_contents($jsonPath), true);
+        $this->assertIsArray($decoded);
+        $this->assertSame(1, $decoded['schema_version']);
+        $this->assertArrayHasKey('petstore-3.0', $decoded['specs']);
     }
 
     #[Test]

--- a/tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php
+++ b/tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php
@@ -912,6 +912,30 @@ class OpenApiCoverageExtensionTest extends TestCase
     }
 
     #[Test]
+    public function bootstrap_fatal_when_json_output_is_empty(): void
+    {
+        // Reuses resolveOutputPathParameter() helper validated for junit_output;
+        // pin the parameter name so a future helper rewrite that drops
+        // json_output wiring is caught.
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'json_output' => '',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+            $this->fail('expected InvalidCoverageOutputPathException');
+        } catch (InvalidCoverageOutputPathException $e) {
+            $this->assertSame('json_output', $e->parameterName);
+            $this->assertStringContainsString('empty', $e->getMessage());
+        }
+
+        $this->assertStringContainsString('FATAL', $this->readStderr());
+    }
+
+    #[Test]
     public function bootstrap_fatal_when_junit_output_parent_dir_not_writable(): void
     {
         // Surface the misconfiguration at bootstrap rather than as a runtime

--- a/tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php
+++ b/tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php
@@ -959,6 +959,31 @@ class OpenApiCoverageExtensionTest extends TestCase
         $this->assertStringContainsString('FATAL', $this->readStderr());
     }
 
+    #[Test]
+    public function bootstrap_fatal_when_json_output_parent_dir_not_writable(): void
+    {
+        // Parity with the junit_output check — the shared
+        // resolveOutputPathParameter() helper should fail closed for
+        // json_output too. Guards against a future change to the helper that
+        // accidentally pins it to one parameter name.
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'json_output' => '/proc/0/nonexistent/coverage.json',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+            $this->fail('expected InvalidCoverageOutputPathException');
+        } catch (InvalidCoverageOutputPathException $e) {
+            $this->assertSame('json_output', $e->parameterName);
+            $this->assertStringContainsString('not writable', $e->getMessage());
+        }
+
+        $this->assertStringContainsString('FATAL', $this->readStderr());
+    }
+
     private function readStderr(): string
     {
         if ($this->stderrBuffer === null) {


### PR DESCRIPTION
## Summary

Third format in the #116 series: `JsonCoverageRenderer` plus `json_output` (PHPUnit Extension) and `--json-output` (merge CLI). After this PR, users can pin `<parameter name="json_output" value="build/coverage.json"/>` (or pass `--json-output=build/coverage.json`) and feed contract test coverage into custom dashboards, analytics pipelines, and scripted CI gates.

## Why

Markdown is for humans, JUnit XML is for CI dashboards, and **JSON is for tooling**. Users who want to build a custom dashboard, drive a release-blocker check from coverage thresholds, or correlate coverage with other metrics need a stable, machine-readable shape. The paratest sidecar JSON is wire-format-only (internal `STATE_FORMAT_VERSION`, no derived states, no `operation_id`, no `unexpected_observations`) — this is the first public consumer-facing JSON shape.

## Schema highlights

Mirrors the computed `CoverageResult` array (not `exportState()`), serialised as snake_case with namespaced enum fields. See `docs/coverage-json-schema.md` for the full reference.

```json
{
  "schema_version": 1,
  "generated_at": "2026-05-11T12:34:56+00:00",
  "tool": { "name": "studio-design/openapi-contract-testing", "version": "..." },
  "aggregate": { "endpoint_total": 2, "endpoint_fully_covered": 1, ... },
  "specs": {
    "petstore": {
      "aggregates": { ... },
      "endpoints": [
        {
          "endpoint": "GET /v1/pets",
          "operation_id": "listPets",
          "endpoint_state": "all-covered",
          "request_reached": true,
          "responses": [
            { "status_key": "200", "content_type_key": "application/json",
              "response_state": "validated", "hits": 12, "skip_reason": null }
          ],
          "unexpected_observations": []
        }
      ]
    }
  }
}
```

Design choices documented in the schema doc:
- Top-level `aggregate` rollup so consumers don't re-sum across specs.
- `tool: { name, version }` from `Composer\InstalledVersions` for downstream drift diagnosis.
- `endpoint_state` / `response_state` namespacing — both enums share value strings (e.g. `"uncovered"`); flat `state` would be ambiguous.
- `generated_at` is injectable for tests via an optional second renderer argument (matches `ConsoleCoverageRenderer`'s second-arg pattern).

## Verification

- [x] `composer test` — **1382 tests / 3339 assertions** pass (12 new renderer tests, 1 new extension test, 1 new subscriber happy-path, 1 worker-mode assertion, 1 CLI integration test, 1 CLI write-failure test, 1 parseArgv update)
- [x] `composer stan` — clean (level 6)
- [x] `composer cs-check` — clean for the primary config

## Notes for reviewers

- Reuses the generic `resolveOutputPathParameter()` helper introduced for `junit_output` in #207 — empty value → FATAL, parent-dir writability check.
- Worker mode (`TEST_TOKEN` set) ignores `json_output` because the subscriber early-returns before `buildReportEntries()`; the merge CLI is the canonical paratest renderer.
- Multi-format simultaneous output works: `output_file` + `junit_output` + `json_output` all write independently. Severity asymmetry preserved (subscriber WARN, CLI FATAL+exit 1).
- `JsonCoverageRenderer` is `final class` like the existing renderers; render is `static` to match the established public-API shape. (Public, not `@internal` — users may want to call it directly when building custom subscribers.)
- `json_encode()` failure is detected explicitly (throws `RuntimeException`) — mirrors the `DOMDocument::saveXML()` failure handling added in PR #207.
- `schema_version` bump policy documented in the schema doc: additive changes keep version 1; removals / renames bump it.

## Follow-up

- PR 4 (HTML renderer) — last in the #116 chain

Refs #116. Stacks on #207.