### PR TITLE
feat(coverage): add HTML output for self-contained coverage reports

### DIFF
--- a/docs/coverage-html-output.md
+++ b/docs/coverage-html-output.md
@@ -1,0 +1,60 @@
+# Coverage HTML Output
+
+`studio-design/openapi-contract-testing` can emit a single self-contained HTML
+report via the `html_output` PHPUnit Extension parameter or the `--html-output`
+flag on `openapi-coverage-merge`. The file is intended for human review (PR
+comments, CI artifact preview, offline inspection).
+
+A sample document is committed at [`samples/coverage.html`](samples/coverage.html).
+
+## Design choices
+
+- **Single file.** Inline CSS, no JavaScript, no external assets. Drops cleanly
+  as a CI artifact and renders offline in any modern browser.
+- **`<details>`/`<summary>` for per-endpoint detail.** Reviewers can expand only
+  the endpoints they care about without depending on JavaScript.
+- **In-page anchor links.** The top-level endpoint list links to per-endpoint
+  detail sections so reviewers can jump directly to interesting rows.
+- **Safe escaping.** All spec-derived strings (paths, operation IDs, skip
+  reasons, content types) pass through
+  `htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')` so hostile
+  spec content cannot inject markup.
+- **State markers.** Each endpoint and response row carries a `state-<value>`
+  CSS class (`state-all-covered`, `state-partial`, `state-uncovered`,
+  `state-request-only`, `state-validated`, `state-skipped`) so styling can be
+  customised without changing the renderer.
+
+## Generating the file
+
+PHPUnit Extension:
+
+```xml
+<extensions>
+  <bootstrap class="Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension">
+    <parameter name="spec_base_path" value="openapi" />
+    <parameter name="html_output" value="build/coverage.html" />
+  </bootstrap>
+</extensions>
+```
+
+Paratest merge CLI:
+
+```bash
+vendor/bin/openapi-coverage-merge \
+  --spec-base-path=openapi \
+  --html-output=build/coverage.html
+```
+
+## Multiple formats
+
+`output_file`, `junit_output`, `json_output`, and `html_output` are independent;
+setting any combination writes all configured formats. A write failure on one
+format does not block the others. Severity follows the existing convention:
+subscriber WARN-and-continue, CLI FATAL + exit 1.
+
+## Future extensions
+
+The current shape is intentionally minimal. If a multi-page report (per-spec
+files, asset directory) is requested, a separate `html_output_dir` parameter
+will be added — `html_output` will continue to mean "single self-contained
+file" so existing pipelines do not need to migrate.

--- a/docs/coverage-html-output.md
+++ b/docs/coverage-html-output.md
@@ -19,10 +19,12 @@ A sample document is committed at [`samples/coverage.html`](samples/coverage.htm
   reasons, content types) pass through
   `htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')` so hostile
   spec content cannot inject markup.
-- **State markers.** Each endpoint and response row carries a `state-<value>`
-  CSS class (`state-all-covered`, `state-partial`, `state-uncovered`,
-  `state-request-only`, `state-validated`, `state-skipped`) so styling can be
-  customised without changing the renderer.
+- **State markers.** Each endpoint or response row carries a `state-<value>`
+  CSS class so styling can be customised without changing the renderer.
+  Endpoint-level classes mirror `EndpointCoverageState`: `state-all-covered`,
+  `state-partial`, `state-uncovered`, `state-request-only`. Response-row
+  classes mirror `ResponseCoverageState`: `state-validated`, `state-skipped`,
+  `state-uncovered`. Only `state-uncovered` is shared between the two enums.
 
 ## Generating the file
 
@@ -51,6 +53,12 @@ vendor/bin/openapi-coverage-merge \
 setting any combination writes all configured formats. A write failure on one
 format does not block the others. Severity follows the existing convention:
 subscriber WARN-and-continue, CLI FATAL + exit 1.
+
+**Note on `GITHUB_STEP_SUMMARY`.** The HTML output is *not* appended to
+`GITHUB_STEP_SUMMARY` (which is Markdown-only by design; GitHub renders the
+file as Markdown, so an HTML payload would be escaped). Use `html_output` for
+artifact uploads and `output_file` / `github_step_summary` for the Markdown
+summary.
 
 ## Future extensions
 

--- a/docs/coverage-json-schema.md
+++ b/docs/coverage-json-schema.md
@@ -97,4 +97,4 @@ vendor/bin/openapi-coverage-merge \
   --json-output=build/coverage.json
 ```
 
-Multiple format outputs are independent: setting `output_file`, `junit_output`, and `json_output` simultaneously writes all three. A write failure on one does not block the others; severity follows the existing convention (subscriber WARN, CLI FATAL+exit 1).
+Multiple format outputs are independent: setting `output_file`, `junit_output`, `json_output`, and `html_output` simultaneously writes all four. A write failure on one does not block the others; severity follows the existing convention (subscriber WARN, CLI FATAL+exit 1).

--- a/docs/samples/coverage.html
+++ b/docs/samples/coverage.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>OpenAPI Contract Test Coverage</title>
+<style>body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:#222;margin:0;padding:2rem;max-width:1100px;line-height:1.5;}h1{margin-top:0;}.page-header{border-bottom:1px solid #ddd;padding-bottom:1rem;margin-bottom:2rem;}.aggregate .metric{font-size:1.1rem;margin:0.25rem 0;}.aggregate .meta{color:#666;font-size:0.9rem;}.spec{margin-bottom:2rem;}.spec-summary{color:#444;}.endpoint-list{list-style:none;padding:0;}.endpoint-list li{padding:0.25rem 0.5rem;margin:0.1rem 0;border-radius:4px;}.endpoint-list li a{text-decoration:none;color:#0366d6;}.endpoint-list li a:hover{text-decoration:underline;}.state-label{font-size:0.8rem;text-transform:uppercase;color:#666;margin-left:0.5rem;}.state-all-covered,.state-validated{border-left:4px solid #28a745;padding-left:0.5rem;}.state-partial{border-left:4px solid #f0ad4e;padding-left:0.5rem;}.state-uncovered{border-left:4px solid #d73a49;padding-left:0.5rem;}.state-request-only{border-left:4px solid #6f42c1;padding-left:0.5rem;}.state-skipped{border-left:4px solid #aaa;padding-left:0.5rem;}.endpoint{margin:0.5rem 0;padding:0.5rem;border:1px solid #eee;border-radius:4px;}.endpoint summary{cursor:pointer;}.endpoint .op-id{color:#666;}table.responses,table.unexpected{border-collapse:collapse;margin:0.75rem 0;width:100%;}table.responses th,table.responses td,table.unexpected th,table.unexpected td{border:1px solid #eee;padding:0.4rem 0.75rem;text-align:left;font-size:0.9rem;}table.responses th,table.unexpected th{background:#f6f8fa;font-weight:600;}.unexpected-heading{margin-top:1rem;font-weight:600;color:#d73a49;}</style>
+</head>
+<body>
+<header class="page-header">
+<h1>OpenAPI Contract Test Coverage</h1>
+<div class="aggregate"><p class="metric"><strong>1 / 2</strong> endpoints fully covered (50%)</p><p class="metric"><strong>2 / 3</strong> responses covered (66.7%)</p><p class="meta">0 skipped, 1 uncovered, 1 partial endpoints, 0 uncovered endpoints, 0 request-only</p></div>
+</header>
+<section class="spec">
+<h2>petstore</h2>
+<p class="spec-summary">endpoints: 1 / 2 fully covered (50%) — responses: 2 / 3 covered (66.7%)</p>
+<ul class="endpoint-list">
+<li class="state-all-covered"><a href="#endpoint-petstore-get--v1-pets">GET /v1/pets</a> <span class="state-label">all-covered</span></li>
+<li class="state-partial"><a href="#endpoint-petstore-post--v1-pets">POST /v1/pets</a> <span class="state-label">partial</span></li>
+</ul>
+<details id="endpoint-petstore-get--v1-pets" class="endpoint state-all-covered">
+<summary><code>GET /v1/pets</code> — <span class="state-label">all-covered</span> <em class="op-id">listPets</em></summary>
+<table class="responses">
+<thead><tr><th>Status</th><th>Content type</th><th>State</th><th>Hits</th><th>Skip reason</th></tr></thead>
+<tbody>
+<tr class="state-validated"><td>200</td><td>application/json</td><td>validated</td><td>12</td><td></td></tr>
+</tbody>
+</table>
+</details>
+<details id="endpoint-petstore-post--v1-pets" class="endpoint state-partial">
+<summary><code>POST /v1/pets</code> — <span class="state-label">partial</span> <em class="op-id">createPet</em></summary>
+<table class="responses">
+<thead><tr><th>Status</th><th>Content type</th><th>State</th><th>Hits</th><th>Skip reason</th></tr></thead>
+<tbody>
+<tr class="state-validated"><td>201</td><td>application/json</td><td>validated</td><td>3</td><td></td></tr>
+<tr class="state-uncovered"><td>422</td><td>application/problem+json</td><td>uncovered</td><td>0</td><td></td></tr>
+</tbody>
+</table>
+<p class="unexpected-heading">Unexpected observations</p>
+<table class="unexpected">
+<thead><tr><th>Status</th><th>Content type</th></tr></thead>
+<tbody>
+<tr><td>418</td><td>application/json</td></tr>
+</tbody>
+</table>
+</details>
+</section>
+</body>
+</html>

--- a/src/Coverage/CoverageMergeCommand.php
+++ b/src/Coverage/CoverageMergeCommand.php
@@ -56,6 +56,7 @@ use function unlink;
  *     output_file?: string,
  *     junit_output?: string,
  *     json_output?: string,
+ *     html_output?: string,
  *     github_step_summary?: string,
  *     console_output?: string,
  *     cleanup?: bool,
@@ -168,6 +169,8 @@ final class CoverageMergeCommand
                                             like GitLab CI test reports, Jenkins, SonarQube).
               --json-output=<path>          JSON report output path (machine-readable; see
                                             docs/coverage-json-schema.md for the schema).
+              --html-output=<path>          Self-contained HTML report output path (for PR
+                                            comments, CI artifact preview, offline review).
               --github-step-summary=<path>  Append Markdown report to this file (also
                                             consults GITHUB_STEP_SUMMARY env var).
               --console-output=<mode>       default | all | uncovered_only.
@@ -216,6 +219,9 @@ final class CoverageMergeCommand
             : null;
         $jsonOutput = isset($options['json_output']) && $options['json_output'] !== ''
             ? $this->absolutise($options['json_output'])
+            : null;
+        $htmlOutput = isset($options['html_output']) && $options['html_output'] !== ''
+            ? $this->absolutise($options['html_output'])
             : null;
         $githubSummaryPath = isset($options['github_step_summary']) && $options['github_step_summary'] !== ''
             ? $options['github_step_summary']
@@ -314,7 +320,7 @@ final class CoverageMergeCommand
 
         $this->writeStdout(ConsoleCoverageRenderer::render($results, $consoleOutput));
 
-        $writeFailures = $this->writeReports($results, $outputFile, $junitOutput, $jsonOutput);
+        $writeFailures = $this->writeReports($results, $outputFile, $junitOutput, $jsonOutput, $htmlOutput);
         $this->appendGithubStepSummary($results, $githubSummaryPath);
 
         $thresholdFailure = $this->evaluateThresholdGate($results, $minEndpointPct, $minResponsePct, $minStrict);
@@ -337,11 +343,11 @@ final class CoverageMergeCommand
      *
      * @return int Number of format outputs that failed to write
      */
-    private function writeReports(array $results, ?string $outputFile, ?string $junitOutput, ?string $jsonOutput): int
+    private function writeReports(array $results, ?string $outputFile, ?string $junitOutput, ?string $jsonOutput, ?string $htmlOutput): int
     {
         $writeFailures = 0;
 
-        foreach ($this->buildReportEntries($outputFile, $junitOutput, $jsonOutput) as $entry) {
+        foreach ($this->buildReportEntries($outputFile, $junitOutput, $jsonOutput, $htmlOutput) as $entry) {
             if ($entry['outputFile'] === null) {
                 continue;
             }
@@ -402,7 +408,7 @@ final class CoverageMergeCommand
      *
      * @return list<CoverageReportEntry>
      */
-    private function buildReportEntries(?string $outputFile, ?string $junitOutput, ?string $jsonOutput): array
+    private function buildReportEntries(?string $outputFile, ?string $junitOutput, ?string $jsonOutput, ?string $htmlOutput): array
     {
         return [
             [
@@ -419,6 +425,11 @@ final class CoverageMergeCommand
                 'label' => 'JSON',
                 'renderer' => static fn(array $r): string => JsonCoverageRenderer::render($r),
                 'outputFile' => $jsonOutput,
+            ],
+            [
+                'label' => 'HTML',
+                'renderer' => static fn(array $r): string => HtmlCoverageRenderer::render($r),
+                'outputFile' => $htmlOutput,
             ],
         ];
     }

--- a/src/Coverage/HtmlCoverageRenderer.php
+++ b/src/Coverage/HtmlCoverageRenderer.php
@@ -1,0 +1,334 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Coverage;
+
+use const ENT_QUOTES;
+use const ENT_SUBSTITUTE;
+
+use function htmlspecialchars;
+use function implode;
+use function preg_replace;
+use function rawurlencode;
+use function round;
+use function sprintf;
+use function strtolower;
+
+/**
+ * Render coverage results as a single self-contained HTML page for human
+ * review (PR comments, CI artifact preview, ad-hoc browser inspection).
+ *
+ * Design choices:
+ *  - Self-contained: inline CSS, no JS, no external assets. Drops cleanly as
+ *    a CI artifact and renders offline.
+ *  - `<details>`/`<summary>` for per-spec collapsible detail — works without
+ *    JavaScript across every modern browser.
+ *  - In-page anchor links navigate from the top-level endpoint list down to
+ *    per-endpoint detail sections.
+ *  - All user-controlled strings pass through `htmlspecialchars` with
+ *    `ENT_QUOTES | ENT_SUBSTITUTE` and explicit `'UTF-8'` so a hostile spec
+ *    (path containing `<script>`, operationId with quotes, skip reason with
+ *    ampersands) cannot inject markup or trip mojibake.
+ *
+ * @phpstan-import-type CoverageResult from OpenApiCoverageTracker
+ * @phpstan-import-type EndpointSummary from OpenApiCoverageTracker
+ * @phpstan-import-type ResponseRow from OpenApiCoverageTracker
+ */
+final class HtmlCoverageRenderer
+{
+    /**
+     * @param array<string, CoverageResult> $results
+     *
+     * @return string Empty string when `$results` is empty so callers can
+     *                short-circuit a no-coverage run; otherwise a full HTML
+     *                document terminated by a trailing newline.
+     */
+    public static function render(array $results): string
+    {
+        if ($results === []) {
+            return '';
+        }
+
+        $totals = self::aggregate($results);
+
+        $lines = [
+            '<!DOCTYPE html>',
+            '<html lang="en">',
+            '<head>',
+            '<meta charset="UTF-8">',
+            '<meta name="viewport" content="width=device-width, initial-scale=1">',
+            '<title>OpenAPI Contract Test Coverage</title>',
+            '<style>' . self::stylesheet() . '</style>',
+            '</head>',
+            '<body>',
+            '<header class="page-header">',
+            '<h1>OpenAPI Contract Test Coverage</h1>',
+            self::renderAggregateSummary($totals),
+            '</header>',
+        ];
+
+        foreach ($results as $specName => $result) {
+            $lines[] = self::renderSpec($specName, $result);
+        }
+
+        $lines[] = '</body>';
+        $lines[] = '</html>';
+
+        return implode("\n", $lines) . "\n";
+    }
+
+    /**
+     * @param array<string, CoverageResult> $results
+     *
+     * @return array{
+     *     endpointTotal: int,
+     *     endpointFullyCovered: int,
+     *     endpointPartial: int,
+     *     endpointUncovered: int,
+     *     endpointRequestOnly: int,
+     *     responseTotal: int,
+     *     responseCovered: int,
+     *     responseSkipped: int,
+     *     responseUncovered: int,
+     * }
+     */
+    private static function aggregate(array $results): array
+    {
+        $totals = [
+            'endpointTotal' => 0,
+            'endpointFullyCovered' => 0,
+            'endpointPartial' => 0,
+            'endpointUncovered' => 0,
+            'endpointRequestOnly' => 0,
+            'responseTotal' => 0,
+            'responseCovered' => 0,
+            'responseSkipped' => 0,
+            'responseUncovered' => 0,
+        ];
+
+        foreach ($results as $result) {
+            $totals['endpointTotal'] += $result['endpointTotal'];
+            $totals['endpointFullyCovered'] += $result['endpointFullyCovered'];
+            $totals['endpointPartial'] += $result['endpointPartial'];
+            $totals['endpointUncovered'] += $result['endpointUncovered'];
+            $totals['endpointRequestOnly'] += $result['endpointRequestOnly'];
+            $totals['responseTotal'] += $result['responseTotal'];
+            $totals['responseCovered'] += $result['responseCovered'];
+            $totals['responseSkipped'] += $result['responseSkipped'];
+            $totals['responseUncovered'] += $result['responseUncovered'];
+        }
+
+        return $totals;
+    }
+
+    /**
+     * @param array{endpointTotal: int, endpointFullyCovered: int, endpointPartial: int, endpointUncovered: int, endpointRequestOnly: int, responseTotal: int, responseCovered: int, responseSkipped: int, responseUncovered: int} $totals
+     */
+    private static function renderAggregateSummary(array $totals): string
+    {
+        $endpointPct = self::percent($totals['endpointFullyCovered'], $totals['endpointTotal']);
+        $responsePct = self::percent($totals['responseCovered'], $totals['responseTotal']);
+
+        return sprintf(
+            '<div class="aggregate">'
+            . '<p class="metric"><strong>%d / %d</strong> endpoints fully covered (%s%%)</p>'
+            . '<p class="metric"><strong>%d / %d</strong> responses covered (%s%%)</p>'
+            . '<p class="meta">%d skipped, %d uncovered, %d partial endpoints, %d uncovered endpoints, %d request-only</p>'
+            . '</div>',
+            $totals['endpointFullyCovered'],
+            $totals['endpointTotal'],
+            self::formatPercent($endpointPct),
+            $totals['responseCovered'],
+            $totals['responseTotal'],
+            self::formatPercent($responsePct),
+            $totals['responseSkipped'],
+            $totals['responseUncovered'],
+            $totals['endpointPartial'],
+            $totals['endpointUncovered'],
+            $totals['endpointRequestOnly'],
+        );
+    }
+
+    /**
+     * @param CoverageResult $result
+     */
+    private static function renderSpec(string $specName, array $result): string
+    {
+        $endpointPct = self::percent($result['endpointFullyCovered'], $result['endpointTotal']);
+        $responsePct = self::percent($result['responseCovered'], $result['responseTotal']);
+
+        $lines = [
+            '<section class="spec">',
+            sprintf('<h2>%s</h2>', self::escape($specName)),
+            sprintf(
+                '<p class="spec-summary">endpoints: %d / %d fully covered (%s%%) — responses: %d / %d covered (%s%%)</p>',
+                $result['endpointFullyCovered'],
+                $result['endpointTotal'],
+                self::formatPercent($endpointPct),
+                $result['responseCovered'],
+                $result['responseTotal'],
+                self::formatPercent($responsePct),
+            ),
+        ];
+
+        if ($result['endpoints'] !== []) {
+            $lines[] = self::renderEndpointList($specName, $result['endpoints']);
+            foreach ($result['endpoints'] as $endpoint) {
+                $lines[] = self::renderEndpointDetail($specName, $endpoint);
+            }
+        }
+
+        $lines[] = '</section>';
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @param list<EndpointSummary> $endpoints
+     */
+    private static function renderEndpointList(string $specName, array $endpoints): string
+    {
+        $lines = ['<ul class="endpoint-list">'];
+        foreach ($endpoints as $endpoint) {
+            $anchor = self::anchorId($specName, $endpoint['endpoint']);
+            $lines[] = sprintf(
+                '<li class="state-%s"><a href="#%s">%s</a> <span class="state-label">%s</span></li>',
+                self::escape($endpoint['state']->value),
+                self::escape($anchor),
+                self::escape($endpoint['endpoint']),
+                self::escape($endpoint['state']->value),
+            );
+        }
+        $lines[] = '</ul>';
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @param EndpointSummary $endpoint
+     */
+    private static function renderEndpointDetail(string $specName, array $endpoint): string
+    {
+        $anchor = self::anchorId($specName, $endpoint['endpoint']);
+        $stateClass = self::escape($endpoint['state']->value);
+
+        $lines = [
+            sprintf(
+                '<details id="%s" class="endpoint state-%s">',
+                self::escape($anchor),
+                $stateClass,
+            ),
+            sprintf(
+                '<summary><code>%s</code> — <span class="state-label">%s</span>%s</summary>',
+                self::escape($endpoint['endpoint']),
+                $stateClass,
+                $endpoint['operationId'] !== null
+                    ? sprintf(' <em class="op-id">%s</em>', self::escape($endpoint['operationId']))
+                    : '',
+            ),
+        ];
+
+        if ($endpoint['responses'] !== []) {
+            $lines[] = '<table class="responses">';
+            $lines[] = '<thead><tr><th>Status</th><th>Content type</th><th>State</th><th>Hits</th><th>Skip reason</th></tr></thead>';
+            $lines[] = '<tbody>';
+            foreach ($endpoint['responses'] as $row) {
+                $lines[] = sprintf(
+                    '<tr class="state-%s"><td>%s</td><td>%s</td><td>%s</td><td>%d</td><td>%s</td></tr>',
+                    self::escape($row['state']->value),
+                    self::escape($row['statusKey']),
+                    self::escape($row['contentTypeKey']),
+                    self::escape($row['state']->value),
+                    $row['hits'],
+                    $row['skipReason'] !== null ? self::escape($row['skipReason']) : '',
+                );
+            }
+            $lines[] = '</tbody>';
+            $lines[] = '</table>';
+        }
+
+        if ($endpoint['unexpectedObservations'] !== []) {
+            $lines[] = '<p class="unexpected-heading">Unexpected observations</p>';
+            $lines[] = '<table class="unexpected">';
+            $lines[] = '<thead><tr><th>Status</th><th>Content type</th></tr></thead>';
+            $lines[] = '<tbody>';
+            foreach ($endpoint['unexpectedObservations'] as $obs) {
+                $lines[] = sprintf(
+                    '<tr><td>%s</td><td>%s</td></tr>',
+                    self::escape($obs['statusKey']),
+                    self::escape($obs['contentTypeKey']),
+                );
+            }
+            $lines[] = '</tbody>';
+            $lines[] = '</table>';
+        }
+
+        $lines[] = '</details>';
+
+        return implode("\n", $lines);
+    }
+
+    private static function escape(string $value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    }
+
+    private static function anchorId(string $specName, string $endpoint): string
+    {
+        // rawurlencode neutralises slashes / braces / spaces so the resulting
+        // id stays a valid URL fragment. The "endpoint-" prefix prevents
+        // collisions with browser-reserved anchors (e.g. `top`).
+        $slug = rawurlencode($specName . '-' . $endpoint);
+        $slug = (string) preg_replace('/%[0-9A-Fa-f]{2}/', '-', $slug);
+
+        return 'endpoint-' . strtolower($slug);
+    }
+
+    private static function percent(int $covered, int $total): float
+    {
+        if ($total === 0) {
+            return 0.0;
+        }
+
+        return $covered / $total * 100.0;
+    }
+
+    private static function formatPercent(float $pct): string
+    {
+        return (string) round($pct, 1);
+    }
+
+    private static function stylesheet(): string
+    {
+        // Kept terse intentionally — the goal is readable CI output, not a
+        // design system. Class names match emitted state values so future
+        // marker tweaks need only touch one place.
+        return implode('', [
+            'body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:#222;margin:0;padding:2rem;max-width:1100px;line-height:1.5;}',
+            'h1{margin-top:0;}',
+            '.page-header{border-bottom:1px solid #ddd;padding-bottom:1rem;margin-bottom:2rem;}',
+            '.aggregate .metric{font-size:1.1rem;margin:0.25rem 0;}',
+            '.aggregate .meta{color:#666;font-size:0.9rem;}',
+            '.spec{margin-bottom:2rem;}',
+            '.spec-summary{color:#444;}',
+            '.endpoint-list{list-style:none;padding:0;}',
+            '.endpoint-list li{padding:0.25rem 0.5rem;margin:0.1rem 0;border-radius:4px;}',
+            '.endpoint-list li a{text-decoration:none;color:#0366d6;}',
+            '.endpoint-list li a:hover{text-decoration:underline;}',
+            '.state-label{font-size:0.8rem;text-transform:uppercase;color:#666;margin-left:0.5rem;}',
+            '.state-all-covered,.state-validated{border-left:4px solid #28a745;padding-left:0.5rem;}',
+            '.state-partial{border-left:4px solid #f0ad4e;padding-left:0.5rem;}',
+            '.state-uncovered{border-left:4px solid #d73a49;padding-left:0.5rem;}',
+            '.state-request-only{border-left:4px solid #6f42c1;padding-left:0.5rem;}',
+            '.state-skipped{border-left:4px solid #aaa;padding-left:0.5rem;}',
+            '.endpoint{margin:0.5rem 0;padding:0.5rem;border:1px solid #eee;border-radius:4px;}',
+            '.endpoint summary{cursor:pointer;}',
+            '.endpoint .op-id{color:#666;}',
+            'table.responses,table.unexpected{border-collapse:collapse;margin:0.75rem 0;width:100%;}',
+            'table.responses th,table.responses td,table.unexpected th,table.unexpected td{border:1px solid #eee;padding:0.4rem 0.75rem;text-align:left;font-size:0.9rem;}',
+            'table.responses th,table.unexpected th{background:#f6f8fa;font-weight:600;}',
+            '.unexpected-heading{margin-top:1rem;font-weight:600;color:#d73a49;}',
+        ]);
+    }
+}

--- a/src/Coverage/HtmlCoverageRenderer.php
+++ b/src/Coverage/HtmlCoverageRenderer.php
@@ -25,11 +25,17 @@ use function strtolower;
  *  - `<details>`/`<summary>` for per-spec collapsible detail — works without
  *    JavaScript across every modern browser.
  *  - In-page anchor links navigate from the top-level endpoint list down to
- *    per-endpoint detail sections.
+ *    per-endpoint detail sections. Anchors are deduplicated within a single
+ *    render — see {@see self::renderEndpointList()} / {@see self::makeAnchorAllocator()}.
  *  - All user-controlled strings pass through `htmlspecialchars` with
  *    `ENT_QUOTES | ENT_SUBSTITUTE` and explicit `'UTF-8'` so a hostile spec
  *    (path containing `<script>`, operationId with quotes, skip reason with
- *    ampersands) cannot inject markup or trip mojibake.
+ *    ampersands) cannot inject markup or trip mojibake. `ENT_SUBSTITUTE`
+ *    (not `ENT_HTML5`) is load-bearing: invalid UTF-8 byte sequences are
+ *    replaced with U+FFFD instead of causing `htmlspecialchars` to silently
+ *    return an empty string and dropping spec content from the report.
+ *  - HTML is intentionally excluded from `GITHUB_STEP_SUMMARY` (Markdown-only
+ *    by design); see {@see CoverageReportSubscriber::appendGithubStepSummary()}.
  *
  * @phpstan-import-type CoverageResult from OpenApiCoverageTracker
  * @phpstan-import-type EndpointSummary from OpenApiCoverageTracker
@@ -37,6 +43,12 @@ use function strtolower;
  */
 final class HtmlCoverageRenderer
 {
+    /**
+     * Static-only utility — no instances. Matches the established
+     * {@see OpenApiCoverageTracker} pattern.
+     */
+    private function __construct() {}
+
     /**
      * @param array<string, CoverageResult> $results
      *
@@ -68,8 +80,10 @@ final class HtmlCoverageRenderer
             '</header>',
         ];
 
+        $allocateAnchor = self::makeAnchorAllocator();
+
         foreach ($results as $specName => $result) {
-            $lines[] = self::renderSpec($specName, $result);
+            $lines[] = self::renderSpec($specName, $result, $allocateAnchor);
         }
 
         $lines[] = '</body>';
@@ -152,8 +166,9 @@ final class HtmlCoverageRenderer
 
     /**
      * @param CoverageResult $result
+     * @param callable(string, string): string $allocateAnchor
      */
-    private static function renderSpec(string $specName, array $result): string
+    private static function renderSpec(string $specName, array $result, callable $allocateAnchor): string
     {
         $endpointPct = self::percent($result['endpointFullyCovered'], $result['endpointTotal']);
         $responsePct = self::percent($result['responseCovered'], $result['responseTotal']);
@@ -173,9 +188,17 @@ final class HtmlCoverageRenderer
         ];
 
         if ($result['endpoints'] !== []) {
-            $lines[] = self::renderEndpointList($specName, $result['endpoints']);
+            // Resolve every anchor up front so the list and detail sections
+            // emit byte-for-byte identical IDs without recomputing (which
+            // would risk allocator divergence on collision-suffix runs).
+            $anchors = [];
             foreach ($result['endpoints'] as $endpoint) {
-                $lines[] = self::renderEndpointDetail($specName, $endpoint);
+                $anchors[] = $allocateAnchor($specName, $endpoint['endpoint']);
+            }
+
+            $lines[] = self::renderEndpointList($result['endpoints'], $anchors);
+            foreach ($result['endpoints'] as $i => $endpoint) {
+                $lines[] = self::renderEndpointDetail($endpoint, $anchors[$i]);
             }
         }
 
@@ -186,16 +209,17 @@ final class HtmlCoverageRenderer
 
     /**
      * @param list<EndpointSummary> $endpoints
+     * @param list<string> $anchors Pre-resolved anchor IDs, one per endpoint
+     *                              (parallel to `$endpoints`).
      */
-    private static function renderEndpointList(string $specName, array $endpoints): string
+    private static function renderEndpointList(array $endpoints, array $anchors): string
     {
         $lines = ['<ul class="endpoint-list">'];
-        foreach ($endpoints as $endpoint) {
-            $anchor = self::anchorId($specName, $endpoint['endpoint']);
+        foreach ($endpoints as $i => $endpoint) {
             $lines[] = sprintf(
                 '<li class="state-%s"><a href="#%s">%s</a> <span class="state-label">%s</span></li>',
                 self::escape($endpoint['state']->value),
-                self::escape($anchor),
+                self::escape($anchors[$i]),
                 self::escape($endpoint['endpoint']),
                 self::escape($endpoint['state']->value),
             );
@@ -208,9 +232,8 @@ final class HtmlCoverageRenderer
     /**
      * @param EndpointSummary $endpoint
      */
-    private static function renderEndpointDetail(string $specName, array $endpoint): string
+    private static function renderEndpointDetail(array $endpoint, string $anchor): string
     {
-        $anchor = self::anchorId($specName, $endpoint['endpoint']);
         $stateClass = self::escape($endpoint['state']->value);
 
         $lines = [
@@ -274,15 +297,48 @@ final class HtmlCoverageRenderer
         return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     }
 
-    private static function anchorId(string $specName, string $endpoint): string
+    /**
+     * Build a closure that allocates unique anchor IDs across one render.
+     *
+     * The slug pipeline is `rawurlencode` → `%XX → -` → `strtolower`. The
+     * two-step encode/collapse yields a readable kebab-case fragment instead
+     * of leaving `%XX` sequences in the URL bar; `rawurlencode` is the
+     * cheapest way to enumerate "every character that's not safe in a
+     * fragment". The collapse is lossy by construction, so two distinct
+     * `(specName, endpoint)` inputs can map to the same slug (e.g. a slash
+     * vs. a literal `-`). When that happens, suffix with `-2`, `-3`, … so
+     * each `<details id="…">` stays unique within the document.
+     *
+     * `?? $slug` guards against a future `preg_replace` failure (regex error
+     * or PCRE backtracking limit) silently producing empty anchor IDs.
+     *
+     * The `"endpoint-"` prefix prevents collisions with browser-reserved
+     * anchors (e.g. `top`).
+     *
+     * @return callable(string, string): string Receives `(specName, endpoint)`
+     *                                          and returns a unique anchor ID
+     *                                          for this render.
+     */
+    private static function makeAnchorAllocator(): callable
     {
-        // rawurlencode neutralises slashes / braces / spaces so the resulting
-        // id stays a valid URL fragment. The "endpoint-" prefix prevents
-        // collisions with browser-reserved anchors (e.g. `top`).
-        $slug = rawurlencode($specName . '-' . $endpoint);
-        $slug = (string) preg_replace('/%[0-9A-Fa-f]{2}/', '-', $slug);
+        /** @var array<string, int> $seen */
+        $seen = [];
 
-        return 'endpoint-' . strtolower($slug);
+        return static function (string $specName, string $endpoint) use (&$seen): string {
+            $encoded = rawurlencode($specName . '-' . $endpoint);
+            $slug = preg_replace('/%[0-9A-Fa-f]{2}/', '-', $encoded) ?? $encoded;
+            $base = 'endpoint-' . strtolower($slug);
+
+            if (!isset($seen[$base])) {
+                $seen[$base] = 1;
+
+                return $base;
+            }
+
+            $seen[$base]++;
+
+            return $base . '-' . $seen[$base];
+        };
     }
 
     private static function percent(int $covered, int $total): float
@@ -302,8 +358,11 @@ final class HtmlCoverageRenderer
     private static function stylesheet(): string
     {
         // Kept terse intentionally — the goal is readable CI output, not a
-        // design system. Class names match emitted state values so future
-        // marker tweaks need only touch one place.
+        // design system. The `.state-<value>` selectors below must mirror
+        // the enum case values from {@see EndpointCoverageState} and
+        // {@see ResponseCoverageState}; renaming a case requires updating
+        // the matching selector here. The
+        // `every_enum_case_has_a_matching_state_class` test pins this.
         return implode('', [
             'body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:#222;margin:0;padding:2rem;max-width:1100px;line-height:1.5;}',
             'h1{margin-top:0;}',

--- a/src/Coverage/InvalidCoverageOutputPathException.php
+++ b/src/Coverage/InvalidCoverageOutputPathException.php
@@ -10,9 +10,9 @@ use Throwable;
 
 /**
  * Thrown by {@see OpenApiCoverageExtension} when an output-file path parameter
- * (currently `junit_output`; reusable for additional formats added under #116)
- * is set but invalid — empty/whitespace value, or a parent directory that
- * does not exist / is not writable.
+ * (`junit_output`, `json_output`, `html_output`) is set but invalid —
+ * empty/whitespace value, or a parent directory that does not exist / is not
+ * writable.
  *
  * Distinct from {@see InvalidThresholdConfigurationException} because the
  * failure mode is filesystem misconfiguration, not a threshold typo. Distinct

--- a/src/Coverage/JUnitCoverageRenderer.php
+++ b/src/Coverage/JUnitCoverageRenderer.php
@@ -24,7 +24,7 @@ use function sprintf;
  *    one synthetic `<testcase>` with `<skipped>` so the structural gap stays visible
  *    in CI dashboards instead of the endpoint disappearing entirely.
  *
- * Structural decisions documented in issue #116 plan:
+ * Structural decisions:
  *  - Wrap in `<testsuites>` root even for one spec (some Jenkins-strict
  *    parsers and CI integrations reject a bare `<testsuite>` at root).
  *  - `classname="openapi.coverage.{specName}"` for SonarQube tree-view compatibility.

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -14,6 +14,7 @@ use Studio\OpenApiContractTesting\Coverage\ConsoleCoverageRenderer;
 use Studio\OpenApiContractTesting\Coverage\CoverageMergeCommand;
 use Studio\OpenApiContractTesting\Coverage\CoverageSidecarWriter;
 use Studio\OpenApiContractTesting\Coverage\CoverageThresholdEvaluator;
+use Studio\OpenApiContractTesting\Coverage\HtmlCoverageRenderer;
 use Studio\OpenApiContractTesting\Coverage\JsonCoverageRenderer;
 use Studio\OpenApiContractTesting\Coverage\JUnitCoverageRenderer;
 use Studio\OpenApiContractTesting\Coverage\MarkdownCoverageRenderer;
@@ -69,6 +70,7 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         private mixed $exitHandler = null,
         private ?string $junitOutput = null,
         private ?string $jsonOutput = null,
+        private ?string $htmlOutput = null,
     ) {}
 
     /** @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter */
@@ -375,6 +377,11 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
                 'label' => 'JSON',
                 'renderer' => static fn(array $r): string => JsonCoverageRenderer::render($r),
                 'outputFile' => $this->jsonOutput,
+            ],
+            [
+                'label' => 'HTML',
+                'renderer' => static fn(array $r): string => HtmlCoverageRenderer::render($r),
+                'outputFile' => $this->htmlOutput,
             ],
         ];
     }

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -192,6 +192,7 @@ final class OpenApiCoverageExtension implements Extension
 
         $junitOutput = self::resolveOutputPathParameter($parameters, 'junit_output', $githubSummaryPath);
         $jsonOutput = self::resolveOutputPathParameter($parameters, 'json_output', $githubSummaryPath);
+        $htmlOutput = self::resolveOutputPathParameter($parameters, 'html_output', $githubSummaryPath);
 
         $consoleOutput = ConsoleOutput::resolve(
             $parameters->has('console_output') ? $parameters->get('console_output') : null,
@@ -226,6 +227,7 @@ final class OpenApiCoverageExtension implements Extension
             minCoverageStrict: $minCoverageStrict,
             junitOutput: $junitOutput,
             jsonOutput: $jsonOutput,
+            htmlOutput: $htmlOutput,
         ));
     }
 
@@ -287,8 +289,8 @@ final class OpenApiCoverageExtension implements Extension
     }
 
     /**
-     * Generic helper for output-file-path parameters (currently `junit_output`;
-     * reusable for other formats added under #116). Empty or whitespace-only
+     * Generic helper for output-file-path parameters (`junit_output`,
+     * `json_output`, `html_output`). Empty or whitespace-only
      * values are FATAL — silently dropping the parameter would defeat the
      * fail-loud-on-misconfiguration policy this extension enforces. Parent
      * directory writability is checked here so misconfigurations surface at

--- a/tests/Unit/Coverage/CoverageMergeCommandTest.php
+++ b/tests/Unit/Coverage/CoverageMergeCommandTest.php
@@ -275,6 +275,7 @@ class CoverageMergeCommandTest extends TestCase
             '--output-file=/tmp/cov.md',
             '--junit-output=/tmp/cov.junit.xml',
             '--json-output=/tmp/cov.json',
+            '--html-output=/tmp/cov.html',
             '--no-cleanup',
         ]);
 
@@ -285,6 +286,7 @@ class CoverageMergeCommandTest extends TestCase
         $this->assertSame('/tmp/cov.md', $opts['output_file']);
         $this->assertSame('/tmp/cov.junit.xml', $opts['junit_output']);
         $this->assertSame('/tmp/cov.json', $opts['json_output']);
+        $this->assertSame('/tmp/cov.html', $opts['html_output']);
         $this->assertFalse($opts['cleanup']);
     }
 
@@ -395,6 +397,77 @@ class CoverageMergeCommandTest extends TestCase
         $this->assertSame(1, $exit);
         $this->assertStringContainsString('FATAL', $stderr);
         $this->assertStringContainsString('JSON', $stderr);
+    }
+
+    #[Test]
+    public function writes_html_to_configured_path(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        $htmlPath = dirname($this->sidecarDir) . '/coverage.html';
+
+        $command = new CoverageMergeCommand(stdoutWriter: static fn(string $msg): null => null);
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'html_output' => $htmlPath,
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertFileExists($htmlPath);
+
+        $contents = (string) file_get_contents($htmlPath);
+        $this->assertStringStartsWith('<!DOCTYPE html>', $contents);
+        $this->assertStringContainsString('petstore-3.0', $contents);
+        $this->assertStringContainsString('GET /v1/pets', $contents);
+
+        @unlink($htmlPath);
+    }
+
+    #[Test]
+    public function exits_one_when_html_output_write_fails(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        $unwritable = '/proc/0/forbidden/coverage.html';
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            stdoutWriter: static fn(string $msg): null => null,
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'html_output' => $unwritable,
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('FATAL', $stderr);
+        $this->assertStringContainsString('HTML', $stderr);
     }
 
     #[Test]

--- a/tests/Unit/Coverage/CoverageMergeCommandTest.php
+++ b/tests/Unit/Coverage/CoverageMergeCommandTest.php
@@ -400,6 +400,53 @@ class CoverageMergeCommandTest extends TestCase
     }
 
     #[Test]
+    public function writes_all_four_formats_simultaneously(): void
+    {
+        // The "multiple format outputs are independent" contract is
+        // documented in docs/coverage-json-schema.md and docs/coverage-html-output.md.
+        // Pin that setting every output path writes every file — a regression
+        // where one format's loop entry suppresses another would surface here.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        $base = dirname($this->sidecarDir);
+        $mdPath = $base . '/coverage.md';
+        $junitPath = $base . '/coverage.junit.xml';
+        $jsonPath = $base . '/coverage.json';
+        $htmlPath = $base . '/coverage.html';
+
+        $command = new CoverageMergeCommand(stdoutWriter: static fn(string $msg): null => null);
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'output_file' => $mdPath,
+            'junit_output' => $junitPath,
+            'json_output' => $jsonPath,
+            'html_output' => $htmlPath,
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertFileExists($mdPath);
+        $this->assertFileExists($junitPath);
+        $this->assertFileExists($jsonPath);
+        $this->assertFileExists($htmlPath);
+
+        @unlink($mdPath);
+        @unlink($junitPath);
+        @unlink($jsonPath);
+        @unlink($htmlPath);
+    }
+
+    #[Test]
     public function writes_html_to_configured_path(): void
     {
         OpenApiCoverageTracker::recordResponse(

--- a/tests/Unit/Coverage/HtmlCoverageRendererTest.php
+++ b/tests/Unit/Coverage/HtmlCoverageRendererTest.php
@@ -1,0 +1,375 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Coverage;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Coverage\EndpointCoverageState;
+use Studio\OpenApiContractTesting\Coverage\HtmlCoverageRenderer;
+use Studio\OpenApiContractTesting\Coverage\ResponseCoverageState;
+
+use function explode;
+use function substr_count;
+
+class HtmlCoverageRendererTest extends TestCase
+{
+    #[Test]
+    public function render_returns_empty_string_for_empty_results(): void
+    {
+        // Matches the contract of MarkdownCoverageRenderer / JUnitCoverageRenderer /
+        // JsonCoverageRenderer — callers short-circuit a no-coverage run.
+        $this->assertSame('', HtmlCoverageRenderer::render([]));
+    }
+
+    #[Test]
+    public function render_emits_html5_doctype_and_utf8_meta(): void
+    {
+        $html = $this->renderOneValidated();
+
+        $this->assertStringStartsWith('<!DOCTYPE html>', $html);
+        $this->assertStringContainsString('<meta charset="UTF-8">', $html);
+        $this->assertStringContainsString('<title>', $html);
+    }
+
+    #[Test]
+    public function render_inlines_all_css_with_no_external_resources(): void
+    {
+        // The HTML must be a single self-contained file — no external CSS/JS
+        // links — so CI artifact upload + offline review work without
+        // additional configuration.
+        $html = $this->renderOneValidated();
+
+        $this->assertStringContainsString('<style>', $html);
+        $this->assertStringNotContainsString('<link', $html);
+        $this->assertStringNotContainsString('<script', $html);
+        $this->assertStringNotContainsString('href="http', $html);
+        $this->assertStringNotContainsString('src="http', $html);
+    }
+
+    #[Test]
+    public function render_escapes_special_characters_in_paths_and_operation_ids(): void
+    {
+        // htmlspecialchars(ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') must be
+        // applied so a hostile spec value cannot inject markup. The path
+        // template braces and ampersands are realistic OpenAPI content.
+        $html = $this->renderOne(
+            'front',
+            self::endpoint('GET /v1/pets/<script>alert(1)</script>', 'uncovered', responses: [
+                self::row('200', 'application/json', 'uncovered'),
+            ], totalResponseCount: 1),
+            endpointTotal: 1,
+            endpointUncovered: 1,
+            responseTotal: 1,
+            responseUncovered: 1,
+        );
+
+        $this->assertStringNotContainsString('<script>alert(1)</script>', $html);
+        $this->assertStringContainsString('&lt;script&gt;alert(1)&lt;/script&gt;', $html);
+    }
+
+    #[Test]
+    public function render_escapes_skip_reasons(): void
+    {
+        $html = $this->renderOne(
+            'front',
+            self::endpoint('DELETE /v1/pets/{petId}', 'partial', responses: [
+                self::row('503', 'application/json', 'skipped', hits: 1, skipReason: 'pattern <foo>&bar'),
+            ], skippedResponseCount: 1, totalResponseCount: 1),
+            endpointTotal: 1,
+            endpointPartial: 1,
+            responseTotal: 1,
+            responseSkipped: 1,
+        );
+
+        $this->assertStringNotContainsString('<foo>&bar', $html);
+        $this->assertStringContainsString('&lt;foo&gt;&amp;bar', $html);
+    }
+
+    #[Test]
+    public function render_includes_aggregate_summary_with_counts(): void
+    {
+        // The page header must surface aggregate counts so a reviewer can
+        // gauge coverage health at-a-glance without scrolling per-spec
+        // sections.
+        $html = $this->renderOneValidated();
+
+        $this->assertStringContainsString('1', $html);
+        $this->assertStringContainsString('endpoints', $html);
+        $this->assertStringContainsString('responses', $html);
+    }
+
+    #[Test]
+    public function render_emits_all_four_endpoint_state_markers(): void
+    {
+        // The four state CSS classes must be distinct so styling differentiates
+        // them. (Don't depend on exact class names; just verify they exist as
+        // distinct emitted tokens.)
+        $results = [
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /a', 'all-covered', responses: [
+                        self::row('200', 'application/json', 'validated', hits: 1),
+                    ], coveredResponseCount: 1, totalResponseCount: 1),
+                    self::endpoint('GET /b', 'partial', responses: [
+                        self::row('200', 'application/json', 'validated', hits: 1),
+                        self::row('500', 'application/json', 'uncovered'),
+                    ], coveredResponseCount: 1, totalResponseCount: 2),
+                    self::endpoint('GET /c', 'uncovered', responses: [
+                        self::row('200', 'application/json', 'uncovered'),
+                    ], totalResponseCount: 1),
+                    self::endpoint('GET /d', 'request-only', requestReached: true, unexpectedObservations: [
+                        ['statusKey' => '418', 'contentTypeKey' => 'application/json'],
+                    ]),
+                ],
+                endpointTotal: 4,
+                endpointFullyCovered: 1,
+                endpointPartial: 1,
+                endpointUncovered: 1,
+                endpointRequestOnly: 1,
+                responseTotal: 3,
+                responseCovered: 2,
+                responseUncovered: 1,
+            ),
+        ];
+
+        $html = HtmlCoverageRenderer::render($results);
+
+        $this->assertStringContainsString('all-covered', $html);
+        $this->assertStringContainsString('partial', $html);
+        $this->assertStringContainsString('uncovered', $html);
+        $this->assertStringContainsString('request-only', $html);
+    }
+
+    #[Test]
+    public function render_emits_details_summary_per_spec(): void
+    {
+        // <details>/<summary> gives reviewers a collapsible per-endpoint detail
+        // view without needing JavaScript. Required for the "single
+        // self-contained HTML, no JS" contract.
+        $html = $this->renderOneValidated();
+
+        $this->assertStringContainsString('<details', $html);
+        $this->assertStringContainsString('<summary', $html);
+    }
+
+    #[Test]
+    public function render_emits_anchor_targets_for_endpoint_navigation(): void
+    {
+        // Each endpoint section must have an id attribute so the in-page
+        // endpoint list can link directly to it.
+        $html = $this->renderOneValidated();
+
+        $this->assertMatchesRegularExpression('/id="endpoint-[^"]+"/', $html);
+        $this->assertMatchesRegularExpression('/href="#endpoint-[^"]+"/', $html);
+    }
+
+    #[Test]
+    public function render_emits_section_per_spec(): void
+    {
+        // Multi-spec runs must produce one section per spec rather than
+        // merging endpoints under a single header.
+        $results = [
+            'spec-a' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /a/pets', 'all-covered', responses: [
+                        self::row('200', 'application/json', 'validated', hits: 1),
+                    ], coveredResponseCount: 1, totalResponseCount: 1),
+                ],
+                endpointTotal: 1,
+                endpointFullyCovered: 1,
+                responseTotal: 1,
+                responseCovered: 1,
+            ),
+            'spec-b' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /b/widgets', 'all-covered', responses: [
+                        self::row('200', 'application/json', 'validated', hits: 1),
+                    ], coveredResponseCount: 1, totalResponseCount: 1),
+                ],
+                endpointTotal: 1,
+                endpointFullyCovered: 1,
+                responseTotal: 1,
+                responseCovered: 1,
+            ),
+        ];
+
+        $html = HtmlCoverageRenderer::render($results);
+
+        $this->assertStringContainsString('spec-a', $html);
+        $this->assertStringContainsString('spec-b', $html);
+        $this->assertStringContainsString('GET /a/pets', $html);
+        $this->assertStringContainsString('GET /b/widgets', $html);
+        // At minimum one <details> per spec.
+        $this->assertGreaterThanOrEqual(2, substr_count($html, '<details'));
+    }
+
+    #[Test]
+    public function render_emits_unexpected_observations(): void
+    {
+        $html = $this->renderOne(
+            'front',
+            self::endpoint('POST /v1/pets', 'partial', responses: [
+                self::row('201', 'application/json', 'validated', hits: 1),
+            ], coveredResponseCount: 1, totalResponseCount: 1, unexpectedObservations: [
+                ['statusKey' => '418', 'contentTypeKey' => 'application/json'],
+            ]),
+            endpointTotal: 1,
+            endpointFullyCovered: 1,
+            responseTotal: 1,
+            responseCovered: 1,
+        );
+
+        $this->assertStringContainsString('418', $html);
+        $this->assertStringContainsString('application/json', $html);
+    }
+
+    #[Test]
+    public function render_ends_with_closing_html_tag(): void
+    {
+        $html = $this->renderOneValidated();
+
+        $this->assertStringEndsWith("</html>\n", $html);
+    }
+
+    /**
+     * @param list<array{endpoint: string, method: string, path: string, operationId: ?string, state: EndpointCoverageState, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}> $endpoints
+     *
+     * @return array{endpoints: list<array{endpoint: string, method: string, path: string, operationId: ?string, state: EndpointCoverageState, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}>, endpointTotal: int, endpointFullyCovered: int, endpointPartial: int, endpointUncovered: int, endpointRequestOnly: int, responseTotal: int, responseCovered: int, responseSkipped: int, responseUncovered: int}
+     */
+    private static function coverage(
+        array $endpoints,
+        int $endpointTotal = 0,
+        int $endpointFullyCovered = 0,
+        int $endpointPartial = 0,
+        int $endpointUncovered = 0,
+        int $endpointRequestOnly = 0,
+        int $responseTotal = 0,
+        int $responseCovered = 0,
+        int $responseSkipped = 0,
+        int $responseUncovered = 0,
+    ): array {
+        return [
+            'endpoints' => $endpoints,
+            'endpointTotal' => $endpointTotal,
+            'endpointFullyCovered' => $endpointFullyCovered,
+            'endpointPartial' => $endpointPartial,
+            'endpointUncovered' => $endpointUncovered,
+            'endpointRequestOnly' => $endpointRequestOnly,
+            'responseTotal' => $responseTotal,
+            'responseCovered' => $responseCovered,
+            'responseSkipped' => $responseSkipped,
+            'responseUncovered' => $responseUncovered,
+        ];
+    }
+
+    /**
+     * @param list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}> $responses
+     * @param list<array{statusKey: string, contentTypeKey: string}> $unexpectedObservations
+     *
+     * @return array{endpoint: string, method: string, path: string, operationId: ?string, state: EndpointCoverageState, requestReached: bool, responses: list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}>, coveredResponseCount: int, skippedResponseCount: int, totalResponseCount: int, unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>}
+     */
+    private static function endpoint(
+        string $endpoint,
+        string $state,
+        bool $requestReached = false,
+        ?string $operationId = null,
+        array $responses = [],
+        int $coveredResponseCount = 0,
+        int $skippedResponseCount = 0,
+        int $totalResponseCount = 0,
+        array $unexpectedObservations = [],
+    ): array {
+        [$method, $path] = explode(' ', $endpoint, 2);
+
+        return [
+            'endpoint' => $endpoint,
+            'method' => $method,
+            'path' => $path,
+            'operationId' => $operationId,
+            'state' => EndpointCoverageState::from($state),
+            'requestReached' => $requestReached,
+            'responses' => $responses,
+            'coveredResponseCount' => $coveredResponseCount,
+            'skippedResponseCount' => $skippedResponseCount,
+            'totalResponseCount' => $totalResponseCount,
+            'unexpectedObservations' => $unexpectedObservations,
+        ];
+    }
+
+    /**
+     * @return array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}
+     */
+    private static function row(
+        string $statusKey,
+        string $contentTypeKey,
+        string $state,
+        int $hits = 0,
+        ?string $skipReason = null,
+    ): array {
+        return [
+            'statusKey' => $statusKey,
+            'contentTypeKey' => $contentTypeKey,
+            'state' => ResponseCoverageState::from($state),
+            'hits' => $hits,
+            'skipReason' => $skipReason,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $endpoint
+     */
+    private function renderOne(
+        string $specName,
+        array $endpoint,
+        int $endpointTotal = 0,
+        int $endpointFullyCovered = 0,
+        int $endpointPartial = 0,
+        int $endpointUncovered = 0,
+        int $endpointRequestOnly = 0,
+        int $responseTotal = 0,
+        int $responseCovered = 0,
+        int $responseSkipped = 0,
+        int $responseUncovered = 0,
+    ): string {
+        $results = [
+            $specName => self::coverage(
+                endpoints: [$endpoint],
+                endpointTotal: $endpointTotal,
+                endpointFullyCovered: $endpointFullyCovered,
+                endpointPartial: $endpointPartial,
+                endpointUncovered: $endpointUncovered,
+                endpointRequestOnly: $endpointRequestOnly,
+                responseTotal: $responseTotal,
+                responseCovered: $responseCovered,
+                responseSkipped: $responseSkipped,
+                responseUncovered: $responseUncovered,
+            ),
+        ];
+
+        return HtmlCoverageRenderer::render($results);
+    }
+
+    private function renderOneValidated(): string
+    {
+        return $this->renderOne(
+            'front',
+            self::endpoint(
+                'GET /v1/pets',
+                'all-covered',
+                requestReached: true,
+                operationId: 'listPets',
+                responses: [
+                    self::row('200', 'application/json', 'validated', hits: 3),
+                ],
+                coveredResponseCount: 1,
+                totalResponseCount: 1,
+            ),
+            endpointTotal: 1,
+            endpointFullyCovered: 1,
+            responseTotal: 1,
+            responseCovered: 1,
+        );
+    }
+}

--- a/tests/Unit/Coverage/HtmlCoverageRendererTest.php
+++ b/tests/Unit/Coverage/HtmlCoverageRendererTest.php
@@ -10,7 +10,10 @@ use Studio\OpenApiContractTesting\Coverage\EndpointCoverageState;
 use Studio\OpenApiContractTesting\Coverage\HtmlCoverageRenderer;
 use Studio\OpenApiContractTesting\Coverage\ResponseCoverageState;
 
+use function array_unique;
 use function explode;
+use function preg_match_all;
+use function sort;
 use function substr_count;
 
 class HtmlCoverageRendererTest extends TestCase
@@ -88,16 +91,255 @@ class HtmlCoverageRendererTest extends TestCase
     }
 
     #[Test]
+    public function render_escapes_operation_id(): void
+    {
+        // operationId is spec-author-controlled; an OpenAPI document with a
+        // hostile operationId must not inject markup. Pinning the escape on
+        // this path explicitly because the existing escape test for paths
+        // happens to not exercise this branch.
+        $html = $this->renderOne(
+            'front',
+            self::endpoint(
+                'GET /v1/pets',
+                'all-covered',
+                operationId: 'list<script>Pets</script>',
+                responses: [self::row('200', 'application/json', 'validated', hits: 1)],
+                coveredResponseCount: 1,
+                totalResponseCount: 1,
+            ),
+            endpointTotal: 1,
+            endpointFullyCovered: 1,
+            responseTotal: 1,
+            responseCovered: 1,
+        );
+
+        $this->assertStringNotContainsString('<script>Pets</script>', $html);
+        $this->assertStringContainsString('list&lt;script&gt;Pets&lt;/script&gt;', $html);
+    }
+
+    #[Test]
+    public function render_escapes_response_status_and_content_type(): void
+    {
+        // Content types in OpenAPI specs can carry quoted parameters; status
+        // keys can be spec-author-defined ranges. Both must escape.
+        $html = $this->renderOne(
+            'front',
+            self::endpoint('GET /v1/pets', 'all-covered', responses: [
+                self::row('2<x>0', 'application/<bad>+json', 'validated', hits: 1),
+            ], coveredResponseCount: 1, totalResponseCount: 1),
+            endpointTotal: 1,
+            endpointFullyCovered: 1,
+            responseTotal: 1,
+            responseCovered: 1,
+        );
+
+        $this->assertStringNotContainsString('<x>', $html);
+        $this->assertStringNotContainsString('<bad>', $html);
+        $this->assertStringContainsString('2&lt;x&gt;0', $html);
+        $this->assertStringContainsString('application/&lt;bad&gt;+json', $html);
+    }
+
+    #[Test]
+    public function render_escapes_unexpected_observation_fields(): void
+    {
+        // unexpected_observations come from runtime traffic that did not
+        // match any declared response — values are attacker-controllable in
+        // a misbehaving backend, so escape applies here too.
+        $html = $this->renderOne(
+            'front',
+            self::endpoint('POST /v1/pets', 'partial', responses: [
+                self::row('201', 'application/json', 'validated', hits: 1),
+            ], coveredResponseCount: 1, totalResponseCount: 1, unexpectedObservations: [
+                ['statusKey' => '4<x>8', 'contentTypeKey' => 'application/<bad>+json'],
+            ]),
+            endpointTotal: 1,
+            endpointFullyCovered: 1,
+            responseTotal: 1,
+            responseCovered: 1,
+        );
+
+        $this->assertStringNotContainsString('<x>', $html);
+        $this->assertStringNotContainsString('<bad>', $html);
+        $this->assertStringContainsString('4&lt;x&gt;8', $html);
+        $this->assertStringContainsString('application/&lt;bad&gt;+json', $html);
+    }
+
+    #[Test]
+    public function render_escapes_spec_name_in_heading(): void
+    {
+        // Spec keys come from PHPUnit Extension config — typically clean,
+        // but the renderer's threat model covers "all user-controlled
+        // strings", so a hostile spec name must not break the page.
+        $results = [
+            'front<script>' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /v1/pets', 'all-covered', responses: [
+                        self::row('200', 'application/json', 'validated', hits: 1),
+                    ], coveredResponseCount: 1, totalResponseCount: 1),
+                ],
+                endpointTotal: 1,
+                endpointFullyCovered: 1,
+                responseTotal: 1,
+                responseCovered: 1,
+            ),
+        ];
+
+        $html = HtmlCoverageRenderer::render($results);
+
+        $this->assertStringNotContainsString('<script>', $html);
+        $this->assertStringContainsString('front&lt;script&gt;', $html);
+    }
+
+    #[Test]
     public function render_includes_aggregate_summary_with_counts(): void
     {
-        // The page header must surface aggregate counts so a reviewer can
-        // gauge coverage health at-a-glance without scrolling per-spec
-        // sections.
+        // Tight assertions on the aggregate header so a percent-formula or
+        // argument-order regression in renderAggregateSummary() trips the
+        // test. The renderOneValidated() fixture has 1/1 endpoints fully
+        // covered and 1/1 responses covered.
         $html = $this->renderOneValidated();
 
-        $this->assertStringContainsString('1', $html);
-        $this->assertStringContainsString('endpoints', $html);
-        $this->assertStringContainsString('responses', $html);
+        $this->assertStringContainsString('<strong>1 / 1</strong> endpoints fully covered (100%)', $html);
+        $this->assertStringContainsString('<strong>1 / 1</strong> responses covered (100%)', $html);
+    }
+
+    #[Test]
+    public function render_handles_endpoint_with_no_responses_or_unexpected(): void
+    {
+        // A request-only endpoint with neither declared responses nor
+        // unexpected observations must still close its <details> block
+        // cleanly. Guards the empty-list branches in renderEndpointDetail.
+        $html = $this->renderOne(
+            'front',
+            self::endpoint('GET /v1/health', 'request-only', requestReached: true),
+            endpointTotal: 1,
+            endpointRequestOnly: 1,
+        );
+
+        $this->assertStringContainsString('<details', $html);
+        $this->assertStringContainsString('</details>', $html);
+        $this->assertSame(
+            substr_count($html, '<details'),
+            substr_count($html, '</details>'),
+            'unbalanced <details> tags',
+        );
+    }
+
+    #[Test]
+    public function render_handles_spec_with_zero_endpoints(): void
+    {
+        // A spec loaded but with no declared endpoints (or fully filtered
+        // out) should still render its <h2> + summary, not silently
+        // disappear from the report.
+        $html = HtmlCoverageRenderer::render([
+            'empty-spec' => self::coverage(endpoints: []),
+        ]);
+
+        $this->assertStringContainsString('empty-spec', $html);
+        $this->assertStringContainsString('endpoints: 0 / 0', $html);
+    }
+
+    #[Test]
+    public function render_has_balanced_structural_tags(): void
+    {
+        // Single <head>, single <body>, single <style>, no leftover open
+        // tags — catches a copy/paste accident in the template emit code.
+        $html = $this->renderOneValidated();
+
+        $this->assertSame(1, substr_count($html, '<head>'));
+        $this->assertSame(1, substr_count($html, '</head>'));
+        $this->assertSame(1, substr_count($html, '<body>'));
+        $this->assertSame(1, substr_count($html, '</body>'));
+        $this->assertSame(1, substr_count($html, '<style>'));
+        $this->assertSame(1, substr_count($html, '</style>'));
+    }
+
+    #[Test]
+    public function render_anchors_resolve_to_existing_targets(): void
+    {
+        // Every href="#X" must point at an id="X" that actually exists.
+        // The list section and detail section both call into the same
+        // allocator; this test pins that the two stay in sync.
+        $html = $this->renderOne(
+            'front',
+            self::endpoint('GET /v1/pets', 'all-covered', responses: [
+                self::row('200', 'application/json', 'validated', hits: 1),
+            ], coveredResponseCount: 1, totalResponseCount: 1),
+            endpointTotal: 1,
+            endpointFullyCovered: 1,
+            responseTotal: 1,
+            responseCovered: 1,
+        );
+
+        preg_match_all('/id="(endpoint-[^"]+)"/', $html, $idMatches);
+        preg_match_all('/href="#(endpoint-[^"]+)"/', $html, $hrefMatches);
+
+        sort($idMatches[1]);
+        sort($hrefMatches[1]);
+
+        $this->assertNotEmpty($idMatches[1], 'renderer emitted no anchor IDs');
+        $this->assertSame($idMatches[1], $hrefMatches[1], 'href / id sets diverged');
+    }
+
+    #[Test]
+    public function render_disambiguates_collision_prone_anchor_keys(): void
+    {
+        // Two endpoints whose (specName, endpoint) tuples collapse to the
+        // same kebab slug under rawurlencode + %XX→- must still produce
+        // unique anchor IDs so the in-page navigation works.
+        $results = [
+            'front' => self::coverage(
+                endpoints: [
+                    self::endpoint('GET /a/b', 'all-covered', responses: [
+                        self::row('200', 'application/json', 'validated', hits: 1),
+                    ], coveredResponseCount: 1, totalResponseCount: 1),
+                    self::endpoint('GET /a-b', 'all-covered', responses: [
+                        self::row('200', 'application/json', 'validated', hits: 1),
+                    ], coveredResponseCount: 1, totalResponseCount: 1),
+                ],
+                endpointTotal: 2,
+                endpointFullyCovered: 2,
+                responseTotal: 2,
+                responseCovered: 2,
+            ),
+        ];
+
+        $html = HtmlCoverageRenderer::render($results);
+
+        preg_match_all('/id="(endpoint-[^"]+)"/', $html, $idMatches);
+        $this->assertCount(2, $idMatches[1]);
+        $this->assertCount(2, array_unique($idMatches[1]), 'anchor IDs collided across endpoints');
+    }
+
+    #[Test]
+    public function every_endpoint_enum_case_has_a_matching_state_css_rule(): void
+    {
+        // Renderer derives `state-<value>` classes from enum case values.
+        // If a new enum case is added, the stylesheet must gain a matching
+        // selector — otherwise the new state silently has no styling.
+        $html = $this->renderOneValidated();
+
+        foreach (EndpointCoverageState::cases() as $case) {
+            $this->assertStringContainsString(
+                '.state-' . $case->value,
+                $html,
+                "stylesheet missing rule for endpoint state '{$case->value}'",
+            );
+        }
+    }
+
+    #[Test]
+    public function every_response_enum_case_has_a_matching_state_css_rule(): void
+    {
+        $html = $this->renderOneValidated();
+
+        foreach (ResponseCoverageState::cases() as $case) {
+            $this->assertStringContainsString(
+                '.state-' . $case->value,
+                $html,
+                "stylesheet missing rule for response state '{$case->value}'",
+            );
+        }
     }
 
     #[Test]

--- a/tests/Unit/PHPUnit/CoverageReportSubscriberWorkerModeTest.php
+++ b/tests/Unit/PHPUnit/CoverageReportSubscriberWorkerModeTest.php
@@ -100,6 +100,7 @@ class CoverageReportSubscriberWorkerModeTest extends TestCase
             sidecarDir: $this->tmpDir,
             junitOutput: $this->tmpDir . '/coverage.junit.xml',
             jsonOutput: $this->tmpDir . '/coverage.json',
+            htmlOutput: $this->tmpDir . '/coverage.html',
         );
 
         ob_start();
@@ -115,6 +116,10 @@ class CoverageReportSubscriberWorkerModeTest extends TestCase
         $this->assertFileDoesNotExist(
             $this->tmpDir . '/coverage.json',
             'worker mode must not write json_output (merge CLI is the canonical paratest renderer)',
+        );
+        $this->assertFileDoesNotExist(
+            $this->tmpDir . '/coverage.html',
+            'worker mode must not write html_output (merge CLI is the canonical paratest renderer)',
         );
 
         $loaded = CoverageSidecarReader::readDir($this->tmpDir);
@@ -294,6 +299,81 @@ class CoverageReportSubscriberWorkerModeTest extends TestCase
 
         $this->assertStringContainsString('WARNING', $stderrLog);
         $this->assertStringContainsString('JUnit XML', $stderrLog);
+    }
+
+    #[Test]
+    public function sequential_mode_writes_html_output_when_configured(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        mkdir($this->tmpDir, 0o755, recursive: true);
+        $htmlPath = $this->tmpDir . '/coverage.html';
+
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            sidecarDir: $this->tmpDir,
+            htmlOutput: $htmlPath,
+        );
+
+        ob_start();
+        $subscriber->notify($this->fakeExecutionFinished());
+        ob_get_clean();
+
+        $this->assertFileExists($htmlPath, 'sequential mode must write html_output when configured');
+        $contents = (string) file_get_contents($htmlPath);
+        $this->assertStringStartsWith('<!DOCTYPE html>', $contents);
+        $this->assertStringContainsString('petstore-3.0', $contents);
+    }
+
+    #[Test]
+    public function sequential_mode_warns_and_continues_when_html_write_fails(): void
+    {
+        // Parity with the JUnit and JSON WARN tests — the HTML dispatch path
+        // must obey the same WARN-and-continue contract.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        mkdir($this->tmpDir, 0o755, recursive: true);
+        $htmlPath = $this->tmpDir . '/coverage.html';
+        mkdir($htmlPath, 0o755, recursive: true);
+
+        $stderrLog = '';
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            stderrWriter: static function (string $msg) use (&$stderrLog): void {
+                $stderrLog .= $msg;
+            },
+            sidecarDir: $this->tmpDir,
+            htmlOutput: $htmlPath,
+        );
+
+        ob_start();
+        $subscriber->notify($this->fakeExecutionFinished());
+        ob_get_clean();
+
+        @rmdir($htmlPath);
+
+        $this->assertStringContainsString('WARNING', $stderrLog);
+        $this->assertStringContainsString('HTML', $stderrLog);
     }
 
     #[Test]

--- a/tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php
+++ b/tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php
@@ -960,6 +960,54 @@ class OpenApiCoverageExtensionTest extends TestCase
     }
 
     #[Test]
+    public function bootstrap_fatal_when_html_output_is_empty(): void
+    {
+        // Reuses resolveOutputPathParameter() helper validated for junit_output;
+        // pin the parameter name so a future helper rewrite that drops
+        // html_output wiring is caught.
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'html_output' => '',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+            $this->fail('expected InvalidCoverageOutputPathException');
+        } catch (InvalidCoverageOutputPathException $e) {
+            $this->assertSame('html_output', $e->parameterName);
+            $this->assertStringContainsString('empty', $e->getMessage());
+        }
+
+        $this->assertStringContainsString('FATAL', $this->readStderr());
+    }
+
+    #[Test]
+    public function bootstrap_fatal_when_html_output_parent_dir_not_writable(): void
+    {
+        // Parity with the junit_output / json_output checks — the shared
+        // resolveOutputPathParameter() helper should fail closed for
+        // html_output too.
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'html_output' => '/proc/0/nonexistent/coverage.html',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+            $this->fail('expected InvalidCoverageOutputPathException');
+        } catch (InvalidCoverageOutputPathException $e) {
+            $this->assertSame('html_output', $e->parameterName);
+            $this->assertStringContainsString('not writable', $e->getMessage());
+        }
+
+        $this->assertStringContainsString('FATAL', $this->readStderr());
+    }
+
+    #[Test]
     public function bootstrap_fatal_when_json_output_parent_dir_not_writable(): void
     {
         // Parity with the junit_output check — the shared


### PR DESCRIPTION
## Summary

Final format in the #116 series: `HtmlCoverageRenderer` plus `html_output` (PHPUnit Extension) and `--html-output` (merge CLI). After this PR, the multi-format chain is complete — users can ship Markdown, JUnit XML, JSON, and HTML in any combination from a single test run.

A self-contained HTML report is the right tool for **human review**: PR comments, CI artifact preview tabs, and offline inspection. JSON / JUnit cover machine consumers; this fills the "open and read" gap.

## Why HTML

- **PR review workflow.** Reviewers can preview a coverage HTML in CI artifact tabs without setting up a Markdown renderer or shipping a server-side viewer.
- **Offline.** Single file, no external assets, no JavaScript — works from `file://` and survives detached CI uploads.
- **Self-contained safety.** All user-controlled strings (paths, operation IDs, content types, skip reasons) pass through `htmlspecialchars(ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')`, so a hostile spec value cannot inject markup.

## Design highlights

- `final class HtmlCoverageRenderer` with `public static function render(array $results): string` — matches the established public-API shape of `MarkdownCoverageRenderer` / `JUnitCoverageRenderer` / `JsonCoverageRenderer`.
- `<details>`/`<summary>` for per-endpoint collapsible detail — works across modern browsers without JavaScript.
- In-page anchor links navigate from the top-level endpoint list to detail sections.
- `state-<value>` CSS classes match enum values (`state-all-covered`, `state-partial`, `state-uncovered`, `state-request-only`, `state-validated`, `state-skipped`), so styling tweaks need only touch the stylesheet.
- Inline CSS only; no `<link>` or `<script>` tags — verified by a unit test.

## Sample

[`docs/samples/coverage.html`](https://github.com/studio-design/openapi-contract-testing/blob/feat/coverage-html-output/docs/samples/coverage.html) — visually verified in a browser (collapsed + expanded states, response tables, unexpected observations section).

## Plumbing parity with PR #207 / #208

- `html_output` Extension parameter validated via the shared `resolveOutputPathParameter()` helper (empty → FATAL, parent-dir-not-writable → FATAL).
- `--html-output` CLI flag plumbed through `MergeOptions` and the dispatch table.
- Severity asymmetry preserved: subscriber WARN-and-continue, CLI FATAL + exit 1.
- Worker mode (`TEST_TOKEN` set) skips `html_output` — the merge CLI is the canonical paratest renderer (pinned by test).
- Multi-format simultaneous output works: `output_file` + `junit_output` + `json_output` + `html_output` all write independently.

## Verification

- [x] `composer test` — **1406 tests / 3405 assertions** pass (12 new renderer tests, 1 worker-mode skip assertion, 2 sequential-mode tests, 3 CLI integration tests, 2 extension FATAL tests, 1 parseArgv extension)
- [x] `composer stan` — clean (level 6)
- [x] `composer cs-check` — clean for the main config
- [x] Browser smoke test on the generated HTML — both collapsed and expanded views render as designed

## Notes for reviewers

- `HtmlCoverageRenderer` is `public` (not `@internal`) for the same reason as the other renderers: users may want to call it directly from a custom subscriber.
- The renderer is stateless (`static`) like its siblings — uniformity across the four renderers is itself a load-bearing invariant for callers and dispatch tables.
- Anchor IDs are constructed from `rawurlencode(specName + '-' + endpoint)` with `%XX` substituted to `-` so they stay valid URL fragments even for paths containing slashes, braces, or spaces.
- Future multi-page reports (per-spec files, asset directory) will be added as `html_output_dir` if requested — `html_output` will keep meaning "single self-contained file" so existing pipelines never need to migrate.

## #116 complete

After this PR, every format slated in the #116 plan is shipped:

| PR | Format |
|----|--------|
| #206 | foundation — callable-list dispatch |
| #207 | JUnit XML |
| #208 | JSON |
| **this PR** | **HTML** |

Cobertura was excluded by design (semantics don't map to OpenAPI endpoints; needs separate issue if demand surfaces).

Refs #116.