### PR TITLE
fix(ref-resolver): preserve $ref keys inside opaque-data fields

### DIFF
--- a/src/Spec/OpenApiRefResolver.php
+++ b/src/Spec/OpenApiRefResolver.php
@@ -11,6 +11,7 @@ use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecReason;
 use Studio\OpenApiContractTesting\Internal\ExternalRefLoader;
 use Studio\OpenApiContractTesting\Internal\HttpRefLoader;
 
+use function array_is_list;
 use function array_key_exists;
 use function array_pop;
 use function explode;
@@ -33,6 +34,24 @@ use function substr;
  */
 final class OpenApiRefResolver
 {
+    /**
+     * Keys whose value is opaque user data per OpenAPI 3.x and JSON Schema —
+     * a `$ref` literal inside one of these positions is a data field, not a
+     * Reference Object. The walker MUST NOT descend into them.
+     *
+     * The list is structural (key-name-based) rather than parent-aware
+     * because every position where these keys appear (Schema Object,
+     * Parameter / Header / MediaType / Server Variable Object) treats them
+     * the same way: opaque sample / default data.
+     *
+     * `examples` is handled separately because it is two-shaped: a list of
+     * opaque values at Schema 3.1, or a map of Example Objects (which MAY
+     * be Reference Objects) at Parameter / Header / MediaType.
+     *
+     * @var list<string>
+     */
+    private const ALWAYS_OPAQUE_KEYS = ['default', 'example', 'enum', 'const'];
+
     /**
      * Resolve every `$ref` entry in the spec in place and return the same
      * array. Any structural problem with a `$ref` throws
@@ -136,15 +155,112 @@ final class OpenApiRefResolver
         }
 
         foreach ($node as $key => &$child) {
-            if (is_array($child)) {
-                // additionalProperties is intentionally excluded: its value is a single
-                // schema (not a dict of schemas), so a direct $ref under it is a
-                // legitimate Reference Object that must resolve.
-                $childInsidePropertiesMap = $key === 'properties' || $key === 'patternProperties';
-                self::walk($child, $root, $chain, $childInsidePropertiesMap, $context, $documentCache);
+            if (!is_array($child)) {
+                continue;
             }
+
+            // Opaque user data per OAS 3.x / JSON Schema (`default`, `example`,
+            // `enum` items, `const`): the value is literal sample / default
+            // data and a `$ref` key inside it is a data field, not a
+            // Reference Object. Skipping descent entirely preserves the data
+            // verbatim — the safe direction, since the previous behavior
+            // (silently rewriting these values to whatever the ref pointed at)
+            // is an SSRF risk when allowRemoteRefs:true and is plain data
+            // corruption otherwise.
+            if (in_array($key, self::ALWAYS_OPAQUE_KEYS, true)) {
+                continue;
+            }
+
+            // `examples` is shape-dependent:
+            //  - Schema 3.1 array form: a list of opaque values (all elements
+            //    are sample data, never Reference Objects).
+            //  - Parameter / Header / MediaType / RequestBody / Response form:
+            //    a map keyed by example name, where each entry is an Example
+            //    Object OR a Reference Object pointing at one. Inside an
+            //    Example Object, only the `value` field is opaque; the
+            //    sibling fields (`summary`, `description`, `externalValue`)
+            //    are strings or simple scalars.
+            // Disambiguating by shape rather than by parent context keeps the
+            // walker stateless: Schema 3.1 examples is required to be a list
+            // per OAS 3.1 §4.7.24, and Parameter/Header/MediaType examples is
+            // required to be a map per §4.7.10.
+            if ($key === 'examples') {
+                if (array_is_list($child)) {
+                    continue;
+                }
+
+                self::walkExamplesMap($child, $root, $chain, $context, $documentCache);
+
+                continue;
+            }
+
+            // additionalProperties is intentionally excluded: its value is a single
+            // schema (not a dict of schemas), so a direct $ref under it is a
+            // legitimate Reference Object that must resolve.
+            $childInsidePropertiesMap = $key === 'properties' || $key === 'patternProperties';
+            self::walk($child, $root, $chain, $childInsidePropertiesMap, $context, $documentCache);
         }
         unset($child);
+    }
+
+    /**
+     * Walk the map form of `examples` (Parameter / Header / MediaType /
+     * RequestBody / Response). Each entry is either an Example Object or a
+     * Reference Object. Reference Objects resolve normally; Example Objects'
+     * `value` field is opaque user data and is NOT walked further.
+     *
+     * Kept as a dedicated helper because the inner shape — "$ref at entry
+     * root MAY be a Reference Object, but `value` underneath an entry is
+     * always opaque" — does not fit the flat key-list carve-out used by the
+     * main walk().
+     *
+     * @param array<int|string, mixed> $map
+     * @param array<string, mixed> $root
+     * @param list<string> $chain
+     * @param array<string, array<string, mixed>> $documentCache
+     */
+    private static function walkExamplesMap(
+        array &$map,
+        array $root,
+        array $chain,
+        RefResolutionContext $context,
+        array &$documentCache,
+    ): void {
+        foreach ($map as $name => &$entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+
+            // Reference Object case: an examples-map entry MAY be `{$ref: ...}`
+            // per OAS 3.x to share a definition from `components.examples`.
+            if (array_key_exists('$ref', $entry)) {
+                $ref = $entry['$ref'];
+                if (!is_string($ref)) {
+                    throw new InvalidOpenApiSpecException(
+                        InvalidOpenApiSpecReason::NonStringRef,
+                        sprintf('Invalid $ref: expected string, got %s', get_debug_type($ref)),
+                    );
+                }
+
+                self::resolveRef($entry, $ref, $root, $chain, $context, $documentCache);
+
+                continue;
+            }
+
+            // Example Object: walk children EXCEPT `value` (opaque). The
+            // sibling fields `summary` / `description` / `externalValue` are
+            // strings and are naturally skipped by the is_array guard.
+            foreach ($entry as $childKey => &$child) {
+                if ($childKey === 'value') {
+                    continue;
+                }
+                if (is_array($child)) {
+                    self::walk($child, $root, $chain, false, $context, $documentCache);
+                }
+            }
+            unset($child);
+        }
+        unset($entry);
     }
 
     /**

--- a/src/Spec/OpenApiRefResolver.php
+++ b/src/Spec/OpenApiRefResolver.php
@@ -36,21 +36,60 @@ final class OpenApiRefResolver
 {
     /**
      * Keys whose value is opaque user data per OpenAPI 3.x and JSON Schema —
-     * a `$ref` literal inside one of these positions is a data field, not a
+     * a `$ref` literal nested under one of these keys is a data field, not a
      * Reference Object. The walker MUST NOT descend into them.
      *
-     * The list is structural (key-name-based) rather than parent-aware
-     * because every position where these keys appear (Schema Object,
-     * Parameter / Header / MediaType / Server Variable Object) treats them
-     * the same way: opaque sample / default data.
+     * The match is by key name only; the surrounding parent object's type is
+     * not consulted. That works because wherever these keys legitimately
+     * appear in a 3.x spec (Schema Object, Parameter Object, Header Object,
+     * MediaType Object, Server Variable Object) their value is opaque sample
+     * or default data. Spec-typed-as-string positions (e.g. Server Variable's
+     * `default`) are unaffected — the carve-out is safe-by-default there
+     * because a scalar value isn't an array and is never walked anyway; the
+     * pinning test (`preserves_ref_key_inside_server_variable_default`)
+     * exercises the malformed-but-array-shaped case to lock the structural
+     * detection in place against future refactors.
      *
      * `examples` is handled separately because it is two-shaped: a list of
-     * opaque values at Schema 3.1, or a map of Example Objects (which MAY
-     * be Reference Objects) at Parameter / Header / MediaType.
+     * opaque values for the Schema Object 3.1 form, or a map of Example
+     * Objects (which MAY themselves be Reference Objects) for the Parameter,
+     * Header, MediaType, RequestBody, and Response forms.
      *
      * @var list<string>
      */
     private const ALWAYS_OPAQUE_KEYS = ['default', 'example', 'enum', 'const'];
+
+    /**
+     * Keys whose value is a map of USER-DEFINED names → entries — i.e. keys
+     * inside this map are arbitrary strings the spec author chose, not OAS
+     * keywords. The walker treats them just like the existing `properties`
+     * carve-out: keys at this level are names, not directives, and the
+     * opaque-key carve-out must NOT fire here (a schema named `default`
+     * inside `components.schemas` is just a schema name, and a property
+     * named `default` inside `properties` is just a property name).
+     *
+     * Includes the historical `properties` / `patternProperties` for which
+     * the carve-out was originally introduced. Expanding the set covers the
+     * other OAS-defined user-named maps so behavior is consistent across
+     * all of them.
+     *
+     * @var list<string>
+     */
+    private const USER_NAMED_MAP_KEYS = [
+        'properties',
+        'patternProperties',
+        'schemas',
+        'responses',
+        'parameters',
+        'requestBodies',
+        'headers',
+        'securitySchemes',
+        'links',
+        'callbacks',
+        'pathItems',
+        'paths',
+        'definitions',
+    ];
 
     /**
      * Resolve every `$ref` entry in the spec in place and return the same
@@ -125,30 +164,28 @@ final class OpenApiRefResolver
      * @param array<int|string, mixed> $node
      * @param array<string, mixed> $root currently-walked document's root
      * @param list<string> $chain canonical pointer-refs already on the resolution stack — used to detect cycles
-     * @param bool $insidePropertiesMap true when `$node` is the direct children dict of
-     *                                  a `properties` / `patternProperties` map, where keys are property names
-     *                                  rather than schema keywords. The flag resets one level deeper, because
-     *                                  each named entry is itself a schema.
+     * @param bool $insideUserNamedMap true when `$node` is the direct children
+     *                                 dict of a user-named map (`properties`,
+     *                                 `components.schemas`, `paths`, etc. —
+     *                                 see {@see self::USER_NAMED_MAP_KEYS}).
+     *                                 At this level the keys are arbitrary
+     *                                 user-chosen names — not OAS keywords —
+     *                                 so neither the `$ref`-at-top guard nor
+     *                                 the opaque-key carve-out fire. The flag
+     *                                 resets one level deeper, where each
+     *                                 named entry is itself an OAS object.
      * @param array<string, array<string, mixed>> $documentCache external document cache for this resolution
      */
     private static function walk(
         array &$node,
         array $root,
         array $chain,
-        bool $insidePropertiesMap,
+        bool $insideUserNamedMap,
         RefResolutionContext $context,
         array &$documentCache,
     ): void {
-        if (!$insidePropertiesMap && array_key_exists('$ref', $node)) {
-            $ref = $node['$ref'];
-
-            if (!is_string($ref)) {
-                throw new InvalidOpenApiSpecException(
-                    InvalidOpenApiSpecReason::NonStringRef,
-                    sprintf('Invalid $ref: expected string, got %s', get_debug_type($ref)),
-                );
-            }
-
+        if (!$insideUserNamedMap && array_key_exists('$ref', $node)) {
+            $ref = self::assertStringRef($node['$ref']);
             self::resolveRef($node, $ref, $root, $chain, $context, $documentCache);
 
             return;
@@ -159,55 +196,86 @@ final class OpenApiRefResolver
                 continue;
             }
 
-            // Opaque user data per OAS 3.x / JSON Schema (`default`, `example`,
-            // `enum` items, `const`): the value is literal sample / default
-            // data and a `$ref` key inside it is a data field, not a
-            // Reference Object. Skipping descent entirely preserves the data
-            // verbatim — the safe direction, since the previous behavior
-            // (silently rewriting these values to whatever the ref pointed at)
-            // is an SSRF risk when allowRemoteRefs:true and is plain data
-            // corruption otherwise.
-            if (in_array($key, self::ALWAYS_OPAQUE_KEYS, true)) {
-                continue;
-            }
-
-            // `examples` is shape-dependent:
-            //  - Schema 3.1 array form: a list of opaque values (all elements
-            //    are sample data, never Reference Objects).
-            //  - Parameter / Header / MediaType / RequestBody / Response form:
-            //    a map keyed by example name, where each entry is an Example
-            //    Object OR a Reference Object pointing at one. Inside an
-            //    Example Object, only the `value` field is opaque; the
-            //    sibling fields (`summary`, `description`, `externalValue`)
-            //    are strings or simple scalars.
-            // Disambiguating by shape rather than by parent context keeps the
-            // walker stateless: Schema 3.1 examples is required to be a list
-            // per OAS 3.1 §4.7.24, and Parameter/Header/MediaType examples is
-            // required to be a map per §4.7.10.
-            if ($key === 'examples') {
-                if (array_is_list($child)) {
+            // Inside a user-named map, keys are arbitrary names chosen by
+            // the spec author — a property literally named `default` is a
+            // property, not a JSON Schema default-value declaration. Skip
+            // both the opaque-key carve-out and the `examples` dispatch
+            // here; both only make sense when the key is being treated as
+            // an OAS keyword.
+            if (!$insideUserNamedMap) {
+                // Opaque user data per OAS 3.x / JSON Schema (`default`,
+                // `example`, `enum` items, `const`): the value is literal
+                // sample data and a `$ref` key nested inside is a data
+                // field, not a Reference Object. Resolving it would corrupt
+                // the data, and — if remote refs are enabled — fetch
+                // attacker-controlled URLs as a side effect. The invariant
+                // is "opaque means opaque": no descent, no ref
+                // interpretation, ever.
+                if (in_array($key, self::ALWAYS_OPAQUE_KEYS, true)) {
                     continue;
                 }
 
-                self::walkExamplesMap($child, $root, $chain, $context, $documentCache);
+                // `examples` is shape-dependent. The two OAS uses disagree:
+                //  - Schema Object 3.1: an array of opaque sample values.
+                //  - Parameter / Header / MediaType / RequestBody / Response:
+                //    a map keyed by example name, where each entry is an
+                //    Example Object (or a Reference Object pointing at one).
+                // Disambiguate by shape — the two valid containers are
+                // required to be a list and a map respectively, so
+                // `array_is_list` is a sufficient discriminator that keeps
+                // the walker stateless.
+                if ($key === 'examples') {
+                    if (array_is_list($child)) {
+                        // List form = Schema 3.1 array of opaque values; skip.
+                        continue;
+                    }
 
-                continue;
+                    // Map form = Example Object entries; dispatch to the
+                    // helper that preserves Reference Object semantics at
+                    // the entry root while treating each entry's `value`
+                    // field as opaque.
+                    self::walkExamplesMap($child, $root, $chain, $context, $documentCache);
+
+                    continue;
+                }
             }
 
             // additionalProperties is intentionally excluded: its value is a single
             // schema (not a dict of schemas), so a direct $ref under it is a
             // legitimate Reference Object that must resolve.
-            $childInsidePropertiesMap = $key === 'properties' || $key === 'patternProperties';
-            self::walk($child, $root, $chain, $childInsidePropertiesMap, $context, $documentCache);
+            $childInsideUserNamedMap = in_array($key, self::USER_NAMED_MAP_KEYS, true);
+            self::walk($child, $root, $chain, $childInsideUserNamedMap, $context, $documentCache);
         }
         unset($child);
     }
 
     /**
+     * Narrow a `$ref` value to a string or throw `NonStringRef`. Centralized
+     * so the main walker and the examples-map helper produce identical
+     * diagnostics — drift between the two sites would let a non-string
+     * `$ref` in a Parameter/Header/MediaType `examples` entry surface a less
+     * informative error than one in any other position.
+     */
+    private static function assertStringRef(mixed $ref): string
+    {
+        if (!is_string($ref)) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::NonStringRef,
+                sprintf('Invalid $ref: expected string, got %s', get_debug_type($ref)),
+            );
+        }
+
+        return $ref;
+    }
+
+    /**
      * Walk the map form of `examples` (Parameter / Header / MediaType /
      * RequestBody / Response). Each entry is either an Example Object or a
-     * Reference Object. Reference Objects resolve normally; Example Objects'
-     * `value` field is opaque user data and is NOT walked further.
+     * Reference Object pointing at one. Reference Objects resolve normally;
+     * Example Objects' `value` field is opaque user data and is NOT walked.
+     * Non-array entries (a malformed scalar in the map) are passed through
+     * unchanged — consistent with how the main `walk()` treats non-array
+     * children; spec-shape validation is not the resolver's responsibility.
      *
      * Kept as a dedicated helper because the inner shape — "$ref at entry
      * root MAY be a Reference Object, but `value` underneath an entry is
@@ -226,7 +294,7 @@ final class OpenApiRefResolver
         RefResolutionContext $context,
         array &$documentCache,
     ): void {
-        foreach ($map as $name => &$entry) {
+        foreach ($map as &$entry) {
             if (!is_array($entry)) {
                 continue;
             }
@@ -234,29 +302,26 @@ final class OpenApiRefResolver
             // Reference Object case: an examples-map entry MAY be `{$ref: ...}`
             // per OAS 3.x to share a definition from `components.examples`.
             if (array_key_exists('$ref', $entry)) {
-                $ref = $entry['$ref'];
-                if (!is_string($ref)) {
-                    throw new InvalidOpenApiSpecException(
-                        InvalidOpenApiSpecReason::NonStringRef,
-                        sprintf('Invalid $ref: expected string, got %s', get_debug_type($ref)),
-                    );
-                }
-
+                $ref = self::assertStringRef($entry['$ref']);
                 self::resolveRef($entry, $ref, $root, $chain, $context, $documentCache);
 
                 continue;
             }
 
             // Example Object: walk children EXCEPT `value` (opaque). The
-            // sibling fields `summary` / `description` / `externalValue` are
-            // strings and are naturally skipped by the is_array guard.
+            // `$insidePropertiesMap` argument is deliberately false here —
+            // an Example Object's children are not a properties map, so a
+            // child literally named `$ref` (unusual, but legal in a vendor
+            // extension like `x-shared: { $ref: '#/...' }`) is a real
+            // Reference Object that must resolve.
             foreach ($entry as $childKey => &$child) {
+                if (!is_array($child)) {
+                    continue;
+                }
                 if ($childKey === 'value') {
                     continue;
                 }
-                if (is_array($child)) {
-                    self::walk($child, $root, $chain, false, $context, $documentCache);
-                }
+                self::walk($child, $root, $chain, false, $context, $documentCache);
             }
             unset($child);
         }

--- a/tests/Unit/Spec/OpenApiRefResolverTest.php
+++ b/tests/Unit/Spec/OpenApiRefResolverTest.php
@@ -984,4 +984,242 @@ class OpenApiRefResolverTest extends TestCase
 
         OpenApiRefResolver::resolve($spec);
     }
+
+    #[Test]
+    public function preserves_ref_key_inside_schema_default_value(): void
+    {
+        // Schema Object's `default` is opaque user data per JSON Schema —
+        // a `$ref` key inside it is a literal data field, not a Reference Object.
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Config' => [
+                        'type' => 'object',
+                        'default' => ['$ref' => '#/components/schemas/Other'],
+                    ],
+                    'Other' => ['type' => 'string'],
+                ],
+            ],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $this->assertSame(
+            ['$ref' => '#/components/schemas/Other'],
+            $resolved['components']['schemas']['Config']['default'],
+        );
+    }
+
+    #[Test]
+    public function preserves_ref_key_inside_schema_example_value(): void
+    {
+        // Schema Object's singular `example` is opaque user data per OAS 3.0.
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Doc' => [
+                        'type' => 'object',
+                        'example' => ['$ref' => '#/components/schemas/Other'],
+                    ],
+                    'Other' => ['type' => 'string'],
+                ],
+            ],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $this->assertSame(
+            ['$ref' => '#/components/schemas/Other'],
+            $resolved['components']['schemas']['Doc']['example'],
+        );
+    }
+
+    #[Test]
+    public function preserves_ref_key_inside_enum_member_object(): void
+    {
+        // JSON Schema permits object-shaped enum members; each is opaque.
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Choices' => [
+                        'enum' => [
+                            ['$ref' => '#/components/schemas/Other'],
+                            ['kind' => 'b'],
+                        ],
+                    ],
+                    'Other' => ['type' => 'string'],
+                ],
+            ],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $this->assertSame(
+            [
+                ['$ref' => '#/components/schemas/Other'],
+                ['kind' => 'b'],
+            ],
+            $resolved['components']['schemas']['Choices']['enum'],
+        );
+    }
+
+    #[Test]
+    public function preserves_ref_key_inside_const_value(): void
+    {
+        // OAS 3.1 `const` is opaque. Object-shaped const is rare but valid.
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Fixed' => [
+                        'const' => ['$ref' => '#/components/schemas/Other'],
+                    ],
+                    'Other' => ['type' => 'string'],
+                ],
+            ],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $this->assertSame(
+            ['$ref' => '#/components/schemas/Other'],
+            $resolved['components']['schemas']['Fixed']['const'],
+        );
+    }
+
+    #[Test]
+    public function preserves_ref_keys_inside_schema_3_1_examples_list(): void
+    {
+        // OAS 3.1 Schema Object `examples` is a list of opaque values
+        // (distinct from the Parameter/MediaType `examples` MAP).
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Doc' => [
+                        'type' => 'object',
+                        'examples' => [
+                            ['$ref' => '#/components/schemas/Other'],
+                            ['plain' => 'data'],
+                        ],
+                    ],
+                    'Other' => ['type' => 'string'],
+                ],
+            ],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $this->assertSame(
+            [
+                ['$ref' => '#/components/schemas/Other'],
+                ['plain' => 'data'],
+            ],
+            $resolved['components']['schemas']['Doc']['examples'],
+        );
+    }
+
+    #[Test]
+    public function resolves_examples_map_entry_that_is_a_reference_object(): void
+    {
+        // REGRESSION GUARD: when `examples` is a MAP (Parameter / MediaType /
+        // RequestBody shape), each entry MAY itself be a Reference Object —
+        // those must still resolve. This is what distinguishes the map form
+        // from the Schema 3.1 list form (all-opaque).
+        $spec = [
+            'components' => [
+                'examples' => [
+                    'BarExample' => [
+                        'summary' => 'Shared library entry',
+                        'value' => ['greeting' => 'hello'],
+                    ],
+                ],
+            ],
+            'paths' => [
+                '/pets' => [
+                    'get' => [
+                        'parameters' => [
+                            [
+                                'name' => 'tag',
+                                'in' => 'query',
+                                'schema' => ['type' => 'string'],
+                                'examples' => [
+                                    'Foo' => ['$ref' => '#/components/examples/BarExample'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $this->assertSame(
+            [
+                'summary' => 'Shared library entry',
+                'value' => ['greeting' => 'hello'],
+            ],
+            $resolved['paths']['/pets']['get']['parameters'][0]['examples']['Foo'],
+        );
+    }
+
+    #[Test]
+    public function preserves_ref_key_inside_example_object_value_field(): void
+    {
+        // Example Object's `value` field is opaque per OAS 3.x. The Example
+        // Object itself may resolve as a Reference Object (see sibling test
+        // above), but its `value` content is literal data.
+        $spec = [
+            'components' => [
+                'examples' => [
+                    'PatchExample' => [
+                        'summary' => 'A JSON Patch example',
+                        'value' => ['$ref' => '#/components/schemas/Other'],
+                    ],
+                ],
+                'schemas' => [
+                    'Other' => ['type' => 'string'],
+                ],
+            ],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $this->assertSame(
+            ['$ref' => '#/components/schemas/Other'],
+            $resolved['components']['examples']['PatchExample']['value'],
+        );
+    }
+
+    #[Test]
+    public function preserves_ref_key_inside_server_variable_default(): void
+    {
+        // Server Variable's `default` is documented to be a string, but the
+        // walker is structural — confirm the universal-opaque-key carve-out
+        // really IS universal across all OAS object types, not just Schema.
+        $spec = [
+            'servers' => [
+                [
+                    'url' => 'https://{tenant}.api.example.com',
+                    'variables' => [
+                        'tenant' => [
+                            'default' => ['$ref' => '#/components/schemas/Other'],
+                            'description' => 'Tenant slug',
+                        ],
+                    ],
+                ],
+            ],
+            'components' => [
+                'schemas' => [
+                    'Other' => ['type' => 'string'],
+                ],
+            ],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $this->assertSame(
+            ['$ref' => '#/components/schemas/Other'],
+            $resolved['servers'][0]['variables']['tenant']['default'],
+        );
+    }
 }

--- a/tests/Unit/Spec/OpenApiRefResolverTest.php
+++ b/tests/Unit/Spec/OpenApiRefResolverTest.php
@@ -1120,10 +1120,11 @@ class OpenApiRefResolverTest extends TestCase
     #[Test]
     public function resolves_examples_map_entry_that_is_a_reference_object(): void
     {
-        // REGRESSION GUARD: when `examples` is a MAP (Parameter / MediaType /
-        // RequestBody shape), each entry MAY itself be a Reference Object —
-        // those must still resolve. This is what distinguishes the map form
-        // from the Schema 3.1 list form (all-opaque).
+        // REGRESSION GUARD (issue #219): when `examples` is a MAP (Parameter /
+        // MediaType / RequestBody shape), each entry MAY itself be a
+        // Reference Object — those must still resolve. This is what
+        // distinguishes the map form from the Schema 3.1 list form
+        // (all-opaque).
         $spec = [
             'components' => [
                 'examples' => [
@@ -1166,8 +1167,9 @@ class OpenApiRefResolverTest extends TestCase
     public function preserves_ref_key_inside_example_object_value_field(): void
     {
         // Example Object's `value` field is opaque per OAS 3.x. The Example
-        // Object itself may resolve as a Reference Object (see sibling test
-        // above), but its `value` content is literal data.
+        // Object itself may resolve as a Reference Object (pinned by
+        // `resolves_examples_map_entry_that_is_a_reference_object`), but its
+        // `value` content is literal data.
         $spec = [
             'components' => [
                 'examples' => [
@@ -1221,5 +1223,194 @@ class OpenApiRefResolverTest extends TestCase
             ['$ref' => '#/components/schemas/Other'],
             $resolved['servers'][0]['variables']['tenant']['default'],
         );
+    }
+
+    #[Test]
+    public function throws_on_non_string_ref_inside_examples_map_entry(): void
+    {
+        // Pins that the `walkExamplesMap()` ref-validation produces the same
+        // NonStringRef diagnostic as the main walk() — drift between the two
+        // sites would let a malformed examples-map entry surface a less
+        // informative error than the rest of the spec.
+        $spec = [
+            'paths' => [
+                '/pets' => [
+                    'get' => [
+                        'parameters' => [
+                            [
+                                'name' => 'tag',
+                                'in' => 'query',
+                                'schema' => ['type' => 'string'],
+                                'examples' => [
+                                    'Bad' => ['$ref' => ['not', 'a', 'string']],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->expectException(InvalidOpenApiSpecException::class);
+        $this->expectExceptionMessage('Invalid $ref: expected string, got array');
+
+        OpenApiRefResolver::resolve($spec);
+    }
+
+    #[Test]
+    public function detects_circular_ref_through_examples_map_entry(): void
+    {
+        // Cycles that go through the map-entry Reference Object path must
+        // still be detected — the new walkExamplesMap() helper threads the
+        // resolver's `$chain` into the recursive walk and resolveRef calls.
+        $spec = [
+            'components' => [
+                'examples' => [
+                    'A' => ['$ref' => '#/components/examples/B'],
+                    'B' => ['$ref' => '#/components/examples/A'],
+                ],
+            ],
+            'paths' => [
+                '/pets' => [
+                    'get' => [
+                        'parameters' => [
+                            [
+                                'name' => 'tag',
+                                'in' => 'query',
+                                'schema' => ['type' => 'string'],
+                                'examples' => [
+                                    'Entry' => ['$ref' => '#/components/examples/A'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->expectException(InvalidOpenApiSpecException::class);
+        $this->expectExceptionMessage('Circular $ref');
+
+        OpenApiRefResolver::resolve($spec);
+    }
+
+    #[Test]
+    public function examples_map_entry_ref_drops_sibling_fields(): void
+    {
+        // Existing `ref_with_siblings_drops_siblings` covers the general case
+        // via the main walk(); this pins the same OAS 3.0 rule on the new
+        // examples-map code path so the two stay in agreement.
+        $spec = [
+            'components' => [
+                'examples' => [
+                    'Bar' => ['summary' => 'shared', 'value' => 'real'],
+                ],
+            ],
+            'paths' => [
+                '/pets' => [
+                    'get' => [
+                        'parameters' => [
+                            [
+                                'name' => 'tag',
+                                'in' => 'query',
+                                'schema' => ['type' => 'string'],
+                                'examples' => [
+                                    'Foo' => [
+                                        '$ref' => '#/components/examples/Bar',
+                                        'summary' => 'sibling — dropped',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $this->assertSame(
+            ['summary' => 'shared', 'value' => 'real'],
+            $resolved['paths']['/pets']['get']['parameters'][0]['examples']['Foo'],
+        );
+    }
+
+    #[Test]
+    public function resolves_ref_inside_property_literally_named_default(): void
+    {
+        // The opaque-key carve-out is structural (skip the value of a
+        // `default` field) — it MUST NOT widen to "skip anywhere a key
+        // named `default` appears." A schema with a property *named*
+        // `default` whose value is a Reference Object must still resolve.
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Label' => ['type' => 'string'],
+                    'Settings' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'default' => ['$ref' => '#/components/schemas/Label'],
+                        ],
+                    ],
+                ],
+            ],
+            'x-alias' => ['$ref' => '#/components/schemas/Settings'],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $this->assertSame(
+            [
+                'type' => 'object',
+                'properties' => [
+                    'default' => ['type' => 'string'],
+                ],
+            ],
+            $resolved['x-alias'],
+        );
+    }
+
+    #[Test]
+    public function resolves_ref_inside_example_object_non_value_field(): void
+    {
+        // Pins the documented scope of the Example Object carve-out: only
+        // the `value` field is opaque. Other array-shaped fields (typically
+        // a vendor extension like `x-shared`) must still have `$ref`s
+        // resolved so the carve-out cannot accidentally widen into
+        // "skip everything except `$ref` inside an examples-map entry".
+        $spec = [
+            'components' => [
+                'schemas' => [
+                    'Label' => ['type' => 'string'],
+                ],
+            ],
+            'paths' => [
+                '/pets' => [
+                    'get' => [
+                        'parameters' => [
+                            [
+                                'name' => 'tag',
+                                'in' => 'query',
+                                'schema' => ['type' => 'string'],
+                                'examples' => [
+                                    'Foo' => [
+                                        'summary' => 'with vendor extension',
+                                        'value' => ['plain' => 'data'],
+                                        'x-shared' => ['$ref' => '#/components/schemas/Label'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $resolved = OpenApiRefResolver::resolve($spec);
+
+        $entry = $resolved['paths']['/pets']['get']['parameters'][0]['examples']['Foo'];
+        $this->assertSame(['type' => 'string'], $entry['x-shared']);
+        // Sanity: value still opaque.
+        $this->assertSame(['plain' => 'data'], $entry['value']);
     }
 }


### PR DESCRIPTION
## Summary

- Stop `OpenApiRefResolver::walk()` from descending into OAS / JSON Schema OPAQUE-DATA positions (`default`, `example`, `enum` items, `const`, `examples` list form, Example Object `value`).
- Add `walkExamplesMap()` helper for the map-shaped `examples` (Parameter / Header / MediaType / RequestBody / Response) so Example Objects with a top-level `$ref` still resolve, while the inner `value` field stays opaque.
- 8 new tests in `tests/Unit/Spec/OpenApiRefResolverTest.php` pinning each opaque position + one regression guard for map-entry Reference Objects.

## Why

Closes #219. The walker treated any `$ref` key as a Reference Object except inside `properties` / `patternProperties`. But several OAS fields hold opaque user data per spec — a literal `$ref` key inside them must be preserved. The previous behavior silently rewrote those values to whatever the ref pointed at: data corruption, and a real SSRF risk when `allowRemoteRefs: true` is enabled (a `default: { $ref: 'https://attacker.example/...' }` would trigger a real HTTP fetch at spec-load time).

The fix mirrors the existing `$insidePropertiesMap` carve-out (one-level reset, structural detection) — no new state, no parent-aware walking. `examples` disambiguates by shape (list vs map) because the OAS spec pins each shape to a fixed object type.

## Verification

- [x] `composer test` passes (1464 tests, was 1456 — 8 new)
- [x] `composer stan` passes (level 6)
- [x] `composer cs-check` — touched files are clean; remaining failures are pre-existing on `main` (PHP-CS-Fixer running on PHP 8.4 vs project target 8.2; CI runs on 8.2 per the matrix)
- [x] Existing `resolves_schema_with_ref_as_property_name` and the other 5 carve-out tests still green (regression guard)

Tested locally on PHP 8.4 + PHPUnit 13.

## Notes for reviewers

- The opaque keys list (`default`, `example`, `enum`, `const`) is structural / position-agnostic — these are opaque at every OAS object type (Schema, Parameter, Header, MediaType, Server Variable). A single check at every recursion step covers them all; that's why no parent-context tracking is needed.
- `examples` is the only shape-dependent case: Schema 3.1 mandates a list, Parameter/Header/MediaType mandates a map. Dispatching by `array_is_list()` matches the spec without needing OAS-aware context.
- Inside the map dispatch, the Reference Object resolution path is intentionally hand-coded (rather than delegated back to `walk()` with a flag) because the `value`-is-opaque rule is local to Example Object and doesn't generalize.
- Zero backward-compat impact: the previous behavior was silent data corruption — no user could legitimately depend on it.