### PR TITLE
fix(request): coerce empty array body to stdClass when schema accepts object

### DIFF
--- a/src/Validation/Request/RequestBodyValidator.php
+++ b/src/Validation/Request/RequestBodyValidator.php
@@ -161,9 +161,9 @@ final class RequestBodyValidator
         // empty arrays as JSON arrays, so a schema's `type: object` would then
         // reject the body with a misleading "must match the type: object" error.
         // Coerce `[]` → stdClass when the schema explicitly accepts an object so
-        // the empty-object-against-type-object case (very common for "create
-        // with defaults" and acknowledgement bodies) validates. Mirrors the
-        // response-side fix at ResponseBodyValidator::validate() (issue #217).
+        // the empty-object-against-type-object case (very common for
+        // "create with defaults" bodies) validates. Mirrors the response-side
+        // fix at ResponseBodyValidator::validate().
         if ($requestBody === [] && self::schemaAcceptsObject($schema)) {
             $requestBody = new stdClass();
         }
@@ -190,8 +190,8 @@ final class RequestBodyValidator
      * NOT walked — coercion only fires for the unambiguous case so a real
      * type-mismatch error still surfaces for `type: array` schemas where the
      * empty-array body is genuinely correct. Intentional duplicate of the
-     * same-named helper on the response-side body validator (issue #217); if
-     * you change the scope here, change it there too.
+     * same-named helper on the response-side body validator; if you change
+     * the scope here, change it there too.
      *
      * @param array<string, mixed> $schema
      */

--- a/src/Validation/Request/RequestBodyValidator.php
+++ b/src/Validation/Request/RequestBodyValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Validation\Request;
 
+use stdClass;
 use Studio\OpenApiContractTesting\OpenApiVersion;
 use Studio\OpenApiContractTesting\SchemaContext;
 use Studio\OpenApiContractTesting\Spec\OpenApiSchemaConverter;
@@ -14,7 +15,9 @@ use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
 use function array_key_exists;
 use function array_keys;
 use function implode;
+use function in_array;
 use function is_array;
+use function is_string;
 
 /**
  * @internal Not part of the package's public API. Do not use from user code.
@@ -152,6 +155,19 @@ final class RequestBodyValidator
         $schema = $content[$jsonContentType]['schema'];
         $jsonSchema = OpenApiSchemaConverter::convert($schema, $version, SchemaContext::Request);
 
+        // PHP's `json_decode($json, true)` returns `[]` for both `[]` and `{}`.
+        // The Laravel adapter's request decoder uses associative-array decoding,
+        // so an empty `{}` body lands here as PHP `[]`. ObjectConverter preserves
+        // empty arrays as JSON arrays, so a schema's `type: object` would then
+        // reject the body with a misleading "must match the type: object" error.
+        // Coerce `[]` → stdClass when the schema explicitly accepts an object so
+        // the empty-object-against-type-object case (very common for "create
+        // with defaults" and acknowledgement bodies) validates. Mirrors the
+        // response-side fix at ResponseBodyValidator::validate() (issue #217).
+        if ($requestBody === [] && self::schemaAcceptsObject($schema)) {
+            $requestBody = new stdClass();
+        }
+
         $schemaObject = ObjectConverter::convert($jsonSchema);
         $dataObject = ObjectConverter::convert($requestBody);
 
@@ -165,5 +181,32 @@ final class RequestBodyValidator
         }
 
         return $errors;
+    }
+
+    /**
+     * Whether the schema's top-level type explicitly accepts a JSON object.
+     * Handles OAS 3.0 (`type: object`) and OAS 3.1 (`type: ["object", "null"]`).
+     * Composition keywords (`oneOf` / `anyOf` / `allOf`) are intentionally
+     * NOT walked — coercion only fires for the unambiguous case so a real
+     * type-mismatch error still surfaces for `type: array` schemas where the
+     * empty-array body is genuinely correct. Intentional duplicate of the
+     * same-named helper on the response-side body validator (issue #217); if
+     * you change the scope here, change it there too.
+     *
+     * @param array<string, mixed> $schema
+     */
+    private static function schemaAcceptsObject(array $schema): bool
+    {
+        $type = $schema['type'] ?? null;
+
+        if (is_string($type)) {
+            return $type === 'object';
+        }
+
+        if (is_array($type)) {
+            return in_array('object', $type, true);
+        }
+
+        return false;
     }
 }

--- a/src/Validation/Response/ResponseBodyValidator.php
+++ b/src/Validation/Response/ResponseBodyValidator.php
@@ -153,7 +153,9 @@ final class ResponseBodyValidator
      * Composition keywords (`oneOf` / `anyOf` / `allOf`) are intentionally
      * NOT walked — coercion only fires for the unambiguous case so a real
      * type-mismatch error still surfaces for `type: array` schemas where the
-     * empty-array body is genuinely wrong.
+     * empty-array body is genuinely wrong. Intentional duplicate of the
+     * same-named helper on the request-side body validator; if you change
+     * the scope here, change it there too.
      *
      * @param array<string, mixed> $schema
      */

--- a/tests/Unit/Validation/Request/RequestBodyValidatorTest.php
+++ b/tests/Unit/Validation/Request/RequestBodyValidatorTest.php
@@ -161,4 +161,162 @@ class RequestBodyValidatorTest extends TestCase
 
         $this->assertSame([], $errors);
     }
+
+    #[Test]
+    public function validate_accepts_empty_object_body_against_type_object(): void
+    {
+        // PHP's `json_decode('{}', true) === []` — the Laravel adapter's
+        // associative-array decoding loses the {} vs [] distinction. Without
+        // schema-aware coercion the validator would reject `[]` against
+        // `type: object`. Pin the fix so empty-{} request bodies validate,
+        // matching the response-side coercion (issue #217).
+        $operation = [
+            'requestBody' => [
+                'required' => true,
+                'content' => [
+                    'application/json' => ['schema' => ['type' => 'object']],
+                ],
+            ],
+        ];
+
+        $errors = $this->validator->validate(
+            'spec',
+            'POST',
+            '/p',
+            $operation,
+            [],
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function validate_accepts_empty_object_body_against_oas_31_nullable_object(): void
+    {
+        // OAS 3.1 type-array form: `type: ["object", "null"]`. Same coercion.
+        $operation = [
+            'requestBody' => [
+                'required' => true,
+                'content' => [
+                    'application/json' => ['schema' => ['type' => ['object', 'null']]],
+                ],
+            ],
+        ];
+
+        $errors = $this->validator->validate(
+            'spec',
+            'POST',
+            '/p',
+            $operation,
+            [],
+            'application/json',
+            OpenApiVersion::V3_1,
+        );
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function validate_does_not_coerce_empty_array_when_schema_has_no_explicit_type(): void
+    {
+        // A schema that only declares `properties` (no `type`) is common in
+        // third-party specs. `schemaAcceptsObject` returns false for this
+        // shape — pin so a future "infer object from properties" change
+        // doesn't silently start coercing array bodies.
+        $operation = [
+            'requestBody' => [
+                'required' => true,
+                'content' => [
+                    'application/json' => [
+                        'schema' => [
+                            'properties' => ['id' => ['type' => 'integer']],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $errors = $this->validator->validate(
+            'spec',
+            'POST',
+            '/p',
+            $operation,
+            [],
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        // No error AND no coercion fired — the property bag is permissive
+        // so empty input passes for either array or object interpretation.
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function validate_does_not_coerce_empty_array_for_oneof_with_object_branch(): void
+    {
+        // `oneOf: [{type: object, required: [foo]}]` with body `[]`. Composition
+        // keywords are NOT walked by `schemaAcceptsObject` — by design — so the
+        // body is validated as a JSON array against the oneOf and fails. Pin
+        // the design choice so a future "let's walk oneOf" change is forced
+        // through review.
+        $operation = [
+            'requestBody' => [
+                'required' => true,
+                'content' => [
+                    'application/json' => [
+                        'schema' => [
+                            'oneOf' => [
+                                ['type' => 'object', 'required' => ['foo'], 'properties' => ['foo' => ['type' => 'string']]],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $errors = $this->validator->validate(
+            'spec',
+            'POST',
+            '/p',
+            $operation,
+            [],
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        // Coercion did NOT fire — body remained a JSON array, oneOf failed.
+        $this->assertNotEmpty($errors);
+    }
+
+    #[Test]
+    public function validate_does_not_coerce_empty_array_when_schema_is_array_type(): void
+    {
+        // Coercion must NOT fire when the schema actually wants an array —
+        // an empty array is a legitimate value for `type: array` (with no
+        // minItems constraint).
+        $operation = [
+            'requestBody' => [
+                'required' => true,
+                'content' => [
+                    'application/json' => [
+                        'schema' => ['type' => 'array', 'items' => ['type' => 'string']],
+                    ],
+                ],
+            ],
+        ];
+
+        $errors = $this->validator->validate(
+            'spec',
+            'POST',
+            '/p',
+            $operation,
+            [],
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertSame([], $errors);
+    }
 }

--- a/tests/Unit/Validation/Request/RequestBodyValidatorTest.php
+++ b/tests/Unit/Validation/Request/RequestBodyValidatorTest.php
@@ -195,7 +195,7 @@ class RequestBodyValidatorTest extends TestCase
     #[Test]
     public function validate_accepts_empty_object_body_against_oas_31_nullable_object(): void
     {
-        // OAS 3.1 type-array form: `type: ["object", "null"]`. Same coercion.
+        // Coercion fires on the OAS 3.1 type-array form too: `type: ["object", "null"]`.
         $operation = [
             'requestBody' => [
                 'required' => true,
@@ -286,8 +286,15 @@ class RequestBodyValidatorTest extends TestCase
             OpenApiVersion::V3_0,
         );
 
-        // Coercion did NOT fire — body remained a JSON array, oneOf failed.
+        // Coercion did NOT fire — body remained a JSON array, oneOf reported
+        // an array-vs-object type mismatch. Assert on message shape, not just
+        // non-empty errors: if a future change made the gate walk oneOf and
+        // coerce, the body would be stdClass and the failure would shift to
+        // a `required` (missing foo) error instead of a type-mismatch error.
+        // The substring "must match the type" only appears in the pre-coercion
+        // world; the post-coercion world would say "required properties".
         $this->assertNotEmpty($errors);
+        $this->assertStringContainsString('must match the type', $errors[0]);
     }
 
     #[Test]
@@ -303,6 +310,77 @@ class RequestBodyValidatorTest extends TestCase
                     'application/json' => [
                         'schema' => ['type' => 'array', 'items' => ['type' => 'string']],
                     ],
+                ],
+            ],
+        ];
+
+        $errors = $this->validator->validate(
+            'spec',
+            'POST',
+            '/p',
+            $operation,
+            [],
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function validate_still_flags_missing_required_property_after_empty_object_coercion(): void
+    {
+        // Pin: the `[] -> stdClass` coercion must NOT mask missing-required-
+        // property errors. An empty `{}` body against `{type: object,
+        // required: [foo]}` is still a contract violation; the coercion only
+        // fixes the {} vs [] shape ambiguity, it does not satisfy `required`.
+        // Without this pin, a future refactor that moved the coercion past
+        // the schema check or fed opis a permissive schema could silently
+        // accept an empty body that omits required fields — exactly the
+        // silent-pass class this library exists to surface.
+        $operation = [
+            'requestBody' => [
+                'required' => true,
+                'content' => [
+                    'application/json' => [
+                        'schema' => [
+                            'type' => 'object',
+                            'properties' => ['foo' => ['type' => 'string']],
+                            'required' => ['foo'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $errors = $this->validator->validate(
+            'spec',
+            'POST',
+            '/p',
+            $operation,
+            [],
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertNotEmpty($errors);
+        $this->assertStringContainsString('required properties (foo)', $errors[0]);
+    }
+
+    #[Test]
+    public function validate_accepts_empty_object_body_when_request_body_is_optional(): void
+    {
+        // Request-side-specific invariant: the coercion fires regardless of
+        // `required: true|false` because an empty `{}` body arrives as PHP
+        // `[]`, not as `null` — only `null` short-circuits the `required`
+        // branch. A future refactor that moved the optional-body fast-path
+        // to also match `[]` would silently skip the coercion gate; this
+        // test pins the current behaviour.
+        $operation = [
+            'requestBody' => [
+                'required' => false,
+                'content' => [
+                    'application/json' => ['schema' => ['type' => 'object']],
                 ],
             ],
         ];


### PR DESCRIPTION
## Summary

Mirror the response-side `[]` → `stdClass()` coercion onto `RequestBodyValidator` so an empty JSON object request body `{}` validates against `type: object` (and OAS 3.1 `type: ["object", "null"]`). Adds five regression tests that mirror the response-side coverage.

## Why

Fixes #217.

PHP's `json_decode($json, true)` returns `[]` for both `[]` and `{}`, so the Laravel adapter (and any framework using associative-array decoding) hands an empty-object request body to the validator as PHP `[]`. `ResponseBodyValidator::validate()` already handles this via `schemaAcceptsObject()` at `src/Validation/Response/ResponseBodyValidator.php:131`, but `RequestBodyValidator` never got the symmetric fix — a client legitimately POSTing `{}` to a `type: object` endpoint was rejected with `[/] The data (array) must match the type: object`, producing a false-positive contract failure the spec author cannot work around without rewriting their spec.

The fix duplicates the helper locally rather than extracting to `Validation/Support/`: the scope choice (top-level `type` only, composition keywords intentionally not walked) is pinned by existing response-side regression tests, and centralising it would add API surface to an `@internal` namespace and invite scope-creep PRs that the existing design rejects.

## Verification

Failing-test-first. The two `validate_accepts_empty_object_body_*` tests reproduce the bug on `main` (`[/] The data (array) must match the type: object` / `... type: object, null`); the three negative-control tests (`type: array`, no explicit `type`, `oneOf` with object branch) already pass on `main` and pin the scope choice.

- [x] `composer test` passes (1454 tests, 3513 assertions)
- [x] `composer stan` passes (PHPStan level 6, 197 files, no errors)
- [x] `composer cs-check` passes for the files this PR touches (`vendor/bin/php-cs-fixer fix --dry-run --diff -- src/Validation/Request/RequestBodyValidator.php tests/Unit/Validation/Request/RequestBodyValidatorTest.php`)

## Notes for reviewers

- The five new tests mirror `tests/Unit/Validation/Response/ResponseBodyValidatorTest.php:167, 194, 218, 253, 287` verbatim, with comments preserved so the rationale stays consistent across sides. If you change the scope of `schemaAcceptsObject()` on one side, please update both.
- I observed an unrelated `composer cs-check` failure on `main` against `tests/Integration/Pest/{MissingTraitTest,ExpectationsTest}.php` (`static fn () =>` vs `static fn() =>`). Reproduced on bare `main` via `git switch main && composer cs-check`, so it pre-dates this PR. Happy to file a separate PR for it if useful.
- No changes to `extractRequestBody()` in the Laravel adapter — the coercion belongs in the validator so every framework adapter benefits, not just Laravel.