### PR TITLE
fix(schema-converter): preserve sibling items as additionalItems when lowering prefixItems

### DIFF
--- a/src/Spec/OpenApiSchemaConverter.php
+++ b/src/Spec/OpenApiSchemaConverter.php
@@ -227,6 +227,16 @@ final class OpenApiSchemaConverter
             }
         }
 
+        // `additionalItems` is set by handlePrefixItems when a 3.1 spec
+        // declares `items` alongside `prefixItems`. The captured sibling is
+        // a 2020-12 subschema that may itself need lowering (nested
+        // prefixItems, $dynamicRef, etc.). The other Draft 07 recursion
+        // sites (items / properties / combiners / additionalProperties /
+        // not) don't reach it, so route it through convertInPlace here.
+        if (isset($schema['additionalItems']) && is_array($schema['additionalItems'])) {
+            self::convertInPlace($schema['additionalItems'], $version, $context);
+        }
+
         foreach (['allOf', 'oneOf', 'anyOf'] as $combiner) {
             if (isset($schema[$combiner]) && is_array($schema[$combiner])) {
                 foreach ($schema[$combiner] as &$item) {
@@ -532,14 +542,30 @@ final class OpenApiSchemaConverter
     /**
      * Convert Draft 2020-12 prefixItems to Draft 07 items array (tuple validation).
      *
+     * If `items` appears alongside `prefixItems` (2020-12 semantics:
+     * "schema for every element at index >= count(prefixItems)"), preserve
+     * that constraint as Draft 07 `additionalItems`. Overwriting `items`
+     * without preserving its sibling would silently drop the overflow
+     * constraint — a contract bypass (issue #212). `items: true` is the
+     * implicit Draft 07 default and is omitted instead of emitted.
+     *
      * @param array<string, mixed> $schema
      */
     private static function handlePrefixItems(array &$schema): void
     {
-        if (isset($schema['prefixItems']) && is_array($schema['prefixItems'])) {
-            $schema['items'] = $schema['prefixItems'];
-            unset($schema['prefixItems']);
+        if (!isset($schema['prefixItems']) || !is_array($schema['prefixItems'])) {
+            return;
         }
+
+        if (array_key_exists('items', $schema)) {
+            $overflow = $schema['items'];
+            if ($overflow !== true) {
+                $schema['additionalItems'] = $overflow;
+            }
+        }
+
+        $schema['items'] = $schema['prefixItems'];
+        unset($schema['prefixItems']);
     }
 
     /**

--- a/src/Spec/OpenApiSchemaConverter.php
+++ b/src/Spec/OpenApiSchemaConverter.php
@@ -15,6 +15,7 @@ use function get_debug_type;
 use function implode;
 use function in_array;
 use function is_array;
+use function is_bool;
 use function is_string;
 use function sprintf;
 use function trigger_error;
@@ -227,12 +228,12 @@ final class OpenApiSchemaConverter
             }
         }
 
-        // `additionalItems` is set by handlePrefixItems when a 3.1 spec
-        // declares `items` alongside `prefixItems`. The captured sibling is
-        // a 2020-12 subschema that may itself need lowering (nested
-        // prefixItems, $dynamicRef, etc.). The other Draft 07 recursion
-        // sites (items / properties / combiners / additionalProperties /
-        // not) don't reach it, so route it through convertInPlace here.
+        // Primary trigger: handlePrefixItems hoists a 3.1 sibling `items`
+        // into `additionalItems` (a 2020-12 subschema that may itself need
+        // lowering — nested prefixItems, $dynamicRef, etc.). Also handles
+        // hand-authored Draft-07-style input that declares `additionalItems`
+        // directly. None of the other recursion sites in convertInPlace
+        // descend into it, so route it through here.
         if (isset($schema['additionalItems']) && is_array($schema['additionalItems'])) {
             self::convertInPlace($schema['additionalItems'], $version, $context);
         }
@@ -547,7 +548,18 @@ final class OpenApiSchemaConverter
      * that constraint as Draft 07 `additionalItems`. Overwriting `items`
      * without preserving its sibling would silently drop the overflow
      * constraint — a contract bypass (issue #212). `items: true` is the
-     * implicit Draft 07 default and is omitted instead of emitted.
+     * implicit Draft 07 default and is omitted instead of emitted; this
+     * relies on the validator running under Draft 07, pinned by
+     * SchemaValidatorRunner's `setDefaultDraftVersion('07')` call. Should
+     * that default change, the
+     * `prefix_items_with_items_true_matches_prefix_items_without_sibling_under_opis_draft07`
+     * regression test will fail.
+     *
+     * A non-bool / non-array `items` sibling is a spec defect (JSON Schema
+     * 2020-12 §10.3 requires `Schema | bool`). Hoisting it into
+     * `additionalItems` would surface much later as an opis parse error
+     * with no clue to the source — emit a one-shot E_USER_WARNING and drop
+     * it, matching the pattern used by {@see warnIfUnknownFormat()}.
      *
      * @param array<string, mixed> $schema
      */
@@ -559,13 +571,34 @@ final class OpenApiSchemaConverter
 
         if (array_key_exists('items', $schema)) {
             $overflow = $schema['items'];
-            if ($overflow !== true) {
-                $schema['additionalItems'] = $overflow;
+            if (is_array($overflow) || is_bool($overflow)) {
+                if ($overflow !== true) {
+                    $schema['additionalItems'] = $overflow;
+                }
+            } else {
+                self::warnMalformedPrefixItemsSibling($overflow);
             }
         }
 
         $schema['items'] = $schema['prefixItems'];
         unset($schema['prefixItems']);
+    }
+
+    private static function warnMalformedPrefixItemsSibling(mixed $overflow): void
+    {
+        $dedupKey = 'prefix-items-sibling-malformed:' . get_debug_type($overflow);
+        if (isset(self::$warnedKeywords[$dedupKey])) {
+            return;
+        }
+
+        self::$warnedKeywords[$dedupKey] = true;
+        trigger_error(
+            sprintf(
+                "[OpenAPI Schema] sibling 'items' of 'prefixItems' must be a schema object or boolean per JSON Schema 2020-12 §10.3, got %s. The overflow constraint is silently dropped — any element past the tuple is NOT enforced. Fix the spec.",
+                get_debug_type($overflow),
+            ),
+            E_USER_WARNING,
+        );
     }
 
     /**

--- a/tests/Unit/Spec/OpenApiSchemaConverterTest.php
+++ b/tests/Unit/Spec/OpenApiSchemaConverterTest.php
@@ -226,6 +226,99 @@ class OpenApiSchemaConverterTest extends TestCase
         $this->assertCount(2, $result['items']);
         $this->assertSame(['type' => 'string'], $result['items'][0]);
         $this->assertSame(['type' => 'integer'], $result['items'][1]);
+        // No sibling `items` declared on input → no `additionalItems` emitted.
+        // Draft 07 defaults to "anything allowed" past the tuple, matching
+        // 2020-12 semantics when `items` is absent alongside `prefixItems`.
+        $this->assertArrayNotHasKey('additionalItems', $result);
+    }
+
+    #[Test]
+    public function v31_prefix_items_with_sibling_items_schema_is_lowered_to_additional_items(): void
+    {
+        // 2020-12: `items` alongside `prefixItems` is the schema applied to
+        // every element at index >= count(prefixItems). Draft 07 expresses
+        // this via `additionalItems` when `items` is array-form. Dropping it
+        // would be a silent contract bypass (issue #212).
+        $schema = [
+            'type' => 'array',
+            'prefixItems' => [
+                ['type' => 'string'],
+                ['type' => 'integer'],
+            ],
+            'items' => ['type' => 'boolean'],
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+
+        $this->assertArrayNotHasKey('prefixItems', $result);
+        $this->assertCount(2, $result['items']);
+        $this->assertSame(['type' => 'string'], $result['items'][0]);
+        $this->assertSame(['type' => 'integer'], $result['items'][1]);
+        $this->assertArrayHasKey('additionalItems', $result);
+        $this->assertSame(['type' => 'boolean'], $result['additionalItems']);
+    }
+
+    #[Test]
+    public function v31_prefix_items_with_items_false_lowers_to_additional_items_false(): void
+    {
+        // Closed-tuple idiom: `prefixItems + items: false` means "exactly N
+        // elements, in this order, nothing more". Draft 07 encodes the same
+        // closure as `additionalItems: false`.
+        $schema = [
+            'type' => 'array',
+            'prefixItems' => [['type' => 'string']],
+            'items' => false,
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+
+        $this->assertArrayNotHasKey('prefixItems', $result);
+        $this->assertCount(1, $result['items']);
+        $this->assertArrayHasKey('additionalItems', $result);
+        $this->assertFalse($result['additionalItems']);
+    }
+
+    #[Test]
+    public function v31_prefix_items_with_items_true_omits_additional_items(): void
+    {
+        // `items: true` is the 2020-12 explicit form of the implicit default
+        // ("any overflow allowed"). Draft 07's implicit default is the same,
+        // so emitting `additionalItems: true` would be redundant noise — drop it.
+        $schema = [
+            'type' => 'array',
+            'prefixItems' => [['type' => 'string']],
+            'items' => true,
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+
+        $this->assertArrayNotHasKey('prefixItems', $result);
+        $this->assertCount(1, $result['items']);
+        $this->assertArrayNotHasKey('additionalItems', $result);
+    }
+
+    #[Test]
+    public function v31_nested_prefix_items_inside_additional_items_converted_recursively(): void
+    {
+        // The schema we route to `additionalItems` may itself be a 2020-12
+        // subschema (here: a nested array with its own `prefixItems`).
+        // Without recursion into `additionalItems`, the inner `prefixItems`
+        // would survive into the lowered output and crash opis Draft 07.
+        $schema = [
+            'type' => 'array',
+            'prefixItems' => [['type' => 'string']],
+            'items' => [
+                'type' => 'array',
+                'prefixItems' => [['type' => 'integer']],
+            ],
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+
+        $this->assertArrayHasKey('additionalItems', $result);
+        $this->assertArrayNotHasKey('prefixItems', $result['additionalItems']);
+        $this->assertArrayHasKey('items', $result['additionalItems']);
+        $this->assertSame([['type' => 'integer']], $result['additionalItems']['items']);
     }
 
     #[Test]

--- a/tests/Unit/Spec/OpenApiSchemaConverterTest.php
+++ b/tests/Unit/Spec/OpenApiSchemaConverterTest.php
@@ -235,10 +235,9 @@ class OpenApiSchemaConverterTest extends TestCase
     #[Test]
     public function v31_prefix_items_with_sibling_items_schema_is_lowered_to_additional_items(): void
     {
-        // 2020-12: `items` alongside `prefixItems` is the schema applied to
-        // every element at index >= count(prefixItems). Draft 07 expresses
-        // this via `additionalItems` when `items` is array-form. Dropping it
-        // would be a silent contract bypass (issue #212).
+        // Anchor case for the issue #212 fix: sibling `items` must survive
+        // as `additionalItems`. The handlePrefixItems docblock carries the
+        // full 2020-12 § 10.3 rationale; this test pins the canonical mapping.
         $schema = [
             'type' => 'array',
             'prefixItems' => [
@@ -282,8 +281,10 @@ class OpenApiSchemaConverterTest extends TestCase
     public function v31_prefix_items_with_items_true_omits_additional_items(): void
     {
         // `items: true` is the 2020-12 explicit form of the implicit default
-        // ("any overflow allowed"). Draft 07's implicit default is the same,
-        // so emitting `additionalItems: true` would be redundant noise — drop it.
+        // ("any overflow allowed"). Draft 07's implicit default is the same
+        // under opis's pinned Draft 07 runtime, so the key is omitted rather
+        // than emitted. The opis-equivalence regression test in
+        // SchemaValidatorRunnerTest pins the "absent === true" assumption.
         $schema = [
             'type' => 'array',
             'prefixItems' => [['type' => 'string']],
@@ -300,10 +301,10 @@ class OpenApiSchemaConverterTest extends TestCase
     #[Test]
     public function v31_nested_prefix_items_inside_additional_items_converted_recursively(): void
     {
-        // The schema we route to `additionalItems` may itself be a 2020-12
+        // The schema routed to `additionalItems` may itself be a 2020-12
         // subschema (here: a nested array with its own `prefixItems`).
         // Without recursion into `additionalItems`, the inner `prefixItems`
-        // would survive into the lowered output and crash opis Draft 07.
+        // would survive into the lowered output.
         $schema = [
             'type' => 'array',
             'prefixItems' => [['type' => 'string']],
@@ -319,6 +320,105 @@ class OpenApiSchemaConverterTest extends TestCase
         $this->assertArrayNotHasKey('prefixItems', $result['additionalItems']);
         $this->assertArrayHasKey('items', $result['additionalItems']);
         $this->assertSame([['type' => 'integer']], $result['additionalItems']['items']);
+    }
+
+    #[Test]
+    public function v31_prefix_items_with_sibling_items_inside_one_of_lowers_recursively(): void
+    {
+        // Pins the recursion order: handlePrefixItems must run at the top of
+        // convertInPlace for each frame, so a `prefixItems + items` carried
+        // inside a combiner is lowered on the combiner's own pass. A future
+        // refactor that moved handlePrefixItems below the combiner loop would
+        // silently regress this — the test fails for the right reason.
+        $schema = [
+            'oneOf' => [
+                [
+                    'type' => 'array',
+                    'prefixItems' => [['type' => 'string']],
+                    'items' => ['type' => 'boolean'],
+                ],
+                ['type' => 'string'],
+            ],
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+
+        $tupleBranch = $result['oneOf'][0];
+        $this->assertArrayNotHasKey('prefixItems', $tupleBranch);
+        $this->assertSame([['type' => 'string']], $tupleBranch['items']);
+        $this->assertSame(['type' => 'boolean'], $tupleBranch['additionalItems']);
+    }
+
+    #[Test]
+    public function v31_prefix_items_with_sibling_items_inside_additional_properties_lowers_recursively(): void
+    {
+        // additionalProperties is one of the other recursion sites; a
+        // `prefixItems + items` value placed there must lower the same way.
+        $schema = [
+            'type' => 'object',
+            'additionalProperties' => [
+                'type' => 'array',
+                'prefixItems' => [['type' => 'string']],
+                'items' => ['type' => 'boolean'],
+            ],
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+
+        $value = $result['additionalProperties'];
+        $this->assertArrayNotHasKey('prefixItems', $value);
+        $this->assertSame([['type' => 'string']], $value['items']);
+        $this->assertSame(['type' => 'boolean'], $value['additionalItems']);
+    }
+
+    #[Test]
+    public function v31_prefix_items_with_malformed_items_sibling_warns_and_drops(): void
+    {
+        // JSON Schema 2020-12 §10.3 requires `items` to be `Schema | bool`.
+        // A scalar like `items: "string"` is a spec defect; hoisting it
+        // into `additionalItems` would surface as an opis parse error far
+        // from the source. handlePrefixItems must warn and drop it.
+        $schema = [
+            'type' => 'array',
+            'prefixItems' => [['type' => 'string']],
+            'items' => 'boolean',
+        ];
+
+        $captured = $this->captureWarnings(
+            static fn() => OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1),
+        );
+
+        $this->assertCount(1, $captured);
+        $this->assertStringContainsString("sibling 'items' of 'prefixItems'", $captured[0]);
+        $this->assertStringContainsString('string', $captured[0]);
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+        $this->assertArrayNotHasKey('additionalItems', $result);
+        $this->assertSame([['type' => 'string']], $result['items']);
+    }
+
+    #[Test]
+    public function v30_literal_additional_items_recursively_lowered_for_nullable(): void
+    {
+        // Draft 04 (which OAS 3.0 inherits) defines `additionalItems` as a
+        // real keyword. A hand-authored 3.0 spec that uses it must still
+        // see its nested 3.0-only keys (nullable, etc.) lowered — the
+        // converter must recurse into additionalItems regardless of
+        // whether handlePrefixItems put it there.
+        $schema = [
+            'type' => 'array',
+            'items' => [['type' => 'string']],
+            'additionalItems' => [
+                'type' => 'string',
+                'nullable' => true,
+            ],
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_0);
+
+        $this->assertArrayHasKey('additionalItems', $result);
+        $this->assertArrayNotHasKey('nullable', $result['additionalItems']);
+        $this->assertSame(['string', 'null'], $result['additionalItems']['type']);
     }
 
     #[Test]
@@ -733,6 +833,24 @@ class OpenApiSchemaConverterTest extends TestCase
                     '$dynamicRef' => '#meta',
                 ],
             ],
+        ];
+        $original = $schema;
+
+        OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+
+        $this->assertSame($original, $schema);
+    }
+
+    #[Test]
+    public function convert_does_not_mutate_input_schema_v31_with_sibling_items(): void
+    {
+        // handlePrefixItems writes `additionalItems` on the working copy
+        // when `prefixItems + items` is present. Pin that the new write
+        // path doesn't leak back to the caller's input array.
+        $schema = [
+            'type' => 'array',
+            'prefixItems' => [['type' => 'string']],
+            'items' => ['type' => 'boolean'],
         ];
         $original = $schema;
 

--- a/tests/Unit/Validation/Support/SchemaValidatorRunnerTest.php
+++ b/tests/Unit/Validation/Support/SchemaValidatorRunnerTest.php
@@ -7,6 +7,8 @@ namespace Studio\OpenApiContractTesting\Tests\Unit\Validation\Support;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\OpenApiVersion;
+use Studio\OpenApiContractTesting\Spec\OpenApiSchemaConverter;
 use Studio\OpenApiContractTesting\Validation\Support\ObjectConverter;
 use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
 
@@ -1022,6 +1024,39 @@ class SchemaValidatorRunnerTest extends TestCase
             '/',
             $errors,
             'cascade for the slash-bearing declared name must be dropped',
+        );
+    }
+
+    #[Test]
+    public function prefix_items_with_sibling_items_rejects_violating_overflow_after_converter_lowering(): void
+    {
+        // Issue #212 end-to-end regression: prior to the fix,
+        // `handlePrefixItems` clobbered the sibling `items` constraint, so a
+        // body whose overflow element violated `items: {type: boolean}`
+        // would validate green — a silent contract bypass. Run the full
+        // converter → validator path and assert the overflow violation
+        // surfaces. Without the fix this assertion fails (errors === []).
+        $converted = OpenApiSchemaConverter::convert(
+            [
+                'type' => 'array',
+                'prefixItems' => [
+                    ['type' => 'string'],
+                    ['type' => 'integer'],
+                ],
+                'items' => ['type' => 'boolean'],
+            ],
+            OpenApiVersion::V3_1,
+        );
+
+        $errors = (new SchemaValidatorRunner(0))->validate(
+            ObjectConverter::convert($converted),
+            ObjectConverter::convert(['hello', 42, 'oops']),
+        );
+
+        $this->assertNotSame(
+            [],
+            $errors,
+            'prefixItems + items: {type: boolean} must reject a string at the overflow index',
         );
     }
 

--- a/tests/Unit/Validation/Support/SchemaValidatorRunnerTest.php
+++ b/tests/Unit/Validation/Support/SchemaValidatorRunnerTest.php
@@ -1028,6 +1028,34 @@ class SchemaValidatorRunnerTest extends TestCase
     }
 
     #[Test]
+    public function prefix_items_with_items_true_matches_prefix_items_without_sibling_under_opis_draft07(): void
+    {
+        // handlePrefixItems omits `additionalItems` when the sibling is
+        // `items: true`, relying on opis Draft 07 treating absent and
+        // explicit-true identically. That assumption is opis-runtime-
+        // dependent (parallel to the KNOWN_OPIS_FORMATS pin); this test
+        // anchors it so a future opis upgrade that distinguishes the two
+        // surfaces as a failure here rather than as a silent contract
+        // shift in `handlePrefixItems`.
+        $tuple = [['type' => 'string'], ['type' => 'integer']];
+        $body = ObjectConverter::convert(['hello', 42, 'overflow-1', 'overflow-2']);
+        $runner = new SchemaValidatorRunner(0);
+
+        $absentSchema = ObjectConverter::convert(['type' => 'array', 'items' => $tuple]);
+        $explicitTrueSchema = ObjectConverter::convert([
+            'type' => 'array',
+            'items' => $tuple,
+            'additionalItems' => true,
+        ]);
+
+        $this->assertSame(
+            $runner->validate($absentSchema, $body),
+            $runner->validate($explicitTrueSchema, $body),
+            'absent additionalItems must validate the same as additionalItems: true under opis Draft 07',
+        );
+    }
+
+    #[Test]
     public function prefix_items_with_sibling_items_rejects_violating_overflow_after_converter_lowering(): void
     {
         // Issue #212 end-to-end regression: prior to the fix,


### PR DESCRIPTION
## Summary

`OpenApiSchemaConverter::handlePrefixItems()` was unconditionally overwriting the sibling `items` keyword when lowering OAS 3.1 `prefixItems` to Draft 07. Route the sibling to Draft 07 `additionalItems` (schema | bool) so the constraint isn't silently dropped, and recurse into `additionalItems` from `convertInPlace` so a 2020-12 subschema captured there is also lowered.

## Why

In 2020-12, `items` alongside `prefixItems` is the schema applied to every element at index `>= count(prefixItems)`. Before this patch:

```yaml
type: array
prefixItems: [{type: string}, {type: integer}]
items: {type: boolean}
```

was being lowered to plain `items: [<string>, <integer>]`, dropping the boolean overflow constraint. A response body of `['hello', 42, 'oops']` validated green even though `'oops'` violates the declared `items` schema — a silent contract bypass on a library whose whole purpose is contract enforcement.

The fix maps:
- `items: <schema>` → `additionalItems: <schema>`
- `items: false` → `additionalItems: false` (closed-tuple idiom)
- `items: true` → omitted (Draft 07 implicit default; emitting it would be redundant)
- `items` absent → unchanged

Fixes #212

## Verification

Failing-test-then-fix:

- Added 4 shape tests in `tests/Unit/Spec/OpenApiSchemaConverterTest.php` covering each `items` branch (`<schema>`, `false`, `true`-omit, and a nested-recursion case).
- Added 1 end-to-end regression in `tests/Unit/Validation/Support/SchemaValidatorRunnerTest.php` that runs the converted schema through `SchemaValidatorRunner` and asserts the overflow violation now surfaces — pinning the "no silent bypass" property, not just the array shape.
- All 5 new tests fail on the prior `handlePrefixItems` implementation and pass after.

- [x] `composer test` passes (1423 tests, 3462 assertions)
- [x] `composer stan` passes (no errors)
- [x] `composer cs-check` passes for the files touched in this PR (the unrelated pre-existing `tests/Integration/Pest/*Test.php` warnings reproduce on `main` and stem from running PHP-CS-Fixer on PHP 8.4 vs the CI matrix's PHP 8.2 — out of scope here)

## Notes for reviewers

- `handlePrefixItems` uses `array_key_exists('items', ...)` (not `isset`) so `items: false` is detected.
- The new `additionalItems` recursion site is not version-gated, matching the existing `items` / `properties` / combiner / `additionalProperties` / `not` recursion blocks. Inputs from 3.0 won't reach the new branch in practice (3.0 doesn't have `prefixItems`), but recursing regardless keeps the symmetry obvious.
- No fixture or public-API changes. `handlePrefixItems` is `private`.