### PR TITLE
feat(strict-required): aggregate paratest worker observations via sidecar envelope v2

### DIFF
--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -49,6 +49,7 @@ vendor/bin/openapi-coverage-merge \
 | `--min-endpoint-coverage=<pct>` | — | Threshold gate (see [Coverage threshold gate](coverage.md#coverage-threshold-gate)) |
 | `--min-response-coverage=<pct>` | — | Threshold gate at `(method, path, status, content-type)` granularity |
 | `--min-coverage-strict` | `false` (warn-only) | Treat threshold misses as exit non-zero |
+| `--strict-required=<mode>` | `off` | `off` / `warn` / `fail`. Assert no schema under-description drift across worker observations. See [`strict-required.md`](strict-required.md#paratest) |
 | `--no-cleanup` | (cleanup is on by default) | Keep sidecar files after merge |
 
 Sidecar dir defaults are deliberately stable — workers and the merge CLI
@@ -67,6 +68,11 @@ path if `sys_get_temp_dir()` is unavailable in your runner.
   same `OpenApiCoverageTracker` static, so each Pest worker drops a
   sidecar exactly like a paratest worker would. No additional wiring
   needed beyond the merge step shown above.
+- **`strict_required` aggregates across workers.** Workers always export
+  observations via the sidecar envelope (v2). The merge CLI's
+  `--strict-required` flag decides whether to assert the gate; the
+  `strict_required` parameter on the PHPUnit extension does not propagate
+  to the merge step. See [`strict-required.md`](strict-required.md#paratest).
 - **Worker counts are not exposed by paratest.** A child cannot reliably
   tell how many siblings it has, so the merge has to run as a separate
   step rather than auto-firing from "the last worker." This matches how

--- a/docs/strict-required.md
+++ b/docs/strict-required.md
@@ -16,7 +16,7 @@ The most common gap that slips past conformance checks is *under-description*: t
 
 1. On every Success result, `OpenApiResponseValidator` records the **top-level keys** of the decoded response body, keyed by `(spec, METHOD path, status, content-type)`.
 2. Across the run, the tracker keeps the **intersection** of every observed key set — the keys that appeared in *every* recorded response for that group. `hits` counts the observations that contributed.
-3. At PHPUnit's `ExecutionFinished` event (or the merge step for paratest — currently unsupported, see Known limitations), the asserter loads each spec and, for each group, computes `intersection - schema.required`. Any keys that survive are flagged: the impl always returns them but the spec does not declare them required.
+3. At PHPUnit's `ExecutionFinished` event (or the merge step for paratest — see "Paratest" below), the asserter loads each spec and, for each group, computes `intersection - schema.required`. Any keys that survive are flagged: the impl always returns them but the spec does not declare them required.
 4. The result is emitted to STDERR and GitHub Step Summary (`$GITHUB_STEP_SUMMARY`) following the same format as the existing enum-drift block, and — in `fail` mode — terminates the run with `exit(1)`.
 
 Only **conformance-passing** responses are recorded. A response that fails the existing JSON Schema check is excluded (its body shape is suspect); skipped statuses (e.g. matching `skipResponseCode`) are excluded too.
@@ -95,9 +95,25 @@ After re-running the suite the diagnostic disappears and downstream SDK consumer
 - It does **not** flag fields the impl returns that are not declared in `properties`. Use `additionalProperties: false` for that — also already supported by the existing validator.
 - It does **not** read the spec for endpoints your tests never touched. Strict required is a runtime-observation gate; coverage-tracking gaps are reported separately by `OpenApiCoverageExtension`'s coverage report.
 
+## Paratest
+
+Paratest / Pest `--parallel` is supported. Each worker exports its observations via the coverage sidecar envelope (v2). Pass `--strict-required=<mode>` to the merge CLI to evaluate the gate after the workers complete:
+
+```bash
+vendor/bin/openapi-coverage-merge \
+  --spec-base-path=tests/fixtures/specs \
+  --specs=front \
+  --sidecar-dir=$RUNNER_TEMP/openapi-sidecars \
+  --strict-required=fail
+```
+
+`--strict-required` accepts `off` (default), `warn` (emit diagnostic, exit 0), and `fail` (emit diagnostic, exit 1). The `strict_required` parameter on the PHPUnit extension does **not** propagate to the merge CLI — workers always export observations, and the merge step decides whether to assert. This keeps mode flips a single-knob CI operation without per-worker reruns.
+
+The diagnostic block is rendered after the coverage report (Markdown, JUnit, JSON, HTML, GITHUB_STEP_SUMMARY) so a fatal drift does not suppress the coverage output that helps triage the failure.
+
 ## Known limitations
 
-- **Paratest is currently sequential-only.** Each worker maintains its own in-memory observations, but the sidecar protocol used by the merge CLI carries only coverage state. When `strict_required` is enabled in worker mode the subscriber emits a one-line `NOTE` and skips the asserter; run the suite sequentially to evaluate the gate, or follow the parallel-runner support follow-up issue.
+- **Mixed sidecar versions.** Workers running an older library version write a v1 (coverage-only) sidecar. The merge CLI still accepts those and merges their coverage, but their strict_required contribution is empty. Upgrade all workers to share the gate fully.
 - **Top-level keys only.** Nested object schemas' `required` arrays are not yet evaluated — only the outermost. A follow-up issue covers nested-object support.
 - **`allOf` is unioned; `anyOf` / `oneOf` are not walked.** `allOf` semantics are AND, so the union of `required` arrays across branches is sound. `anyOf` / `oneOf` are disjunctions and there is no safe AND-semantic for "required" across them; the asserter ignores those branches when collecting `required`. **Consequence:** for a schema whose top-level shape is purely `anyOf` / `oneOf`, the collected `required` is `[]` and *every* always-present key will be reported as drift. Prefer `allOf` for required-set composition, or open a follow-up issue with your use case.
 - **Per-call mode is not implemented.** The Issue #224 design noted an alternative "warn on every optional field present in a single observation" mode — the run-level intersection is the MVP because per-call warns indiscriminately on every legitimately-optional field. If you need it, follow up.

--- a/src/Coverage/CoverageMergeCommand.php
+++ b/src/Coverage/CoverageMergeCommand.php
@@ -14,6 +14,9 @@ use Studio\OpenApiContractTesting\PHPUnit\ConsoleOutput;
 use Studio\OpenApiContractTesting\PHPUnit\CoverageReportSubscriber;
 use Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredAsserter;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredMode;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredTracker;
 use Throwable;
 
 use function array_filter;
@@ -24,6 +27,7 @@ use function explode;
 use function file_put_contents;
 use function getcwd;
 use function getenv;
+use function implode;
 use function in_array;
 use function is_callable;
 use function is_numeric;
@@ -63,6 +67,7 @@ use function unlink;
  *     min_endpoint_coverage?: float|string,
  *     min_response_coverage?: float|string,
  *     min_coverage_strict?: bool,
+ *     strict_required?: string,
  *     help?: bool,
  * }
  *
@@ -179,6 +184,9 @@ final class CoverageMergeCommand
               --min-response-coverage=<pct> Same, at (method, path, status, content-type) granularity.
               --min-coverage-strict[=BOOL]  Treat threshold misses as exit non-zero (default
                                             warn-only).
+              --strict-required=<mode>      off | warn | fail. Aggregate worker observations
+                                            and assert no schema under-description drift
+                                            (Issue #224 / #226). Defaults to off.
               --no-cleanup                  Keep sidecar files after merge (default: cleanup).
               --help                        Show this message.
 
@@ -240,6 +248,16 @@ final class CoverageMergeCommand
         $minEndpointPct = $endpointResolution['value'];
         $minResponsePct = $responseResolution['value'];
 
+        try {
+            $strictRequiredMode = StrictRequiredMode::fromConfigValue($options['strict_required'] ?? null);
+        } catch (InvalidArgumentException $e) {
+            // Same severity as a malformed threshold (exit 2). A typo here
+            // silently disables the gate the user opted into via CI flag.
+            $this->writeStderr(sprintf("[OpenAPI Strict Required] FATAL: %s\n", $e->getMessage()));
+
+            return 2;
+        }
+
         if ($specBasePath === null) {
             $this->writeStderr("[OpenAPI Coverage] FATAL: --spec-base-path is required\n");
 
@@ -290,9 +308,14 @@ final class CoverageMergeCommand
         OpenApiSpecLoader::configure($specBasePath, $stripPrefixes);
 
         OpenApiCoverageTracker::reset();
+        StrictRequiredTracker::reset();
         foreach ($payloads as $payload) {
             try {
-                OpenApiCoverageTracker::importState($payload);
+                $parsed = CoverageSidecarEnvelope::parse($payload);
+                OpenApiCoverageTracker::importState($parsed['coverage']);
+                if ($parsed['strictRequired'] !== null) {
+                    StrictRequiredTracker::importState($parsed['strictRequired']);
+                }
             } catch (InvalidArgumentException $e) {
                 $this->writeStderr(sprintf("[OpenAPI Coverage] FATAL: invalid sidecar payload: %s\n", $e->getMessage()));
 
@@ -325,11 +348,16 @@ final class CoverageMergeCommand
 
         $thresholdFailure = $this->evaluateThresholdGate($results, $minEndpointPct, $minResponsePct, $minStrict);
 
+        // Issue #226: aggregate strict_required across workers and run the
+        // gate after the report is rendered so a fatal drift doesn't suppress
+        // the coverage output users rely on for triage.
+        $strictFailure = $this->evaluateStrictRequiredGate($strictRequiredMode, $githubSummaryPath);
+
         if ($cleanup) {
             $this->cleanup($sidecarDir);
         }
 
-        return $writeFailures > 0 || $thresholdFailure ? 1 : 0;
+        return $writeFailures > 0 || $thresholdFailure || $strictFailure ? 1 : 0;
     }
 
     /**
@@ -486,6 +514,57 @@ final class CoverageMergeCommand
         $this->writeStderr($evaluation['message']);
 
         return $strict;
+    }
+
+    /**
+     * Aggregate strict_required observations imported from worker sidecars
+     * and surface any drift. Returns `true` when the run should exit
+     * non-zero (Fail mode + drift); Warn mode reports drift but returns
+     * `false` so the merge CLI's exit stays driven by the user's intent.
+     *
+     * Mirrors {@see CoverageReportSubscriber::evaluateStrictRequiredGate()}
+     * but translates fatality into a return value instead of `exit()`ing —
+     * the CLI surface joins it with `writeFailures`/`thresholdFailure` into
+     * one exit code.
+     *
+     * Off mode short-circuits before touching the asserter so unrelated
+     * runs pay nothing for the import-time tracker reset.
+     */
+    private function evaluateStrictRequiredGate(StrictRequiredMode $mode, ?string $githubSummaryPath): bool
+    {
+        if ($mode === StrictRequiredMode::Off) {
+            return false;
+        }
+
+        $reports = StrictRequiredAsserter::detectAll($mode);
+        $unresolved = StrictRequiredAsserter::detectUnresolvedGroups($mode);
+
+        if ($unresolved !== []) {
+            // Observed an endpoint with no matching response schema. The user
+            // cannot distinguish "no drift" from "no schema to compare" by
+            // reading the no-drift report alone — surface every offender so
+            // they can spot the spec lookup miss.
+            $this->writeStderr(sprintf(
+                "[OpenAPI Strict Required] NOTE: %d observation group(s) had no matching response schema; skipped from drift detection:\n  - %s\n",
+                count($unresolved),
+                implode("\n  - ", $unresolved),
+            ));
+        }
+
+        if ($reports === []) {
+            return false;
+        }
+
+        $isFatal = $mode === StrictRequiredMode::Fail;
+        $message = StrictRequiredAsserter::renderMessage($reports, $isFatal);
+        $this->writeStderr($message . "\n");
+        OpenApiCoverageExtension::appendGithubStepSummaryStrictRequiredBlock(
+            $githubSummaryPath,
+            $message,
+            $isFatal,
+        );
+
+        return $isFatal;
     }
 
     /**

--- a/src/Coverage/CoverageMergeCommand.php
+++ b/src/Coverage/CoverageMergeCommand.php
@@ -519,21 +519,40 @@ final class CoverageMergeCommand
     /**
      * Aggregate strict_required observations imported from worker sidecars
      * and surface any drift. Returns `true` when the run should exit
-     * non-zero (Fail mode + drift); Warn mode reports drift but returns
-     * `false` so the merge CLI's exit stays driven by the user's intent.
+     * non-zero (Fail mode + drift, or Fail mode + zero observations);
+     * Warn mode reports drift but returns `false` so the merge CLI's exit
+     * stays driven by the user's intent.
      *
      * Mirrors {@see CoverageReportSubscriber::evaluateStrictRequiredGate()}
      * but translates fatality into a return value instead of `exit()`ing —
      * the CLI surface joins it with `writeFailures`/`thresholdFailure` into
-     * one exit code.
+     * one exit code. The subscriber's partial-run skip branch is omitted
+     * here because aggregated worker output carries no per-process filter
+     * context.
      *
-     * Off mode short-circuits before touching the asserter so unrelated
-     * runs pay nothing for the import-time tracker reset.
+     * Off mode short-circuits before invoking the asserter so unrelated
+     * runs do not pay for spec loading and intersection diffing.
      */
     private function evaluateStrictRequiredGate(StrictRequiredMode $mode, ?string $githubSummaryPath): bool
     {
         if ($mode === StrictRequiredMode::Off) {
             return false;
+        }
+
+        // Fail-loud guard: when the user opted into --strict-required=fail
+        // but no worker recorded any observation (e.g., a fleet still on the
+        // pre-envelope library version, or a misconfigured paratest run),
+        // the gate cannot evaluate the contract. Silent-pass here would
+        // defeat the whole point of opting into fail-fast — symmetric with
+        // the threshold gate's no-coverage FATAL in `run()`.
+        if ($mode === StrictRequiredMode::Fail && StrictRequiredTracker::recordedSpecs() === []) {
+            $this->writeStderr(
+                '[OpenAPI Strict Required] FATAL: --strict-required=fail requested but '
+                . 'no worker recorded any strict_required observations; the gate cannot '
+                . "be evaluated. Verify all workers are running the v2 sidecar envelope.\n",
+            );
+
+            return true;
         }
 
         $reports = StrictRequiredAsserter::detectAll($mode);

--- a/src/Coverage/CoverageSidecarEnvelope.php
+++ b/src/Coverage/CoverageSidecarEnvelope.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Coverage;
+
+use InvalidArgumentException;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredTracker;
+
+use function array_key_exists;
+use function get_debug_type;
+use function is_array;
+use function is_int;
+use function sprintf;
+
+/**
+ * Wire-format helper for the v2 sidecar envelope.
+ *
+ * v2 wraps two tracker payloads — the existing {@see OpenApiCoverageTracker}
+ * coverage state and the {@see StrictRequiredTracker} observations — under
+ * a single JSON object so paratest workers can hand both off in one atomic
+ * write. The merge CLI then aggregates each side via its tracker's
+ * `importState()` and runs the strict_required gate against the union.
+ *
+ * Wire shape (v2):
+ * ```json
+ * {
+ *   "envelopeVersion": 2,
+ *   "coverage":       { "version": 1, "specs":        { ... } },
+ *   "strictRequired": { "version": 1, "observations": { ... } }
+ * }
+ * ```
+ *
+ * Backwards compatibility: workers running an older library version write
+ * a bare v1 coverage payload (`{ "version": 1, "specs": { ... } }`) with no
+ * `envelopeVersion` key. {@see self::parse()} detects this shape and
+ * returns the legacy payload as `coverage` with `strictRequired => null`,
+ * so a mixed-version fleet can still merge coverage cleanly.
+ *
+ * The envelope intentionally does NOT flatten the inner tracker payloads —
+ * each `version` field remains owned by its respective tracker and can
+ * evolve independently of the envelope version.
+ *
+ * @phpstan-import-type CoverageStatePayload from OpenApiCoverageTracker
+ * @phpstan-import-type StrictRequiredStatePayload from StrictRequiredTracker
+ *
+ * @phpstan-type SidecarEnvelopePayload array{
+ *     envelopeVersion: int,
+ *     coverage: CoverageStatePayload,
+ *     strictRequired: StrictRequiredStatePayload,
+ * }
+ * @phpstan-type ParsedEnvelope array{
+ *     coverage: array<string, mixed>,
+ *     strictRequired: array<string, mixed>|null,
+ * }
+ */
+final class CoverageSidecarEnvelope
+{
+    /**
+     * Envelope wire-format version. Importers reject unknown values rather
+     * than guessing — a future v3 worker writing into an older merge CLI
+     * must fail loudly so partial-upgrade silos surface immediately.
+     */
+    public const ENVELOPE_VERSION = 2;
+
+    private function __construct() {}
+
+    /**
+     * Compose a v2 envelope from the two tracker `exportState()` payloads.
+     *
+     * @param array<string, mixed> $coverageState output of {@see OpenApiCoverageTracker::exportState()}
+     * @param array<string, mixed> $strictRequiredState output of {@see StrictRequiredTracker::exportState()}
+     *
+     * @return array{envelopeVersion: int, coverage: array<string, mixed>, strictRequired: array<string, mixed>}
+     */
+    public static function build(array $coverageState, array $strictRequiredState): array
+    {
+        return [
+            'envelopeVersion' => self::ENVELOPE_VERSION,
+            'coverage' => $coverageState,
+            'strictRequired' => $strictRequiredState,
+        ];
+    }
+
+    /**
+     * Route a sidecar payload into its tracker-shaped parts.
+     *
+     * Discriminator priority:
+     *  1. `envelopeVersion` present → v2 path. Unknown values are rejected.
+     *  2. `version` + `specs` keys → legacy v1 bare coverage payload;
+     *     returns `strictRequired => null`.
+     *  3. Otherwise reject (unrecognised shape).
+     *
+     * @param array<string, mixed> $payload
+     *
+     * @return array{coverage: array<string, mixed>, strictRequired: null|array<string, mixed>}
+     *
+     * @throws InvalidArgumentException on unknown envelope version or
+     *                                  unrecognised payload shape
+     */
+    public static function parse(array $payload): array
+    {
+        if (array_key_exists('envelopeVersion', $payload)) {
+            return self::parseEnvelope($payload);
+        }
+
+        if (array_key_exists('version', $payload) && array_key_exists('specs', $payload)) {
+            // Legacy v1 bare coverage payload. Hand it back as the coverage
+            // half so OpenApiCoverageTracker::importState() validates the
+            // inner shape on its own terms.
+            return [
+                'coverage' => $payload,
+                'strictRequired' => null,
+            ];
+        }
+
+        throw new InvalidArgumentException(
+            'Unrecognised sidecar payload: missing both "envelopeVersion" (v2) and "version"+"specs" (v1).',
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array{coverage: array<string, mixed>, strictRequired: null|array<string, mixed>}
+     */
+    private static function parseEnvelope(array $payload): array
+    {
+        $version = $payload['envelopeVersion'] ?? null;
+        if (!is_int($version) || $version !== self::ENVELOPE_VERSION) {
+            throw new InvalidArgumentException(sprintf(
+                'Unsupported sidecar envelope version: got %s, expected %d.',
+                is_int($version) ? (string) $version : get_debug_type($version),
+                self::ENVELOPE_VERSION,
+            ));
+        }
+
+        $coverage = $payload['coverage'] ?? null;
+        if (!is_array($coverage)) {
+            throw new InvalidArgumentException(sprintf(
+                'Sidecar envelope "coverage" must be an array; got %s.',
+                get_debug_type($coverage),
+            ));
+        }
+
+        $strictRequired = $payload['strictRequired'] ?? null;
+        if ($strictRequired !== null && !is_array($strictRequired)) {
+            throw new InvalidArgumentException(sprintf(
+                'Sidecar envelope "strictRequired" must be an array or absent; got %s.',
+                get_debug_type($strictRequired),
+            ));
+        }
+
+        return [
+            'coverage' => $coverage,
+            'strictRequired' => $strictRequired,
+        ];
+    }
+}

--- a/src/Coverage/CoverageSidecarEnvelope.php
+++ b/src/Coverage/CoverageSidecarEnvelope.php
@@ -39,7 +39,10 @@ use function sprintf;
  *
  * The envelope intentionally does NOT flatten the inner tracker payloads —
  * each `version` field remains owned by its respective tracker and can
- * evolve independently of the envelope version.
+ * evolve independently of the envelope version. The wrapper key is
+ * `envelopeVersion` (not `version`) precisely so legacy v1 bare coverage
+ * payloads — which already use `version` at the top level — remain
+ * distinguishable; see {@see self::parse()}'s discriminator order.
  *
  * @phpstan-import-type CoverageStatePayload from OpenApiCoverageTracker
  * @phpstan-import-type StrictRequiredStatePayload from StrictRequiredTracker
@@ -67,11 +70,13 @@ final class CoverageSidecarEnvelope
 
     /**
      * Compose a v2 envelope from the two tracker `exportState()` payloads.
+     * Typed `@phpstan-param`s flow the tracker shapes through so PHPStan
+     * catches a tracker-side `exportState()` regression at this boundary.
      *
-     * @param array<string, mixed> $coverageState output of {@see OpenApiCoverageTracker::exportState()}
-     * @param array<string, mixed> $strictRequiredState output of {@see StrictRequiredTracker::exportState()}
+     * @phpstan-param CoverageStatePayload $coverageState
+     * @phpstan-param StrictRequiredStatePayload $strictRequiredState
      *
-     * @return array{envelopeVersion: int, coverage: array<string, mixed>, strictRequired: array<string, mixed>}
+     * @return SidecarEnvelopePayload
      */
     public static function build(array $coverageState, array $strictRequiredState): array
     {
@@ -93,7 +98,7 @@ final class CoverageSidecarEnvelope
      *
      * @param array<string, mixed> $payload
      *
-     * @return array{coverage: array<string, mixed>, strictRequired: null|array<string, mixed>}
+     * @return ParsedEnvelope
      *
      * @throws InvalidArgumentException on unknown envelope version or
      *                                  unrecognised payload shape
@@ -105,6 +110,20 @@ final class CoverageSidecarEnvelope
         }
 
         if (array_key_exists('version', $payload) && array_key_exists('specs', $payload)) {
+            // Forward-compat: a v1 shape must NOT carry a `strictRequired`
+            // half. Accepting it would silently discard observations when
+            // (a) a future writer ships a coverage-only v3 wire that drops
+            // `envelopeVersion`, or (b) a hand-edited sidecar happens to
+            // land in the v1 fast-path. Mirror the strict version check
+            // {@see StrictRequiredTracker::importState()} performs on its
+            // own payload.
+            if (array_key_exists('strictRequired', $payload)) {
+                throw new InvalidArgumentException(
+                    'Legacy v1 sidecar payload must not contain a top-level "strictRequired" key; '
+                    . 'expected an envelopeVersion=2 envelope when strict_required data is present.',
+                );
+            }
+
             // Legacy v1 bare coverage payload. Hand it back as the coverage
             // half so OpenApiCoverageTracker::importState() validates the
             // inner shape on its own terms.
@@ -122,7 +141,7 @@ final class CoverageSidecarEnvelope
     /**
      * @param array<string, mixed> $payload
      *
-     * @return array{coverage: array<string, mixed>, strictRequired: null|array<string, mixed>}
+     * @return ParsedEnvelope
      */
     private static function parseEnvelope(array $payload): array
     {

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -12,6 +12,7 @@ use PHPUnit\Event\TestRunner\ExecutionFinishedSubscriber;
 use RuntimeException;
 use Studio\OpenApiContractTesting\Coverage\ConsoleCoverageRenderer;
 use Studio\OpenApiContractTesting\Coverage\CoverageMergeCommand;
+use Studio\OpenApiContractTesting\Coverage\CoverageSidecarEnvelope;
 use Studio\OpenApiContractTesting\Coverage\CoverageSidecarWriter;
 use Studio\OpenApiContractTesting\Coverage\CoverageThresholdEvaluator;
 use Studio\OpenApiContractTesting\Coverage\HtmlCoverageRenderer;
@@ -25,6 +26,7 @@ use Studio\OpenApiContractTesting\Internal\PartialRunDecision;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredAsserter;
 use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredMode;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredTracker;
 use Throwable;
 
 use function count;
@@ -94,7 +96,6 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         $workerToken = self::resolveWorkerToken();
         if ($workerToken !== null) {
             $this->writeWorkerSidecar($workerToken);
-            $this->warnStrictRequiredNotSupportedInWorker();
 
             // Free cached spec data; the merge CLI re-loads on its own.
             OpenApiSpecLoader::clearCache();
@@ -228,29 +229,6 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
     }
 
     /**
-     * Issue #224 MVP scope limitation: paratest workers each maintain their
-     * own in-memory StrictRequiredTracker, but the current sidecar protocol
-     * carries only coverage state. The merge CLI therefore cannot run the
-     * asserter against the union of worker observations, so strict_required
-     * is effectively a no-op in worker mode.
-     *
-     * Surface this as a one-line NOTE so users who enabled `strict_required`
-     * in parallel CI immediately see why the asserter never fired, rather
-     * than silently shipping under-described specs.
-     */
-    private function warnStrictRequiredNotSupportedInWorker(): void
-    {
-        if ($this->strictRequiredMode === StrictRequiredMode::Off) {
-            return;
-        }
-        $this->writeStderr(
-            '[OpenAPI Strict Required] NOTE: strict_required is currently sequential-only '
-            . 'and does not aggregate across paratest workers. Run the suite sequentially to '
-            . "evaluate the gate, or follow up on issue #226 for parallel support.\n",
-        );
-    }
-
-    /**
      * Issue #135: in sequential PHPUnit, evaluate the optional coverage
      * threshold after the report renders. Worker mode never reaches here
      * (the worker-token branch returns earlier) — the merge CLI is the gate
@@ -340,8 +318,18 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
     {
         $dir = $this->sidecarDir ?? OpenApiCoverageExtension::defaultSidecarDir();
 
+        // Sidecar envelope (v2) carries both coverage and strict_required
+        // observations so the merge CLI can aggregate the gate across all
+        // paratest workers. The strict_required half is always exported,
+        // independent of the worker's `strict_required` mode — the merge
+        // CLI decides whether to assert (Issue #226).
+        $envelope = CoverageSidecarEnvelope::build(
+            OpenApiCoverageTracker::exportState(),
+            StrictRequiredTracker::exportState(),
+        );
+
         try {
-            CoverageSidecarWriter::write($dir, $token, OpenApiCoverageTracker::exportState());
+            CoverageSidecarWriter::write($dir, $token, $envelope);
         } catch (RuntimeException $e) {
             // The contract assertion that triggered notify() has already
             // passed; we don't fail the test run on sidecar I/O. But we

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -268,9 +268,9 @@ final class OpenApiCoverageExtension implements Extension
         // Issue #224: schema under-description detection. Reset the tracker
         // at bootstrap so observations from a previous PHPUnit process (or
         // a leaked test-class static) do not contaminate this run's
-        // intersection — same lifecycle pattern as
-        // `OpenApiCoverageTracker::reset()` would have if we wanted strict
-        // mode to be parallel-safe; for now (MVP) sequential-only.
+        // intersection — mirrors `OpenApiCoverageTracker::reset()`'s
+        // bootstrap-reset pattern. Worker observations are aggregated across
+        // paratest workers via the sidecar envelope (Issue #226).
         $strictRequiredMode = self::resolveStrictRequiredMode($parameters, $githubSummaryPath);
         StrictRequiredTracker::reset();
 

--- a/src/Validation/Strict/StrictRequiredTracker.php
+++ b/src/Validation/Strict/StrictRequiredTracker.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio\OpenApiContractTesting\Validation\Strict;
 
 use InvalidArgumentException;
+use Studio\OpenApiContractTesting\Coverage\CoverageSidecarEnvelope;
 
 use function array_intersect;
 use function array_is_list;
@@ -36,13 +37,11 @@ use function strtoupper;
  *  - once `alwaysPresent` shrinks to `[]` it stays empty for the rest of
  *    the run; reporting is then trivially a no-op for this group
  *
- * {@see self::exportState()} / {@see self::importState()} mirror the shape
- * used by {@see \Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker}'s
- * sidecar protocol, but they are NOT yet wired into the worker sidecar
- * writer or the merge CLI — strict_required is sequential-only in this
- * release; see `docs/strict-required.md` "Known limitations". The methods
- * exist so the paratest follow-up (issue #226) can plug in without
- * changing the wire format.
+ * {@see self::exportState()} / {@see self::importState()} are wired into
+ * the v2 sidecar envelope ({@see CoverageSidecarEnvelope}):
+ * paratest workers export observations to disk and the merge CLI re-imports
+ * them to run the gate across all workers. See `docs/strict-required.md`
+ * "Paratest" for the operator-facing flow.
  *
  * @phpstan-type StrictRequiredRow array{hits: int, alwaysPresent: list<string>}
  * @phpstan-type StrictRequiredEndpoint array<string, StrictRequiredRow>

--- a/tests/Integration/CoverageMergeCliIntegrationTest.php
+++ b/tests/Integration/CoverageMergeCliIntegrationTest.php
@@ -6,9 +6,11 @@ namespace Studio\OpenApiContractTesting\Tests\Integration;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Coverage\CoverageSidecarEnvelope;
 use Studio\OpenApiContractTesting\Coverage\CoverageSidecarWriter;
 use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredTracker;
 
 use function dirname;
 use function escapeshellarg;
@@ -46,6 +48,7 @@ class CoverageMergeCliIntegrationTest extends TestCase
     {
         parent::setUp();
         OpenApiCoverageTracker::reset();
+        StrictRequiredTracker::reset();
         OpenApiSpecLoader::reset();
 
         $this->repoRoot = realpath(__DIR__ . '/../..') ?: __DIR__ . '/../..';
@@ -67,6 +70,7 @@ class CoverageMergeCliIntegrationTest extends TestCase
         @rmdir(dirname($this->sidecarDir));
 
         OpenApiCoverageTracker::reset();
+        StrictRequiredTracker::reset();
         OpenApiSpecLoader::reset();
         parent::tearDown();
     }
@@ -218,6 +222,62 @@ class CoverageMergeCliIntegrationTest extends TestCase
 
         $this->assertSame(1, $exit);
         $this->assertStringContainsString('failed to write a sidecar', $stderr);
+    }
+
+    #[Test]
+    public function bin_aggregates_strict_required_and_fails_in_fail_mode(): void
+    {
+        // Two workers each observe that PUT /signed-url 200 always returns
+        // expires/signed_url/url — but the under-described spec marks them
+        // optional. With --strict-required=fail this must exit 1.
+        OpenApiSpecLoader::configure($this->repoRoot . '/tests/fixtures/specs');
+        $this->writeStrictRequiredSidecar('1');
+        $this->writeStrictRequiredSidecar('2');
+        OpenApiCoverageTracker::reset();
+        StrictRequiredTracker::reset();
+        OpenApiSpecLoader::reset();
+
+        [$exit, $stdout, $stderr] = $this->runCli([
+            '--spec-base-path=' . $this->repoRoot . '/tests/fixtures/specs',
+            '--specs=under-described',
+            '--sidecar-dir=' . $this->sidecarDir,
+            '--output-file=' . $this->outputFile,
+            '--strict-required=fail',
+        ]);
+
+        $this->assertSame(1, $exit, "stdout: {$stdout}\nstderr: {$stderr}");
+        $this->assertStringContainsString('[OpenAPI Strict Required] FATAL', $stderr);
+        $this->assertStringContainsString('PUT /signed-url', $stderr);
+    }
+
+    private function writeStrictRequiredSidecar(string $token): void
+    {
+        OpenApiCoverageTracker::reset();
+        StrictRequiredTracker::reset();
+        OpenApiCoverageTracker::recordResponse(
+            'under-described',
+            'PUT',
+            '/signed-url',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        StrictRequiredTracker::record(
+            'under-described',
+            'PUT',
+            '/signed-url',
+            '200',
+            'application/json',
+            ['expires', 'signed_url', 'url'],
+        );
+        CoverageSidecarWriter::write(
+            $this->sidecarDir,
+            $token,
+            CoverageSidecarEnvelope::build(
+                OpenApiCoverageTracker::exportState(),
+                StrictRequiredTracker::exportState(),
+            ),
+        );
     }
 
     /**

--- a/tests/Unit/Coverage/CoverageMergeCommandTest.php
+++ b/tests/Unit/Coverage/CoverageMergeCommandTest.php
@@ -7,9 +7,11 @@ namespace Studio\OpenApiContractTesting\Tests\Unit\Coverage;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\Coverage\CoverageMergeCommand;
+use Studio\OpenApiContractTesting\Coverage\CoverageSidecarEnvelope;
 use Studio\OpenApiContractTesting\Coverage\CoverageSidecarWriter;
 use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredTracker;
 
 use function dirname;
 use function file_exists;
@@ -39,6 +41,7 @@ class CoverageMergeCommandTest extends TestCase
     {
         parent::setUp();
         OpenApiCoverageTracker::reset();
+        StrictRequiredTracker::reset();
         OpenApiSpecLoader::reset();
 
         $base = sys_get_temp_dir() . '/openapi-coverage-merge-' . uniqid('', true);
@@ -60,6 +63,7 @@ class CoverageMergeCommandTest extends TestCase
         }
 
         OpenApiCoverageTracker::reset();
+        StrictRequiredTracker::reset();
         OpenApiSpecLoader::reset();
         parent::tearDown();
     }
@@ -1085,6 +1089,199 @@ class CoverageMergeCommandTest extends TestCase
 
         $this->assertSame(1, $exit);
         $this->assertStringContainsString('Failed to write Markdown report', $stderr);
+    }
+
+    #[Test]
+    public function merges_strict_required_observations_across_workers_in_warn_mode(): void
+    {
+        $this->writeStrictRequiredWorkerSidecar('1', ['expires', 'signed_url', 'url']);
+        $this->writeStrictRequiredWorkerSidecar('2', ['expires', 'signed_url', 'url']);
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stdoutWriter: static fn(string $msg): null => null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['under-described'],
+            'output_file' => $this->outputFile,
+            'strict_required' => 'warn',
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('[OpenAPI Strict Required] WARNING', $stderr);
+        $this->assertStringContainsString('PUT /signed-url', $stderr);
+    }
+
+    #[Test]
+    public function merge_fails_with_exit_one_in_strict_required_fail_mode_on_drift(): void
+    {
+        $this->writeStrictRequiredWorkerSidecar('1', ['expires', 'signed_url', 'url']);
+        $this->writeStrictRequiredWorkerSidecar('2', ['expires', 'signed_url', 'url']);
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stdoutWriter: static fn(string $msg): null => null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['under-described'],
+            'output_file' => $this->outputFile,
+            'strict_required' => 'fail',
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('[OpenAPI Strict Required] FATAL', $stderr);
+    }
+
+    #[Test]
+    public function merge_passes_in_off_mode_even_when_drift_exists(): void
+    {
+        $this->writeStrictRequiredWorkerSidecar('1', ['expires', 'signed_url', 'url']);
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stdoutWriter: static fn(string $msg): null => null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['under-described'],
+            'output_file' => $this->outputFile,
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertStringNotContainsString('[OpenAPI Strict Required]', $stderr);
+    }
+
+    #[Test]
+    public function merge_rejects_unknown_strict_required_value_with_exit_two(): void
+    {
+        $this->writeStrictRequiredWorkerSidecar('1', ['expires', 'signed_url', 'url']);
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stdoutWriter: static fn(string $msg): null => null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['under-described'],
+            'output_file' => $this->outputFile,
+            'strict_required' => 'loud',
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(2, $exit);
+        $this->assertStringContainsString('[OpenAPI Strict Required] FATAL', $stderr);
+    }
+
+    #[Test]
+    public function merge_tolerates_mixed_v1_and_v2_sidecars(): void
+    {
+        // Worker A: legacy v1 (bare coverage payload, no strict_required).
+        // Simulates a worker still on an older library version during an
+        // upgrade window — coverage merges; strict_required half is absent.
+        OpenApiCoverageTracker::recordResponse(
+            'under-described',
+            'GET',
+            '/users/{id}',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+        OpenApiCoverageTracker::reset();
+
+        // Worker B: v2 envelope with drift-inducing observations.
+        $this->writeStrictRequiredWorkerSidecar('2', ['expires', 'signed_url', 'url']);
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stdoutWriter: static fn(string $msg): null => null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['under-described'],
+            'output_file' => $this->outputFile,
+            'strict_required' => 'warn',
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('[OpenAPI Strict Required] WARNING', $stderr);
+        // Coverage from worker A must still be merged.
+        $contents = (string) file_get_contents($this->outputFile);
+        $this->assertStringContainsString('GET /users/{id}', $contents);
+    }
+
+    #[Test]
+    public function parse_argv_accepts_strict_required_flag(): void
+    {
+        $opts = CoverageMergeCommand::parseArgv(['--strict-required=warn']);
+        $this->assertSame('warn', $opts['strict_required'] ?? null);
+    }
+
+    /**
+     * Write a worker sidecar carrying an under-described drift observation:
+     * a response that always returned `expires`/`signed_url`/`url` even
+     * though the spec declares them optional.
+     *
+     * @param list<string> $alwaysPresent
+     */
+    private function writeStrictRequiredWorkerSidecar(string $token, array $alwaysPresent): void
+    {
+        OpenApiCoverageTracker::reset();
+        StrictRequiredTracker::reset();
+        OpenApiCoverageTracker::recordResponse(
+            'under-described',
+            'PUT',
+            '/signed-url',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        StrictRequiredTracker::record(
+            'under-described',
+            'PUT',
+            '/signed-url',
+            '200',
+            'application/json',
+            $alwaysPresent,
+        );
+        $envelope = CoverageSidecarEnvelope::build(
+            OpenApiCoverageTracker::exportState(),
+            StrictRequiredTracker::exportState(),
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, $token, $envelope);
+        OpenApiCoverageTracker::reset();
+        StrictRequiredTracker::reset();
     }
 
     /** @return list<string> */

--- a/tests/Unit/Coverage/CoverageMergeCommandTest.php
+++ b/tests/Unit/Coverage/CoverageMergeCommandTest.php
@@ -1198,6 +1198,271 @@ class CoverageMergeCommandTest extends TestCase
     }
 
     #[Test]
+    public function strict_required_emits_unresolved_groups_note_in_warn_mode(): void
+    {
+        // The merge CLI's unresolved-groups NOTE branch must surface
+        // observations that have no matching response schema. Without this
+        // pin, a refactor of evaluateStrictRequiredGate() could drop the
+        // detectUnresolvedGroups() call and the user would no longer be
+        // told why no drift block appeared.
+        OpenApiCoverageTracker::reset();
+        StrictRequiredTracker::reset();
+        // GET on /signed-url has no schema in the fixture (only PUT does)
+        // — the observation cannot be resolved against any spec response.
+        OpenApiCoverageTracker::recordResponse(
+            'under-described',
+            'GET',
+            '/signed-url',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        StrictRequiredTracker::record(
+            'under-described',
+            'GET',
+            '/signed-url',
+            '200',
+            'application/json',
+            ['expires'],
+        );
+        $envelope = CoverageSidecarEnvelope::build(
+            OpenApiCoverageTracker::exportState(),
+            StrictRequiredTracker::exportState(),
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', $envelope);
+        OpenApiCoverageTracker::reset();
+        StrictRequiredTracker::reset();
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stdoutWriter: static fn(string $msg): null => null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['under-described'],
+            'output_file' => $this->outputFile,
+            'strict_required' => 'warn',
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(0, $exit, "stderr: {$stderr}");
+        $this->assertStringContainsString('[OpenAPI Strict Required] NOTE', $stderr);
+        $this->assertStringContainsString('GET /signed-url', $stderr);
+        // No drift was detected — only the unresolved NOTE should appear.
+        $this->assertStringNotContainsString('[OpenAPI Strict Required] WARNING', $stderr);
+    }
+
+    #[Test]
+    public function strict_required_fail_appends_block_to_github_step_summary(): void
+    {
+        // The merge CLI must surface drift to $GITHUB_STEP_SUMMARY so a CI
+        // user reading the run summary tab sees the FATAL block. Without
+        // this pin a refactor that drops the github_step_summary argument
+        // from evaluateStrictRequiredGate() would regress silently.
+        $this->writeStrictRequiredWorkerSidecar('1', ['expires', 'signed_url', 'url']);
+
+        $githubSummary = $this->outputFile . '.github-summary.md';
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stdoutWriter: static fn(string $msg): null => null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['under-described'],
+            'output_file' => $this->outputFile,
+            'github_step_summary' => $githubSummary,
+            'strict_required' => 'fail',
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $contents = (string) file_get_contents($githubSummary);
+        $this->assertStringContainsString(':rotating_light: FATAL OpenAPI strict_required drift', $contents);
+        $this->assertStringContainsString('PUT /signed-url', $contents);
+
+        @unlink($githubSummary);
+    }
+
+    #[Test]
+    public function strict_required_warn_appends_warning_block_to_github_step_summary(): void
+    {
+        // Pin the warn-mode block label too — the heading swap (rotating_light
+        // vs warning) lives in OpenApiCoverageExtension::appendGithub… and
+        // changing it accidentally would mislead CI users about severity.
+        $this->writeStrictRequiredWorkerSidecar('1', ['expires', 'signed_url', 'url']);
+
+        $githubSummary = $this->outputFile . '.github-summary.md';
+        $command = new CoverageMergeCommand(
+            stdoutWriter: static fn(string $msg): null => null,
+            stderrWriter: static fn(string $msg): null => null,
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['under-described'],
+            'output_file' => $this->outputFile,
+            'github_step_summary' => $githubSummary,
+            'strict_required' => 'warn',
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $contents = (string) file_get_contents($githubSummary);
+        $this->assertStringContainsString(':warning: OpenAPI strict_required drift', $contents);
+
+        @unlink($githubSummary);
+    }
+
+    #[Test]
+    public function strict_required_fail_writes_all_coverage_outputs_before_aborting(): void
+    {
+        // Pin the documented "render report first, assert gate second"
+        // contract: a strict_required=fail drift must NOT suppress the
+        // coverage outputs users rely on for triage. A future refactor that
+        // re-orders evaluateStrictRequiredGate() ahead of writeReports() /
+        // appendGithubStepSummary() must fail this test.
+        $this->writeStrictRequiredWorkerSidecar('1', ['expires', 'signed_url', 'url']);
+        $this->writeStrictRequiredWorkerSidecar('2', ['expires', 'signed_url', 'url']);
+
+        $junitOutput = $this->outputFile . '.junit.xml';
+        $jsonOutput = $this->outputFile . '.json';
+        $htmlOutput = $this->outputFile . '.html';
+        $githubSummary = $this->outputFile . '.github-summary.md';
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stdoutWriter: static fn(string $msg): null => null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['under-described'],
+            'output_file' => $this->outputFile,
+            'junit_output' => $junitOutput,
+            'json_output' => $jsonOutput,
+            'html_output' => $htmlOutput,
+            'github_step_summary' => $githubSummary,
+            'strict_required' => 'fail',
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('[OpenAPI Strict Required] FATAL', $stderr);
+
+        // Every configured coverage output must exist and contain the
+        // endpoint that triggered the drift — proving the renderer ran
+        // before the gate decided to fail.
+        foreach ([$this->outputFile, $junitOutput, $jsonOutput, $htmlOutput, $githubSummary] as $path) {
+            $this->assertFileExists($path, "coverage output {$path} must be written before strict gate aborts");
+            $this->assertStringContainsString('PUT /signed-url', (string) file_get_contents($path), "expected PUT /signed-url in {$path}");
+        }
+
+        // The GH step summary must also carry the strict_required FATAL
+        // block, not just the coverage Markdown — covered separately below.
+
+        @unlink($junitOutput);
+        @unlink($jsonOutput);
+        @unlink($htmlOutput);
+        @unlink($githubSummary);
+    }
+
+    #[Test]
+    public function fail_mode_exits_non_zero_when_no_worker_recorded_strict_observations(): void
+    {
+        // A CI that opted into --strict-required=fail must NOT silently pass
+        // when every worker contributed a legacy v1 sidecar (no strict
+        // observations). The gate cannot evaluate the contract, and that's
+        // a fail-loud condition — symmetric with the threshold gate's
+        // "no contract test coverage was recorded" guard at run() L296.
+        OpenApiCoverageTracker::recordResponse(
+            'under-described',
+            'PUT',
+            '/signed-url',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+        OpenApiCoverageTracker::reset();
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stdoutWriter: static fn(string $msg): null => null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['under-described'],
+            'output_file' => $this->outputFile,
+            'strict_required' => 'fail',
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('[OpenAPI Strict Required] FATAL', $stderr);
+        $this->assertStringContainsString('no worker recorded', $stderr);
+    }
+
+    #[Test]
+    public function warn_mode_passes_silently_when_no_worker_recorded_strict_observations(): void
+    {
+        // Symmetric design: warn mode tolerates "no observations" because
+        // the user explicitly opted out of fail-fast. The mixed v1/v2
+        // upgrade window relies on this — flipping to warn first lets users
+        // roll out v2 workers gradually before turning the gate to fail.
+        OpenApiCoverageTracker::recordResponse(
+            'under-described',
+            'PUT',
+            '/signed-url',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+        OpenApiCoverageTracker::reset();
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stdoutWriter: static fn(string $msg): null => null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['under-described'],
+            'output_file' => $this->outputFile,
+            'strict_required' => 'warn',
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertStringNotContainsString('[OpenAPI Strict Required] FATAL', $stderr);
+    }
+
+    #[Test]
     public function merge_tolerates_mixed_v1_and_v2_sidecars(): void
     {
         // Worker A: legacy v1 (bare coverage payload, no strict_required).

--- a/tests/Unit/Coverage/CoverageSidecarEnvelopeTest.php
+++ b/tests/Unit/Coverage/CoverageSidecarEnvelopeTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Coverage;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Coverage\CoverageSidecarEnvelope;
+
+/**
+ * Pins the v2 sidecar envelope wire format and the v1 ↔ v2 compatibility
+ * routing. The merge CLI relies on this discriminator to keep working when
+ * a worker still on an older library version contributes a bare v1 payload.
+ */
+class CoverageSidecarEnvelopeTest extends TestCase
+{
+    #[Test]
+    public function build_emits_v2_shape_with_both_states(): void
+    {
+        $coverage = ['version' => 1, 'specs' => ['petstore' => []]];
+        $strictRequired = ['version' => 1, 'observations' => ['petstore' => []]];
+
+        $envelope = CoverageSidecarEnvelope::build($coverage, $strictRequired);
+
+        $this->assertSame(2, $envelope['envelopeVersion']);
+        $this->assertSame($coverage, $envelope['coverage']);
+        $this->assertSame($strictRequired, $envelope['strictRequired']);
+    }
+
+    #[Test]
+    public function parse_accepts_v2_payload_and_returns_both_states(): void
+    {
+        $payload = [
+            'envelopeVersion' => 2,
+            'coverage' => ['version' => 1, 'specs' => ['petstore' => []]],
+            'strictRequired' => ['version' => 1, 'observations' => ['petstore' => []]],
+        ];
+
+        $parsed = CoverageSidecarEnvelope::parse($payload);
+
+        $this->assertSame($payload['coverage'], $parsed['coverage']);
+        $this->assertSame($payload['strictRequired'], $parsed['strictRequired']);
+    }
+
+    #[Test]
+    public function parse_accepts_legacy_v1_payload_and_returns_null_strict_required(): void
+    {
+        // v1 bare coverage payload — written by workers running an older
+        // library version. The merge CLI must still load these so a partial
+        // upgrade does not silently break coverage aggregation.
+        $payload = ['version' => 1, 'specs' => ['petstore' => []]];
+
+        $parsed = CoverageSidecarEnvelope::parse($payload);
+
+        $this->assertSame($payload, $parsed['coverage']);
+        $this->assertNull($parsed['strictRequired']);
+    }
+
+    #[Test]
+    public function parse_rejects_unknown_envelope_version(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported sidecar envelope version');
+
+        CoverageSidecarEnvelope::parse([
+            'envelopeVersion' => 99,
+            'coverage' => ['version' => 1, 'specs' => []],
+            'strictRequired' => ['version' => 1, 'observations' => []],
+        ]);
+    }
+
+    #[Test]
+    public function parse_rejects_v2_payload_with_non_array_coverage(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('coverage');
+
+        CoverageSidecarEnvelope::parse([
+            'envelopeVersion' => 2,
+            'coverage' => 'not-an-array',
+            'strictRequired' => ['version' => 1, 'observations' => []],
+        ]);
+    }
+
+    #[Test]
+    public function parse_rejects_payload_with_unrecognised_shape(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unrecognised sidecar payload');
+
+        // Neither v2 (no envelopeVersion) nor v1 (no specs key) — must fail
+        // fast rather than silently treating as empty coverage.
+        CoverageSidecarEnvelope::parse(['hello' => 'world']);
+    }
+
+    #[Test]
+    public function parse_treats_missing_strict_required_in_v2_as_null(): void
+    {
+        // Forward-compat: if a future writer omits strictRequired entirely
+        // (rather than emitting empty observations), parse() degrades to
+        // null so the merge CLI skips strict_required import cleanly.
+        $payload = [
+            'envelopeVersion' => 2,
+            'coverage' => ['version' => 1, 'specs' => []],
+        ];
+
+        $parsed = CoverageSidecarEnvelope::parse($payload);
+
+        $this->assertNull($parsed['strictRequired']);
+    }
+}

--- a/tests/Unit/Coverage/CoverageSidecarEnvelopeTest.php
+++ b/tests/Unit/Coverage/CoverageSidecarEnvelopeTest.php
@@ -96,6 +96,23 @@ class CoverageSidecarEnvelopeTest extends TestCase
     }
 
     #[Test]
+    public function parse_rejects_v1_shape_carrying_unexpected_strict_required_key(): void
+    {
+        // Forward-compat guard: a v1 payload that also carries a top-level
+        // `strictRequired` key is ambiguous — either the writer is using an
+        // unknown wire variant or the envelopeVersion key was dropped. Fail
+        // loudly rather than silently discarding observations.
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('strictRequired');
+
+        CoverageSidecarEnvelope::parse([
+            'version' => 1,
+            'specs' => [],
+            'strictRequired' => ['version' => 1, 'observations' => []],
+        ]);
+    }
+
+    #[Test]
     public function parse_treats_missing_strict_required_in_v2_as_null(): void
     {
         // Forward-compat: if a future writer omits strictRequired entirely

--- a/tests/Unit/Coverage/CoverageSidecarTest.php
+++ b/tests/Unit/Coverage/CoverageSidecarTest.php
@@ -7,9 +7,11 @@ namespace Studio\OpenApiContractTesting\Tests\Unit\Coverage;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use Studio\OpenApiContractTesting\Coverage\CoverageSidecarEnvelope;
 use Studio\OpenApiContractTesting\Coverage\CoverageSidecarReader;
 use Studio\OpenApiContractTesting\Coverage\CoverageSidecarWriter;
 use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredTracker;
 
 use function array_map;
 use function file_put_contents;
@@ -36,6 +38,7 @@ class CoverageSidecarTest extends TestCase
     {
         parent::setUp();
         OpenApiCoverageTracker::reset();
+        StrictRequiredTracker::reset();
         $this->tmpDir = sys_get_temp_dir() . '/openapi-coverage-test-' . uniqid('', true);
         mkdir($this->tmpDir, 0o755, recursive: true);
     }
@@ -43,6 +46,7 @@ class CoverageSidecarTest extends TestCase
     protected function tearDown(): void
     {
         OpenApiCoverageTracker::reset();
+        StrictRequiredTracker::reset();
         if (is_dir($this->tmpDir)) {
             $entries = glob($this->tmpDir . '/*') ?: [];
             foreach ($entries as $entry) {
@@ -136,6 +140,94 @@ class CoverageSidecarTest extends TestCase
         $merged = OpenApiCoverageTracker::exportState();
         $this->assertArrayHasKey('GET /v1/pets', $merged['specs']['petstore-3.0']);
         $this->assertArrayHasKey('POST /v1/pets', $merged['specs']['petstore-3.0']);
+    }
+
+    #[Test]
+    public function reader_round_trips_envelope_with_strict_required_observations(): void
+    {
+        // Two workers observe the same endpoint with intersecting key sets.
+        // After merging via the envelope, the tracker must hold the
+        // intersection-of-intersections — pin that the sidecar carries the
+        // strict_required half end-to-end.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        StrictRequiredTracker::record('petstore-3.0', 'GET', '/v1/pets', '200', 'application/json', ['id', 'name', 'tag']);
+        $envelopeA = CoverageSidecarEnvelope::build(
+            OpenApiCoverageTracker::exportState(),
+            StrictRequiredTracker::exportState(),
+        );
+
+        OpenApiCoverageTracker::reset();
+        StrictRequiredTracker::reset();
+
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        StrictRequiredTracker::record('petstore-3.0', 'GET', '/v1/pets', '200', 'application/json', ['id', 'name']);
+        $envelopeB = CoverageSidecarEnvelope::build(
+            OpenApiCoverageTracker::exportState(),
+            StrictRequiredTracker::exportState(),
+        );
+
+        CoverageSidecarWriter::write($this->tmpDir, '1', $envelopeA);
+        CoverageSidecarWriter::write($this->tmpDir, '2', $envelopeB);
+
+        $loaded = CoverageSidecarReader::readDir($this->tmpDir);
+        $this->assertCount(2, $loaded);
+
+        OpenApiCoverageTracker::reset();
+        StrictRequiredTracker::reset();
+        foreach ($loaded as $payload) {
+            $parsed = CoverageSidecarEnvelope::parse($payload);
+            OpenApiCoverageTracker::importState($parsed['coverage']);
+            $this->assertNotNull($parsed['strictRequired']);
+            StrictRequiredTracker::importState($parsed['strictRequired']);
+        }
+
+        $observed = StrictRequiredTracker::getObservations('petstore-3.0');
+        $this->assertArrayHasKey('GET /v1/pets', $observed);
+        $row = $observed['GET /v1/pets']['200:application/json'];
+        $this->assertSame(2, $row['hits']);
+        // Intersection: A had [id, name, tag], B had [id, name] → [id, name].
+        $this->assertSame(['id', 'name'], $row['alwaysPresent']);
+    }
+
+    #[Test]
+    public function reader_still_loads_legacy_v1_payloads(): void
+    {
+        // Worker on an older library version writes a bare v1 coverage
+        // payload (no envelopeVersion). The reader returns it verbatim;
+        // the envelope parser yields a null strictRequired half so the
+        // merge CLI can mix versioned sidecars during an upgrade window.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        $legacyPayload = OpenApiCoverageTracker::exportState();
+
+        CoverageSidecarWriter::write($this->tmpDir, '1', $legacyPayload);
+
+        $loaded = CoverageSidecarReader::readDir($this->tmpDir);
+        $this->assertCount(1, $loaded);
+
+        $parsed = CoverageSidecarEnvelope::parse($loaded[0]);
+        $this->assertSame($legacyPayload, $parsed['coverage']);
+        $this->assertNull($parsed['strictRequired']);
     }
 
     #[Test]

--- a/tests/Unit/PHPUnit/CoverageReportSubscriberStrictRequiredTest.php
+++ b/tests/Unit/PHPUnit/CoverageReportSubscriberStrictRequiredTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Event\TestRunner\ExecutionFinished;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use Studio\OpenApiContractTesting\Coverage\CoverageSidecarEnvelope;
+use Studio\OpenApiContractTesting\Coverage\CoverageSidecarReader;
 use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\Internal\PartialRunDecision;
 use Studio\OpenApiContractTesting\PHPUnit\ConsoleOutput;
@@ -17,14 +19,22 @@ use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredMode;
 use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredTracker;
 
 use function getenv;
+use function glob;
+use function is_dir;
+use function mkdir;
 use function ob_get_clean;
 use function ob_start;
 use function putenv;
+use function rmdir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
 
 class CoverageReportSubscriberStrictRequiredTest extends TestCase
 {
     private const SPEC_NAME = 'under-described';
     private ?string $previousTestToken = null;
+    private string $tmpSidecarDir = '';
 
     protected function setUp(): void
     {
@@ -37,6 +47,9 @@ class CoverageReportSubscriberStrictRequiredTest extends TestCase
         $current = getenv('TEST_TOKEN');
         $this->previousTestToken = $current === false ? null : $current;
         putenv('TEST_TOKEN');
+
+        $this->tmpSidecarDir = sys_get_temp_dir() . '/openapi-strict-worker-' . uniqid('', true);
+        mkdir($this->tmpSidecarDir, 0o755, recursive: true);
     }
 
     protected function tearDown(): void
@@ -49,6 +62,13 @@ class CoverageReportSubscriberStrictRequiredTest extends TestCase
         StrictRequiredTracker::reset();
         OpenApiCoverageTracker::reset();
         OpenApiSpecLoader::reset();
+        if (is_dir($this->tmpSidecarDir)) {
+            $entries = glob($this->tmpSidecarDir . '/*') ?: [];
+            foreach ($entries as $entry) {
+                @unlink($entry);
+            }
+            @rmdir($this->tmpSidecarDir);
+        }
         parent::tearDown();
     }
 
@@ -138,24 +158,84 @@ class CoverageReportSubscriberStrictRequiredTest extends TestCase
     }
 
     #[Test]
-    public function worker_mode_emits_note_when_strict_required_is_enabled(): void
+    public function worker_mode_writes_strict_required_observations_to_sidecar(): void
     {
+        // Worker branch must export strict_required observations alongside
+        // coverage so the merge CLI can aggregate across paratest workers
+        // and assert the gate. Without this the gate is silent-pass in CI.
         putenv('TEST_TOKEN=2');
+        StrictRequiredTracker::record(
+            self::SPEC_NAME,
+            'PUT',
+            '/signed-url',
+            '200',
+            'application/json',
+            ['expires', 'signed_url', 'url'],
+        );
 
         $stderr = '';
-        $subscriber = $this->makeSubscriber(
+        $subscriber = $this->makeSubscriberWithSidecarDir(
             mode: StrictRequiredMode::Warn,
             stderr: $stderr,
             exitCode: $exitCode,
+            sidecarDir: $this->tmpSidecarDir,
         );
 
         ob_start();
         $subscriber->notify($this->fakeExecutionFinished());
         ob_get_clean();
 
-        $this->assertStringContainsString('[OpenAPI Strict Required] NOTE', $stderr);
-        $this->assertStringContainsString('sequential-only', $stderr);
-        $this->assertStringContainsString('issue #226', $stderr);
+        // Legacy NOTE must be gone — workers now contribute to the gate.
+        $this->assertStringNotContainsString('[OpenAPI Strict Required] NOTE', $stderr);
+        $this->assertStringNotContainsString('issue #226', $stderr);
+        $this->assertNull($exitCode);
+
+        $payloads = CoverageSidecarReader::readDir($this->tmpSidecarDir);
+        $this->assertCount(1, $payloads);
+        $parsed = CoverageSidecarEnvelope::parse($payloads[0]);
+        $this->assertNotNull($parsed['strictRequired']);
+        $observations = $parsed['strictRequired']['observations'] ?? null;
+        $this->assertIsArray($observations);
+        $this->assertArrayHasKey(self::SPEC_NAME, $observations);
+        $row = $observations[self::SPEC_NAME]['PUT /signed-url']['200:application/json'];
+        $this->assertSame(1, $row['hits']);
+        $this->assertSame(['expires', 'signed_url', 'url'], $row['alwaysPresent']);
+    }
+
+    #[Test]
+    public function worker_mode_writes_envelope_even_when_strict_required_is_off(): void
+    {
+        // Workers export observations unconditionally so the merge CLI can
+        // decide at aggregation time whether to assert. This keeps mode
+        // changes a single-knob operation without per-worker reruns.
+        putenv('TEST_TOKEN=3');
+        StrictRequiredTracker::record(
+            self::SPEC_NAME,
+            'PUT',
+            '/signed-url',
+            '200',
+            'application/json',
+            ['expires', 'signed_url', 'url'],
+        );
+
+        $stderr = '';
+        $subscriber = $this->makeSubscriberWithSidecarDir(
+            mode: StrictRequiredMode::Off,
+            stderr: $stderr,
+            exitCode: $exitCode,
+            sidecarDir: $this->tmpSidecarDir,
+        );
+
+        ob_start();
+        $subscriber->notify($this->fakeExecutionFinished());
+        ob_get_clean();
+
+        $this->assertSame('', $stderr);
+        $payloads = CoverageSidecarReader::readDir($this->tmpSidecarDir);
+        $this->assertCount(1, $payloads);
+        $parsed = CoverageSidecarEnvelope::parse($payloads[0]);
+        $this->assertNotNull($parsed['strictRequired']);
+        $this->assertArrayHasKey(self::SPEC_NAME, $parsed['strictRequired']['observations']);
     }
 
     #[Test]
@@ -245,6 +325,34 @@ class CoverageReportSubscriberStrictRequiredTest extends TestCase
                 $stderr .= $msg;
             },
             sidecarDir: null,
+            exitHandler: static function (int $code) use (&$exitCode): void {
+                $exitCode = $code;
+            },
+            strictRequiredMode: $mode,
+        );
+    }
+
+    /**
+     * @param-out null|int $exitCode
+     * @param-out string $stderr
+     */
+    private function makeSubscriberWithSidecarDir(
+        StrictRequiredMode $mode,
+        string &$stderr,
+        ?int &$exitCode,
+        string $sidecarDir,
+    ): CoverageReportSubscriber {
+        $exitCode = null;
+
+        return new CoverageReportSubscriber(
+            specs: [self::SPEC_NAME],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            sidecarDir: $sidecarDir,
             exitHandler: static function (int $code) use (&$exitCode): void {
                 $exitCode = $code;
             },

--- a/tests/Unit/PHPUnit/CoverageReportSubscriberWorkerModeTest.php
+++ b/tests/Unit/PHPUnit/CoverageReportSubscriberWorkerModeTest.php
@@ -124,8 +124,10 @@ class CoverageReportSubscriberWorkerModeTest extends TestCase
 
         $loaded = CoverageSidecarReader::readDir($this->tmpDir);
         $this->assertCount(1, $loaded);
-        $this->assertSame(1, $loaded[0]['version']);
-        $this->assertArrayHasKey('petstore-3.0', $loaded[0]['specs']);
+        // v2 envelope: coverage payload nested under "coverage" key.
+        $this->assertSame(2, $loaded[0]['envelopeVersion']);
+        $this->assertSame(1, $loaded[0]['coverage']['version']);
+        $this->assertArrayHasKey('petstore-3.0', $loaded[0]['coverage']['specs']);
     }
 
     #[Test]
@@ -150,7 +152,7 @@ class CoverageReportSubscriberWorkerModeTest extends TestCase
 
         $loaded = CoverageSidecarReader::readDir($this->tmpDir);
         $this->assertCount(1, $loaded);
-        $this->assertSame([], $loaded[0]['specs']);
+        $this->assertSame([], $loaded[0]['coverage']['specs']);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Workers now export `StrictRequiredTracker` observations alongside coverage state inside a v2 sidecar envelope (`{envelopeVersion, coverage, strictRequired}`). The merge CLI gains `--strict-required=<off|warn|fail>` which aggregates worker observations and runs the asserter at merge time — so paratest / Pest `--parallel` runs can finally evaluate the schema under-description gate.

The new `CoverageSidecarEnvelope` helper routes payloads: v2 envelopes go through both trackers, while legacy v1 (bare coverage) payloads from workers on older library versions still merge their coverage half cleanly with `strictRequired` degrading to `null`.

## Why

PR #225 (Issue #224) introduced `strict_required` but only for sequential PHPUnit. In paratest mode each worker kept its observations in-memory, the subscriber emitted a NOTE, and the asserter was skipped — so `strict_required=fail` in parallel CI silently passed. This is the follow-up issue called out at the end of PR #225.

Fixes #226

## Verification

- New unit suite `CoverageSidecarEnvelopeTest` pins build/parse, v1↔v2 routing, and rejection of unknown versions.
- `CoverageSidecarTest::reader_round_trips_envelope_with_strict_required_observations` proves intersection-of-intersections survives the sidecar round-trip.
- `CoverageSidecarTest::reader_still_loads_legacy_v1_payloads` proves the v1 compat path.
- Subscriber tests assert `worker_mode_writes_strict_required_observations_to_sidecar` and `worker_mode_writes_envelope_even_when_strict_required_is_off`; the legacy NOTE test is replaced.
- Merge CLI tests cover warn/fail/off/unknown-value/mixed-v1-v2 paths and the new `--strict-required` argv parsing.
- Integration test `bin_aggregates_strict_required_and_fails_in_fail_mode` spawns the real `bin/openapi-coverage-merge` against two v2 sidecars and asserts exit 1 plus the FATAL diagnostic.

- [x] `composer test` passes (1573 tests, 3751 assertions)
- [x] `composer stan` passes (level 6, no errors)
- [x] `composer cs-check` passes

## Notes for reviewers

- **Envelope discriminator.** I chose `envelopeVersion` (not `version`) at the top level so the v1 payload's existing `version` key cannot collide. `parse()` checks `envelopeVersion` first, then falls back to the v1 structural shape (`version` + `specs`), else rejects.
- **Workers always export observations.** Worker branch is mode-agnostic — even with `strict_required=off` the envelope carries an empty `strictRequired.observations`. This lets CI flip the merge-CLI flag on without per-worker reruns; cost is ~30 bytes of JSON per sidecar.
- **CLI doesn't use `assertNoDrift()`.** That method throws `StrictRequiredDriftException` which is appropriate inside a PHPUnit subscriber but ugly in a CLI (stack trace on stderr). The new `evaluateStrictRequiredGate()` mirrors the existing `evaluateThresholdGate()` pattern: render → bool → exit code via the existing `$writeFailures || $thresholdFailure || $strictFailure` join.
- **Mixed v1+v2 fleets.** Tested explicitly. v1 sidecars merge their coverage half and contribute no strict_required observations — `strict_required=fail` against an all-v1 fleet exits 0 because there are zero observations to drift against. Documented under "Known limitations" in `docs/strict-required.md`.
- **SemVer:** additive — new envelope version (importer accepts old), new optional CLI flag (default off), no public API renames or removals. The pre-existing `warnStrictRequiredNotSupportedInWorker()` was `@internal` (in a `@internal` subscriber) so its removal is safe.