### PR TITLE
docs(coverage): document partial-run skip behavior (#221)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ To validate every response automatically, set `'auto_assert' => true` and drop t
 | HTML coverage output | [`docs/coverage-html-output.md`](docs/coverage-html-output.md) |
 | JSON coverage output schema | [`docs/coverage-json-schema.md`](docs/coverage-json-schema.md) |
 | Parallel test runners (paratest / Pest `--parallel`) | [`docs/parallel.md`](docs/parallel.md) |
-| CI integration (GitHub Actions, PR comments, output formats) | [`docs/ci.md`](docs/ci.md) |
+| CI integration (GitHub Actions, PR comments, output formats, partial-run handling) | [`docs/ci.md`](docs/ci.md) |
 | API reference (`OpenApiResponseValidator`, `OpenApiSpecLoader`, `OpenApiCoverageTracker`) | [`docs/api-reference.md`](docs/api-reference.md) |
 | Supported features, known limitations, warning channel | [`docs/supported-features.md`](docs/supported-features.md) |
 | Versioning policy & support matrix | [`docs/versioning.md`](docs/versioning.md) |

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -92,3 +92,42 @@ vendor/bin/openapi-coverage-merge \
 > the file as Markdown, so an HTML/JUnit/JSON payload would be escaped. Use
 > the per-format flags above for artifact uploads and `output_file` /
 > `github_step_summary` for the in-PR summary.
+
+## Partial test runs (`--filter`, `--testsuite`, path args, …)
+
+If you commit your coverage doc to the repo (e.g. `docs/openapi-coverage.md`
+under `output_file`), running a subset of the suite locally is no longer a
+hazard: when the extension detects a partial run, **every persistent
+coverage artifact write is skipped** and a single stderr `WARNING` lists
+which targets were skipped.
+
+A run is treated as partial when any of these PHPUnit selection signals
+are active (mirrors PHPUnit's own filter set plus the `TestSuiteBuilder`-
+stage selections that bypass the `TestSuite\Filtered` event):
+
+- positional path arguments (`phpunit tests/Feature/Foo/`)
+- `--filter` / `--exclude-filter`
+- `--group` / `--exclude-group`
+- `--testsuite` / `--exclude-testsuite`
+- `--covers` / `--uses`
+- `--requires-php-extension`
+
+Skipped artifacts: `output_file`, `junit_output`, `json_output`,
+`html_output`, and `GITHUB_STEP_SUMMARY`. Console rendering still prints
+(it's transient, scoped to your terminal), and the optional coverage
+threshold gate (`min_endpoint_coverage` / `min_response_coverage`) still
+evaluates against the in-memory subset — re-run the full suite to refresh
+the persistent doc.
+
+```text
+$ vendor/bin/phpunit --filter UserTest
+# … console summary prints as usual …
+[OpenAPI Coverage] WARNING: Skipping output_file, junit_output write
+because PHPUnit is running a partial subset (--filter). Coverage reports
+are not written on partial runs to avoid overwriting persistent docs with
+subset data. Re-run the full suite to refresh.
+```
+
+Paratest workers (`TEST_TOKEN` set) are unaffected — they always write
+their sidecar so the merge CLI can aggregate. The persistent-write skip
+only fires on the sequential (or merge) rendering path.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -51,7 +51,7 @@ Add the coverage extension to your `phpunit.xml`:
 | `spec_base_path` | Yes* | — | Path to bundled spec directory (relative paths resolve from `getcwd()`) |
 | `strip_prefixes` | No | `[]` | Comma-separated prefixes to strip from request paths (e.g., `/api`) |
 | `specs` | No | `front` | Comma-separated spec names for coverage tracking |
-| `output_file` | No | — | File path to write Markdown coverage report (relative paths resolve from `getcwd()`) |
+| `output_file` | No | — | File path to write Markdown coverage report (relative paths resolve from `getcwd()`). Skipped on partial runs — see [Partial test runs](ci.md#partial-test-runs-filter-testsuite-path-args-) |
 | `junit_output` | No | — | File path to write JUnit XML coverage report (for CI dashboards — GitLab CI, Jenkins, SonarQube, Bitrise). Empty value or unwritable parent directory is FATAL at bootstrap. See [Coverage output formats](ci.md#coverage-output-formats) |
 | `json_output` | No | — | File path to write machine-readable JSON coverage report (custom dashboards, analytics, scripted gating). Schema: [`coverage-json-schema.md`](coverage-json-schema.md) |
 | `html_output` | No | — | File path to write self-contained HTML coverage report (PR comments, CI artifact preview, offline review). See [`coverage-html-output.md`](coverage-html-output.md) |


### PR DESCRIPTION
## Summary

Documents the partial-run skip behavior introduced in #222. Adds a "Partial test runs" section to `docs/ci.md` covering detection signals, the list of skipped artifacts, the paratest worker exemption, and a sample stderr message. Cross-references the section from `docs/setup.md`'s `output_file` row and from the README's documentation index.

## Why

Tracks #221. Companion to #222 (code change). Splitting the docs into a separate PR keeps each review surface focused: #222 is reviewed for behavior, this PR is reviewed for prose accuracy.

## Verification

- [x] Wording verified against the actual behavior pinned by `CoverageReportSubscriberPartialRunTest`
- [x] Section anchor IDs work (`ci.md#partial-test-runs-filter-testsuite-path-args-` is the GitHub-rendered slug)
- [x] No code changes — composer test/stan/cs-check unaffected

## Notes for reviewers

- **Depends on #222** — merge that one first so the documented behavior actually exists on `main`. If #222 is amended, this PR's wording may need a follow-up tweak.
- This PR was originally accidentally pushed directly to `main` as commit `9d0ad35`; that was immediately reverted in `4833122` and the change rebased onto a proper feature branch. Apologies for the noise.