### PR TITLE
feat(validator): add strict_required_per_call mode for per-call drift detection

### DIFF
--- a/docs/strict-required.md
+++ b/docs/strict-required.md
@@ -10,7 +10,9 @@ The most common gap that slips past conformance checks is *under-description*: t
 - [Configuration](#configuration)
 - [Example](#example)
 - [Per-call mode](#per-call-mode)
+  - [Per-call silent paths and NOTE channel](#per-call-silent-paths-and-note-channel)
 - [What it does NOT do](#what-it-does-not-do)
+- [Paratest](#paratest)
 - [Known limitations](#known-limitations)
 
 ## How it works
@@ -177,6 +179,18 @@ Per-call by definition fires on every legitimately-optional field that happens t
 
 Both gates can be enabled together; they read the same per-response observation but make different calls about when to act on it.
 
+### Per-call silent paths and NOTE channel
+
+Per-call mode has no equivalent to the run-level asserter's `ExecutionFinished` summary, so several "infrastructure-level" no-ops cannot be surfaced as drift. To keep these visible without escalating them to per-test failures, the checker emits a **one-shot stderr NOTE** the first time each condition is hit per process:
+
+- **Spec load failure mid-run** (the spec file was unlinked or rewritten after bootstrap eager-load).
+- **Unresolvable response schema** for an observation (path-matcher / asserter disagreement, or a `$ref` resolved to an unexpected shape — both bug-level).
+- **Disjunction-covered observation** (the pointer falls under an `anyOf` / `oneOf` node, or the response root is itself unwalkable). Per-call cannot emit "add to `required`" advice safely here.
+
+NOTE volume is deduped (one per spec for load failures, one per `(spec, endpoint, response)` for unresolved schemas, one per `(spec, endpoint, response, covering-pointer)` for disjunctions). All NOTEs use the `[OpenAPI Strict Required per-call] NOTE:` prefix and write through the same channel as the WARN messages, so a single log scrape covers both severities.
+
+Under paratest, each worker maintains its own NOTE dedupe set, so the same condition can produce N NOTEs across N workers — by design, so the parent run can see which workers tripped the condition.
+
 ### Suppressing per-call drift
 
 There is currently no per-test or per-field suppression mechanism for per-call mode — if a field is genuinely optional and you do not want the warning, the recommended workflows are:
@@ -209,6 +223,8 @@ vendor/bin/openapi-coverage-merge \
 `--strict-required` accepts `off` (default), `warn` (emit diagnostic, exit 0), and `fail` (emit diagnostic, exit 1). The `strict_required` parameter on the PHPUnit extension does **not** propagate to the merge CLI — workers always export observations, and the merge step decides whether to assert. This keeps mode flips a single-knob CI operation without per-worker reruns.
 
 The diagnostic block is rendered after the coverage report (Markdown, JUnit, JSON, HTML, GITHUB_STEP_SUMMARY) so a fatal drift does not suppress the coverage output that helps triage the failure.
+
+**Per-call mode is worker-local.** `strict_required_per_call=warn` fires `E_USER_WARNING` inside the worker process. PHPUnit's `failOnWarning="true"` converts those warnings into per-worker test failures, which paratest aggregates into its own non-zero exit code — the gate works correctly under paratest. The `strict_required_per_call` parameter is **not** consumed by the merge CLI; there is no `--strict-required-per-call` flag because the per-call decision is made entirely inside the worker. NOTEs (see [Per-call silent paths](#per-call-silent-paths-and-note-channel)) are also per-worker, so the same condition may produce multiple NOTEs across a paratest run.
 
 ## Known limitations
 

--- a/docs/strict-required.md
+++ b/docs/strict-required.md
@@ -9,6 +9,7 @@ The most common gap that slips past conformance checks is *under-description*: t
 - [How it works](#how-it-works)
 - [Configuration](#configuration)
 - [Example](#example)
+- [Per-call mode](#per-call-mode)
 - [What it does NOT do](#what-it-does-not-do)
 - [Known limitations](#known-limitations)
 
@@ -125,6 +126,67 @@ The fix is to update the spec:
 
 After re-running the suite the diagnostic disappears and downstream SDK consumers receive concrete (non-optional) types for the three fields.
 
+## Per-call mode
+
+The default `strict_required` mode aggregates observations and reports drift only after the run finishes. Endpoints with a single test case never reach the `hits >= 2` threshold needed to confirm "this key appears in *every* call" — they silently pass even when the spec is under-described.
+
+`strict_required_per_call` is a separate, lightweight gate that fires immediately on every conformance-passing response: any optional field present in this single observation is reported as `E_USER_WARNING`. Pair it with PHPUnit's `failOnWarning="true"` to convert per-call drift into per-test failures.
+
+```xml
+<extensions>
+    <bootstrap class="Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension">
+        <parameter name="spec_base_path" value="openapi/bundled"/>
+        <parameter name="specs" value="front,admin"/>
+        <parameter name="strict_required"          value="fail"/>  <!-- run-level safe gate  -->
+        <parameter name="strict_required_per_call" value="warn"/>  <!-- per-call early signal -->
+    </bootstrap>
+</extensions>
+```
+
+| Value | Behaviour |
+|---|---|
+| `off` (default) | The checker short-circuits; no per-call comparison runs. |
+| `warn` | Each Success response is diffed against the matching schema's `required`. Drift triggers `E_USER_WARNING` with the prefix `[OpenAPI Strict Required per-call]`. |
+
+`fail` is **not** an accepted value — silently demoting it to `warn` would mislead a CI that opted in by mistake. Per-call must stay warn-only by design (see trade-off below). Use `failOnWarning="true"` if you want hard test failures.
+
+Sample output (one warning per drifting observation):
+
+```
+[OpenAPI Strict Required per-call] WARN: PUT /signed-url  200  application/json: response carries 3 optional field(s) not declared in `required` at the matching schema pointer(s):
+  / : expires, signed_url, url
+Action: add these fields to the schema's `required` array, or set strict_required_per_call=off if intentional.
+Note: per-call mode warns on every legitimately-optional field present in this single observation. See docs/strict-required.md "Per-call mode" for the trade-off.
+```
+
+The `[OpenAPI Strict Required per-call]` prefix is intentionally distinct from the run-level `[OpenAPI Strict Required]` block so log scrapers can route the two channels independently.
+
+### Why no `fail` mode?
+
+Per-call by definition fires on every legitimately-optional field that happens to be present in any one observation — nullable fields, conditional payloads, fields gated by feature flags. Forcing the run to exit non-zero on the first such hit would push false positives onto every test suite. Run-level intersection mode (`strict_required=fail`) is the stable fail-gate; per-call is the early-visibility companion.
+
+### Run-level vs per-call: which gate when?
+
+| | Run-level (`strict_required`) | Per-call (`strict_required_per_call`) |
+|---|---|---|
+| When does it fire? | Once at `ExecutionFinished` | Immediately on each Success response |
+| Aggregation | Intersection across every observation per pointer | None — uses the single observation's keys |
+| False positives | Low (a field must appear in *every* call) | Higher (any optional-but-present field) |
+| Single-observation endpoint | Silently skipped | Surfaces drift |
+| Recommended escalation path | `off` → `warn` → `fail` | `off` → `warn` (no `fail`) |
+
+Both gates can be enabled together; they read the same per-response observation but make different calls about when to act on it.
+
+### Suppressing per-call drift
+
+There is currently no per-test or per-field suppression mechanism for per-call mode — if a field is genuinely optional and you do not want the warning, the recommended workflows are:
+
+1. **Add the field to the schema's `required` array** if the implementation actually always returns it.
+2. **Disable per-call** (`strict_required_per_call=off`) for the suite and rely on the run-level intersection gate, which already handles the "sometimes-present" case correctly.
+3. **Avoid `failOnWarning="true"`** at the global level if you only want per-call warnings as advisory output.
+
+A future release may add an opt-out attribute (e.g. `#[StrictRequiredPerCallIgnore]`) for endpoints with known noisy optional fields — see Issue #228 follow-up tracking. The MVP ships without it so the noise floor of the gate is observed in real CI before deciding the suppression API.
+
 ## What it does NOT do
 
 - It does **not** flag fields the impl returns *sometimes* but not always. By design — those fields are legitimately optional, and `required` only describes invariant fields.
@@ -153,6 +215,5 @@ The diagnostic block is rendered after the coverage report (Markdown, JUnit, JSO
 - **Mixed sidecar versions.** Workers running an older library version write a v1 (coverage-only) sidecar. The merge CLI still accepts those and merges their coverage, but their strict_required contribution is empty. Upgrade all workers to share the gate fully.
 - **Mixed strict_required wire versions.** Starting with this release the strict_required tracker emits state format **v2** (per-pointer rows). The merge CLI rejects v1 strict_required payloads with a loud error rather than silently downgrading nested observations to root-only. Coverage merging is unaffected (the envelope still tolerates v1 coverage payloads); only the strict_required half requires version-aligned workers.
 - **`additionalProperties` schemas are not walked.** When a schema sets `additionalProperties: <schema>` (object form), the asserter does not descend into that schema to look for `required` on dynamically-keyed properties. Walk-depth follows declared `properties` and `items` only. **Consequence:** dynamically-keyed response objects (`{"user-42": {...}, "user-43": {...}}`-style maps) silently miss strict-required coverage on their values. If you need strict-required coverage on map-shaped responses, pin the shape with declared `properties` instead.
-- **`allOf` is unioned; `anyOf` / `oneOf` are not walked.** `allOf` semantics are AND, so the union of `required` arrays across branches is sound — applied at every level of descent. `anyOf` / `oneOf` are disjunctions and there is no safe AND-semantic for "required" across them; the asserter stops descending at such a node. **Consequence:** observations under an `anyOf` / `oneOf` node surface as a separate `NOTE` block (not drift), pointing to the disjunction site so reviewers can pin the shape with `allOf` if strict-required coverage matters there. Drift advice ("add to `required`") is suppressed for these pointers because it would be actively wrong.
-- **Per-call mode is not implemented.** An alternative "warn on every optional field present in a single observation" mode was considered but rejected: per-call would warn indiscriminately on every legitimately-optional field that happens to be present. The run-level intersection ("the field appears in *every* call") is the deliberate trade-off.
+- **`allOf` is unioned; `anyOf` / `oneOf` are not walked.** `allOf` semantics are AND, so the union of `required` arrays across branches is sound — applied at every level of descent. `anyOf` / `oneOf` are disjunctions and there is no safe AND-semantic for "required" across them; the asserter stops descending at such a node. **Consequence:** observations under an `anyOf` / `oneOf` node surface as a separate `NOTE` block (not drift), pointing to the disjunction site so reviewers can pin the shape with `allOf` if strict-required coverage matters there. Drift advice ("add to `required`") is suppressed for these pointers because it would be actively wrong. Per-call mode applies the same rule: pointers under a disjunction are silently skipped (per-call has no NOTE channel).
 - **Empty `{}` and `[]` at child positions are skipped.** PHP cannot distinguish empty object from empty list once `json_decode` lands them both as `[]`. To avoid polluting observations with ambiguous shapes, the walker records empty `{}` only at the response root (preserving "empty response collapses the intersection"). Empty arrays at nested positions contribute no pointer to that observation — combined with the tracker's "absence drops the pointer" rule, a sometimes-empty nested array silently drops its `[*]` row from cross-response analysis. If you need strict-required coverage on a nullable array property, pin the shape with a more specific spec (e.g. `oneOf` with concrete element types — though see disjunction limitation above).

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -14,6 +14,7 @@ use Studio\OpenApiContractTesting\Validation\Response\ResponseBodyValidationResu
 use Studio\OpenApiContractTesting\Validation\Response\ResponseBodyValidator;
 use Studio\OpenApiContractTesting\Validation\Response\ResponseHeaderValidator;
 use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredBodyWalker;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredPerCallChecker;
 use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredTracker;
 use Studio\OpenApiContractTesting\Validation\Support\PathDiagnosticsFormatter;
 use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
@@ -241,14 +242,18 @@ final class OpenApiResponseValidator
     }
 
     /**
-     * Feed the strict-required tracker one observation. The body is walked
-     * recursively via {@see StrictRequiredBodyWalker::collectPointers()}
-     * which produces a `pointer => list<string>` map describing every
-     * object node observed; {@see StrictRequiredAsserter} diffs each
-     * pointer's keys against the spec's `required` array at the matching
-     * schema node.
+     * Feed the strict-required tracker one observation, and (when per-call
+     * mode is enabled) emit an immediate `E_USER_WARNING` for any
+     * already-drifting pointer.
      *
-     * Only recorded on the Success path (caller guarantees `$errors === []`):
+     * The body is walked once via {@see StrictRequiredBodyWalker::collectPointers()}
+     * and the resulting `pointer => list<string>` map is shared with both
+     * the run-level tracker (intersection mode, asserts at
+     * `ExecutionFinished`) and the per-call checker (Issue #228, fires
+     * immediately). Walking once keeps the cost flat regardless of how many
+     * gates the user enabled.
+     *
+     * Only invoked on the Success path (caller guarantees `$errors === []`):
      * a conformance failure means the body shape itself is suspect, and
      * skipped responses are explicitly excluded from coverage too — both
      * cases would poison the intersection.
@@ -270,6 +275,7 @@ final class OpenApiResponseValidator
         if ($pointers === []) {
             return;
         }
+        $contentTypeKey = $matchedContentType ?? StrictRequiredTracker::ANY_CONTENT_TYPE;
 
         try {
             StrictRequiredTracker::record(
@@ -277,7 +283,7 @@ final class OpenApiResponseValidator
                 $method,
                 $matchedPath,
                 $statusKey,
-                $matchedContentType ?? StrictRequiredTracker::ANY_CONTENT_TYPE,
+                $contentTypeKey,
                 $pointers,
             );
         } catch (InvalidArgumentException $e) {
@@ -304,6 +310,21 @@ final class OpenApiResponseValidator
             // installed by the test framework.
             fwrite(STDERR, $message);
         }
+
+        // Per-call mode (Issue #228) is independent of the run-level
+        // tracker: even when the tracker rejected the row above, the
+        // per-call checker reads the same pointer map, so a malformed map
+        // affects both gates symmetrically. The checker short-circuits
+        // when its mode is Off, which is the default for users who only
+        // opted into the run-level gate.
+        StrictRequiredPerCallChecker::maybeWarn(
+            $specName,
+            $method,
+            $matchedPath,
+            $statusKey,
+            $contentTypeKey,
+            $pointers,
+        );
     }
 
     /**

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting;
 
-use const STDERR;
-
 use InvalidArgumentException;
 use RuntimeException;
+use Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension;
 use Studio\OpenApiContractTesting\Spec\OpenApiPathMatcher;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\Validation\Response\ResponseBodyValidationResult;
@@ -24,7 +23,6 @@ use Studio\OpenApiContractTesting\Validation\Support\ValidatorErrorBoundary;
 
 use function array_keys;
 use function array_merge;
-use function fwrite;
 use function get_debug_type;
 use function is_array;
 use function sprintf;
@@ -253,15 +251,27 @@ final class OpenApiResponseValidator
      * immediately). Walking once keeps the cost flat regardless of how many
      * gates the user enabled.
      *
-     * Only invoked on the Success path (caller guarantees `$errors === []`):
-     * a conformance failure means the body shape itself is suspect, and
-     * skipped responses are explicitly excluded from coverage too — both
-     * cases would poison the intersection.
+     * Only invoked on the Success path (caller guarantees `$errors === []`).
+     * Conformance-failing bodies are filtered out by the caller; skipped
+     * statuses (matched skip pattern) short-circuit far earlier in
+     * `validate()` and never reach this method, so neither gate sees them.
      *
      * Body-shape handling is delegated to the walker (see its docblock for
      * the full matrix). The validator only short-circuits when the walker
-     * yields an empty map — null / scalar bodies, or arrays whose only
-     * elements are scalars (no object structure to intersect).
+     * yields an empty map — strictly: when no object node is observed
+     * anywhere in the body (null / scalar root, or arrays containing no
+     * object element at any nesting depth).
+     *
+     * Tracker-side malformed-map guard: if the tracker rejects the pointer
+     * map (`InvalidArgumentException` from `record()`), we suppress the
+     * per-call checker too rather than letting it iterate the same bad
+     * data. The per-call checker has no input-shape validation of its own
+     * — `findCoveringDisjunction()` would TypeError on a non-string key,
+     * `array_diff()` would silently produce a corrupted "missing" list on
+     * a non-list value. Failing the user's test with either is the wrong
+     * fingerprint when the underlying bug is in the walker. The single
+     * LIBRARY BUG line covers both gates by name so the reader knows
+     * neither contributed to drift detection for this observation.
      */
     private function maybeRecordStrictRequired(
         string $specName,
@@ -290,33 +300,38 @@ final class OpenApiResponseValidator
             // The walker's contract is "every value is a list of strings,
             // every key is a non-empty pointer string." A throw here means
             // the walker produced something malformed — a library bug, not
-            // a user-test failure. Failing the actual test with this
-            // exception would blame the user for our regression. Emit a
-            // one-shot stderr WARNING with a clear library-bug prefix and
-            // disable strict_required for this observation; the rest of the
-            // test continues normally.
+            // a user-test failure. Emit a one-shot stderr WARNING with a
+            // clear library-bug prefix naming both gates, then return so
+            // the per-call checker is not handed the same malformed map
+            // (it has no input-shape validation; iterating would TypeError
+            // or emit a corrupted warning misattributing the fault to the
+            // user). The rest of the test continues normally.
             $message = sprintf(
                 '[OpenAPI Strict Required] LIBRARY BUG: walker produced malformed pointer map for %s %s %s; '
-                . 'strict_required recording skipped for this observation. Please report at '
-                . 'https://github.com/studio-design/openapi-contract-testing/issues '
+                . 'strict_required and strict_required_per_call recording skipped for this observation. '
+                . 'Please report at https://github.com/studio-design/openapi-contract-testing/issues '
                 . "with the cause: %s\n",
                 strtoupper($method),
                 $matchedPath,
                 $statusKey,
                 $e->getMessage(),
             );
-            // Write directly to STDERR rather than via trigger_error so the
-            // message is unconditional and not subject to error handlers
-            // installed by the test framework.
-            fwrite(STDERR, $message);
+            // Routed through the extension's writer rather than `fwrite`
+            // so test seams that override stderr capture the LIBRARY BUG
+            // line, and so paratest workers' diagnostics travel through
+            // the same channel as every other extension stderr line.
+            // `OpenApiCoverageExtension::writeStderr()` falls back to bare
+            // STDERR when no override is set, so the validator stays usable
+            // outside the PHPUnit extension context.
+            OpenApiCoverageExtension::writeStderr($message);
+
+            return;
         }
 
-        // Per-call mode (Issue #228) is independent of the run-level
-        // tracker: even when the tracker rejected the row above, the
-        // per-call checker reads the same pointer map, so a malformed map
-        // affects both gates symmetrically. The checker short-circuits
-        // when its mode is Off, which is the default for users who only
-        // opted into the run-level gate.
+        // Per-call mode (Issue #228) reads the same pointer map the
+        // tracker just accepted. The checker short-circuits when its mode
+        // is Off (the default for users who only opted into the run-level
+        // gate), so unconditional invocation here is the cheapest path.
         StrictRequiredPerCallChecker::maybeWarn(
             $specName,
             $method,

--- a/src/PHPUnit/InvalidStrictRequiredConfigurationException.php
+++ b/src/PHPUnit/InvalidStrictRequiredConfigurationException.php
@@ -8,12 +8,22 @@ use RuntimeException;
 use Throwable;
 
 /**
- * Thrown by {@see OpenApiCoverageExtension} when the `strict_required`
- * parameter carries an unrecognised value (anything outside `off` / `warn`
- * / `fail`).
+ * Thrown by {@see OpenApiCoverageExtension} when either the run-level
+ * `strict_required` parameter or the per-call `strict_required_per_call`
+ * parameter carries an unrecognised value.
+ *
+ * The two parameters have different accepted-value sets:
+ *  - `strict_required`          accepts `off` / `warn` / `fail`
+ *  - `strict_required_per_call` accepts `off` / `warn` only
+ *
+ * `fail` IS valid for the run-level parameter but is intentionally rejected
+ * for the per-call one: per-call mode warns on every legitimately-optional
+ * field present in any one observation, and a fail-gate over that surface
+ * would shower false positives. Silently demoting a per-call `fail` typo to
+ * `warn` would mislead a CI that opted into a hard gate by accident.
  *
  * Bootstrap catches this alongside the other extension-config exceptions
- * and translates it to `exit(1)`. A typo in `strict_required` must fail
+ * and translates it to `exit(1)`. A typo in either parameter must fail
  * loud rather than silently disabling the feature — silently dropping the
  * gate is exactly the silent-pass mode the extension exists to prevent.
  */

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -26,6 +26,8 @@ use Studio\OpenApiContractTesting\Schema\EnumDriftAsserter;
 use Studio\OpenApiContractTesting\Schema\EnumDriftReport;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredMode;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredPerCallChecker;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredPerCallMode;
 use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredTracker;
 
 use function array_filter;
@@ -273,6 +275,15 @@ final class OpenApiCoverageExtension implements Extension
         // paratest workers via the sidecar envelope (Issue #226).
         $strictRequiredMode = self::resolveStrictRequiredMode($parameters, $githubSummaryPath);
         StrictRequiredTracker::reset();
+
+        // Issue #228: per-call strict_required mode. Independent of the
+        // run-level parameter above — both gates can be wired in the same
+        // run. Reset the checker so a leaked `configure()` from a previous
+        // process does not persist; configure with the parsed mode (Off
+        // when the parameter is absent).
+        $strictRequiredPerCallMode = self::resolveStrictRequiredPerCallMode($parameters, $githubSummaryPath);
+        StrictRequiredPerCallChecker::reset();
+        StrictRequiredPerCallChecker::configure($strictRequiredPerCallMode);
 
         if ($facade === null) {
             return;
@@ -605,6 +616,37 @@ final class OpenApiCoverageExtension implements Extension
                 trim($raw) === '' ? '<empty>' : $raw,
             );
             self::writeStderr("[OpenAPI Strict Required] FATAL: {$reason}\n");
+            self::appendGithubStepSummaryStrictRequiredBlock($githubSummaryPath, $reason, isFatal: true);
+
+            throw new InvalidStrictRequiredConfigurationException($reason, $e);
+        }
+    }
+
+    /**
+     * Issue #228: read the `strict_required_per_call` parameter. Mirrors
+     * {@see resolveStrictRequiredMode()} with one deliberate difference —
+     * the per-call enum rejects `fail` outright (per-call is warn-only;
+     * the run-level mode is the safe fail-gate). Unrecognised values stay
+     * FATAL for the same opt-in fail-loud rationale.
+     */
+    private static function resolveStrictRequiredPerCallMode(
+        ParameterCollection $parameters,
+        ?string $githubSummaryPath,
+    ): StrictRequiredPerCallMode {
+        if (!$parameters->has('strict_required_per_call')) {
+            return StrictRequiredPerCallMode::Off;
+        }
+
+        $raw = $parameters->get('strict_required_per_call');
+
+        try {
+            return StrictRequiredPerCallMode::fromConfigValue($raw);
+        } catch (InvalidArgumentException $e) {
+            $reason = sprintf(
+                'strict_required_per_call=%s is not recognised. Accepted: off, warn.',
+                trim($raw) === '' ? '<empty>' : $raw,
+            );
+            self::writeStderr("[OpenAPI Strict Required per-call] FATAL: {$reason}\n");
             self::appendGithubStepSummaryStrictRequiredBlock($githubSummaryPath, $reason, isFatal: true);
 
             throw new InvalidStrictRequiredConfigurationException($reason, $e);

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -98,7 +98,11 @@ final class OpenApiCoverageExtension implements Extension
     /**
      * Append a Markdown block describing a strict_required outcome to the
      * GitHub Actions Step Summary file. Mirrors
-     * {@see appendGithubStepSummaryEnumDriftBlock()}.
+     * {@see appendGithubStepSummaryEnumDriftBlock()} structurally, but the
+     * body text is intentionally distinct ("schema under-description" vs
+     * "checks failed") so log scrapers can route the two channels by
+     * grepping the title — keep the wording divergent if you ever touch
+     * either method.
      *
      * @internal Exposed so {@see CoverageReportSubscriber} can reuse the same
      *           rendering path when invoking the asserter at ExecutionFinished.
@@ -278,9 +282,13 @@ final class OpenApiCoverageExtension implements Extension
 
         // Issue #228: per-call strict_required mode. Independent of the
         // run-level parameter above — both gates can be wired in the same
-        // run. Reset the checker so a leaked `configure()` from a previous
-        // process does not persist; configure with the parsed mode (Off
-        // when the parameter is absent).
+        // run. Resolve first so an invalid value FATAL-throws BEFORE we
+        // touch the checker state; reset then runs only on the happy path
+        // and on test seams where setupExtension() is invoked multiple
+        // times in one PHP process. The follow-up `configure()` overwrites
+        // unconditionally, so the reset matters specifically for the
+        // failed-resolve early-return path (where configure never runs)
+        // and for repeated bootstrap calls.
         $strictRequiredPerCallMode = self::resolveStrictRequiredPerCallMode($parameters, $githubSummaryPath);
         StrictRequiredPerCallChecker::reset();
         StrictRequiredPerCallChecker::configure($strictRequiredPerCallMode);

--- a/src/Validation/Strict/StrictRequiredAsserter.php
+++ b/src/Validation/Strict/StrictRequiredAsserter.php
@@ -286,9 +286,7 @@ final class StrictRequiredAsserter
                     continue;
                 }
 
-                $analysis = StrictRequiredSchemaWalker::collectRequiredByPointer($schemaNode);
-                $walked = $analysis['walked'];
-                $disjunctions = $analysis['disjunctions'];
+                $analysis = StrictRequiredSchemaWalker::analyse($schemaNode);
 
                 // Sort the observed pointers so generated reports are
                 // deterministic — useful for snapshot-style assertions and
@@ -297,8 +295,8 @@ final class StrictRequiredAsserter
                 ksort($pointers);
 
                 foreach ($pointers as $pointer => $alwaysPresent) {
-                    $disjunction = StrictRequiredSchemaWalker::findCoveringDisjunction($pointer, $disjunctions);
-                    if ($disjunction !== null) {
+                    $lookup = $analysis->lookup($pointer);
+                    if ($lookup instanceof StrictRequiredDisjunctionMatch) {
                         // The spec node at (or above) this pointer is a
                         // disjunction (`anyOf` / `oneOf`); the "add to
                         // required" advice does not apply. Surface as a
@@ -309,15 +307,14 @@ final class StrictRequiredAsserter
                             $endpointKey,
                             $responseKey,
                             $pointer,
-                            $disjunction['reason'],
-                            $disjunction['pointer'] === '' ? '<root>' : $disjunction['pointer'],
+                            $lookup->reason,
+                            $lookup->coveringPointer === '' ? '<root>' : $lookup->coveringPointer,
                         );
 
                         continue;
                     }
 
-                    $specRequired = $walked[$pointer] ?? [];
-                    $missing = array_values(array_diff($alwaysPresent, $specRequired));
+                    $missing = array_values(array_diff($alwaysPresent, $lookup->required));
                     if ($missing === []) {
                         continue;
                     }

--- a/src/Validation/Strict/StrictRequiredAsserter.php
+++ b/src/Validation/Strict/StrictRequiredAsserter.php
@@ -16,21 +16,12 @@ use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 use function array_diff;
 use function array_keys;
 use function array_map;
-use function array_unique;
 use function array_values;
 use function count;
 use function implode;
-use function is_array;
-use function is_string;
 use function ksort;
 use function sort;
 use function sprintf;
-use function str_replace;
-use function str_starts_with;
-use function strpos;
-use function strtolower;
-use function strtoupper;
-use function substr;
 use function trigger_error;
 
 /**
@@ -45,12 +36,9 @@ use function trigger_error;
  *    arrays (per-test-run aggregate), walked through nested objects and
  *    array elements.
  *
- * `allOf` is walked at every level when collecting `required`. `anyOf` /
- * `oneOf` are intentionally NOT walked — they are disjunctions and there is
- * no safe AND-semantic for "required" across them. The collected `required`
- * at such a node is therefore `[]`, which makes *every* always-present key
- * at that node surface as drift. Consult `docs/strict-required.md`
- * "Known limitations" before relying on those constructs.
+ * Schema-walking helpers (path resolution, `allOf` union, disjunction
+ * detection) live in {@see StrictRequiredSchemaWalker} so the per-call
+ * checker can share them without duplication.
  *
  * Observations whose `(method, path, status, content-type)` does not resolve
  * to a response schema in the spec are silently skipped from drift reporting
@@ -274,10 +262,10 @@ final class StrictRequiredAsserter
         $unresolved = [];
         $unwalkable = [];
         foreach ($observations as $endpointKey => $responses) {
-            [$method, $path] = self::splitEndpointKey($endpointKey);
+            [$method, $path] = StrictRequiredSchemaWalker::splitEndpointKey($endpointKey);
             foreach ($responses as $responseKey => $row) {
-                [$statusKey, $contentTypeKey] = self::splitResponseKey($responseKey);
-                $schemaNode = self::resolveResponseSchema(
+                [$statusKey, $contentTypeKey] = StrictRequiredSchemaWalker::splitResponseKey($responseKey);
+                $schemaNode = StrictRequiredSchemaWalker::resolveResponseSchema(
                     $spec,
                     $method,
                     $path,
@@ -298,7 +286,7 @@ final class StrictRequiredAsserter
                     continue;
                 }
 
-                $analysis = self::collectRequiredByPointer($schemaNode);
+                $analysis = StrictRequiredSchemaWalker::collectRequiredByPointer($schemaNode);
                 $walked = $analysis['walked'];
                 $disjunctions = $analysis['disjunctions'];
 
@@ -309,7 +297,7 @@ final class StrictRequiredAsserter
                 ksort($pointers);
 
                 foreach ($pointers as $pointer => $alwaysPresent) {
-                    $disjunction = self::findCoveringDisjunction($pointer, $disjunctions);
+                    $disjunction = StrictRequiredSchemaWalker::findCoveringDisjunction($pointer, $disjunctions);
                     if ($disjunction !== null) {
                         // The spec node at (or above) this pointer is a
                         // disjunction (`anyOf` / `oneOf`); the "add to
@@ -350,354 +338,5 @@ final class StrictRequiredAsserter
         }
 
         return ['reports' => $reports, 'unresolved' => $unresolved, 'unwalkable' => $unwalkable];
-    }
-
-    /**
-     * Return the disjunction descriptor covering an observed pointer, or
-     * `null` if none. An ancestor matches when the observed pointer equals
-     * the disjunction's pointer OR descends from it via a `/` or `[`
-     * separator boundary. A disjunction with an empty pointer (`""`) marks
-     * "root schema is unwalkable" and covers every observation.
-     *
-     * @param list<array{pointer: string, reason: string}> $disjunctions
-     *
-     * @return null|array{pointer: string, reason: string}
-     */
-    private static function findCoveringDisjunction(string $pointer, array $disjunctions): ?array
-    {
-        foreach ($disjunctions as $d) {
-            $dp = $d['pointer'];
-            if ($dp === '') {
-                return $d;
-            }
-            if ($pointer === $dp) {
-                return $d;
-            }
-            if (str_starts_with($pointer, $dp . '/') || str_starts_with($pointer, $dp . '[')) {
-                return $d;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * @return array{0: string, 1: string}
-     */
-    private static function splitEndpointKey(string $endpointKey): array
-    {
-        $spacePos = strpos($endpointKey, ' ');
-        if ($spacePos === false) {
-            return [strtoupper($endpointKey), '/'];
-        }
-
-        return [
-            strtoupper(substr($endpointKey, 0, $spacePos)),
-            substr($endpointKey, $spacePos + 1),
-        ];
-    }
-
-    /**
-     * @return array{0: string, 1: string}
-     */
-    private static function splitResponseKey(string $responseKey): array
-    {
-        $colonPos = strpos($responseKey, ':');
-        if ($colonPos === false) {
-            return [$responseKey, StrictRequiredTracker::ANY_CONTENT_TYPE];
-        }
-
-        return [
-            substr($responseKey, 0, $colonPos),
-            substr($responseKey, $colonPos + 1),
-        ];
-    }
-
-    /**
-     * Locate the response schema dict for `(method, path, statusKey,
-     * contentTypeKey)`. Returns `null` when any segment of the descent does
-     * not resolve.
-     *
-     * @param array<string, mixed> $spec
-     *
-     * @return null|array<string, mixed>
-     */
-    private static function resolveResponseSchema(
-        array $spec,
-        string $method,
-        string $path,
-        string $statusKey,
-        string $contentTypeKey,
-    ): ?array {
-        $lowerMethod = strtolower($method);
-        $operation = $spec['paths'][$path][$lowerMethod] ?? null;
-        if (!is_array($operation)) {
-            return null;
-        }
-        $responses = $operation['responses'] ?? null;
-        if (!is_array($responses)) {
-            return null;
-        }
-        $response = $responses[$statusKey] ?? null;
-        if (!is_array($response)) {
-            return null;
-        }
-        $content = $response['content'] ?? null;
-        if (!is_array($content)) {
-            return null;
-        }
-        $entry = $content[$contentTypeKey] ?? null;
-        if (!is_array($entry)) {
-            return null;
-        }
-        $schema = $entry['schema'] ?? null;
-        if (!is_array($schema)) {
-            return null;
-        }
-
-        return $schema;
-    }
-
-    /**
-     * Descend the response schema producing two parallel maps:
-     *  - `walked`: `pointer => required-keys` for each object node reached.
-     *    `allOf` branches are unioned at every level.
-     *  - `disjunctions`: pointers where descent stopped because the node is
-     *    `anyOf` / `oneOf` (no safe AND-semantic for `required` across
-     *    disjunctions). The caller uses this to surface observations under
-     *    these pointers as NOTE rather than misleading drift advice.
-     *
-     * If the root schema itself is unwalkable, the disjunction list carries
-     * an empty-pointer entry meaning "every observation is unwalkable."
-     *
-     * @param array<string, mixed> $schema
-     *
-     * @return array{walked: array<string, list<string>>, disjunctions: list<array{pointer: string, reason: string}>}
-     */
-    private static function collectRequiredByPointer(array $schema): array
-    {
-        $walked = [];
-        $disjunctions = [];
-        $rootShape = self::inferShape($schema);
-        if ($rootShape === null) {
-            // Root schema is itself unwalkable (anyOf/oneOf/scalar/empty).
-            // Use an empty-pointer disjunction so any observed pointer
-            // matches; the body could be either object- or array-shaped.
-            $disjunctions[] = [
-                'pointer' => '',
-                'reason' => self::disjunctionReason($schema),
-            ];
-
-            return ['walked' => $walked, 'disjunctions' => $disjunctions];
-        }
-        // Root-array schemas use bare `[*]` for their element pointer
-        // (matching the walker's root-list convention); object roots start
-        // at `/`.
-        $rootPointer = $rootShape === 'array' ? '' : '/';
-        self::descendSchema($schema, $rootPointer, $walked, $disjunctions);
-
-        return ['walked' => $walked, 'disjunctions' => $disjunctions];
-    }
-
-    /**
-     * @param array<string, mixed> $schema
-     * @param array<string, list<string>> $walked
-     * @param list<array{pointer: string, reason: string}> $disjunctions
-     */
-    private static function descendSchema(array $schema, string $pointer, array &$walked, array &$disjunctions): void
-    {
-        $type = self::inferShape($schema);
-        if ($type === 'object') {
-            $walked[$pointer] = self::collectRequiredFromSchema($schema);
-            foreach (self::collectPropertyBranches($schema) as $propName => $propSchema) {
-                $childPointer = self::appendProperty($pointer, $propName);
-                self::descendSchema($propSchema, $childPointer, $walked, $disjunctions);
-            }
-
-            return;
-        }
-        if ($type === 'array') {
-            $items = self::collectItemsSchema($schema);
-            if ($items !== null) {
-                self::descendSchema($items, $pointer . '[*]', $walked, $disjunctions);
-            }
-
-            return;
-        }
-        // type is null — scalar leaf, anyOf / oneOf, or malformed node.
-        // For disjunctions specifically, surface the descent stop as a
-        // disjunction entry so the caller can emit a NOTE rather than
-        // misleading drift advice. Scalar / empty nodes are silently
-        // skipped — an observed pointer landing there really is "spec
-        // doesn't model this" and surfacing as drift is appropriate.
-        $reason = self::disjunctionReason($schema);
-        if ($reason !== null) {
-            $disjunctions[] = ['pointer' => $pointer, 'reason' => $reason];
-        }
-    }
-
-    /**
-     * Classify a schema node that {@see self::inferShape()} reported as
-     * non-descendable. Returns the disjunction kind if applicable (so the
-     * caller can emit a NOTE), `null` for scalar / empty leaves (which
-     * legitimately do not contribute to `required` semantics).
-     *
-     * @param array<string, mixed> $schema
-     */
-    private static function disjunctionReason(array $schema): ?string
-    {
-        if (isset($schema['anyOf']) && is_array($schema['anyOf'])) {
-            return 'anyOf';
-        }
-        if (isset($schema['oneOf']) && is_array($schema['oneOf'])) {
-            return 'oneOf';
-        }
-
-        return null;
-    }
-
-    /**
-     * @param array<string, mixed> $schema
-     *
-     * @return null|'array'|'object'
-     */
-    private static function inferShape(array $schema): ?string
-    {
-        $type = $schema['type'] ?? null;
-        if ($type === 'object' || isset($schema['properties'])) {
-            return 'object';
-        }
-        if ($type === 'array' || isset($schema['items'])) {
-            return 'array';
-        }
-        // allOf-only schema with no explicit type: treat as object if any
-        // branch declares object-shape. Matches OpenAPI's "object inferred
-        // from properties / required" convention.
-        if (isset($schema['allOf']) && is_array($schema['allOf'])) {
-            foreach ($schema['allOf'] as $branch) {
-                if (is_array($branch) && (
-                    ($branch['type'] ?? null) === 'object' ||
-                    isset($branch['properties']) ||
-                    isset($branch['required'])
-                )) {
-                    return 'object';
-                }
-                if (is_array($branch) && (
-                    ($branch['type'] ?? null) === 'array' || isset($branch['items'])
-                )) {
-                    return 'array';
-                }
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Union of `required` arrays at this schema node, walking `allOf`
-     * branches so nested descent inherits AND-semantic `required`
-     * composition.
-     *
-     * @param array<string, mixed> $schema
-     *
-     * @return list<string>
-     */
-    private static function collectRequiredFromSchema(array $schema): array
-    {
-        $collected = [];
-        if (isset($schema['required']) && is_array($schema['required'])) {
-            foreach ($schema['required'] as $entry) {
-                if (is_string($entry)) {
-                    $collected[] = $entry;
-                }
-            }
-        }
-        if (isset($schema['allOf']) && is_array($schema['allOf'])) {
-            foreach ($schema['allOf'] as $branch) {
-                if (is_array($branch)) {
-                    foreach (self::collectRequiredFromSchema($branch) as $key) {
-                        $collected[] = $key;
-                    }
-                }
-            }
-        }
-
-        return array_values(array_unique($collected));
-    }
-
-    /**
-     * Yield `propertyName => propertySchema` from this schema node plus any
-     * `allOf` branches' properties. Later branches override earlier ones —
-     * matches the OpenAPI composition convention.
-     *
-     * @param array<string, mixed> $schema
-     *
-     * @return array<string, array<string, mixed>>
-     */
-    private static function collectPropertyBranches(array $schema): array
-    {
-        $out = [];
-        $properties = $schema['properties'] ?? null;
-        if (is_array($properties)) {
-            foreach ($properties as $name => $sub) {
-                if (is_string($name) && is_array($sub)) {
-                    $out[$name] = $sub;
-                }
-            }
-        }
-        if (isset($schema['allOf']) && is_array($schema['allOf'])) {
-            foreach ($schema['allOf'] as $branch) {
-                if (!is_array($branch)) {
-                    continue;
-                }
-                foreach (self::collectPropertyBranches($branch) as $name => $sub) {
-                    $out[$name] = $sub;
-                }
-            }
-        }
-
-        return $out;
-    }
-
-    /**
-     * Resolve the `items` schema for an array node, looking through `allOf`
-     * branches if the direct `items` field is absent.
-     *
-     * @param array<string, mixed> $schema
-     *
-     * @return null|array<string, mixed>
-     */
-    private static function collectItemsSchema(array $schema): ?array
-    {
-        $items = $schema['items'] ?? null;
-        if (is_array($items)) {
-            return $items;
-        }
-        if (isset($schema['allOf']) && is_array($schema['allOf'])) {
-            foreach ($schema['allOf'] as $branch) {
-                if (!is_array($branch)) {
-                    continue;
-                }
-                $branchItems = self::collectItemsSchema($branch);
-                if ($branchItems !== null) {
-                    return $branchItems;
-                }
-            }
-        }
-
-        return null;
-    }
-
-    private static function appendProperty(string $pointer, string $propertyName): string
-    {
-        $escaped = str_replace('~', '~0', $propertyName);
-        $escaped = str_replace('/', '~1', $escaped);
-        $escaped = str_replace('[*]', '[~*]', $escaped);
-
-        if ($pointer === '/') {
-            return '/' . $escaped;
-        }
-
-        return $pointer . '/' . $escaped;
     }
 }

--- a/src/Validation/Strict/StrictRequiredDisjunctionMatch.php
+++ b/src/Validation/Strict/StrictRequiredDisjunctionMatch.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Validation\Strict;
+
+/**
+ * Lookup result returned by {@see StrictRequiredSchemaAnalysis::lookup()}
+ * when the observed pointer falls under a schema node where descent
+ * stopped — `anyOf` / `oneOf` / scalar / unwalkable root. The
+ * `coveringPointer` identifies the schema-side pointer at which descent
+ * stopped (empty string means "the root schema itself is unwalkable").
+ *
+ * Caller code MUST NOT produce "add to `required`" drift advice for these
+ * pointers because `required` has no AND-semantic across disjunctions —
+ * the suggestion would be actively wrong. Run-level mode surfaces these
+ * via the unwalkable NOTE channel; per-call mode silently skips (no NOTE
+ * channel exists for it yet).
+ *
+ * @internal Lookup variants are not part of the SemVer-frozen public API.
+ */
+final class StrictRequiredDisjunctionMatch
+{
+    /**
+     * @param string $coveringPointer schema-side pointer at which descent
+     *                                stopped; empty string means "root
+     *                                schema is unwalkable"
+     * @param string $reason one of `anyOf` / `oneOf` / `unwalkable`
+     */
+    public function __construct(
+        public readonly string $coveringPointer,
+        public readonly string $reason,
+    ) {}
+}

--- a/src/Validation/Strict/StrictRequiredKnownRequired.php
+++ b/src/Validation/Strict/StrictRequiredKnownRequired.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Validation\Strict;
+
+/**
+ * Lookup result returned by {@see StrictRequiredSchemaAnalysis::lookup()}
+ * when the observed pointer resolves to a walkable schema node. Carries
+ * the union of `required` arrays at that node (with `allOf` branches
+ * unioned).
+ *
+ * Companion of {@see StrictRequiredDisjunctionMatch}. Caller code that
+ * diffs observed keys against the schema's required set should branch on
+ * `instanceof` of either variant — the union return type on `lookup()`
+ * (`StrictRequiredKnownRequired|StrictRequiredDisjunctionMatch`) makes
+ * PHPStan exhaustively check the discriminator.
+ *
+ * @internal Lookup variants are not part of the SemVer-frozen public API.
+ */
+final class StrictRequiredKnownRequired
+{
+    /**
+     * @param list<string> $required schema-declared `required` keys at the
+     *                               matching pointer; empty list when the
+     *                               schema node declares no `required`
+     */
+    public function __construct(
+        public readonly array $required,
+    ) {}
+}

--- a/src/Validation/Strict/StrictRequiredPerCallChecker.php
+++ b/src/Validation/Strict/StrictRequiredPerCallChecker.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Validation\Strict;
+
+use const E_USER_WARNING;
+
+use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecException;
+use Studio\OpenApiContractTesting\Exception\SpecFileNotFoundException;
+use Studio\OpenApiContractTesting\OpenApiResponseValidator;
+use Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension;
+use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+
+use function array_diff;
+use function array_values;
+use function count;
+use function implode;
+use function ksort;
+use function sort;
+use function sprintf;
+use function strtoupper;
+use function trigger_error;
+
+/**
+ * Per-call (single-observation) companion to {@see StrictRequiredAsserter}
+ * (Issue #228). Where the asserter aggregates observations across the run
+ * and asserts at `ExecutionFinished`, this checker fires immediately on
+ * every conformance-passing response so under-described endpoints with only
+ * one observation surface as `E_USER_WARNING` — and convert to per-test
+ * failures under PHPUnit's `failOnWarning=true`.
+ *
+ * Trade-off: per-call warns indiscriminately on every legitimately-optional
+ * field that happens to be present in any one response. Use it for early
+ * visibility on single-test endpoints and pair it with the run-level
+ * intersection mode for the safe aggregate gate. See `docs/strict-required.md`
+ * "Per-call mode" for the full trade-off discussion.
+ *
+ * Schema-walking is delegated to {@see StrictRequiredSchemaWalker} — same
+ * semantics as the asserter (`allOf` unioned, `anyOf` / `oneOf` skipped at
+ * the disjunction node, observations under unresolved schemas silently
+ * dropped).
+ *
+ * Static singleton mirrors {@see StrictRequiredTracker} so the validator
+ * can route through a stable static call without changing its public
+ * constructor signature.
+ *
+ * @internal Configured by {@see OpenApiCoverageExtension} and invoked by
+ *           {@see OpenApiResponseValidator}; not part of the SemVer-frozen
+ *           public API.
+ */
+final class StrictRequiredPerCallChecker
+{
+    private static StrictRequiredPerCallMode $mode = StrictRequiredPerCallMode::Off;
+
+    /** Static-only utility — no instances. */
+    private function __construct() {}
+
+    /**
+     * Set the active per-call mode. Called from the extension's bootstrap
+     * after {@see StrictRequiredPerCallMode::fromConfigValue()} has parsed
+     * the `strict_required_per_call` parameter.
+     *
+     * @internal
+     */
+    public static function configure(StrictRequiredPerCallMode $mode): void
+    {
+        self::$mode = $mode;
+    }
+
+    /**
+     * Reset the mode back to {@see StrictRequiredPerCallMode::Off}. Mirrors
+     * {@see StrictRequiredTracker::reset()} so test isolation only needs
+     * one teardown call per checker.
+     *
+     * @internal
+     */
+    public static function reset(): void
+    {
+        self::$mode = StrictRequiredPerCallMode::Off;
+    }
+
+    /**
+     * @internal Used by tests / extension to verify the wired mode.
+     */
+    public static function mode(): StrictRequiredPerCallMode
+    {
+        return self::$mode;
+    }
+
+    /**
+     * Compare a single observation's pointer→keys map against the matching
+     * spec's `required` arrays and emit one `E_USER_WARNING` if any drift
+     * is found. Off mode short-circuits with no spec load.
+     *
+     * The `$pointers` argument carries the same shape produced by
+     * {@see StrictRequiredBodyWalker::collectPointers()} — the validator
+     * computes it once and hands it to both the tracker and this checker
+     * to avoid double-walking the body.
+     *
+     * Spec load failures and unresolvable schemas are silently dropped:
+     * per-call warnings convert to per-test failures under
+     * `failOnWarning=true`, so escalating an infrastructure problem (a spec
+     * file unlinked mid-run) into a user-test failure would attribute the
+     * fault to the wrong layer. The run-level asserter still surfaces these
+     * as a NOTE at `ExecutionFinished`.
+     *
+     * @param array<string, list<string>> $pointers map of JSON-Pointer-like
+     *                                              strings to lists of object keys observed at that node
+     */
+    public static function maybeWarn(
+        string $specName,
+        string $method,
+        string $path,
+        string $statusKey,
+        string $contentTypeKey,
+        array $pointers,
+    ): void {
+        if (self::$mode === StrictRequiredPerCallMode::Off) {
+            return;
+        }
+        if ($pointers === []) {
+            return;
+        }
+
+        try {
+            $spec = OpenApiSpecLoader::load($specName);
+        } catch (InvalidOpenApiSpecException|SpecFileNotFoundException) {
+            return;
+        }
+
+        $upperMethod = strtoupper($method);
+        $schemaNode = StrictRequiredSchemaWalker::resolveResponseSchema(
+            $spec,
+            $upperMethod,
+            $path,
+            $statusKey,
+            $contentTypeKey,
+        );
+        if ($schemaNode === null) {
+            return;
+        }
+
+        $analysis = StrictRequiredSchemaWalker::collectRequiredByPointer($schemaNode);
+        $walked = $analysis['walked'];
+        $disjunctions = $analysis['disjunctions'];
+
+        ksort($pointers);
+
+        $missingByPointer = [];
+        foreach ($pointers as $pointer => $observedKeys) {
+            if (StrictRequiredSchemaWalker::findCoveringDisjunction($pointer, $disjunctions) !== null) {
+                // Same rule as the asserter: `required` has no AND-semantic
+                // across `anyOf` / `oneOf`, so "add to required" advice
+                // would mislead. Silently skip — the run-level asserter
+                // emits the unwalkable NOTE.
+                continue;
+            }
+
+            $specRequired = $walked[$pointer] ?? [];
+            $missing = array_values(array_diff($observedKeys, $specRequired));
+            if ($missing === []) {
+                continue;
+            }
+            sort($missing);
+            $missingByPointer[$pointer] = $missing;
+        }
+
+        if ($missingByPointer === []) {
+            return;
+        }
+
+        trigger_error(
+            self::renderMessage($upperMethod, $path, $statusKey, $contentTypeKey, $missingByPointer),
+            E_USER_WARNING,
+        );
+    }
+
+    /**
+     * Render the diagnostic emitted on a drifting observation. Lives as a
+     * separate method so unit tests can pin the exact wire format —
+     * downstream CI parsers (Slack notifiers, log scrapers) commonly grep
+     * the prefix and split on the colons.
+     *
+     * @param array<string, list<string>> $missingByPointer
+     */
+    private static function renderMessage(
+        string $method,
+        string $path,
+        string $statusKey,
+        string $contentTypeKey,
+        array $missingByPointer,
+    ): string {
+        $header = sprintf(
+            '[OpenAPI Strict Required per-call] WARN: %s %s  %s  %s: response carries %d optional field(s) not declared in `required` at the matching schema pointer(s):',
+            $method,
+            $path,
+            $statusKey,
+            $contentTypeKey,
+            self::sumMissing($missingByPointer),
+        );
+
+        $lines = [];
+        foreach ($missingByPointer as $pointer => $missing) {
+            $lines[] = sprintf('  %s : %s', $pointer, implode(', ', $missing));
+        }
+
+        $footer = "Action: add these fields to the schema's `required` array, or set strict_required_per_call=off if intentional.\n"
+            . 'Note: per-call mode warns on every legitimately-optional field present in this single observation. See docs/strict-required.md "Per-call mode" for the trade-off.';
+
+        return $header . "\n" . implode("\n", $lines) . "\n" . $footer;
+    }
+
+    /**
+     * @param array<string, list<string>> $missingByPointer
+     */
+    private static function sumMissing(array $missingByPointer): int
+    {
+        $total = 0;
+        foreach ($missingByPointer as $missing) {
+            $total += count($missing);
+        }
+
+        return $total;
+    }
+}

--- a/src/Validation/Strict/StrictRequiredPerCallChecker.php
+++ b/src/Validation/Strict/StrictRequiredPerCallChecker.php
@@ -53,6 +53,19 @@ final class StrictRequiredPerCallChecker
 {
     private static StrictRequiredPerCallMode $mode = StrictRequiredPerCallMode::Off;
 
+    /**
+     * Dedupe set keyed by `"<kind>:<spec>:<endpoint>:<response>:<extra>"`.
+     * Each NOTE channel (spec-load failure, unresolved schema, disjunction-
+     * covered observation) writes at most once per key per process so a
+     * long test suite cannot flood STDERR with the same diagnostic.
+     *
+     * Cleared by {@see self::reset()} so paratest workers and repeated
+     * extension bootstraps see a fresh budget.
+     *
+     * @var array<string, true>
+     */
+    private static array $emittedNotes = [];
+
     /** Static-only utility — no instances. */
     private function __construct() {}
 
@@ -69,7 +82,8 @@ final class StrictRequiredPerCallChecker
     }
 
     /**
-     * Reset the mode back to {@see StrictRequiredPerCallMode::Off}. Mirrors
+     * Reset the mode back to {@see StrictRequiredPerCallMode::Off} and
+     * clear the emitted-NOTE dedupe set. Mirrors
      * {@see StrictRequiredTracker::reset()} so test isolation only needs
      * one teardown call per checker.
      *
@@ -78,10 +92,22 @@ final class StrictRequiredPerCallChecker
     public static function reset(): void
     {
         self::$mode = StrictRequiredPerCallMode::Off;
+        self::$emittedNotes = [];
     }
 
     /**
      * @internal Used by tests / extension to verify the wired mode.
+     */
+    public static function isEnabled(): bool
+    {
+        return self::$mode->isEnabled();
+    }
+
+    /**
+     * @internal Used by tests / extension to verify the wired mode. Most
+     *           callers should prefer {@see self::isEnabled()} which
+     *           returns the on/off discriminator without exposing the
+     *           full enum.
      */
     public static function mode(): StrictRequiredPerCallMode
     {
@@ -98,15 +124,22 @@ final class StrictRequiredPerCallChecker
      * computes it once and hands it to both the tracker and this checker
      * to avoid double-walking the body.
      *
-     * Spec load failures and unresolvable schemas are silently dropped:
-     * per-call warnings convert to per-test failures under
-     * `failOnWarning=true`, so escalating an infrastructure problem (a spec
-     * file unlinked mid-run) into a user-test failure would attribute the
-     * fault to the wrong layer. The run-level asserter still surfaces these
-     * as a NOTE at `ExecutionFinished`.
+     * Infrastructure-level no-ops (spec load failures, unresolvable
+     * schemas, unwalkable / disjunction-covered roots) emit a one-shot
+     * stderr NOTE rather than escalating to a per-test warning. Escalating
+     * these to `E_USER_WARNING` would convert an infrastructure problem
+     * (a spec file unlinked mid-run, a `$ref` resolved to an unexpected
+     * shape, an `anyOf` root that has no AND-semantic for `required`)
+     * into a `failOnWarning=true` per-test failure attributed to whichever
+     * test happened to run next — the wrong fingerprint. The dedupe key
+     * keeps NOTE volume bounded across long test suites.
      *
      * @param array<string, list<string>> $pointers map of JSON-Pointer-like
      *                                              strings to lists of object keys observed at that node
+     *
+     * @internal Routed through {@see OpenApiResponseValidator}'s Success-only
+     *           branch; the parameter shape is not part of the SemVer-frozen
+     *           public API.
      */
     public static function maybeWarn(
         string $specName,
@@ -123,13 +156,27 @@ final class StrictRequiredPerCallChecker
             return;
         }
 
+        $upperMethod = strtoupper($method);
+        $endpointId = sprintf('%s %s', $upperMethod, $path);
+        $responseId = sprintf('%s/%s', $statusKey, $contentTypeKey);
+
         try {
             $spec = OpenApiSpecLoader::load($specName);
-        } catch (InvalidOpenApiSpecException|SpecFileNotFoundException) {
+        } catch (InvalidOpenApiSpecException|SpecFileNotFoundException $e) {
+            self::noteOnce(
+                'spec-load:' . $specName,
+                sprintf(
+                    "[OpenAPI Strict Required per-call] NOTE: spec '%s' failed to load at runtime; "
+                    . 'per-call drift detection skipped for subsequent calls against this spec. '
+                    . "Cause: %s. (This usually means the spec file was modified between bootstrap and now.)\n",
+                    $specName,
+                    $e->getMessage(),
+                ),
+            );
+
             return;
         }
 
-        $upperMethod = strtoupper($method);
         $schemaNode = StrictRequiredSchemaWalker::resolveResponseSchema(
             $spec,
             $upperMethod,
@@ -138,27 +185,61 @@ final class StrictRequiredPerCallChecker
             $contentTypeKey,
         );
         if ($schemaNode === null) {
+            self::noteOnce(
+                'unresolved:' . $specName . ':' . $endpointId . ':' . $responseId,
+                sprintf(
+                    '[OpenAPI Strict Required per-call] NOTE: response schema could not be resolved for %s '
+                    . "(%s in spec '%s'); per-call drift detection skipped. (Path matcher / asserter "
+                    . 'key disagreement, or $ref resolved to an unexpected shape — bug-level; the run-level '
+                    . "asserter surfaces the same condition as an unresolved-groups NOTE at run end.)\n",
+                    $endpointId,
+                    $responseId,
+                    $specName,
+                ),
+            );
+
             return;
         }
 
-        $analysis = StrictRequiredSchemaWalker::collectRequiredByPointer($schemaNode);
-        $walked = $analysis['walked'];
-        $disjunctions = $analysis['disjunctions'];
+        $analysis = StrictRequiredSchemaWalker::analyse($schemaNode);
 
         ksort($pointers);
 
         $missingByPointer = [];
         foreach ($pointers as $pointer => $observedKeys) {
-            if (StrictRequiredSchemaWalker::findCoveringDisjunction($pointer, $disjunctions) !== null) {
+            $lookup = $analysis->lookup($pointer);
+            if ($lookup instanceof StrictRequiredDisjunctionMatch) {
                 // Same rule as the asserter: `required` has no AND-semantic
                 // across `anyOf` / `oneOf`, so "add to required" advice
-                // would mislead. Silently skip — the run-level asserter
-                // emits the unwalkable NOTE.
+                // would mislead. Drop the observation, but emit a one-shot
+                // NOTE so per-call-only configurations can still see that
+                // the endpoint is invisible to per-call drift detection.
+                self::noteOnce(
+                    sprintf(
+                        'disjunction:%s:%s:%s:%s',
+                        $specName,
+                        $endpointId,
+                        $responseId,
+                        $lookup->coveringPointer,
+                    ),
+                    sprintf(
+                        "[OpenAPI Strict Required per-call] NOTE: %s (%s in spec '%s') observation at "
+                        . "pointer '%s' is covered by %s at '%s'; per-call drift detection skipped because "
+                        . '`required` has no AND-semantic across disjunctions. Pin the shape with `allOf` '
+                        . "if you need per-call coverage here.\n",
+                        $endpointId,
+                        $responseId,
+                        $specName,
+                        $pointer,
+                        $lookup->reason,
+                        $lookup->coveringPointer === '' ? '<root>' : $lookup->coveringPointer,
+                    ),
+                );
+
                 continue;
             }
 
-            $specRequired = $walked[$pointer] ?? [];
-            $missing = array_values(array_diff($observedKeys, $specRequired));
+            $missing = array_values(array_diff($observedKeys, $lookup->required));
             if ($missing === []) {
                 continue;
             }
@@ -222,5 +303,23 @@ final class StrictRequiredPerCallChecker
         }
 
         return $total;
+    }
+
+    /**
+     * Emit `$message` to stderr (via the extension's overridable writer so
+     * tests can capture, and so paratest worker NOTEs route through the
+     * same path as every other extension diagnostic) at most once per
+     * `$key` per process. Keys are cleared by {@see self::reset()}.
+     *
+     * The message must include its own trailing newline — `writeStderr`
+     * does no formatting.
+     */
+    private static function noteOnce(string $key, string $message): void
+    {
+        if (isset(self::$emittedNotes[$key])) {
+            return;
+        }
+        self::$emittedNotes[$key] = true;
+        OpenApiCoverageExtension::writeStderr($message);
     }
 }

--- a/src/Validation/Strict/StrictRequiredPerCallMode.php
+++ b/src/Validation/Strict/StrictRequiredPerCallMode.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Validation\Strict;
+
+use InvalidArgumentException;
+
+use function array_map;
+use function implode;
+use function sprintf;
+use function strtolower;
+use function trim;
+
+/**
+ * Operating mode for the per-call strict-required check (Issue #228).
+ *
+ * Configured via the PHPUnit extension parameter `strict_required_per_call`,
+ * orthogonal to the run-level {@see StrictRequiredMode} parameter:
+ *
+ *  - `off`  — default; the per-call checker short-circuits and no warnings
+ *             are emitted on the validator success path
+ *  - `warn` — every conformance-passing response is diffed in-place against
+ *             the matching schema's `required` array, and any
+ *             always-present-yet-optional key triggers `E_USER_WARNING`
+ *             with the `[OpenAPI Strict Required per-call]` prefix so
+ *             `failOnWarning=true` test runs surface the gap as a per-test
+ *             failure
+ *
+ * Why no `fail` mode? Per-call necessarily warns on legitimately-optional
+ * fields that happen to be present in any one observation (a nullable field,
+ * a conditional payload). The run-level intersection mode is the safer
+ * fail-gate (issue #224 / PR #225 docs); per-call is the lightweight
+ * single-observation surface and is intentionally warn-only. Users that
+ * want hard failures on per-call drift can enable `failOnWarning` in
+ * `phpunit.xml`.
+ *
+ * Run-level mode and per-call mode are independent: a CI may run
+ * `strict_required=fail` for the safe aggregate gate AND
+ * `strict_required_per_call=warn` for early visibility on single-observation
+ * endpoints.
+ */
+enum StrictRequiredPerCallMode: string
+{
+    case Off = 'off';
+    case Warn = 'warn';
+
+    /**
+     * Parse the `strict_required_per_call` extension parameter. `null` and
+     * the empty string both resolve to {@see self::Off} so the extension can
+     * call this with `$parameters->has('strict_required_per_call') ?
+     * $parameters->get(...) : null` without a separate fallback path.
+     *
+     * Whitespace is trimmed and the value is matched case-insensitively to
+     * stay tolerant of `<parameter>Warn</parameter>` typos in phpunit.xml.
+     *
+     * `fail` is rejected loudly even though it is a valid run-level value —
+     * the per-call mode is intentionally warn-only and silently demoting
+     * `fail` to `warn` would defeat a CI that mistakenly typed `fail`
+     * thinking it was the same gate.
+     *
+     * @throws InvalidArgumentException when a non-empty value does not match
+     *                                  any case
+     */
+    public static function fromConfigValue(?string $value): self
+    {
+        if ($value === null) {
+            return self::Off;
+        }
+
+        $normalized = strtolower(trim($value));
+        if ($normalized === '') {
+            return self::Off;
+        }
+
+        $match = self::tryFrom($normalized);
+        if ($match !== null) {
+            return $match;
+        }
+
+        $accepted = implode(', ', array_map(static fn(self $c): string => $c->value, self::cases()));
+
+        throw new InvalidArgumentException(sprintf(
+            "Unknown strict_required_per_call value '%s'. Accepted: %s.",
+            $value,
+            $accepted,
+        ));
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this !== self::Off;
+    }
+}

--- a/src/Validation/Strict/StrictRequiredPerCallMode.php
+++ b/src/Validation/Strict/StrictRequiredPerCallMode.php
@@ -73,6 +73,22 @@ enum StrictRequiredPerCallMode: string
             return self::Off;
         }
 
+        if ($normalized === 'fail') {
+            // `fail` is the value most likely to be tried by mistake — it
+            // works for the run-level `strict_required` parameter but is
+            // intentionally rejected here. A generic "unknown value" error
+            // would leave the user wondering whether they typoed it; the
+            // directive message explains the design and points at the two
+            // legitimate alternatives so the fix is self-evident.
+            throw new InvalidArgumentException(
+                "strict_required_per_call does not support 'fail' — per-call mode is "
+                . 'warn-only by design (see docs/strict-required.md "Per-call mode" → '
+                . '"Why no `fail` mode?"). For hard failures on per-call drift use '
+                . "phpunit.xml's failOnWarning=\"true\". For an aggregate fail-gate "
+                . 'use the run-level `strict_required=fail`.',
+            );
+        }
+
         $match = self::tryFrom($normalized);
         if ($match !== null) {
             return $match;

--- a/src/Validation/Strict/StrictRequiredSchemaAnalysis.php
+++ b/src/Validation/Strict/StrictRequiredSchemaAnalysis.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Validation\Strict;
+
+/**
+ * Result of {@see StrictRequiredSchemaWalker::analyse()}: the parallel
+ * (walked-required, disjunctions) pair produced by descending an OpenAPI
+ * response schema once.
+ *
+ * Both fields are filled together by a single descent and consumed
+ * together by the asserter and the per-call checker. Wrapping the pair
+ * in this object enforces the "check disjunctions first, then look up
+ * required" rule structurally — callers go through {@see self::lookup()}
+ * which returns either a {@see StrictRequiredDisjunctionMatch} (caller
+ * must skip / NOTE) or a {@see StrictRequiredKnownRequired} (caller can
+ * diff against observed keys). PHPStan exhaustively checks the
+ * `instanceof` discriminator on the union return type.
+ *
+ * Diagnostic accessors (`disjunctions()`, `walkedPointers()`) are exposed
+ * for the asserter's NOTE-rendering loop and for unit-test introspection;
+ * neither should be used to bypass the `lookup()` rule.
+ *
+ * @internal Returned by the schema walker; consumers are the asserter and
+ *           the per-call checker.
+ */
+final class StrictRequiredSchemaAnalysis
+{
+    /**
+     * @param array<string, list<string>> $walked
+     * @param list<array{pointer: string, reason: string}> $disjunctions
+     */
+    public function __construct(
+        private readonly array $walked,
+        private readonly array $disjunctions,
+    ) {}
+
+    /**
+     * Resolve a single observed pointer against the schema. Always returns
+     * one of the two leaf variants — never null — so callers' `instanceof`
+     * branches are exhaustive.
+     */
+    public function lookup(string $pointer): StrictRequiredDisjunctionMatch|StrictRequiredKnownRequired
+    {
+        $covering = StrictRequiredSchemaWalker::findCoveringDisjunction($pointer, $this->disjunctions);
+        if ($covering !== null) {
+            return new StrictRequiredDisjunctionMatch($covering['pointer'], $covering['reason']);
+        }
+
+        return new StrictRequiredKnownRequired($this->walked[$pointer] ?? []);
+    }
+
+    /**
+     * @return list<array{pointer: string, reason: string}>
+     */
+    public function disjunctions(): array
+    {
+        return $this->disjunctions;
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public function walkedPointers(): array
+    {
+        return $this->walked;
+    }
+}

--- a/src/Validation/Strict/StrictRequiredSchemaWalker.php
+++ b/src/Validation/Strict/StrictRequiredSchemaWalker.php
@@ -40,6 +40,14 @@ final class StrictRequiredSchemaWalker
     /**
      * Split a tracker endpoint key (`"METHOD path"`) back into its parts.
      *
+     * Tolerates hand-built keys without a space by treating the whole
+     * string as the method and defaulting the path to `/`. Production
+     * tracker output always contains a space (see
+     * {@see StrictRequiredTracker::record()}) so this fallback is reached
+     * only from direct test inputs — surfacing a sensible default keeps
+     * unit tests terse without obscuring real malformed keys via a hidden
+     * throw.
+     *
      * @return array{0: string, 1: string}
      */
     public static function splitEndpointKey(string $endpointKey): array
@@ -58,6 +66,10 @@ final class StrictRequiredSchemaWalker
     /**
      * Split a tracker response key (`"statusKey:contentTypeKey"`) back into
      * its parts.
+     *
+     * As with {@see self::splitEndpointKey()}, a hand-built key without a
+     * colon falls back to `[$key, ANY_CONTENT_TYPE]` — the production
+     * tracker always emits the colon form, so this branch is test-only.
      *
      * @return array{0: string, 1: string}
      */
@@ -120,6 +132,23 @@ final class StrictRequiredSchemaWalker
     }
 
     /**
+     * Descend the response schema and return a {@see StrictRequiredSchemaAnalysis}
+     * value object that pairs the walked-required map with the disjunction
+     * list. Preferred over {@see self::collectRequiredByPointer()} when
+     * downstream code wants the structural "check disjunction first, then
+     * look up required" guarantee — call `$analysis->lookup($pointer)` and
+     * branch on the union return type.
+     *
+     * @param array<string, mixed> $schema
+     */
+    public static function analyse(array $schema): StrictRequiredSchemaAnalysis
+    {
+        $raw = self::collectRequiredByPointer($schema);
+
+        return new StrictRequiredSchemaAnalysis($raw['walked'], $raw['disjunctions']);
+    }
+
+    /**
      * Descend the response schema producing two parallel maps:
      *  - `walked`: `pointer => required-keys` for each object node reached.
      *    `allOf` branches are unioned at every level.
@@ -130,6 +159,12 @@ final class StrictRequiredSchemaWalker
      *
      * If the root schema itself is unwalkable, the disjunction list carries
      * an empty-pointer entry meaning "every observation is unwalkable."
+     *
+     * Production callers should prefer {@see self::analyse()}, which wraps
+     * the same data in a {@see StrictRequiredSchemaAnalysis} value object
+     * that prevents callers forgetting to consult the disjunction list. This
+     * raw-array entry is retained for unit tests that need to inspect the
+     * descent output directly without the wrapping abstraction.
      *
      * @param array<string, mixed> $schema
      *
@@ -146,11 +181,14 @@ final class StrictRequiredSchemaWalker
             // matches; the body could be either object- or array-shaped.
             // For scalar / empty roots `disjunctionReason()` returns null —
             // surface as the literal "unwalkable" so the unwalkable NOTE
-            // line stays grep-friendly. The validator's "skip empty pointer
-            // map" branch makes this branch unreachable for scalar bodies
-            // in practice; the fallback exists to preserve the strict
-            // `reason: string` contract for any future caller that loads a
-            // pre-walked schema directly.
+            // line stays grep-friendly. In practice this fallback is
+            // unreachable from production paths: a scalar / empty *schema*
+            // combined with any body that produces pointers is a conformance
+            // failure, so the validator's Success-only branch never reaches
+            // the per-call checker / tracker for such observations. The
+            // fallback exists to preserve the strict `reason: string`
+            // contract for any future caller that loads a pre-walked
+            // schema directly.
             $disjunctions[] = [
                 'pointer' => '',
                 'reason' => self::disjunctionReason($schema) ?? 'unwalkable',
@@ -268,8 +306,13 @@ final class StrictRequiredSchemaWalker
             return 'array';
         }
         // allOf-only schema with no explicit type: treat as object if any
-        // branch declares object-shape. Matches OpenAPI's "object inferred
-        // from properties / required" convention.
+        // branch declares object-shape. Pragmatic inference matching how
+        // most OpenAPI / JSON-Schema validators interpret untyped allOf
+        // branches that declare `properties` / `required` / `items`. The
+        // spec is technically ambiguous here, but treating dominant intent
+        // as the descent rule avoids dropping coverage on otherwise-
+        // walkable allOf compositions (e.g. `/orders/{id}` and `/deep` in
+        // the test fixture).
         if (isset($schema['allOf']) && is_array($schema['allOf'])) {
             foreach ($schema['allOf'] as $branch) {
                 if (is_array($branch) && (
@@ -385,6 +428,18 @@ final class StrictRequiredSchemaWalker
         return null;
     }
 
+    /**
+     * Append a property name to a JSON-Pointer-like path with RFC 6901
+     * escaping (`~` → `~0`, `/` → `~1`) plus the `[*]` → `[~*]` extension
+     * shared with {@see StrictRequiredBodyWalker::appendProperty()}.
+     *
+     * Inlined rather than shared because the two walkers stay drop-in
+     * independent — the body walker walks observed JSON, this walker walks
+     * the spec, and the escape rules are intentionally pinned to the body
+     * walker's pointer notation. If a new escape is ever needed (e.g.
+     * for a future container syntax), both implementations must move
+     * together — add a regression test in both walkers' test files.
+     */
     private static function appendProperty(string $pointer, string $propertyName): string
     {
         $escaped = str_replace('~', '~0', $propertyName);

--- a/src/Validation/Strict/StrictRequiredSchemaWalker.php
+++ b/src/Validation/Strict/StrictRequiredSchemaWalker.php
@@ -1,0 +1,400 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Validation\Strict;
+
+use function array_unique;
+use function array_values;
+use function is_array;
+use function is_string;
+use function str_replace;
+use function str_starts_with;
+use function strpos;
+use function strtolower;
+use function strtoupper;
+use function substr;
+
+/**
+ * Pure helpers for resolving observed `(method, path, status, content-type,
+ * pointer)` tuples against an OpenAPI schema's `required` arrays. Shared by
+ * {@see StrictRequiredAsserter} (run-level intersection mode) and
+ * {@see StrictRequiredPerCallChecker} (per-call warn mode) so both code
+ * paths walk the spec the same way.
+ *
+ * `allOf` is unioned at every level when collecting `required`. `anyOf` /
+ * `oneOf` are intentionally NOT walked — they are disjunctions and there is
+ * no safe AND-semantic for "required" across them. The collected `required`
+ * at such a node is therefore `[]`, and the descent stop is recorded as a
+ * disjunction entry so callers can emit a NOTE rather than misleading drift
+ * advice. See `docs/strict-required.md` "Known limitations" before relying on
+ * those constructs.
+ *
+ * @internal Consumed by the strict-required asserter / per-call checker only.
+ */
+final class StrictRequiredSchemaWalker
+{
+    /** Static-only utility — no instances. */
+    private function __construct() {}
+
+    /**
+     * Split a tracker endpoint key (`"METHOD path"`) back into its parts.
+     *
+     * @return array{0: string, 1: string}
+     */
+    public static function splitEndpointKey(string $endpointKey): array
+    {
+        $spacePos = strpos($endpointKey, ' ');
+        if ($spacePos === false) {
+            return [strtoupper($endpointKey), '/'];
+        }
+
+        return [
+            strtoupper(substr($endpointKey, 0, $spacePos)),
+            substr($endpointKey, $spacePos + 1),
+        ];
+    }
+
+    /**
+     * Split a tracker response key (`"statusKey:contentTypeKey"`) back into
+     * its parts.
+     *
+     * @return array{0: string, 1: string}
+     */
+    public static function splitResponseKey(string $responseKey): array
+    {
+        $colonPos = strpos($responseKey, ':');
+        if ($colonPos === false) {
+            return [$responseKey, StrictRequiredTracker::ANY_CONTENT_TYPE];
+        }
+
+        return [
+            substr($responseKey, 0, $colonPos),
+            substr($responseKey, $colonPos + 1),
+        ];
+    }
+
+    /**
+     * Locate the response schema dict for `(method, path, statusKey,
+     * contentTypeKey)`. Returns `null` when any segment of the descent does
+     * not resolve.
+     *
+     * @param array<string, mixed> $spec
+     *
+     * @return null|array<string, mixed>
+     */
+    public static function resolveResponseSchema(
+        array $spec,
+        string $method,
+        string $path,
+        string $statusKey,
+        string $contentTypeKey,
+    ): ?array {
+        $lowerMethod = strtolower($method);
+        $operation = $spec['paths'][$path][$lowerMethod] ?? null;
+        if (!is_array($operation)) {
+            return null;
+        }
+        $responses = $operation['responses'] ?? null;
+        if (!is_array($responses)) {
+            return null;
+        }
+        $response = $responses[$statusKey] ?? null;
+        if (!is_array($response)) {
+            return null;
+        }
+        $content = $response['content'] ?? null;
+        if (!is_array($content)) {
+            return null;
+        }
+        $entry = $content[$contentTypeKey] ?? null;
+        if (!is_array($entry)) {
+            return null;
+        }
+        $schema = $entry['schema'] ?? null;
+        if (!is_array($schema)) {
+            return null;
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Descend the response schema producing two parallel maps:
+     *  - `walked`: `pointer => required-keys` for each object node reached.
+     *    `allOf` branches are unioned at every level.
+     *  - `disjunctions`: pointers where descent stopped because the node is
+     *    `anyOf` / `oneOf` (no safe AND-semantic for `required` across
+     *    disjunctions). Callers use this to surface observations under
+     *    these pointers as NOTE rather than misleading drift advice.
+     *
+     * If the root schema itself is unwalkable, the disjunction list carries
+     * an empty-pointer entry meaning "every observation is unwalkable."
+     *
+     * @param array<string, mixed> $schema
+     *
+     * @return array{walked: array<string, list<string>>, disjunctions: list<array{pointer: string, reason: string}>}
+     */
+    public static function collectRequiredByPointer(array $schema): array
+    {
+        $walked = [];
+        $disjunctions = [];
+        $rootShape = self::inferShape($schema);
+        if ($rootShape === null) {
+            // Root schema is itself unwalkable (anyOf/oneOf/scalar/empty).
+            // Use an empty-pointer disjunction so any observed pointer
+            // matches; the body could be either object- or array-shaped.
+            // For scalar / empty roots `disjunctionReason()` returns null —
+            // surface as the literal "unwalkable" so the unwalkable NOTE
+            // line stays grep-friendly. The validator's "skip empty pointer
+            // map" branch makes this branch unreachable for scalar bodies
+            // in practice; the fallback exists to preserve the strict
+            // `reason: string` contract for any future caller that loads a
+            // pre-walked schema directly.
+            $disjunctions[] = [
+                'pointer' => '',
+                'reason' => self::disjunctionReason($schema) ?? 'unwalkable',
+            ];
+
+            return ['walked' => $walked, 'disjunctions' => $disjunctions];
+        }
+        // Root-array schemas use bare `[*]` for their element pointer
+        // (matching the walker's root-list convention); object roots start
+        // at `/`.
+        $rootPointer = $rootShape === 'array' ? '' : '/';
+        self::descendSchema($schema, $rootPointer, $walked, $disjunctions);
+
+        return ['walked' => $walked, 'disjunctions' => $disjunctions];
+    }
+
+    /**
+     * Return the disjunction descriptor covering an observed pointer, or
+     * `null` if none. An ancestor matches when the observed pointer equals
+     * the disjunction's pointer OR descends from it via a `/` or `[`
+     * separator boundary. A disjunction with an empty pointer (`""`) marks
+     * "root schema is unwalkable" and covers every observation.
+     *
+     * @param list<array{pointer: string, reason: string}> $disjunctions
+     *
+     * @return null|array{pointer: string, reason: string}
+     */
+    public static function findCoveringDisjunction(string $pointer, array $disjunctions): ?array
+    {
+        foreach ($disjunctions as $d) {
+            $dp = $d['pointer'];
+            if ($dp === '') {
+                return $d;
+            }
+            if ($pointer === $dp) {
+                return $d;
+            }
+            if (str_starts_with($pointer, $dp . '/') || str_starts_with($pointer, $dp . '[')) {
+                return $d;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     * @param array<string, list<string>> $walked
+     * @param list<array{pointer: string, reason: string}> $disjunctions
+     */
+    private static function descendSchema(array $schema, string $pointer, array &$walked, array &$disjunctions): void
+    {
+        $type = self::inferShape($schema);
+        if ($type === 'object') {
+            $walked[$pointer] = self::collectRequiredFromSchema($schema);
+            foreach (self::collectPropertyBranches($schema) as $propName => $propSchema) {
+                $childPointer = self::appendProperty($pointer, $propName);
+                self::descendSchema($propSchema, $childPointer, $walked, $disjunctions);
+            }
+
+            return;
+        }
+        if ($type === 'array') {
+            $items = self::collectItemsSchema($schema);
+            if ($items !== null) {
+                self::descendSchema($items, $pointer . '[*]', $walked, $disjunctions);
+            }
+
+            return;
+        }
+        // type is null — scalar leaf, anyOf / oneOf, or malformed node.
+        // For disjunctions specifically, surface the descent stop as a
+        // disjunction entry so the caller can emit a NOTE rather than
+        // misleading drift advice. Scalar / empty nodes are silently
+        // skipped — an observed pointer landing there really is "spec
+        // doesn't model this" and surfacing as drift is appropriate.
+        $reason = self::disjunctionReason($schema);
+        if ($reason !== null) {
+            $disjunctions[] = ['pointer' => $pointer, 'reason' => $reason];
+        }
+    }
+
+    /**
+     * Classify a schema node that {@see self::inferShape()} reported as
+     * non-descendable. Returns the disjunction kind if applicable (so the
+     * caller can emit a NOTE), `null` for scalar / empty leaves (which
+     * legitimately do not contribute to `required` semantics).
+     *
+     * @param array<string, mixed> $schema
+     */
+    private static function disjunctionReason(array $schema): ?string
+    {
+        if (isset($schema['anyOf']) && is_array($schema['anyOf'])) {
+            return 'anyOf';
+        }
+        if (isset($schema['oneOf']) && is_array($schema['oneOf'])) {
+            return 'oneOf';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     *
+     * @return null|'array'|'object'
+     */
+    private static function inferShape(array $schema): ?string
+    {
+        $type = $schema['type'] ?? null;
+        if ($type === 'object' || isset($schema['properties'])) {
+            return 'object';
+        }
+        if ($type === 'array' || isset($schema['items'])) {
+            return 'array';
+        }
+        // allOf-only schema with no explicit type: treat as object if any
+        // branch declares object-shape. Matches OpenAPI's "object inferred
+        // from properties / required" convention.
+        if (isset($schema['allOf']) && is_array($schema['allOf'])) {
+            foreach ($schema['allOf'] as $branch) {
+                if (is_array($branch) && (
+                    ($branch['type'] ?? null) === 'object' ||
+                    isset($branch['properties']) ||
+                    isset($branch['required'])
+                )) {
+                    return 'object';
+                }
+                if (is_array($branch) && (
+                    ($branch['type'] ?? null) === 'array' || isset($branch['items'])
+                )) {
+                    return 'array';
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Union of `required` arrays at this schema node, walking `allOf`
+     * branches so nested descent inherits AND-semantic `required`
+     * composition.
+     *
+     * @param array<string, mixed> $schema
+     *
+     * @return list<string>
+     */
+    private static function collectRequiredFromSchema(array $schema): array
+    {
+        $collected = [];
+        if (isset($schema['required']) && is_array($schema['required'])) {
+            foreach ($schema['required'] as $entry) {
+                if (is_string($entry)) {
+                    $collected[] = $entry;
+                }
+            }
+        }
+        if (isset($schema['allOf']) && is_array($schema['allOf'])) {
+            foreach ($schema['allOf'] as $branch) {
+                if (is_array($branch)) {
+                    foreach (self::collectRequiredFromSchema($branch) as $key) {
+                        $collected[] = $key;
+                    }
+                }
+            }
+        }
+
+        return array_values(array_unique($collected));
+    }
+
+    /**
+     * Yield `propertyName => propertySchema` from this schema node plus any
+     * `allOf` branches' properties. Later branches override earlier ones —
+     * matches the OpenAPI composition convention.
+     *
+     * @param array<string, mixed> $schema
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private static function collectPropertyBranches(array $schema): array
+    {
+        $out = [];
+        $properties = $schema['properties'] ?? null;
+        if (is_array($properties)) {
+            foreach ($properties as $name => $sub) {
+                if (is_string($name) && is_array($sub)) {
+                    $out[$name] = $sub;
+                }
+            }
+        }
+        if (isset($schema['allOf']) && is_array($schema['allOf'])) {
+            foreach ($schema['allOf'] as $branch) {
+                if (!is_array($branch)) {
+                    continue;
+                }
+                foreach (self::collectPropertyBranches($branch) as $name => $sub) {
+                    $out[$name] = $sub;
+                }
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * Resolve the `items` schema for an array node, looking through `allOf`
+     * branches if the direct `items` field is absent.
+     *
+     * @param array<string, mixed> $schema
+     *
+     * @return null|array<string, mixed>
+     */
+    private static function collectItemsSchema(array $schema): ?array
+    {
+        $items = $schema['items'] ?? null;
+        if (is_array($items)) {
+            return $items;
+        }
+        if (isset($schema['allOf']) && is_array($schema['allOf'])) {
+            foreach ($schema['allOf'] as $branch) {
+                if (!is_array($branch)) {
+                    continue;
+                }
+                $branchItems = self::collectItemsSchema($branch);
+                if ($branchItems !== null) {
+                    return $branchItems;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static function appendProperty(string $pointer, string $propertyName): string
+    {
+        $escaped = str_replace('~', '~0', $propertyName);
+        $escaped = str_replace('/', '~1', $escaped);
+        $escaped = str_replace('[*]', '[~*]', $escaped);
+
+        if ($pointer === '/') {
+            return '/' . $escaped;
+        }
+
+        return $pointer . '/' . $escaped;
+    }
+}

--- a/tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php
+++ b/tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php
@@ -21,6 +21,8 @@ use Studio\OpenApiContractTesting\Internal\EnumScanner;
 use Studio\OpenApiContractTesting\PHPUnit\InvalidStrictRequiredConfigurationException;
 use Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredPerCallChecker;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredPerCallMode;
 use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredTracker;
 
 use function fclose;
@@ -1086,6 +1088,120 @@ class OpenApiCoverageExtensionTest extends TestCase
         $extension->setupExtension(null, $parameters, null);
 
         $this->assertSame([], StrictRequiredTracker::getObservations('refs-valid'));
+    }
+
+    #[Test]
+    public function strict_required_per_call_warn_configures_checker_at_bootstrap(): void
+    {
+        StrictRequiredPerCallChecker::reset();
+
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'strict_required_per_call' => 'warn',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+            $this->assertSame(StrictRequiredPerCallMode::Warn, StrictRequiredPerCallChecker::mode());
+        } finally {
+            StrictRequiredPerCallChecker::reset();
+        }
+    }
+
+    #[Test]
+    public function strict_required_per_call_absent_keeps_checker_off(): void
+    {
+        StrictRequiredPerCallChecker::reset();
+
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+            $this->assertSame(StrictRequiredPerCallMode::Off, StrictRequiredPerCallChecker::mode());
+        } finally {
+            StrictRequiredPerCallChecker::reset();
+        }
+    }
+
+    #[Test]
+    public function strict_required_per_call_unknown_value_throws_invalid_config(): void
+    {
+        StrictRequiredPerCallChecker::reset();
+
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'strict_required_per_call' => 'enforce',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+            $this->fail('expected InvalidStrictRequiredConfigurationException');
+        } catch (InvalidStrictRequiredConfigurationException $e) {
+            $this->assertStringContainsString('strict_required_per_call=enforce', $e->getMessage());
+        } finally {
+            StrictRequiredPerCallChecker::reset();
+        }
+
+        $this->assertStringContainsString('[OpenAPI Strict Required per-call] FATAL', $this->readStderr());
+    }
+
+    #[Test]
+    public function strict_required_per_call_rejects_fail_value(): void
+    {
+        // Per-call is intentionally warn-only — the FATAL message must use
+        // the per-call prefix so users grepping for `[OpenAPI Strict
+        // Required per-call]` find it, and the accepted-list must NOT
+        // include `fail`.
+        StrictRequiredPerCallChecker::reset();
+
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'strict_required_per_call' => 'fail',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+            $this->fail('expected InvalidStrictRequiredConfigurationException');
+        } catch (InvalidStrictRequiredConfigurationException $e) {
+            $this->assertStringContainsString('strict_required_per_call=fail', $e->getMessage());
+        } finally {
+            StrictRequiredPerCallChecker::reset();
+        }
+
+        $stderr = $this->readStderr();
+        $this->assertStringContainsString('[OpenAPI Strict Required per-call] FATAL', $stderr);
+        $this->assertStringContainsString('Accepted: off, warn', $stderr);
+    }
+
+    #[Test]
+    public function strict_required_per_call_and_run_level_can_coexist(): void
+    {
+        StrictRequiredPerCallChecker::reset();
+
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'strict_required' => 'warn',
+            'strict_required_per_call' => 'warn',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+            $this->assertSame(StrictRequiredPerCallMode::Warn, StrictRequiredPerCallChecker::mode());
+        } finally {
+            StrictRequiredPerCallChecker::reset();
+        }
     }
 
     private function readStderr(): string

--- a/tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php
+++ b/tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php
@@ -1184,6 +1184,78 @@ class OpenApiCoverageExtensionTest extends TestCase
     }
 
     #[Test]
+    public function strict_required_per_call_invalid_value_appends_fatal_block_to_step_summary(): void
+    {
+        // Issue #228 review: a typoed strict_required_per_call must emit
+        // its FATAL block to GITHUB_STEP_SUMMARY just like every other
+        // bootstrap-level FATAL. Without this pin, a future refactor that
+        // drops the appendGithubStepSummaryStrictRequiredBlock() call would
+        // remove the most-visible CI signal for per-call misconfiguration —
+        // the failure would only surface in scrolling stderr logs.
+        StrictRequiredPerCallChecker::reset();
+        $tmp = tempnam(sys_get_temp_dir(), 'openapi-summary-');
+        if ($tmp === false) {
+            $this->fail('Could not create temp file for GITHUB_STEP_SUMMARY');
+        }
+        $this->githubSummaryTmp = $tmp;
+
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'strict_required_per_call' => 'enforce',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, $tmp);
+            $this->fail('expected InvalidStrictRequiredConfigurationException');
+        } catch (InvalidStrictRequiredConfigurationException) {
+            // expected
+        } finally {
+            StrictRequiredPerCallChecker::reset();
+        }
+
+        $contents = (string) file_get_contents($tmp);
+        $this->assertStringContainsString('FATAL OpenAPI strict_required drift', $contents);
+        $this->assertStringContainsString('strict_required_per_call=enforce', $contents);
+    }
+
+    #[Test]
+    public function strict_required_per_call_fail_value_appends_fatal_block_to_step_summary(): void
+    {
+        // Parallel pin to the unknown-value case above — `fail` is the
+        // single most likely typo (users coming from the run-level docs
+        // assume it works) and the FATAL block must surface the design
+        // rationale on the GitHub side too.
+        StrictRequiredPerCallChecker::reset();
+        $tmp = tempnam(sys_get_temp_dir(), 'openapi-summary-');
+        if ($tmp === false) {
+            $this->fail('Could not create temp file for GITHUB_STEP_SUMMARY');
+        }
+        $this->githubSummaryTmp = $tmp;
+
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'strict_required_per_call' => 'fail',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, $tmp);
+            $this->fail('expected InvalidStrictRequiredConfigurationException');
+        } catch (InvalidStrictRequiredConfigurationException) {
+            // expected
+        } finally {
+            StrictRequiredPerCallChecker::reset();
+        }
+
+        $contents = (string) file_get_contents($tmp);
+        $this->assertStringContainsString('FATAL OpenAPI strict_required drift', $contents);
+        $this->assertStringContainsString('strict_required_per_call=fail', $contents);
+    }
+
+    #[Test]
     public function strict_required_per_call_and_run_level_can_coexist(): void
     {
         StrictRequiredPerCallChecker::reset();

--- a/tests/Unit/Validation/Strict/StrictRequiredPerCallCheckerTest.php
+++ b/tests/Unit/Validation/Strict/StrictRequiredPerCallCheckerTest.php
@@ -8,17 +8,26 @@ use const E_USER_WARNING;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredPerCallChecker;
 use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredPerCallMode;
 
+use function fopen;
 use function restore_error_handler;
+use function rewind;
 use function set_error_handler;
+use function stream_get_contents;
+use function strpos;
+use function substr_count;
 
 final class StrictRequiredPerCallCheckerTest extends TestCase
 {
     private const SPEC_BASE_PATH = __DIR__ . '/../../../fixtures/specs';
     private const SPEC_NAME = 'under-described';
+
+    /** @var null|resource */
+    private $stderrBuffer;
 
     protected function setUp(): void
     {
@@ -26,10 +35,19 @@ final class StrictRequiredPerCallCheckerTest extends TestCase
         OpenApiSpecLoader::reset();
         OpenApiSpecLoader::configure(self::SPEC_BASE_PATH);
         StrictRequiredPerCallChecker::reset();
+
+        $buffer = fopen('php://memory', 'w+');
+        if ($buffer === false) {
+            $this->fail('Could not open in-memory buffer for STDERR capture');
+        }
+        $this->stderrBuffer = $buffer;
+        OpenApiCoverageExtension::overrideStderrForTesting($buffer);
     }
 
     protected function tearDown(): void
     {
+        OpenApiCoverageExtension::overrideStderrForTesting(null);
+        $this->stderrBuffer = null;
         StrictRequiredPerCallChecker::reset();
         OpenApiSpecLoader::reset();
         parent::tearDown();
@@ -165,14 +183,14 @@ final class StrictRequiredPerCallCheckerTest extends TestCase
     }
 
     #[Test]
-    public function warn_mode_skips_pointers_under_disjunction(): void
+    public function warn_mode_does_not_warn_under_disjunction_but_emits_one_shot_note(): void
     {
         StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
 
-        // /either-shape root is `anyOf`. Per-call must not warn about
-        // anything under it — the disjunction has no AND-semantic for
-        // `required`. The asserter would emit an unwalkable NOTE, but
-        // per-call has no NOTE channel; silent skip is the safe default.
+        // /either-shape root is `anyOf`. Per-call must not warn (the
+        // disjunction has no AND-semantic for `required`) BUT it emits a
+        // one-shot stderr NOTE so per-call-only configurations can still
+        // see that the endpoint is invisible to per-call drift detection.
         $captured = $this->captureFirstWarning(static function (): void {
             StrictRequiredPerCallChecker::maybeWarn(
                 self::SPEC_NAME,
@@ -185,16 +203,48 @@ final class StrictRequiredPerCallCheckerTest extends TestCase
         });
 
         $this->assertNull($captured);
+
+        $stderr = $this->readStderr();
+        $this->assertStringContainsString('[OpenAPI Strict Required per-call] NOTE:', $stderr);
+        $this->assertStringContainsString('GET /either-shape', $stderr);
+        $this->assertStringContainsString('anyOf', $stderr);
+        $this->assertStringContainsString('<root>', $stderr);
     }
 
     #[Test]
-    public function warn_mode_silently_skips_unknown_endpoint(): void
+    public function warn_mode_one_of_disjunction_also_emits_note(): void
     {
         StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
 
-        // Endpoint not in spec — per-call must not fail-loud here because
-        // converting an infrastructure mismatch into a per-test warning
-        // would attribute the bug to the wrong test layer.
+        // Parallel coverage to anyOf above — `/either-shape-oneof` exists
+        // in the fixture specifically so a future refactor that adds
+        // `oneOf` descent fails loudly here.
+        $captured = $this->captureFirstWarning(static function (): void {
+            StrictRequiredPerCallChecker::maybeWarn(
+                self::SPEC_NAME,
+                'GET',
+                '/either-shape-oneof',
+                '200',
+                'application/json',
+                ['/' => ['a']],
+            );
+        });
+
+        $this->assertNull($captured);
+        $stderr = $this->readStderr();
+        $this->assertStringContainsString('GET /either-shape-oneof', $stderr);
+        $this->assertStringContainsString('oneOf', $stderr);
+    }
+
+    #[Test]
+    public function warn_mode_does_not_warn_for_unknown_endpoint_but_emits_note(): void
+    {
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+
+        // Endpoint not in spec — per-call must not fail-loud (escalating
+        // an infrastructure mismatch into a per-test warning attributes
+        // the bug to the wrong test layer), but it emits a NOTE so
+        // per-call-only users can detect path-matcher / asserter drift.
         $captured = $this->captureFirstWarning(static function (): void {
             StrictRequiredPerCallChecker::maybeWarn(
                 self::SPEC_NAME,
@@ -207,15 +257,88 @@ final class StrictRequiredPerCallCheckerTest extends TestCase
         });
 
         $this->assertNull($captured);
+
+        $stderr = $this->readStderr();
+        $this->assertStringContainsString('[OpenAPI Strict Required per-call] NOTE:', $stderr);
+        $this->assertStringContainsString('GET /does-not-exist', $stderr);
+        $this->assertStringContainsString('could not be resolved', $stderr);
     }
 
     #[Test]
-    public function warn_mode_silently_skips_when_spec_load_fails(): void
+    public function warn_mode_does_not_warn_when_spec_is_malformed_json_but_emits_note(): void
+    {
+        // The catch list covers both SpecFileNotFoundException AND
+        // InvalidOpenApiSpecException — a future refactor that narrowed
+        // the catch to only the missing-file case would escalate a
+        // malformed-spec exception into a per-test warning, which is the
+        // exact misattribution the silent-skip is documented to prevent.
+        // The `malformed-json` fixture throws InvalidOpenApiSpecException
+        // on load.
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+
+        $captured = $this->captureFirstWarning(static function (): void {
+            StrictRequiredPerCallChecker::maybeWarn(
+                'malformed-json',
+                'GET',
+                '/foo',
+                '200',
+                'application/json',
+                ['/' => ['anything']],
+            );
+        });
+
+        $this->assertNull($captured);
+        $this->assertStringContainsString(
+            "[OpenAPI Strict Required per-call] NOTE: spec 'malformed-json' failed to load",
+            $this->readStderr(),
+        );
+    }
+
+    #[Test]
+    public function warn_mode_emits_pointers_in_alphabetical_order(): void
+    {
+        // CI parsers grep the message and split on the per-pointer lines;
+        // a deterministic order across runs matters. The checker calls
+        // `ksort($pointers)` so the output is alphabetic regardless of
+        // input iteration order. Pin this so a refactor that drops the
+        // ksort does not silently make CI diffs noisy.
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+
+        // /teams/{id} declares `id`+`data` required at root, and `name`
+        // required under /data. Body adds both unwanted optional fields
+        // so two pointers drift simultaneously — the order in the output
+        // must always be `/` before `/data`.
+        $captured = $this->captureFirstWarning(static function (): void {
+            StrictRequiredPerCallChecker::maybeWarn(
+                self::SPEC_NAME,
+                'GET',
+                '/teams/{id}',
+                '200',
+                'application/json',
+                [
+                    // Insertion order deliberately reversed to verify ksort.
+                    '/data' => ['created_at', 'name'],
+                    '/' => ['data', 'extra_root_field', 'id'],
+                ],
+            );
+        });
+
+        $this->assertNotNull($captured);
+        $rootPos = strpos($captured, '/ : ');
+        $dataPos = strpos($captured, '/data : ');
+        $this->assertNotFalse($rootPos);
+        $this->assertNotFalse($dataPos);
+        $this->assertLessThan($dataPos, $rootPos, '`/` pointer must precede `/data` in the diagnostic block');
+    }
+
+    #[Test]
+    public function warn_mode_does_not_warn_when_spec_load_fails_but_emits_note(): void
     {
         StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
 
         // The loader has no spec named 'no-such-spec'; per-call must not
-        // escalate the SpecFileNotFoundException into a per-test warning.
+        // escalate SpecFileNotFoundException into a per-test warning, but
+        // emits a one-shot NOTE per spec so the cause is visible.
         $captured = $this->captureFirstWarning(static function (): void {
             StrictRequiredPerCallChecker::maybeWarn(
                 'no-such-spec',
@@ -228,6 +351,74 @@ final class StrictRequiredPerCallCheckerTest extends TestCase
         });
 
         $this->assertNull($captured);
+
+        $stderr = $this->readStderr();
+        $this->assertStringContainsString('[OpenAPI Strict Required per-call] NOTE:', $stderr);
+        $this->assertStringContainsString("spec 'no-such-spec' failed to load", $stderr);
+    }
+
+    #[Test]
+    public function note_is_only_emitted_once_per_dedupe_key(): void
+    {
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+
+        // Spec-load failure dedupes per spec name. Three calls with the
+        // same spec must emit one NOTE; two distinct specs emit two.
+        for ($i = 0; $i < 3; $i++) {
+            StrictRequiredPerCallChecker::maybeWarn(
+                'no-such-spec',
+                'GET',
+                '/foo',
+                '200',
+                'application/json',
+                ['/' => ['anything']],
+            );
+        }
+        StrictRequiredPerCallChecker::maybeWarn(
+            'also-no-such-spec',
+            'GET',
+            '/foo',
+            '200',
+            'application/json',
+            ['/' => ['anything']],
+        );
+
+        $stderr = $this->readStderr();
+        $occurrences = substr_count($stderr, '[OpenAPI Strict Required per-call] NOTE:');
+        $this->assertSame(2, $occurrences, 'expected one NOTE per distinct spec, got: ' . $stderr);
+    }
+
+    #[Test]
+    public function reset_clears_emitted_notes_so_dedupe_starts_fresh(): void
+    {
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+
+        // First call writes a NOTE; second is suppressed by dedupe.
+        StrictRequiredPerCallChecker::maybeWarn(
+            'no-such-spec',
+            'GET',
+            '/foo',
+            '200',
+            'application/json',
+            ['/' => ['anything']],
+        );
+
+        // Reset clears the dedupe set; the same call should write again.
+        StrictRequiredPerCallChecker::reset();
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+
+        StrictRequiredPerCallChecker::maybeWarn(
+            'no-such-spec',
+            'GET',
+            '/foo',
+            '200',
+            'application/json',
+            ['/' => ['anything']],
+        );
+
+        $stderr = $this->readStderr();
+        $occurrences = substr_count($stderr, '[OpenAPI Strict Required per-call] NOTE:');
+        $this->assertSame(2, $occurrences);
     }
 
     #[Test]
@@ -275,5 +466,15 @@ final class StrictRequiredPerCallCheckerTest extends TestCase
         }
 
         return $captured;
+    }
+
+    private function readStderr(): string
+    {
+        if ($this->stderrBuffer === null) {
+            return '';
+        }
+        rewind($this->stderrBuffer);
+
+        return (string) stream_get_contents($this->stderrBuffer);
     }
 }

--- a/tests/Unit/Validation/Strict/StrictRequiredPerCallCheckerTest.php
+++ b/tests/Unit/Validation/Strict/StrictRequiredPerCallCheckerTest.php
@@ -1,0 +1,279 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Validation\Strict;
+
+use const E_USER_WARNING;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredPerCallChecker;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredPerCallMode;
+
+use function restore_error_handler;
+use function set_error_handler;
+
+final class StrictRequiredPerCallCheckerTest extends TestCase
+{
+    private const SPEC_BASE_PATH = __DIR__ . '/../../../fixtures/specs';
+    private const SPEC_NAME = 'under-described';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(self::SPEC_BASE_PATH);
+        StrictRequiredPerCallChecker::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        StrictRequiredPerCallChecker::reset();
+        OpenApiSpecLoader::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function default_mode_is_off(): void
+    {
+        $this->assertSame(StrictRequiredPerCallMode::Off, StrictRequiredPerCallChecker::mode());
+    }
+
+    #[Test]
+    public function configure_persists_mode_until_reset(): void
+    {
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+        $this->assertSame(StrictRequiredPerCallMode::Warn, StrictRequiredPerCallChecker::mode());
+
+        StrictRequiredPerCallChecker::reset();
+        $this->assertSame(StrictRequiredPerCallMode::Off, StrictRequiredPerCallChecker::mode());
+    }
+
+    #[Test]
+    public function off_mode_does_not_emit_warning_even_with_drift(): void
+    {
+        // Off is the default — the spec under /signed-url declares
+        // expires/signed_url/url as optional, so a warn-mode call would
+        // certainly fire. Verify Off produces silence.
+        $captured = $this->captureFirstWarning(static function (): void {
+            StrictRequiredPerCallChecker::maybeWarn(
+                self::SPEC_NAME,
+                'PUT',
+                '/signed-url',
+                '200',
+                'application/json',
+                ['/' => ['expires', 'signed_url', 'url']],
+            );
+        });
+
+        $this->assertNull($captured);
+    }
+
+    #[Test]
+    public function warn_mode_emits_warning_with_per_call_prefix_and_missing_keys(): void
+    {
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+
+        $captured = $this->captureFirstWarning(static function (): void {
+            StrictRequiredPerCallChecker::maybeWarn(
+                self::SPEC_NAME,
+                'PUT',
+                '/signed-url',
+                '200',
+                'application/json',
+                ['/' => ['expires', 'signed_url', 'url']],
+            );
+        });
+
+        $this->assertNotNull($captured);
+        $this->assertStringContainsString('[OpenAPI Strict Required per-call] WARN:', $captured);
+        $this->assertStringContainsString('PUT /signed-url', $captured);
+        $this->assertStringContainsString('200', $captured);
+        $this->assertStringContainsString('application/json', $captured);
+        $this->assertStringContainsString('/ : expires, signed_url, url', $captured);
+    }
+
+    #[Test]
+    public function warn_mode_does_not_emit_when_observed_keys_are_all_required(): void
+    {
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+
+        $captured = $this->captureFirstWarning(static function (): void {
+            // /users/{id} declares both `id` and `name` as required, so a
+            // body that contains exactly those keys has zero drift.
+            StrictRequiredPerCallChecker::maybeWarn(
+                self::SPEC_NAME,
+                'GET',
+                '/users/{id}',
+                '200',
+                'application/json',
+                ['/' => ['id', 'name']],
+            );
+        });
+
+        $this->assertNull($captured);
+    }
+
+    #[Test]
+    public function warn_mode_emits_only_pointers_with_drift(): void
+    {
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+
+        // /projects/{id} requires id+name; created_at is optional. The
+        // observation has all three, so only `created_at` should drift.
+        $captured = $this->captureFirstWarning(static function (): void {
+            StrictRequiredPerCallChecker::maybeWarn(
+                self::SPEC_NAME,
+                'GET',
+                '/projects/{id}',
+                '200',
+                'application/json',
+                ['/' => ['created_at', 'id', 'name']],
+            );
+        });
+
+        $this->assertNotNull($captured);
+        $this->assertStringContainsString('/ : created_at', $captured);
+        $this->assertStringNotContainsString('id, name', $captured);
+    }
+
+    #[Test]
+    public function warn_mode_reports_nested_pointer_drift(): void
+    {
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+
+        // /teams/{id} → data.required=["name"]. Body always returns
+        // created_at too — drift expected at /data.
+        $captured = $this->captureFirstWarning(static function (): void {
+            StrictRequiredPerCallChecker::maybeWarn(
+                self::SPEC_NAME,
+                'GET',
+                '/teams/{id}',
+                '200',
+                'application/json',
+                [
+                    '/' => ['data', 'id'],
+                    '/data' => ['created_at', 'name'],
+                ],
+            );
+        });
+
+        $this->assertNotNull($captured);
+        $this->assertStringContainsString('/data : created_at', $captured);
+    }
+
+    #[Test]
+    public function warn_mode_skips_pointers_under_disjunction(): void
+    {
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+
+        // /either-shape root is `anyOf`. Per-call must not warn about
+        // anything under it — the disjunction has no AND-semantic for
+        // `required`. The asserter would emit an unwalkable NOTE, but
+        // per-call has no NOTE channel; silent skip is the safe default.
+        $captured = $this->captureFirstWarning(static function (): void {
+            StrictRequiredPerCallChecker::maybeWarn(
+                self::SPEC_NAME,
+                'GET',
+                '/either-shape',
+                '200',
+                'application/json',
+                ['/' => ['a']],
+            );
+        });
+
+        $this->assertNull($captured);
+    }
+
+    #[Test]
+    public function warn_mode_silently_skips_unknown_endpoint(): void
+    {
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+
+        // Endpoint not in spec — per-call must not fail-loud here because
+        // converting an infrastructure mismatch into a per-test warning
+        // would attribute the bug to the wrong test layer.
+        $captured = $this->captureFirstWarning(static function (): void {
+            StrictRequiredPerCallChecker::maybeWarn(
+                self::SPEC_NAME,
+                'GET',
+                '/does-not-exist',
+                '200',
+                'application/json',
+                ['/' => ['anything']],
+            );
+        });
+
+        $this->assertNull($captured);
+    }
+
+    #[Test]
+    public function warn_mode_silently_skips_when_spec_load_fails(): void
+    {
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+
+        // The loader has no spec named 'no-such-spec'; per-call must not
+        // escalate the SpecFileNotFoundException into a per-test warning.
+        $captured = $this->captureFirstWarning(static function (): void {
+            StrictRequiredPerCallChecker::maybeWarn(
+                'no-such-spec',
+                'GET',
+                '/foo',
+                '200',
+                'application/json',
+                ['/' => ['anything']],
+            );
+        });
+
+        $this->assertNull($captured);
+    }
+
+    #[Test]
+    public function warn_mode_skips_when_pointers_map_is_empty(): void
+    {
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+
+        $captured = $this->captureFirstWarning(static function (): void {
+            StrictRequiredPerCallChecker::maybeWarn(
+                self::SPEC_NAME,
+                'PUT',
+                '/signed-url',
+                '200',
+                'application/json',
+                [],
+            );
+        });
+
+        $this->assertNull($captured);
+    }
+
+    /**
+     * Capture the first `E_USER_WARNING` triggered by `$callable` and
+     * return its message. Returns `null` if no warning was triggered.
+     *
+     * Wrapping `set_error_handler` lets the test assert against the
+     * warning text without `failOnWarning` interfering with the
+     * surrounding PHPUnit run.
+     */
+    private function captureFirstWarning(callable $callable): ?string
+    {
+        $captured = null;
+        set_error_handler(static function (int $errno, string $errstr) use (&$captured): bool {
+            if ($captured === null && $errno === E_USER_WARNING) {
+                $captured = $errstr;
+            }
+
+            return true;
+        }, E_USER_WARNING);
+
+        try {
+            $callable();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $captured;
+    }
+}

--- a/tests/Unit/Validation/Strict/StrictRequiredPerCallModeTest.php
+++ b/tests/Unit/Validation/Strict/StrictRequiredPerCallModeTest.php
@@ -50,15 +50,30 @@ final class StrictRequiredPerCallModeTest extends TestCase
     }
 
     #[Test]
-    public function from_config_value_rejects_fail_value(): void
+    public function from_config_value_rejects_fail_value_with_directive_message(): void
     {
         // Per-call mode is intentionally warn-only — the run-level
         // {@see StrictRequiredMode} provides the safe fail-gate. Silently
         // demoting `fail` here would let a CI ship with a misconfigured
-        // gate; reject loudly instead.
+        // gate; reject loudly instead. The error message must be more
+        // specific than the generic "unknown value" branch because `fail`
+        // is the value most likely to be typoed by users coming from the
+        // run-level docs — surfacing the design rationale and the two
+        // legitimate alternatives lets the user self-fix without grep.
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Unknown strict_required_per_call value 'fail'");
+        $this->expectExceptionMessage("strict_required_per_call does not support 'fail'");
+        $this->expectExceptionMessage('warn-only by design');
+        $this->expectExceptionMessage('failOnWarning');
+        $this->expectExceptionMessage('strict_required=fail');
         StrictRequiredPerCallMode::fromConfigValue('fail');
+    }
+
+    #[Test]
+    public function from_config_value_handles_combined_whitespace_and_uppercase(): void
+    {
+        // The realistic phpunit.xml editing artefact — leading newline +
+        // copy-paste casing.
+        $this->assertSame(StrictRequiredPerCallMode::Warn, StrictRequiredPerCallMode::fromConfigValue("  Warn\n"));
     }
 
     #[Test]

--- a/tests/Unit/Validation/Strict/StrictRequiredPerCallModeTest.php
+++ b/tests/Unit/Validation/Strict/StrictRequiredPerCallModeTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Validation\Strict;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredPerCallMode;
+
+final class StrictRequiredPerCallModeTest extends TestCase
+{
+    #[Test]
+    public function from_config_value_returns_off_when_value_is_null(): void
+    {
+        $this->assertSame(StrictRequiredPerCallMode::Off, StrictRequiredPerCallMode::fromConfigValue(null));
+    }
+
+    #[Test]
+    public function from_config_value_returns_off_when_value_is_empty_string(): void
+    {
+        $this->assertSame(StrictRequiredPerCallMode::Off, StrictRequiredPerCallMode::fromConfigValue(''));
+        $this->assertSame(StrictRequiredPerCallMode::Off, StrictRequiredPerCallMode::fromConfigValue('   '));
+    }
+
+    #[Test]
+    public function from_config_value_parses_off(): void
+    {
+        $this->assertSame(StrictRequiredPerCallMode::Off, StrictRequiredPerCallMode::fromConfigValue('off'));
+    }
+
+    #[Test]
+    public function from_config_value_parses_warn(): void
+    {
+        $this->assertSame(StrictRequiredPerCallMode::Warn, StrictRequiredPerCallMode::fromConfigValue('warn'));
+    }
+
+    #[Test]
+    public function from_config_value_is_case_insensitive(): void
+    {
+        $this->assertSame(StrictRequiredPerCallMode::Warn, StrictRequiredPerCallMode::fromConfigValue('Warn'));
+        $this->assertSame(StrictRequiredPerCallMode::Warn, StrictRequiredPerCallMode::fromConfigValue('WARN'));
+    }
+
+    #[Test]
+    public function from_config_value_trims_whitespace(): void
+    {
+        $this->assertSame(StrictRequiredPerCallMode::Warn, StrictRequiredPerCallMode::fromConfigValue('  warn  '));
+    }
+
+    #[Test]
+    public function from_config_value_rejects_fail_value(): void
+    {
+        // Per-call mode is intentionally warn-only — the run-level
+        // {@see StrictRequiredMode} provides the safe fail-gate. Silently
+        // demoting `fail` here would let a CI ship with a misconfigured
+        // gate; reject loudly instead.
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Unknown strict_required_per_call value 'fail'");
+        StrictRequiredPerCallMode::fromConfigValue('fail');
+    }
+
+    #[Test]
+    public function from_config_value_rejects_unknown_value(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Unknown strict_required_per_call value 'enforce'");
+        StrictRequiredPerCallMode::fromConfigValue('enforce');
+    }
+
+    #[Test]
+    public function is_enabled_reflects_non_off_modes(): void
+    {
+        $this->assertFalse(StrictRequiredPerCallMode::Off->isEnabled());
+        $this->assertTrue(StrictRequiredPerCallMode::Warn->isEnabled());
+    }
+}

--- a/tests/Unit/Validation/Strict/StrictRequiredSchemaWalkerTest.php
+++ b/tests/Unit/Validation/Strict/StrictRequiredSchemaWalkerTest.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Validation\Strict;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredSchemaWalker;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredTracker;
+
+final class StrictRequiredSchemaWalkerTest extends TestCase
+{
+    #[Test]
+    public function split_endpoint_key_separates_method_and_path(): void
+    {
+        $this->assertSame(['GET', '/users/{id}'], StrictRequiredSchemaWalker::splitEndpointKey('GET /users/{id}'));
+    }
+
+    #[Test]
+    public function split_endpoint_key_uppercases_method(): void
+    {
+        $this->assertSame(['POST', '/projects'], StrictRequiredSchemaWalker::splitEndpointKey('post /projects'));
+    }
+
+    #[Test]
+    public function split_endpoint_key_falls_back_when_no_space(): void
+    {
+        // The tracker always inserts a space, but the helper is defensive
+        // so a hand-built malformed key surfaces an obvious "/" path
+        // rather than an out-of-bounds substring.
+        $this->assertSame(['GET', '/'], StrictRequiredSchemaWalker::splitEndpointKey('get'));
+    }
+
+    #[Test]
+    public function split_response_key_separates_status_and_content_type(): void
+    {
+        $this->assertSame(['200', 'application/json'], StrictRequiredSchemaWalker::splitResponseKey('200:application/json'));
+    }
+
+    #[Test]
+    public function split_response_key_defaults_content_type_to_any(): void
+    {
+        $this->assertSame(['200', StrictRequiredTracker::ANY_CONTENT_TYPE], StrictRequiredSchemaWalker::splitResponseKey('200'));
+    }
+
+    #[Test]
+    public function resolve_response_schema_returns_schema_for_full_path(): void
+    {
+        $spec = [
+            'paths' => [
+                '/users/{id}' => [
+                    'get' => [
+                        'responses' => [
+                            '200' => [
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => ['type' => 'object', 'properties' => ['id' => ['type' => 'string']]],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $resolved = StrictRequiredSchemaWalker::resolveResponseSchema($spec, 'GET', '/users/{id}', '200', 'application/json');
+
+        $this->assertSame(['type' => 'object', 'properties' => ['id' => ['type' => 'string']]], $resolved);
+    }
+
+    #[Test]
+    public function resolve_response_schema_returns_null_for_missing_method(): void
+    {
+        $spec = ['paths' => ['/users/{id}' => ['get' => []]]];
+
+        $this->assertNull(StrictRequiredSchemaWalker::resolveResponseSchema($spec, 'POST', '/users/{id}', '200', 'application/json'));
+    }
+
+    #[Test]
+    public function resolve_response_schema_returns_null_for_missing_status(): void
+    {
+        $spec = [
+            'paths' => [
+                '/users/{id}' => [
+                    'get' => [
+                        'responses' => [
+                            '404' => ['content' => ['application/json' => ['schema' => []]]],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertNull(StrictRequiredSchemaWalker::resolveResponseSchema($spec, 'GET', '/users/{id}', '200', 'application/json'));
+    }
+
+    #[Test]
+    public function resolve_response_schema_returns_null_for_missing_content_type(): void
+    {
+        $spec = [
+            'paths' => [
+                '/foo' => [
+                    'get' => [
+                        'responses' => [
+                            '200' => ['content' => ['text/plain' => ['schema' => ['type' => 'string']]]],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertNull(StrictRequiredSchemaWalker::resolveResponseSchema($spec, 'GET', '/foo', '200', 'application/json'));
+    }
+
+    #[Test]
+    public function collect_required_by_pointer_walks_object_root_with_required(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'required' => ['id', 'name'],
+            'properties' => [
+                'id' => ['type' => 'string'],
+                'name' => ['type' => 'string'],
+                'created_at' => ['type' => 'string'],
+            ],
+        ];
+
+        $result = StrictRequiredSchemaWalker::collectRequiredByPointer($schema);
+
+        $this->assertSame(['/' => ['id', 'name']], $result['walked']);
+        $this->assertSame([], $result['disjunctions']);
+    }
+
+    #[Test]
+    public function collect_required_by_pointer_unions_all_of_required_at_root(): void
+    {
+        $schema = [
+            'allOf' => [
+                ['type' => 'object', 'required' => ['id'], 'properties' => ['id' => ['type' => 'string']]],
+                ['type' => 'object', 'properties' => ['total' => ['type' => 'integer']]],
+            ],
+        ];
+
+        $result = StrictRequiredSchemaWalker::collectRequiredByPointer($schema);
+
+        $this->assertSame(['/' => ['id']], $result['walked']);
+        $this->assertSame([], $result['disjunctions']);
+    }
+
+    #[Test]
+    public function collect_required_by_pointer_descends_into_nested_object_property(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'required' => ['data'],
+            'properties' => [
+                'data' => [
+                    'type' => 'object',
+                    'required' => ['name'],
+                    'properties' => [
+                        'name' => ['type' => 'string'],
+                        'created_at' => ['type' => 'string'],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = StrictRequiredSchemaWalker::collectRequiredByPointer($schema);
+
+        $this->assertSame(['/' => ['data'], '/data' => ['name']], $result['walked']);
+    }
+
+    #[Test]
+    public function collect_required_by_pointer_descends_into_array_items(): void
+    {
+        $schema = [
+            'type' => 'array',
+            'items' => [
+                'type' => 'object',
+                'required' => ['id'],
+                'properties' => ['id' => ['type' => 'string']],
+            ],
+        ];
+
+        $result = StrictRequiredSchemaWalker::collectRequiredByPointer($schema);
+
+        $this->assertSame(['[*]' => ['id']], $result['walked']);
+        $this->assertSame([], $result['disjunctions']);
+    }
+
+    #[Test]
+    public function collect_required_by_pointer_marks_root_any_of_as_disjunction(): void
+    {
+        $schema = [
+            'anyOf' => [
+                ['type' => 'object', 'required' => ['a'], 'properties' => ['a' => ['type' => 'string']]],
+                ['type' => 'object', 'required' => ['b'], 'properties' => ['b' => ['type' => 'string']]],
+            ],
+        ];
+
+        $result = StrictRequiredSchemaWalker::collectRequiredByPointer($schema);
+
+        $this->assertSame([], $result['walked']);
+        $this->assertSame([['pointer' => '', 'reason' => 'anyOf']], $result['disjunctions']);
+    }
+
+    #[Test]
+    public function collect_required_by_pointer_marks_root_one_of_as_disjunction(): void
+    {
+        $schema = [
+            'oneOf' => [
+                ['type' => 'object', 'required' => ['a'], 'properties' => ['a' => ['type' => 'string']]],
+                ['type' => 'object', 'required' => ['b'], 'properties' => ['b' => ['type' => 'string']]],
+            ],
+        ];
+
+        $result = StrictRequiredSchemaWalker::collectRequiredByPointer($schema);
+
+        $this->assertSame([['pointer' => '', 'reason' => 'oneOf']], $result['disjunctions']);
+    }
+
+    #[Test]
+    public function collect_required_by_pointer_marks_nested_disjunction(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'required' => ['data'],
+            'properties' => [
+                'data' => [
+                    'oneOf' => [
+                        ['type' => 'object', 'required' => ['x'], 'properties' => ['x' => ['type' => 'string']]],
+                        ['type' => 'object', 'required' => ['y'], 'properties' => ['y' => ['type' => 'string']]],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = StrictRequiredSchemaWalker::collectRequiredByPointer($schema);
+
+        $this->assertArrayHasKey('/', $result['walked']);
+        $this->assertSame([['pointer' => '/data', 'reason' => 'oneOf']], $result['disjunctions']);
+    }
+
+    #[Test]
+    public function find_covering_disjunction_matches_root_disjunction_for_any_pointer(): void
+    {
+        $disjunctions = [['pointer' => '', 'reason' => 'anyOf']];
+
+        $this->assertSame($disjunctions[0], StrictRequiredSchemaWalker::findCoveringDisjunction('/foo', $disjunctions));
+        $this->assertSame($disjunctions[0], StrictRequiredSchemaWalker::findCoveringDisjunction('[*]', $disjunctions));
+    }
+
+    #[Test]
+    public function find_covering_disjunction_matches_descendant_via_slash_boundary(): void
+    {
+        $disjunctions = [['pointer' => '/data', 'reason' => 'oneOf']];
+
+        $this->assertSame($disjunctions[0], StrictRequiredSchemaWalker::findCoveringDisjunction('/data/inner', $disjunctions));
+    }
+
+    #[Test]
+    public function find_covering_disjunction_matches_descendant_via_array_marker(): void
+    {
+        $disjunctions = [['pointer' => '/items', 'reason' => 'oneOf']];
+
+        $this->assertSame($disjunctions[0], StrictRequiredSchemaWalker::findCoveringDisjunction('/items[*]', $disjunctions));
+    }
+
+    #[Test]
+    public function find_covering_disjunction_returns_null_for_unrelated_pointer(): void
+    {
+        $disjunctions = [['pointer' => '/data', 'reason' => 'oneOf']];
+
+        // `/dataset` shares a prefix but is a different property — must not
+        // be reported as covered by `/data`'s disjunction.
+        $this->assertNull(StrictRequiredSchemaWalker::findCoveringDisjunction('/dataset', $disjunctions));
+        $this->assertNull(StrictRequiredSchemaWalker::findCoveringDisjunction('/other', $disjunctions));
+    }
+}

--- a/tests/Unit/Validation/Strict/StrictRequiredValidatorIntegrationTest.php
+++ b/tests/Unit/Validation/Strict/StrictRequiredValidatorIntegrationTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Tests\Unit\Validation\Strict;
 
+use const E_USER_WARNING;
+
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -11,7 +13,12 @@ use Studio\OpenApiContractTesting\OpenApiResponseValidator;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredAsserter;
 use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredMode;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredPerCallChecker;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredPerCallMode;
 use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredTracker;
+
+use function restore_error_handler;
+use function set_error_handler;
 
 final class StrictRequiredValidatorIntegrationTest extends TestCase
 {
@@ -23,12 +30,14 @@ final class StrictRequiredValidatorIntegrationTest extends TestCase
         OpenApiSpecLoader::reset();
         OpenApiSpecLoader::configure(__DIR__ . '/../../../fixtures/specs');
         StrictRequiredTracker::reset();
+        StrictRequiredPerCallChecker::reset();
         $this->validator = new OpenApiResponseValidator();
     }
 
     protected function tearDown(): void
     {
         StrictRequiredTracker::reset();
+        StrictRequiredPerCallChecker::reset();
         OpenApiSpecLoader::reset();
         parent::tearDown();
     }
@@ -331,6 +340,107 @@ final class StrictRequiredValidatorIntegrationTest extends TestCase
     }
 
     #[Test]
+    public function per_call_warn_emits_warning_on_first_observation(): void
+    {
+        // Per-call mode (Issue #228) is the lightweight gate: a single
+        // observation with optional fields present must surface as a
+        // warning immediately, without waiting for the run-level
+        // intersection at ExecutionFinished. /signed-url has no `required`
+        // declared, so all three keys drift on the first call.
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+
+        $captured = $this->captureFirstWarning(function (): void {
+            $this->validator->validate(
+                'under-described',
+                'PUT',
+                '/signed-url',
+                200,
+                ['expires' => 3600, 'signed_url' => 's3://...', 'url' => 'https://...'],
+                'application/json',
+            );
+        });
+
+        $this->assertNotNull($captured);
+        $this->assertStringContainsString('[OpenAPI Strict Required per-call] WARN:', $captured);
+        $this->assertStringContainsString('PUT /signed-url', $captured);
+    }
+
+    #[Test]
+    public function per_call_off_emits_no_warning_even_with_drift(): void
+    {
+        // Default mode is Off. The same body that fires above must stay
+        // silent here so existing users see zero behaviour change after
+        // upgrading to a release that ships per-call mode.
+        $captured = $this->captureFirstWarning(function (): void {
+            $this->validator->validate(
+                'under-described',
+                'PUT',
+                '/signed-url',
+                200,
+                ['expires' => 3600, 'signed_url' => 's3://...', 'url' => 'https://...'],
+                'application/json',
+            );
+        });
+
+        $this->assertNull($captured);
+    }
+
+    #[Test]
+    public function per_call_does_not_fire_when_response_fails_conformance(): void
+    {
+        // Per-call hangs off the same Success-only branch as the tracker:
+        // a conformance-failing response must not trigger a per-call
+        // warning. /users/{id} requires `id`+`name`; omitting `id` fails.
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+
+        $captured = $this->captureFirstWarning(function (): void {
+            $this->validator->validate(
+                'under-described',
+                'GET',
+                '/users/{id}',
+                200,
+                ['name' => 'alice'],
+                'application/json',
+            );
+        });
+
+        $this->assertNull($captured);
+    }
+
+    #[Test]
+    public function per_call_warn_and_run_level_warn_are_independent(): void
+    {
+        // CIs may run per-call=warn for early visibility AND run-level=warn
+        // for the safer aggregate. A single observation must trigger the
+        // per-call warning AND record into the tracker so the run-level
+        // asserter still has data to diff at ExecutionFinished.
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+
+        $captured = $this->captureFirstWarning(function (): void {
+            $this->validator->validate(
+                'under-described',
+                'PUT',
+                '/signed-url',
+                200,
+                ['expires' => 3600, 'signed_url' => 's3://...', 'url' => 'https://...'],
+                'application/json',
+            );
+        });
+
+        $this->assertNotNull($captured);
+
+        $observations = StrictRequiredTracker::getObservations('under-described');
+        $this->assertSame(
+            ['hits' => 1, 'pointers' => ['/' => ['expires', 'signed_url', 'url']]],
+            $observations['PUT /signed-url']['200:application/json'],
+        );
+
+        $reports = StrictRequiredAsserter::detectAll(StrictRequiredMode::Warn);
+        $this->assertCount(1, $reports);
+        $this->assertSame(['expires', 'signed_url', 'url'], $reports[0]->missingFromRequired);
+    }
+
+    #[Test]
     public function empty_object_body_is_recorded_as_empty_observation(): void
     {
         // Empty object {} lands here as PHP [] after json_decode($_, true).
@@ -358,5 +468,29 @@ final class StrictRequiredValidatorIntegrationTest extends TestCase
             ['hits' => 1, 'pointers' => ['/' => []]],
             $observations['PUT /signed-url']['200:application/json'],
         );
+    }
+
+    /**
+     * Capture the first `E_USER_WARNING` triggered by `$callable` and
+     * return its message. Returns `null` if no warning was triggered.
+     */
+    private function captureFirstWarning(callable $callable): ?string
+    {
+        $captured = null;
+        set_error_handler(static function (int $errno, string $errstr) use (&$captured): bool {
+            if ($captured === null && $errno === E_USER_WARNING) {
+                $captured = $errstr;
+            }
+
+            return true;
+        }, E_USER_WARNING);
+
+        try {
+            $callable();
+        } finally {
+            restore_error_handler();
+        }
+
+        return $captured;
     }
 }

--- a/tests/Unit/Validation/Strict/StrictRequiredValidatorIntegrationTest.php
+++ b/tests/Unit/Validation/Strict/StrictRequiredValidatorIntegrationTest.php
@@ -408,6 +408,164 @@ final class StrictRequiredValidatorIntegrationTest extends TestCase
     }
 
     #[Test]
+    public function per_call_does_not_fire_when_status_matches_skip_pattern(): void
+    {
+        // 5xx is the default skipResponseCodes pattern; the validator
+        // short-circuits at OpenApiResponseValidator::validate() long
+        // before maybeRecordStrictRequired() runs, so neither gate sees
+        // these responses. A future refactor that hoists per-call earlier
+        // would silently fire warnings on skipped statuses — pin the
+        // current short-circuit so the regression is loud.
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+
+        $captured = $this->captureFirstWarning(function (): void {
+            $this->validator->validate(
+                'under-described',
+                'PUT',
+                '/signed-url',
+                503,
+                ['expires' => 3600, 'signed_url' => 's3://...', 'url' => 'https://...'],
+                'application/json',
+            );
+        });
+
+        $this->assertNull($captured);
+    }
+
+    #[Test]
+    public function per_call_fires_on_array_element_pointer_drift(): void
+    {
+        // /items returns `type: array, items: { required: ["id"], ... }`.
+        // The walker records `[*]` for the element-shape; per-call must
+        // diff against the per-element required set and surface drift at
+        // the `[*]` pointer. Without this pin, a refactor that broke the
+        // `[` separator boundary in findCoveringDisjunction() would silently
+        // disable per-call drift on every list-shaped endpoint.
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+
+        $captured = $this->captureFirstWarning(function (): void {
+            $this->validator->validate(
+                'under-described',
+                'GET',
+                '/items',
+                200,
+                [['id' => '1', 'name' => 'A'], ['id' => '2', 'name' => 'B']],
+                'application/json',
+            );
+        });
+
+        $this->assertNotNull($captured);
+        $this->assertStringContainsString('[OpenAPI Strict Required per-call] WARN:', $captured);
+        $this->assertStringContainsString('GET /items', $captured);
+        $this->assertStringContainsString('[*] : name', $captured);
+    }
+
+    #[Test]
+    public function per_call_fires_on_nested_object_pointer_drift(): void
+    {
+        // End-to-end version of the unit test, exercising the walker →
+        // checker pipeline against the /teams/{id} fixture. A walker bug
+        // producing `data.created_at` (or any other malformed pointer)
+        // instead of `/data` would slip past the unit test (which builds
+        // the pointer map directly) but is caught here.
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+
+        $captured = $this->captureFirstWarning(function (): void {
+            $this->validator->validate(
+                'under-described',
+                'GET',
+                '/teams/{id}',
+                200,
+                [
+                    'id' => '1',
+                    'data' => ['name' => 'A', 'created_at' => '2026-01-01T00:00:00Z'],
+                ],
+                'application/json',
+            );
+        });
+
+        $this->assertNotNull($captured);
+        $this->assertStringContainsString('/data : created_at', $captured);
+    }
+
+    #[Test]
+    public function per_call_fires_on_allof_unioned_required_drift(): void
+    {
+        // /orders/{id} uses an allOf-rooted schema where `id` is the only
+        // required key (carried by one branch). The checker must diff
+        // observed keys against the unioned required set across allOf
+        // branches; without this pin a regression in
+        // collectRequiredFromSchema()'s allOf recursion would surface only
+        // on the run-level path.
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+
+        $captured = $this->captureFirstWarning(function (): void {
+            $this->validator->validate(
+                'under-described',
+                'GET',
+                '/orders/{id}',
+                200,
+                ['id' => '1', 'total' => 4200, 'currency' => 'JPY'],
+                'application/json',
+            );
+        });
+
+        $this->assertNotNull($captured);
+        $this->assertStringContainsString('/ : currency, total', $captured);
+    }
+
+    #[Test]
+    public function per_call_fires_on_stdclass_body(): void
+    {
+        // stdClass bodies are common from framework-agnostic adapters
+        // (Pest plugin, raw json_decode($_, false)). The walker coerces
+        // to associative arrays; the per-call gate must observe the same
+        // drift as if the body had been an assoc array.
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+
+        $body = new stdClass();
+        $body->expires = 3600;
+        $body->signed_url = 's3://...';
+        $body->url = 'https://...';
+
+        $captured = $this->captureFirstWarning(function () use ($body): void {
+            $this->validator->validate(
+                'under-described',
+                'PUT',
+                '/signed-url',
+                200,
+                $body,
+                'application/json',
+            );
+        });
+
+        $this->assertNotNull($captured);
+        $this->assertStringContainsString('/ : expires, signed_url, url', $captured);
+    }
+
+    #[Test]
+    public function per_call_does_not_fire_on_scalar_body(): void
+    {
+        // /scalar declares `type: string`. The walker yields an empty
+        // pointer map, so the validator short-circuits before either gate
+        // runs — neither the tracker nor per-call should observe anything.
+        StrictRequiredPerCallChecker::configure(StrictRequiredPerCallMode::Warn);
+
+        $captured = $this->captureFirstWarning(function (): void {
+            $this->validator->validate(
+                'under-described',
+                'GET',
+                '/scalar',
+                200,
+                'hello-world',
+                'application/json',
+            );
+        });
+
+        $this->assertNull($captured);
+    }
+
+    #[Test]
     public function per_call_warn_and_run_level_warn_are_independent(): void
     {
         // CIs may run per-call=warn for early visibility AND run-level=warn


### PR DESCRIPTION
## Summary

Add an opt-in `strict_required_per_call` PHPUnit extension parameter (Issue #228 follow-up to PR #225) that fires `E_USER_WARNING` immediately on every conformance-passing response whose body contains optional fields not declared in the matching schema's `required` array. Pair with `failOnWarning="true"` to convert per-call drift into per-test failures so single-observation endpoints surface schema under-description that the run-level intersection mode silently skips.

## Why

Closes #228.

The MVP gate from #225 (run-level `strict_required`) requires `hits >= 2` to confirm a key is invariantly returned. Endpoints with a single test case never reach that threshold and silently pass even when the spec is under-described. Issue #228 asked for the lightweight companion: a per-call mode that warns on the first observation, with the explicit trade-off that legitimately-optional fields will warn (acceptable because it's warn-only and opt-in).

The two modes are independent and can be combined — a CI may run `strict_required=fail` for the safe aggregate gate AND `strict_required_per_call=warn` for early visibility. The per-call mode does not accept `fail`: silently demoting a typo into `warn` would mislead a CI; loud rejection follows the same fail-loud-on-misconfiguration policy this extension enforces.

## How it works

- `OpenApiResponseValidator::maybeRecordStrictRequired()` walks the body once via the existing `StrictRequiredBodyWalker` and hands the resulting pointer map to BOTH the run-level tracker (Issue #224) and the new per-call checker. Cost stays flat regardless of how many gates the user enabled.
- `StrictRequiredPerCallChecker` is a static singleton (mirrors `StrictRequiredTracker`). On `Warn` mode it loads the matching spec, descends to the response schema, and diffs each observed pointer's keys against the schema's `required`. Drift triggers one consolidated `trigger_error(..., E_USER_WARNING)` per observation with the prefix `[OpenAPI Strict Required per-call] WARN:` so log scrapers can route the two channels independently.
- Schema descent (object/array/`allOf` walking, `anyOf`/`oneOf` disjunction detection, response-key resolution) is shared with `StrictRequiredAsserter` via a new internal `StrictRequiredSchemaWalker` extracted from the asserter — pure refactor, no behaviour change.
- Spec load failures and unresolved schemas are silently dropped: per-call warnings convert to per-test failures under `failOnWarning=true`, so escalating an infrastructure problem into a user-test failure would attribute the fault to the wrong layer. The run-level asserter still surfaces these as a NOTE at `ExecutionFinished`.

Configuration:

```xml
<parameter name="strict_required"          value="fail"/>  <!-- run-level safe gate    -->
<parameter name="strict_required_per_call" value="warn"/>  <!-- per-call early signal  -->
```

## Scope of this PR

Explicit MVP scope. Each limitation is documented in `docs/strict-required.md`:

- **No `fail` mode for per-call.** Per-call by definition warns on every legitimately-optional field present in any one observation; a hard fail-gate would shower false positives. Run-level intersection (`strict_required=fail`) stays the safe fail-gate.
- **No `#[StrictRequiredPerCallIgnore]` attribute.** Issue #228 hinted at it as a possible suppression mechanism; deferred to a follow-up so the noise floor of the gate is observed in real CI before deciding the suppression API.
- **Pest plugin / Laravel trait per-call opt-in is not added** — per-call is currently extension-parameter-only. Pest / trait integration is a separate follow-up.

## Verification

- `composer ci` is green locally (PHP 8.4 + PHPUnit 13). 1679 tests, 3950 assertions; 49 new tests covering the enum (parsing, `fail` rejection), checker (off/warn/disjunction skip/unknown endpoint/spec load failure/empty pointers/nested drift), schema walker (split helpers, schema resolution null branches, allOf union, disjunction marking + covering match), validator integration (per-call + run-level coexistence, success-path-only firing, default-off compatibility), and extension parameter parsing (warn / absent / unknown / `fail` / coexist with run-level).
- All 23 pre-existing strict_required tests still green after the schema-walker extraction.
- Manual smoke: under-described.json fixture observed exactly the expected `[OpenAPI Strict Required per-call] WARN: PUT /signed-url ...` block with the listed missing keys.

- [x] `composer test` passes
- [x] `composer stan` passes
- [x] `composer cs-check` passes

## Follow-up issues to file

- `#[StrictRequiredPerCallIgnore]` attribute for per-test / per-class suppression once real-CI noise patterns are known.
- Pest plugin / Laravel trait per-call opt-in (currently extension-parameter-only).
- Route per-call output through PHPUnit's Result event so IDEs and GitHub Actions annotations integrate without log scraping.

## Notes for reviewers

- The new `StrictRequiredSchemaWalker` is a strict extraction from `StrictRequiredAsserter` — same logic, same private helpers. The asserter now delegates `splitEndpointKey` / `splitResponseKey` / `resolveResponseSchema` / `collectRequiredByPointer` / `findCoveringDisjunction` to the walker. One small forward-compat tweak: when `inferShape()` returns `null` for a root scalar/empty schema (a branch made unreachable in production by the validator's empty-pointer skip), the disjunction `reason` field falls back to the literal `"unwalkable"` so the type contract `reason: string` holds for any future direct caller. Existing `anyOf`/`oneOf` paths are unchanged because `disjunctionReason()` returns `'anyOf'`/`'oneOf'` before the fallback.
- `OpenApiResponseValidator`'s public signature is unchanged. The per-call checker hangs off the same Success-only branch as the tracker.
- The per-call checker call deliberately runs **after** the tracker `record()` so a tracker-side `InvalidArgumentException` (library-bug guard for malformed walker output) does not suppress the per-call warning. Both gates read the same map.
- New public surface is intentionally minimal: one enum (`StrictRequiredPerCallMode`), one checker, one extension parameter. Behaviour follows the run-level mode's conventions wherever sensible (case/whitespace tolerance, FATAL-on-misconfigured-value, GitHub Step Summary block on FATAL).