### PR TITLE
fix(schema-converter): recurse into if/then/else, patternProperties, propertyNames, contains, dependentSchemas

### DIFF
--- a/src/Spec/OpenApiSchemaConverter.php
+++ b/src/Spec/OpenApiSchemaConverter.php
@@ -257,31 +257,42 @@ final class OpenApiSchemaConverter
             self::convertInPlace($schema['not'], $version, $context);
         }
 
-        // Single-schema subschema positions opis Draft 07 honours
-        // (`if`/`then`/`else`, `propertyNames`, `contains`) plus
-        // `dependentSchemas` values (2019-09 keyword; opis Draft 07 ignores
-        // the outer keyword but the inner schemas are recursed for hygiene
-        // and to stay symmetric with peer positions). Without this descent
-        // (#214), OAS-only keywords (nullable, readOnly/writeOnly) and
-        // 2020-12-only keywords (prefixItems, const) nested inside these
-        // positions survive untouched into the validator — opis Draft 07
-        // then silently ignores them, the same silent-bypass class fixed
-        // by #213 for `prefixItems` siblings.
+        // Descend into the remaining subschema positions opis Draft 07
+        // honours (#214). Without this, OAS-only and 2020-12-only keywords
+        // nested inside them survive untouched into the validator and opis
+        // silently ignores them — the same silent-bypass class fixed by
+        // #213 for `prefixItems` siblings. `dependentSchemas` is a 2019-09
+        // keyword whose outer form opis Draft 07 ignores entirely; we still
+        // recurse into its values for hygiene and to stay symmetric with
+        // the other map-of-schemas positions.
         foreach (['if', 'then', 'else', 'propertyNames', 'contains'] as $key) {
             if (isset($schema[$key]) && is_array($schema[$key])) {
                 self::convertInPlace($schema[$key], $version, $context);
             }
         }
 
-        foreach (['patternProperties', 'dependentSchemas'] as $mapKey) {
-            if (isset($schema[$mapKey]) && is_array($schema[$mapKey])) {
-                foreach ($schema[$mapKey] as &$sub) {
-                    if (is_array($sub)) {
-                        self::convertInPlace($sub, $version, $context);
-                    }
+        if (isset($schema['patternProperties']) && is_array($schema['patternProperties'])) {
+            foreach ($schema['patternProperties'] as &$sub) {
+                if (is_array($sub)) {
+                    self::convertInPlace($sub, $version, $context);
                 }
-                unset($sub);
             }
+            unset($sub);
+        }
+
+        if (isset($schema['dependentSchemas']) && is_array($schema['dependentSchemas'])) {
+            foreach ($schema['dependentSchemas'] as &$sub) {
+                // A list-shaped value here belongs under `dependentRequired`
+                // (an array of property names), not `dependentSchemas` (a
+                // map of schemas). Skip descent so a sibling-keyword misuse
+                // remains a no-op rather than being silently routed through
+                // schema lowering — the same silent-defect class the rest
+                // of this method exists to surface.
+                if (is_array($sub) && !array_is_list($sub)) {
+                    self::convertInPlace($sub, $version, $context);
+                }
+            }
+            unset($sub);
         }
     }
 

--- a/src/Spec/OpenApiSchemaConverter.php
+++ b/src/Spec/OpenApiSchemaConverter.php
@@ -256,6 +256,33 @@ final class OpenApiSchemaConverter
         if (isset($schema['not']) && is_array($schema['not'])) {
             self::convertInPlace($schema['not'], $version, $context);
         }
+
+        // Single-schema subschema positions opis Draft 07 honours
+        // (`if`/`then`/`else`, `propertyNames`, `contains`) plus
+        // `dependentSchemas` values (2019-09 keyword; opis Draft 07 ignores
+        // the outer keyword but the inner schemas are recursed for hygiene
+        // and to stay symmetric with peer positions). Without this descent
+        // (#214), OAS-only keywords (nullable, readOnly/writeOnly) and
+        // 2020-12-only keywords (prefixItems, const) nested inside these
+        // positions survive untouched into the validator — opis Draft 07
+        // then silently ignores them, the same silent-bypass class fixed
+        // by #213 for `prefixItems` siblings.
+        foreach (['if', 'then', 'else', 'propertyNames', 'contains'] as $key) {
+            if (isset($schema[$key]) && is_array($schema[$key])) {
+                self::convertInPlace($schema[$key], $version, $context);
+            }
+        }
+
+        foreach (['patternProperties', 'dependentSchemas'] as $mapKey) {
+            if (isset($schema[$mapKey]) && is_array($schema[$mapKey])) {
+                foreach ($schema[$mapKey] as &$sub) {
+                    if (is_array($sub)) {
+                        self::convertInPlace($sub, $version, $context);
+                    }
+                }
+                unset($sub);
+            }
+        }
     }
 
     /**

--- a/tests/Unit/Spec/OpenApiSchemaConverterTest.php
+++ b/tests/Unit/Spec/OpenApiSchemaConverterTest.php
@@ -1742,9 +1742,10 @@ class OpenApiSchemaConverterTest extends TestCase
     #[Test]
     public function v30_nullable_inside_property_names_is_lowered(): void
     {
-        // propertyNames values are always string schemas; the practical use
-        // case here is a `format: emial` typo or `discriminator` slip that
-        // the warning helpers should still detect at depth.
+        // propertyNames values validate object keys, which are always
+        // strings — `nullable` is semantically nonsensical here. The test
+        // intentionally exercises a degenerate input to pin the structural
+        // descent: it confirms convertInPlace reaches propertyNames at all.
         $schema = [
             'type' => 'object',
             'propertyNames' => ['type' => 'string', 'nullable' => true],
@@ -1989,14 +1990,23 @@ class OpenApiSchemaConverterTest extends TestCase
     }
 
     #[Test]
-    public function const_inside_pattern_properties_actually_rejects_wrong_value(): void
+    public function prefix_items_inside_pattern_properties_actually_rejects_tuple_violation(): void
     {
+        // End-to-end guard for the map-loop body of the new recursion
+        // (`patternProperties` values). `prefixItems` is opis-Draft-07-unknown,
+        // so an un-lowered tuple silently passes — the regression we are
+        // pinning. Cannot reuse `const` here because opis Draft 06+ enforces
+        // `const` natively, masking the silent bypass and rendering the test
+        // useless as a pre-fix regression guard.
         $runner = new SchemaValidatorRunner(20);
         $schema = OpenApiSchemaConverter::convert(
             [
                 'type' => 'object',
                 'patternProperties' => [
-                    '^x-' => ['type' => 'string', 'const' => 'frozen'],
+                    '^x-' => [
+                        'type' => 'array',
+                        'prefixItems' => [['type' => 'string'], ['type' => 'integer']],
+                    ],
                 ],
             ],
             OpenApiVersion::V3_1,
@@ -2004,18 +2014,19 @@ class OpenApiSchemaConverterTest extends TestCase
 
         $errors = $runner->validate(
             ObjectConverter::convert($schema),
-            ObjectConverter::convert((object) ['x-locale' => 'not-frozen']),
+            ObjectConverter::convert((object) ['x-tuple' => [123, 'oops']]),
         );
 
-        $this->assertNotSame([], $errors, 'const constraint inside patternProperties must be enforced');
+        $this->assertNotSame([], $errors, 'tuple ordering must be enforced inside patternProperties');
     }
 
     #[Test]
     public function convert_does_not_mutate_input_schema_with_recursion_into_pattern_properties(): void
     {
-        // Mirror the #213 immutability pin (line 845) for the newly added
-        // recursion sites: writing through &$sub references must not leak
-        // back into the caller's input array.
+        // Mirror `convert_does_not_mutate_input_schema_v31_with_sibling_items`
+        // (the #213 immutability pin) for the newly added recursion sites:
+        // writing through &$sub references must not leak back into the
+        // caller's input array.
         $schema = [
             'type' => 'object',
             'patternProperties' => [
@@ -2058,6 +2069,106 @@ class OpenApiSchemaConverterTest extends TestCase
         OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
 
         $this->assertSame($original, $schema);
+    }
+
+    #[Test]
+    public function convert_does_not_mutate_input_schema_with_multi_entry_pattern_properties(): void
+    {
+        // The classic `foreach (... as &$sub)` leak only manifests with
+        // multiple entries: the by-reference alias survives the loop bound
+        // to the last element, and any later write through that name would
+        // overwrite that entry. The single-entry pin above passes even if
+        // the trailing `unset($sub)` is dropped — this multi-entry version
+        // is what genuinely guards the hazard.
+        $schema = [
+            'type' => 'object',
+            'patternProperties' => [
+                '^x-' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'secret' => ['type' => 'string', 'writeOnly' => true],
+                    ],
+                ],
+                '^y-' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'another' => ['type' => 'string', 'writeOnly' => true],
+                    ],
+                ],
+            ],
+        ];
+        $original = $schema;
+
+        OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_0, SchemaContext::Response);
+
+        $this->assertSame($original, $schema);
+    }
+
+    #[Test]
+    public function convert_does_not_mutate_input_schema_with_multi_entry_dependent_schemas(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'dependentSchemas' => [
+                'creditCard' => [
+                    'properties' => [
+                        'currency' => ['type' => 'string', 'const' => 'USD'],
+                    ],
+                ],
+                'wireTransfer' => [
+                    'properties' => [
+                        'routingNumber' => ['type' => 'string', 'const' => 'US'],
+                    ],
+                ],
+            ],
+        ];
+        $original = $schema;
+
+        OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+
+        $this->assertSame($original, $schema);
+    }
+
+    #[Test]
+    public function boolean_schemas_at_new_recursion_sites_are_preserved(): void
+    {
+        // Boolean schemas (`true`/`false`) are legal at every subschema
+        // position. The `is_array` guards in the recursion block skip them
+        // by design — converting a bool would crash. Pin the no-op so a
+        // future refactor that drops the guard surfaces here.
+        $schema = [
+            'if' => true,
+            'then' => false,
+            'else' => true,
+            'contains' => false,
+            'propertyNames' => true,
+            'patternProperties' => ['^x-' => false],
+            'dependentSchemas' => ['k' => true],
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+
+        $this->assertSame($schema, $result);
+    }
+
+    #[Test]
+    public function dependent_schemas_list_shaped_value_is_skipped(): void
+    {
+        // `dependentSchemas: { k: ["a", "b"] }` is a spec defect — that
+        // list shape belongs under the sibling `dependentRequired`
+        // keyword. The converter must not descend into it (descending a
+        // list of property-name strings as if it were a schema is the
+        // exact silent-routing class the rest of convertInPlace exists to
+        // surface). Pin the no-op via shape equality.
+        $schema = [
+            'dependentSchemas' => [
+                'creditCard' => ['billingAddress', 'cvv'],
+            ],
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+
+        $this->assertSame($schema, $result);
     }
 
     #[Test]

--- a/tests/Unit/Spec/OpenApiSchemaConverterTest.php
+++ b/tests/Unit/Spec/OpenApiSchemaConverterTest.php
@@ -11,6 +11,8 @@ use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\OpenApiVersion;
 use Studio\OpenApiContractTesting\SchemaContext;
 use Studio\OpenApiContractTesting\Spec\OpenApiSchemaConverter;
+use Studio\OpenApiContractTesting\Validation\Support\ObjectConverter;
+use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
 
 use function implode;
 use function restore_error_handler;
@@ -1708,6 +1710,404 @@ class OpenApiSchemaConverterTest extends TestCase
 
         $this->assertArrayNotHasKey('const', $result['items']);
         $this->assertSame(['fixed'], $result['items']['enum']);
+    }
+
+    // ========================================
+    // Recursion: extended subschema positions (#214)
+    // ----------------------------------------
+    // convertInPlace must descend into every JSON-Schema subschema position
+    // opis Draft 07 honours — otherwise OAS-only / 2020-12-only keywords
+    // (nullable, readOnly/writeOnly, prefixItems, const, …) nested inside
+    // them survive untouched and opis silently ignores them. Issue #214
+    // identified five gaps: if/then/else, patternProperties, propertyNames,
+    // contains, and dependentSchemas. The tests below pin each gap closed.
+    // ========================================
+
+    #[Test]
+    public function v30_nullable_inside_pattern_properties_is_lowered(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'patternProperties' => [
+                '^x-' => ['type' => 'string', 'nullable' => true],
+            ],
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_0);
+
+        $this->assertSame(['string', 'null'], $result['patternProperties']['^x-']['type']);
+        $this->assertArrayNotHasKey('nullable', $result['patternProperties']['^x-']);
+    }
+
+    #[Test]
+    public function v30_nullable_inside_property_names_is_lowered(): void
+    {
+        // propertyNames values are always string schemas; the practical use
+        // case here is a `format: emial` typo or `discriminator` slip that
+        // the warning helpers should still detect at depth.
+        $schema = [
+            'type' => 'object',
+            'propertyNames' => ['type' => 'string', 'nullable' => true],
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_0);
+
+        $this->assertSame(['string', 'null'], $result['propertyNames']['type']);
+        $this->assertArrayNotHasKey('nullable', $result['propertyNames']);
+    }
+
+    #[Test]
+    public function v30_nullable_inside_if_branch_is_lowered(): void
+    {
+        // The `if` schema drives branch selection; an unconverted nullable
+        // here would fail opis Draft 07 type matching and silently choose
+        // the wrong branch.
+        $schema = [
+            'if' => ['type' => 'string', 'nullable' => true],
+            'then' => ['type' => 'object'],
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_0);
+
+        $this->assertSame(['string', 'null'], $result['if']['type']);
+        $this->assertArrayNotHasKey('nullable', $result['if']);
+    }
+
+    #[Test]
+    public function v31_prefix_items_inside_then_is_lowered_to_tuple_items(): void
+    {
+        // Bug 1 from issue #214: prefixItems nested inside `then` was not
+        // recognised by opis Draft 07 (which only registers prefixItems on
+        // Draft 2020-12). The lowering must happen at every depth.
+        $schema = [
+            'if' => ['properties' => ['kind' => ['const' => 'tuple']], 'required' => ['kind']],
+            'then' => [
+                'properties' => [
+                    'data' => [
+                        'type' => 'array',
+                        'prefixItems' => [['type' => 'string'], ['type' => 'integer']],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+
+        $this->assertArrayNotHasKey(
+            'prefixItems',
+            $result['then']['properties']['data'],
+        );
+        $this->assertSame(
+            [['type' => 'string'], ['type' => 'integer']],
+            $result['then']['properties']['data']['items'],
+        );
+    }
+
+    #[Test]
+    public function v31_prefix_items_inside_contains_is_lowered(): void
+    {
+        $schema = [
+            'type' => 'array',
+            'contains' => [
+                'type' => 'array',
+                'prefixItems' => [['type' => 'string']],
+            ],
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+
+        $this->assertArrayNotHasKey('prefixItems', $result['contains']);
+        $this->assertSame([['type' => 'string']], $result['contains']['items']);
+    }
+
+    #[Test]
+    public function v31_const_inside_else_is_lowered_to_enum(): void
+    {
+        $schema = [
+            'if' => ['properties' => ['kind' => ['const' => 'a']]],
+            'then' => ['type' => 'object'],
+            'else' => [
+                'properties' => [
+                    'fallback' => ['type' => 'string', 'const' => 'use-default'],
+                ],
+            ],
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+
+        $this->assertArrayNotHasKey('const', $result['else']['properties']['fallback']);
+        $this->assertSame(['use-default'], $result['else']['properties']['fallback']['enum']);
+    }
+
+    #[Test]
+    public function v31_const_lowered_inside_dependent_schemas(): void
+    {
+        // dependentSchemas is a 2019-09 keyword; opis Draft 07 ignores the
+        // outer keyword entirely, but the inner schemas should still be
+        // lowered for hygiene and to stay symmetric with peer positions.
+        $schema = [
+            'type' => 'object',
+            'dependentSchemas' => [
+                'creditCard' => [
+                    'properties' => [
+                        'currency' => ['type' => 'string', 'const' => 'USD'],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+
+        $this->assertArrayNotHasKey(
+            'const',
+            $result['dependentSchemas']['creditCard']['properties']['currency'],
+        );
+        $this->assertSame(
+            ['USD'],
+            $result['dependentSchemas']['creditCard']['properties']['currency']['enum'],
+        );
+    }
+
+    #[Test]
+    public function response_context_write_only_inside_pattern_properties_property_becomes_false(): void
+    {
+        // Bug 2 from issue #214: a writeOnly subproperty nested inside a
+        // patternProperties entry must be replaced with boolean `false`
+        // (forbidden) in Response context, the same way top-level
+        // writeOnly properties are.
+        $schema = [
+            'type' => 'object',
+            'patternProperties' => [
+                '^x-' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'secret' => ['type' => 'string', 'writeOnly' => true],
+                        'public' => ['type' => 'string'],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = OpenApiSchemaConverter::convert(
+            $schema,
+            OpenApiVersion::V3_0,
+            SchemaContext::Response,
+        );
+
+        $this->assertFalse($result['patternProperties']['^x-']['properties']['secret']);
+        $this->assertSame(
+            ['type' => 'string'],
+            $result['patternProperties']['^x-']['properties']['public'],
+        );
+    }
+
+    #[Test]
+    public function response_context_write_only_inside_then_property_becomes_false(): void
+    {
+        $schema = [
+            'if' => ['properties' => ['kind' => ['enum' => ['admin']]], 'required' => ['kind']],
+            'then' => [
+                'properties' => [
+                    'admin_secret' => ['type' => 'string', 'writeOnly' => true],
+                ],
+            ],
+        ];
+
+        $result = OpenApiSchemaConverter::convert(
+            $schema,
+            OpenApiVersion::V3_0,
+            SchemaContext::Response,
+        );
+
+        $this->assertFalse($result['then']['properties']['admin_secret']);
+    }
+
+    #[Test]
+    public function prefix_items_inside_then_actually_rejects_tuple_violation(): void
+    {
+        // End-to-end regression guard for the silent contract bypass from
+        // issue #214: feed the converted schema through opis via the runner
+        // and confirm a violating payload is actually surfaced as an error.
+        $runner = new SchemaValidatorRunner(20);
+        $schema = OpenApiSchemaConverter::convert(
+            [
+                'type' => 'object',
+                'properties' => [
+                    'kind' => ['type' => 'string'],
+                    'data' => ['type' => 'array'],
+                ],
+                'if' => ['properties' => ['kind' => ['const' => 'tuple']], 'required' => ['kind']],
+                'then' => [
+                    'properties' => [
+                        'data' => [
+                            'type' => 'array',
+                            'prefixItems' => [['type' => 'string'], ['type' => 'integer']],
+                        ],
+                    ],
+                ],
+            ],
+            OpenApiVersion::V3_1,
+        );
+
+        $errors = $runner->validate(
+            ObjectConverter::convert($schema),
+            ObjectConverter::convert((object) ['kind' => 'tuple', 'data' => [123, 'oops']]),
+        );
+
+        $this->assertNotSame([], $errors, 'tuple ordering must be enforced inside `then`');
+    }
+
+    #[Test]
+    public function write_only_inside_pattern_properties_actually_rejects_response_leak(): void
+    {
+        $runner = new SchemaValidatorRunner(20);
+        $schema = OpenApiSchemaConverter::convert(
+            [
+                'type' => 'object',
+                'patternProperties' => [
+                    '^x-' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'secret' => ['type' => 'string', 'writeOnly' => true],
+                            'public' => ['type' => 'string'],
+                        ],
+                    ],
+                ],
+            ],
+            OpenApiVersion::V3_0,
+            SchemaContext::Response,
+        );
+
+        $errors = $runner->validate(
+            ObjectConverter::convert($schema),
+            ObjectConverter::convert((object) [
+                'x-meta' => (object) ['secret' => 'leaked', 'public' => 'ok'],
+            ]),
+        );
+
+        $this->assertNotSame([], $errors, 'writeOnly leak inside patternProperties must surface in Response');
+    }
+
+    #[Test]
+    public function const_inside_pattern_properties_actually_rejects_wrong_value(): void
+    {
+        $runner = new SchemaValidatorRunner(20);
+        $schema = OpenApiSchemaConverter::convert(
+            [
+                'type' => 'object',
+                'patternProperties' => [
+                    '^x-' => ['type' => 'string', 'const' => 'frozen'],
+                ],
+            ],
+            OpenApiVersion::V3_1,
+        );
+
+        $errors = $runner->validate(
+            ObjectConverter::convert($schema),
+            ObjectConverter::convert((object) ['x-locale' => 'not-frozen']),
+        );
+
+        $this->assertNotSame([], $errors, 'const constraint inside patternProperties must be enforced');
+    }
+
+    #[Test]
+    public function convert_does_not_mutate_input_schema_with_recursion_into_pattern_properties(): void
+    {
+        // Mirror the #213 immutability pin (line 845) for the newly added
+        // recursion sites: writing through &$sub references must not leak
+        // back into the caller's input array.
+        $schema = [
+            'type' => 'object',
+            'patternProperties' => [
+                '^x-' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'secret' => ['type' => 'string', 'writeOnly' => true],
+                    ],
+                ],
+            ],
+        ];
+        $original = $schema;
+
+        OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_0, SchemaContext::Response);
+
+        $this->assertSame($original, $schema);
+    }
+
+    #[Test]
+    public function convert_does_not_mutate_input_schema_with_recursion_into_if_then_else(): void
+    {
+        $schema = [
+            'if' => ['type' => 'string', 'nullable' => true],
+            'then' => [
+                'properties' => [
+                    'data' => [
+                        'type' => 'array',
+                        'prefixItems' => [['type' => 'string']],
+                    ],
+                ],
+            ],
+            'else' => [
+                'properties' => [
+                    'fallback' => ['type' => 'string', 'const' => 'x'],
+                ],
+            ],
+        ];
+        $original = $schema;
+
+        OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+
+        $this->assertSame($original, $schema);
+    }
+
+    #[Test]
+    public function unknown_format_inside_pattern_properties_warns(): void
+    {
+        // warnIfUnknownFormat already dedups by format value across the
+        // process; confirming it fires at depth is enough.
+        $warnings = $this->captureWarnings(static function (): void {
+            OpenApiSchemaConverter::convert(
+                [
+                    'type' => 'object',
+                    'patternProperties' => [
+                        '^x-' => ['type' => 'string', 'format' => 'emial'],
+                    ],
+                ],
+                OpenApiVersion::V3_0,
+            );
+        });
+
+        $this->assertNotSame([], $warnings, 'unknown format inside patternProperties must warn');
+        $this->assertTrue(
+            str_contains($warnings[0], "format 'emial'"),
+            'warning must name the offending format value',
+        );
+    }
+
+    #[Test]
+    public function discriminator_mapping_inside_then_warns(): void
+    {
+        $warnings = $this->captureWarnings(static function (): void {
+            OpenApiSchemaConverter::convert(
+                [
+                    'if' => ['properties' => ['kind' => ['type' => 'string']]],
+                    'then' => [
+                        'discriminator' => [
+                            'propertyName' => 'kind',
+                            'mapping' => ['a' => '#/components/schemas/A'],
+                        ],
+                        'oneOf' => [['type' => 'object']],
+                    ],
+                ],
+                OpenApiVersion::V3_0,
+            );
+        });
+
+        $this->assertNotSame([], $warnings, 'discriminator.mapping inside `then` must warn');
+        $this->assertTrue(
+            str_contains($warnings[0], 'discriminator.mapping'),
+            'warning must mention discriminator.mapping',
+        );
     }
 
     // ========================================


### PR DESCRIPTION
## Summary

Extend `OpenApiSchemaConverter::convertInPlace()` to recurse into five JSON-Schema subschema positions it previously skipped: `if`/`then`/`else`, `patternProperties`, `propertyNames`, `contains`, and `dependentSchemas`. Adds 16 tests covering lowering, context enforcement, end-to-end opis validation, immutability, and warning parity for the new depths.

## Why

Fixes #214. Without recursion into these positions, OAS-only keywords (`nullable`, `readOnly`/`writeOnly`) and 2020-12-only keywords (`prefixItems`, `const`) nested inside them survived untouched into the validator. opis Draft 07 silently ignored them — the same silent-contract-bypass class fixed by #213 for `prefixItems` siblings.

Three concrete bypasses were confirmed in the issue body and are now guarded by end-to-end regression tests:

1. OAS 3.1 `prefixItems` inside `then` → tuple ordering silently skipped
2. OAS 3.0 `writeOnly` inside `patternProperties` → response leaks writeOnly fields
3. OAS 3.1 `const` inside `patternProperties` → constant constraint silently dropped (Note: opis Draft 07 happens to enforce `const` natively, so this end-to-end test was already green; kept as a behaviour pin)

The fix is a small, mechanical extension of the existing recursion list — all other infrastructure (`handleNullable`, `handlePrefixItems`, `lowerConstToEnum`, `enforceContextOnProperties`, `warnIf*` helpers) fires per-frame and applies automatically at the new depths.

## Verification

- [x] `composer test` passes (1445 tests, 3504 assertions — 16 new)
- [x] `composer stan` passes (level 6, 197 files)
- [x] `composer cs-check` passes for the base config covering touched files (Pest config diff is a pre-existing PHP 8.4-vs-8.2 mismatch on `main`, unrelated to this change)

TDD red→green flow:

1. Wrote 16 new tests in `tests/Unit/Spec/OpenApiSchemaConverterTest.php` under a new section `Recursion: extended subschema positions (#214)`.
2. Pre-fix: 13/16 failed (3 pass: 2 immutability tests since the input wasn't touched either way, and the `const` end-to-end since opis enforces it natively).
3. Applied the recursion change in `convertInPlace`.
4. Post-fix: 16/16 pass; full suite still green at 1445/1445.

## Notes for reviewers

- **Scope deliberately narrow.** Only the recursion sites are added. The existing limitation re. markers buried inside `allOf`/`oneOf`/`anyOf` children (`marker_inside_combiner_child_is_not_enforced_known_limitation`, test at `tests/Unit/Spec/OpenApiSchemaConverterTest.php:797`) is orthogonal and not addressed here. `dependentSchemas` is recursed for symmetry/hygiene even though opis Draft 07 doesn't enforce the outer keyword — a warning for `dependentSchemas` itself can be tracked separately if desired.
- **Code shape mirrors #213.** The new recursion block sits right after the existing `not` handler and follows the same patterns used for `additionalProperties` (single-schema) and `allOf`/`oneOf`/`anyOf` (map by-reference).
- **Immutability preserved.** Two new tests (`convert_does_not_mutate_input_schema_with_recursion_into_*`) mirror the #213 pin to confirm the new write-through-reference paths do not leak mutations back to the caller's input array.