### PR TITLE
refactor(coverage,strict_required): instance + DI trackers (#229)

### DIFF
--- a/src/Coverage/CoverageMergeCommand.php
+++ b/src/Coverage/CoverageMergeCommand.php
@@ -311,8 +311,15 @@ final class CoverageMergeCommand
         // them via setCurrent() routes the static facade (used by the
         // StrictRequiredAsserter helpers) into these same instances, so the
         // gate evaluates against exactly the state this run aggregated.
+        // resetCurrent() first drops any prior process-global state so the
+        // setCurrent() overwrite-guard does not trip on a leftover instance
+        // from an earlier merge invocation in the same process (the
+        // PHPUnit-extension-driven test harness can call run() multiple
+        // times per process).
         $coverageTracker = new OpenApiCoverageTracker();
         $strictRequiredTracker = new StrictRequiredTracker();
+        OpenApiCoverageTracker::resetCurrent();
+        StrictRequiredTracker::resetCurrent();
         OpenApiCoverageTracker::setCurrent($coverageTracker);
         StrictRequiredTracker::setCurrent($strictRequiredTracker);
         foreach ($payloads as $payload) {

--- a/src/Coverage/CoverageMergeCommand.php
+++ b/src/Coverage/CoverageMergeCommand.php
@@ -307,14 +307,20 @@ final class CoverageMergeCommand
         OpenApiSpecLoader::reset();
         OpenApiSpecLoader::configure($specBasePath, $stripPrefixes);
 
-        OpenApiCoverageTracker::reset();
-        StrictRequiredTracker::reset();
+        // Issue #229: each merge invocation owns its trackers. Installing
+        // them via setCurrent() routes the static facade (used by the
+        // StrictRequiredAsserter helpers) into these same instances, so the
+        // gate evaluates against exactly the state this run aggregated.
+        $coverageTracker = new OpenApiCoverageTracker();
+        $strictRequiredTracker = new StrictRequiredTracker();
+        OpenApiCoverageTracker::setCurrent($coverageTracker);
+        StrictRequiredTracker::setCurrent($strictRequiredTracker);
         foreach ($payloads as $payload) {
             try {
                 $parsed = CoverageSidecarEnvelope::parse($payload);
-                OpenApiCoverageTracker::importState($parsed['coverage']);
+                $coverageTracker->importStateOn($parsed['coverage']);
                 if ($parsed['strictRequired'] !== null) {
-                    StrictRequiredTracker::importState($parsed['strictRequired']);
+                    $strictRequiredTracker->importStateOn($parsed['strictRequired']);
                 }
             } catch (InvalidArgumentException $e) {
                 $this->writeStderr(sprintf("[OpenAPI Coverage] FATAL: invalid sidecar payload: %s\n", $e->getMessage()));
@@ -323,7 +329,7 @@ final class CoverageMergeCommand
             }
         }
 
-        $results = $this->computeResults($specs);
+        $results = $this->computeResults($specs, $coverageTracker);
         if ($results === []) {
             $strictGated = $minStrict && ($minEndpointPct !== null || $minResponsePct !== null);
             $this->writeStderr(sprintf(
@@ -351,7 +357,7 @@ final class CoverageMergeCommand
         // Issue #226: aggregate strict_required across workers and run the
         // gate after the report is rendered so a fatal drift doesn't suppress
         // the coverage output users rely on for triage.
-        $strictFailure = $this->evaluateStrictRequiredGate($strictRequiredMode, $githubSummaryPath);
+        $strictFailure = $this->evaluateStrictRequiredGate($strictRequiredMode, $githubSummaryPath, $strictRequiredTracker);
 
         if ($cleanup) {
             $this->cleanup($sidecarDir);
@@ -533,8 +539,11 @@ final class CoverageMergeCommand
      * Off mode short-circuits before invoking the asserter so unrelated
      * runs do not pay for spec loading and intersection diffing.
      */
-    private function evaluateStrictRequiredGate(StrictRequiredMode $mode, ?string $githubSummaryPath): bool
-    {
+    private function evaluateStrictRequiredGate(
+        StrictRequiredMode $mode,
+        ?string $githubSummaryPath,
+        StrictRequiredTracker $strictRequiredTracker,
+    ): bool {
         if ($mode === StrictRequiredMode::Off) {
             return false;
         }
@@ -545,7 +554,7 @@ final class CoverageMergeCommand
         // the gate cannot evaluate the contract. Silent-pass here would
         // defeat the whole point of opting into fail-fast — symmetric with
         // the threshold gate's no-coverage FATAL in `run()`.
-        if ($mode === StrictRequiredMode::Fail && StrictRequiredTracker::recordedSpecs() === []) {
+        if ($mode === StrictRequiredMode::Fail && $strictRequiredTracker->recordedSpecsOn() === []) {
             $this->writeStderr(
                 '[OpenAPI Strict Required] FATAL: --strict-required=fail requested but '
                 . 'no worker recorded any strict_required observations; the gate cannot '
@@ -640,11 +649,11 @@ final class CoverageMergeCommand
      *
      * @return array<string, array<string, mixed>>
      */
-    private function computeResults(array $specs): array
+    private function computeResults(array $specs, OpenApiCoverageTracker $tracker): array
     {
         $hasCoverage = false;
         foreach ($specs as $spec) {
-            if (OpenApiCoverageTracker::hasAnyCoverage($spec)) {
+            if ($tracker->hasAnyCoverageOn($spec)) {
                 $hasCoverage = true;
 
                 break;
@@ -657,7 +666,7 @@ final class CoverageMergeCommand
         $results = [];
         foreach ($specs as $spec) {
             try {
-                $results[$spec] = OpenApiCoverageTracker::computeCoverage($spec);
+                $results[$spec] = $tracker->computeCoverageOn($spec);
             } catch (SpecFileNotFoundException $e) {
                 $this->writeStderr(sprintf("[OpenAPI Coverage] WARNING: Skipping spec '%s': %s\n", $spec, $e->getMessage()));
             } catch (InvalidOpenApiSpecException $e) {

--- a/src/Coverage/OpenApiCoverageTracker.php
+++ b/src/Coverage/OpenApiCoverageTracker.php
@@ -7,8 +7,8 @@ namespace Studio\OpenApiContractTesting\Coverage;
 use const E_USER_WARNING;
 
 use InvalidArgumentException;
-use Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredTracker;
 
 use function array_key_exists;
 use function array_keys;
@@ -152,16 +152,47 @@ final class OpenApiCoverageTracker
     }
 
     /**
-     * Install the "current" tracker instance. Pass `null` to drop the slot
-     * (the next {@see self::current()} call will mint a fresh default).
-     * Called from {@see OpenApiCoverageExtension::setupExtension()}
-     * so the suite-wide tracker is the one wired into the subscriber.
+     * Install the "current" tracker instance. Called from the PHPUnit
+     * extension's bootstrap so the suite-wide tracker is the one wired into
+     * the subscriber. Drop the slot with {@see self::resetCurrent()} when
+     * you want the next {@see self::current()} call to mint a fresh default.
+     *
+     * Triggers `E_USER_WARNING` when overwriting an installed instance that
+     * already has recorded state — that pattern almost always means a test
+     * forgot to call {@see self::resetCurrent()} before re-installing and
+     * is about to silently drop observations. Matches the project's
+     * existing "loud on suspicious state" style (see also
+     * {@see self::warnMalformed()} and the v1-row rejection in
+     * {@see StrictRequiredTracker::validateRow()}).
      *
      * @internal
      */
-    public static function setCurrent(?self $instance): void
+    public static function setCurrent(self $instance): void
     {
+        if (self::$current !== null && self::$current->getCoveredOn() !== []) {
+            trigger_error(
+                '[OpenAPI Coverage] setCurrent() called while the previous '
+                . 'instance still holds recorded coverage; observations on '
+                . 'the outgoing instance will not contribute to reports. '
+                . 'Call resetCurrent() first if this is intentional.',
+                E_USER_WARNING,
+            );
+        }
         self::$current = $instance;
+    }
+
+    /**
+     * Drop the installed instance so the next {@see self::current()} call
+     * mints a fresh default. Symmetric with {@see self::setCurrent()};
+     * splitting the two intents (install vs clear) keeps the type
+     * signatures honest — `setCurrent(self)` is required-non-null, so
+     * accidental `null` arguments are caught at compile time.
+     *
+     * @internal
+     */
+    public static function resetCurrent(): void
+    {
+        self::$current = null;
     }
 
     /**

--- a/src/Coverage/OpenApiCoverageTracker.php
+++ b/src/Coverage/OpenApiCoverageTracker.php
@@ -7,6 +7,7 @@ namespace Studio\OpenApiContractTesting\Coverage;
 use const E_USER_WARNING;
 
 use InvalidArgumentException;
+use Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 
 use function array_key_exists;
@@ -102,6 +103,16 @@ final class OpenApiCoverageTracker
     public const STATE_FORMAT_VERSION = 1;
 
     /**
+     * Service-locator slot for the static facade (Issue #229). The Laravel
+     * `ValidatesOpenApiSchema` trait cannot receive a tracker via DI (traits
+     * have no constructor), so the static methods route through whichever
+     * instance the host installed via {@see self::setCurrent()}. PHPUnit's
+     * extension wires this up at bootstrap; outside of a PHPUnit-managed run
+     * the locator lazily mints a default instance on first access.
+     */
+    private static ?self $current = null;
+
+    /**
      * Per-(spec, endpoint) coverage state. Endpoint key is `"{METHOD} {path}"`.
      *
      * Each (statusKey, contentTypeKey) pair is stored under
@@ -117,10 +128,41 @@ final class OpenApiCoverageTracker
      *
      * @var array<string, array<string, EndpointCoverage>>
      */
-    private static array $covered = [];
+    private array $covered = [];
 
-    /** Static-only utility — no instances. */
-    private function __construct() {}
+    public function __construct() {}
+
+    /**
+     * The "current" tracker instance — what the static facade methods
+     * delegate to. The PHPUnit extension installs a fresh instance at
+     * bootstrap so each test run starts clean; the lazy default exists for
+     * unit tests and other host-less call sites that hit the static facade
+     * before any setup ran.
+     *
+     * @internal The locator is a refactor seam for the static→instance
+     *           migration in Issue #229. Production code should prefer the
+     *           explicit instance API ({@see self::recordRequestOn()},
+     *           {@see self::recordResponseOn()}, etc.); the facade exists
+     *           only for call sites (the Laravel trait) that cannot receive
+     *           DI.
+     */
+    public static function current(): self
+    {
+        return self::$current ??= new self();
+    }
+
+    /**
+     * Install the "current" tracker instance. Pass `null` to drop the slot
+     * (the next {@see self::current()} call will mint a fresh default).
+     * Called from {@see OpenApiCoverageExtension::setupExtension()}
+     * so the suite-wide tracker is the one wired into the subscriber.
+     *
+     * @internal
+     */
+    public static function setCurrent(?self $instance): void
+    {
+        self::$current = $instance;
+    }
 
     /**
      * Mark an endpoint as request-side reached. Used by request validators
@@ -139,39 +181,7 @@ final class OpenApiCoverageTracker
         string $path,
         ?string $skipReason = null,
     ): void {
-        $key = self::endpointKey($method, $path);
-        // Gate the reconciliation on `requestReached` rather than
-        // `isset($covered[...])`. An entry can pre-exist purely because
-        // `recordResponse()` initialised it (the trait orchestrator
-        // currently runs request-before-response, but framework adapters
-        // and the bulk-merge `importState()` path can reach the tracker
-        // in any order). Using $existed would treat such an entry as
-        // "already cleanly request-validated" and silently drop the
-        // skipReason on the first request-side recording — the very
-        // mode this feature was added to surface.
-        $wasRequestReached = self::$covered[$specName][$key]['requestReached'] ?? false;
-        self::$covered[$specName][$key] ??= ['requestReached' => false, 'requestSkipReason' => null, 'responses' => []];
-        self::$covered[$specName][$key]['requestReached'] = true;
-
-        if (!$wasRequestReached) {
-            // First request-side recording for this endpoint — store as-is.
-            self::$covered[$specName][$key]['requestSkipReason'] = $skipReason;
-
-            return;
-        }
-
-        $existingReason = self::$covered[$specName][$key]['requestSkipReason'];
-        if ($skipReason === null) {
-            // Clean recording promotes prior skipped state to validated.
-            // Mirrors the response-side `Validated > Skipped` rule.
-            self::$covered[$specName][$key]['requestSkipReason'] = null;
-        } elseif ($existingReason !== null) {
-            // skipped + skipped: latest non-null reason wins.
-            self::$covered[$specName][$key]['requestSkipReason'] = $skipReason;
-        }
-        // else: existing is null (validated) and new has a reason — keep
-        // null. Once an endpoint has been cleanly request-validated, a
-        // later downgrade does not demote it.
+        self::current()->recordRequestOn($specName, $method, $path, $skipReason);
     }
 
     /**
@@ -195,15 +205,13 @@ final class OpenApiCoverageTracker
         bool $schemaValidated,
         ?string $skipReason = null,
     ): void {
-        $endpointKey = self::endpointKey($method, $path);
-        $contentKey = $contentTypeKey ?? self::ANY_CONTENT_TYPE;
-        $responseKey = $statusKey . ':' . $contentKey;
-
-        self::$covered[$specName][$endpointKey] ??= ['requestReached' => false, 'requestSkipReason' => null, 'responses' => []];
-        self::$covered[$specName][$endpointKey]['responses'][$responseKey] = self::reconcileResponse(
-            self::$covered[$specName][$endpointKey]['responses'][$responseKey] ?? null,
-            $schemaValidated ? ResponseCoverageState::Validated : ResponseCoverageState::Skipped,
-            1,
+        self::current()->recordResponseOn(
+            $specName,
+            $method,
+            $path,
+            $statusKey,
+            $contentTypeKey,
+            $schemaValidated,
             $skipReason,
         );
     }
@@ -216,7 +224,7 @@ final class OpenApiCoverageTracker
      */
     public static function reset(): void
     {
-        self::$covered = [];
+        self::current()->resetOn();
     }
 
     /**
@@ -236,28 +244,7 @@ final class OpenApiCoverageTracker
      */
     public static function exportState(): array
     {
-        $specs = [];
-        foreach (self::$covered as $specName => $endpoints) {
-            $specOut = [];
-            foreach ($endpoints as $endpointKey => $entry) {
-                $responses = [];
-                foreach ($entry['responses'] as $responseKey => $row) {
-                    $responses[$responseKey] = [
-                        'state' => $row['state']->value,
-                        'hits' => $row['hits'],
-                        'skipReason' => $row['skipReason'] ?? null,
-                    ];
-                }
-                $specOut[$endpointKey] = [
-                    'requestReached' => $entry['requestReached'],
-                    'requestSkipReason' => $entry['requestSkipReason'],
-                    'responses' => $responses,
-                ];
-            }
-            $specs[$specName] = $specOut;
-        }
-
-        return ['version' => self::STATE_FORMAT_VERSION, 'specs' => $specs];
+        return self::current()->exportStateOn();
     }
 
     /**
@@ -288,53 +275,7 @@ final class OpenApiCoverageTracker
      */
     public static function importState(array $state): void
     {
-        $normalised = self::validateStatePayload($state);
-        foreach ($normalised as $specName => $endpoints) {
-            foreach ($endpoints as $endpointKey => $entry) {
-                // Same `wasRequestReached` gate as `recordRequest()` —
-                // an entry that exists only because a prior `importState`
-                // or live `recordResponse` initialised it has no
-                // request-side history; treat the incoming entry as
-                // fresh from the request-side perspective so its
-                // `requestSkipReason` is not silently dropped.
-                $wasRequestReached = self::$covered[$specName][$endpointKey]['requestReached'] ?? false;
-                self::$covered[$specName][$endpointKey] ??= ['requestReached' => false, 'requestSkipReason' => null, 'responses' => []];
-                if ($entry['requestReached']) {
-                    self::$covered[$specName][$endpointKey]['requestReached'] = true;
-                }
-                // Mirror the single-record recordRequest reconciliation so
-                // sequential-record and bulk-merge paths cannot drift:
-                //   - first request-side observation: store as-is
-                //   - existing.validated wins over incoming.skipped
-                //   - incoming.validated promotes existing.skipped to validated
-                //   - skipped + skipped: latest non-null reason wins
-                // Only entries whose incoming side actually carries a
-                // request-side observation (`requestReached === true`)
-                // participate in reconciliation — a response-only
-                // incoming entry leaves the request-side state alone.
-                $incomingReason = $entry['requestSkipReason'];
-                if ($entry['requestReached']) {
-                    if (!$wasRequestReached) {
-                        self::$covered[$specName][$endpointKey]['requestSkipReason'] = $incomingReason;
-                    } else {
-                        $existingReason = self::$covered[$specName][$endpointKey]['requestSkipReason'];
-                        if ($incomingReason === null) {
-                            self::$covered[$specName][$endpointKey]['requestSkipReason'] = null;
-                        } elseif ($existingReason !== null) {
-                            self::$covered[$specName][$endpointKey]['requestSkipReason'] = $incomingReason;
-                        }
-                    }
-                }
-                foreach ($entry['responses'] as $responseKey => $row) {
-                    self::$covered[$specName][$endpointKey]['responses'][$responseKey] = self::reconcileResponse(
-                        self::$covered[$specName][$endpointKey]['responses'][$responseKey] ?? null,
-                        $row['state'],
-                        $row['hits'],
-                        $row['skipReason'],
-                    );
-                }
-            }
-        }
+        self::current()->importStateOn($state);
     }
 
     /**
@@ -345,7 +286,7 @@ final class OpenApiCoverageTracker
      */
     public static function hasAnyCoverage(string $specName): bool
     {
-        return (self::$covered[$specName] ?? []) !== [];
+        return self::current()->hasAnyCoverageOn($specName);
     }
 
     /**
@@ -358,9 +299,203 @@ final class OpenApiCoverageTracker
      */
     public static function getCovered(): array
     {
+        return self::current()->getCoveredOn();
+    }
+
+    /**
+     * @return CoverageResult
+     */
+    public static function computeCoverage(string $specName): array
+    {
+        return self::current()->computeCoverageOn($specName);
+    }
+
+    /**
+     * Instance counterpart of {@see self::recordRequest()} (Issue #229).
+     */
+    public function recordRequestOn(
+        string $specName,
+        string $method,
+        string $path,
+        ?string $skipReason = null,
+    ): void {
+        $key = self::endpointKey($method, $path);
+        // Gate the reconciliation on `requestReached` rather than
+        // `isset($covered[...])`. An entry can pre-exist purely because
+        // `recordResponseOn()` initialised it (the trait orchestrator
+        // currently runs request-before-response, but framework adapters
+        // and the bulk-merge `importStateOn()` path can reach the tracker
+        // in any order). Using $existed would treat such an entry as
+        // "already cleanly request-validated" and silently drop the
+        // skipReason on the first request-side recording — the very
+        // mode this feature was added to surface.
+        $wasRequestReached = $this->covered[$specName][$key]['requestReached'] ?? false;
+        $this->covered[$specName][$key] ??= ['requestReached' => false, 'requestSkipReason' => null, 'responses' => []];
+        $this->covered[$specName][$key]['requestReached'] = true;
+
+        if (!$wasRequestReached) {
+            // First request-side recording for this endpoint — store as-is.
+            $this->covered[$specName][$key]['requestSkipReason'] = $skipReason;
+
+            return;
+        }
+
+        $existingReason = $this->covered[$specName][$key]['requestSkipReason'];
+        if ($skipReason === null) {
+            // Clean recording promotes prior skipped state to validated.
+            // Mirrors the response-side `Validated > Skipped` rule.
+            $this->covered[$specName][$key]['requestSkipReason'] = null;
+        } elseif ($existingReason !== null) {
+            // skipped + skipped: latest non-null reason wins.
+            $this->covered[$specName][$key]['requestSkipReason'] = $skipReason;
+        }
+        // else: existing is null (validated) and new has a reason — keep
+        // null. Once an endpoint has been cleanly request-validated, a
+        // later downgrade does not demote it.
+    }
+
+    /**
+     * Instance counterpart of {@see self::recordResponse()} (Issue #229).
+     */
+    public function recordResponseOn(
+        string $specName,
+        string $method,
+        string $path,
+        string $statusKey,
+        ?string $contentTypeKey,
+        bool $schemaValidated,
+        ?string $skipReason = null,
+    ): void {
+        $endpointKey = self::endpointKey($method, $path);
+        $contentKey = $contentTypeKey ?? self::ANY_CONTENT_TYPE;
+        $responseKey = $statusKey . ':' . $contentKey;
+
+        $this->covered[$specName][$endpointKey] ??= ['requestReached' => false, 'requestSkipReason' => null, 'responses' => []];
+        $this->covered[$specName][$endpointKey]['responses'][$responseKey] = self::reconcileResponse(
+            $this->covered[$specName][$endpointKey]['responses'][$responseKey] ?? null,
+            $schemaValidated ? ResponseCoverageState::Validated : ResponseCoverageState::Skipped,
+            1,
+            $skipReason,
+        );
+    }
+
+    /**
+     * Instance counterpart of {@see self::reset()} (Issue #229). Direct
+     * callers can also just drop the instance — there is no global state
+     * to clear.
+     */
+    public function resetOn(): void
+    {
+        $this->covered = [];
+    }
+
+    /**
+     * Instance counterpart of {@see self::exportState()} (Issue #229).
+     *
+     * @return CoverageStatePayload
+     */
+    public function exportStateOn(): array
+    {
+        $specs = [];
+        foreach ($this->covered as $specName => $endpoints) {
+            $specOut = [];
+            foreach ($endpoints as $endpointKey => $entry) {
+                $responses = [];
+                foreach ($entry['responses'] as $responseKey => $row) {
+                    $responses[$responseKey] = [
+                        'state' => $row['state']->value,
+                        'hits' => $row['hits'],
+                        'skipReason' => $row['skipReason'] ?? null,
+                    ];
+                }
+                $specOut[$endpointKey] = [
+                    'requestReached' => $entry['requestReached'],
+                    'requestSkipReason' => $entry['requestSkipReason'],
+                    'responses' => $responses,
+                ];
+            }
+            $specs[$specName] = $specOut;
+        }
+
+        return ['version' => self::STATE_FORMAT_VERSION, 'specs' => $specs];
+    }
+
+    /**
+     * Instance counterpart of {@see self::importState()} (Issue #229).
+     *
+     * @param array<string, mixed> $state
+     *
+     * @throws InvalidArgumentException when the payload shape is unrecognised
+     */
+    public function importStateOn(array $state): void
+    {
+        $normalised = self::validateStatePayload($state);
+        foreach ($normalised as $specName => $endpoints) {
+            foreach ($endpoints as $endpointKey => $entry) {
+                // Same `wasRequestReached` gate as `recordRequestOn()` —
+                // an entry that exists only because a prior `importStateOn`
+                // or live `recordResponseOn` initialised it has no
+                // request-side history; treat the incoming entry as
+                // fresh from the request-side perspective so its
+                // `requestSkipReason` is not silently dropped.
+                $wasRequestReached = $this->covered[$specName][$endpointKey]['requestReached'] ?? false;
+                $this->covered[$specName][$endpointKey] ??= ['requestReached' => false, 'requestSkipReason' => null, 'responses' => []];
+                if ($entry['requestReached']) {
+                    $this->covered[$specName][$endpointKey]['requestReached'] = true;
+                }
+                // Mirror the single-record recordRequestOn reconciliation so
+                // sequential-record and bulk-merge paths cannot drift:
+                //   - first request-side observation: store as-is
+                //   - existing.validated wins over incoming.skipped
+                //   - incoming.validated promotes existing.skipped to validated
+                //   - skipped + skipped: latest non-null reason wins
+                // Only entries whose incoming side actually carries a
+                // request-side observation (`requestReached === true`)
+                // participate in reconciliation — a response-only
+                // incoming entry leaves the request-side state alone.
+                $incomingReason = $entry['requestSkipReason'];
+                if ($entry['requestReached']) {
+                    if (!$wasRequestReached) {
+                        $this->covered[$specName][$endpointKey]['requestSkipReason'] = $incomingReason;
+                    } else {
+                        $existingReason = $this->covered[$specName][$endpointKey]['requestSkipReason'];
+                        if ($incomingReason === null) {
+                            $this->covered[$specName][$endpointKey]['requestSkipReason'] = null;
+                        } elseif ($existingReason !== null) {
+                            $this->covered[$specName][$endpointKey]['requestSkipReason'] = $incomingReason;
+                        }
+                    }
+                }
+                foreach ($entry['responses'] as $responseKey => $row) {
+                    $this->covered[$specName][$endpointKey]['responses'][$responseKey] = self::reconcileResponse(
+                        $this->covered[$specName][$endpointKey]['responses'][$responseKey] ?? null,
+                        $row['state'],
+                        $row['hits'],
+                        $row['skipReason'],
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * Instance counterpart of {@see self::hasAnyCoverage()} (Issue #229).
+     */
+    public function hasAnyCoverageOn(string $specName): bool
+    {
+        return ($this->covered[$specName] ?? []) !== [];
+    }
+
+    /**
+     * Instance counterpart of {@see self::getCovered()} (Issue #229).
+     *
+     * @return array<string, array<string, true>>
+     */
+    public function getCoveredOn(): array
+    {
         $external = [];
 
-        foreach (self::$covered as $spec => $endpoints) {
+        foreach ($this->covered as $spec => $endpoints) {
             foreach ($endpoints as $endpointKey => $entry) {
                 if ($entry['requestReached'] === false && $entry['responses'] === []) {
                     continue;
@@ -373,12 +508,14 @@ final class OpenApiCoverageTracker
     }
 
     /**
+     * Instance counterpart of {@see self::computeCoverage()} (Issue #229).
+     *
      * @return CoverageResult
      */
-    public static function computeCoverage(string $specName): array
+    public function computeCoverageOn(string $specName): array
     {
         $spec = OpenApiSpecLoader::load($specName);
-        $recordedEndpoints = self::$covered[$specName] ?? [];
+        $recordedEndpoints = $this->covered[$specName] ?? [];
         $endpoints = [];
 
         $endpointFullyCovered = 0;

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -43,6 +43,7 @@ final class OpenApiResponseValidator
     private readonly ResponseBodyValidator $bodyValidator;
     private readonly ResponseHeaderValidator $headerValidator;
     private readonly StatusCodePatternSet $skipPatterns;
+    private readonly ?StrictRequiredTracker $strictRequiredTracker;
 
     /**
      * @param string[] $skipResponseCodes Regex patterns (without delimiters or
@@ -50,15 +51,28 @@ final class OpenApiResponseValidator
      *                                    short-circuits validation and returns an `OpenApiValidationResult::skipped()`
      *                                    — isValid() stays true, isSkipped() becomes true, and the matched
      *                                    path is still reported so coverage is recorded.
+     * @param null|StrictRequiredTracker $strictRequiredTracker Optional injected tracker (Issue #229). When
+     *                                                          omitted, recording falls back to
+     *                                                          {@see StrictRequiredTracker::current()}, which
+     *                                                          the PHPUnit extension installs at bootstrap.
+     *                                                          The Laravel `ValidatesOpenApiSchema` trait
+     *                                                          caches one validator per config without
+     *                                                          injecting anything, so the fallback is the
+     *                                                          common production path; tests or framework
+     *                                                          adapters can pass an instance directly to
+     *                                                          assert against without touching the
+     *                                                          process-global locator.
      */
     public function __construct(
         int $maxErrors = 20,
         array $skipResponseCodes = self::DEFAULT_SKIP_RESPONSE_CODES,
+        ?StrictRequiredTracker $strictRequiredTracker = null,
     ) {
         $this->skipPatterns = new StatusCodePatternSet($skipResponseCodes, 'skipResponseCodes');
         $runner = new SchemaValidatorRunner($maxErrors);
         $this->bodyValidator = new ResponseBodyValidator($runner);
         $this->headerValidator = new ResponseHeaderValidator($runner);
+        $this->strictRequiredTracker = $strictRequiredTracker;
     }
 
     /**
@@ -286,9 +300,10 @@ final class OpenApiResponseValidator
             return;
         }
         $contentTypeKey = $matchedContentType ?? StrictRequiredTracker::ANY_CONTENT_TYPE;
+        $tracker = $this->strictRequiredTracker ?? StrictRequiredTracker::current();
 
         try {
-            StrictRequiredTracker::record(
+            $tracker->recordOn(
                 $specName,
                 $method,
                 $matchedPath,

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -47,8 +47,17 @@ use function trim;
  */
 final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscriber
 {
+    private OpenApiCoverageTracker $coverageTracker;
+    private StrictRequiredTracker $strictRequiredTracker;
+
     /**
      * @param string[] $specs
+     * @param null|OpenApiCoverageTracker $coverageTracker Production callers (the PHPUnit extension) pass the
+     *                                                     run-level instance they own. Passing `null` resolves
+     *                                                     once at construction via {@see OpenApiCoverageTracker::current()},
+     *                                                     so the field remains non-null after the ctor and the
+     *                                                     `readonly` invariant holds end-to-end.
+     * @param null|StrictRequiredTracker $strictRequiredTracker Same shape as $coverageTracker.
      * @param null|callable(string): void $stderrWriter Optional sink for warnings (stale/invalid specs,
      *                                                  failed file_put_contents). Falls back to {@see OpenApiCoverageExtension::writeStderr()} when
      *                                                  null. Injected for testability — the extension stays the default backstop in production.
@@ -77,8 +86,8 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         private ?string $outputFile,
         private ConsoleOutput $consoleOutput,
         private ?string $githubSummaryPath,
-        private ?OpenApiCoverageTracker $coverageTracker = null,
-        private ?StrictRequiredTracker $strictRequiredTracker = null,
+        ?OpenApiCoverageTracker $coverageTracker = null,
+        ?StrictRequiredTracker $strictRequiredTracker = null,
         private mixed $stderrWriter = null,
         private ?string $sidecarDir = null,
         private ?float $minEndpointCoverage = null,
@@ -90,7 +99,17 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         private ?string $htmlOutput = null,
         private ?PartialRunDecision $partialRun = null,
         private StrictRequiredMode $strictRequiredMode = StrictRequiredMode::Off,
-    ) {}
+    ) {
+        // Eager resolution at construction time keeps the readonly invariant
+        // honest: by the time any other method runs, $coverageTracker and
+        // $strictRequiredTracker are guaranteed non-null and pinned. Tests
+        // can still pass `null` (or omit the args) and inherit whatever the
+        // process-global locator was wired with at the call site, but the
+        // subscriber's runtime view does not flip-flop between an injected
+        // ref and a live `current()` lookup.
+        $this->coverageTracker = $coverageTracker ?? OpenApiCoverageTracker::current();
+        $this->strictRequiredTracker = $strictRequiredTracker ?? StrictRequiredTracker::current();
+    }
 
     /** @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter */
     public function notify(ExecutionFinished $event): void
@@ -150,23 +169,6 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         }
 
         return $token;
-    }
-
-    /**
-     * Resolve the {@see OpenApiCoverageTracker} this subscriber reports on.
-     * Falls back to {@see OpenApiCoverageTracker::current()} when constructed
-     * without an injected instance — keeps existing test fixtures that pre-date
-     * the DI wiring working unchanged while production code (the extension)
-     * always passes one in.
-     */
-    private function coverageTracker(): OpenApiCoverageTracker
-    {
-        return $this->coverageTracker ?? OpenApiCoverageTracker::current();
-    }
-
-    private function strictRequiredTracker(): StrictRequiredTracker
-    {
-        return $this->strictRequiredTracker ?? StrictRequiredTracker::current();
     }
 
     /**
@@ -356,8 +358,8 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         // independent of the worker's `strict_required` mode — the merge
         // CLI decides whether to assert (Issue #226).
         $envelope = CoverageSidecarEnvelope::build(
-            $this->coverageTracker()->exportStateOn(),
-            $this->strictRequiredTracker()->exportStateOn(),
+            $this->coverageTracker->exportStateOn(),
+            $this->strictRequiredTracker->exportStateOn(),
         );
 
         try {
@@ -391,7 +393,7 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
      */
     private function computeAllResults(): array
     {
-        $tracker = $this->coverageTracker();
+        $tracker = $this->coverageTracker;
 
         $hasCoverage = false;
         foreach ($this->specs as $spec) {

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -77,6 +77,8 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         private ?string $outputFile,
         private ConsoleOutput $consoleOutput,
         private ?string $githubSummaryPath,
+        private ?OpenApiCoverageTracker $coverageTracker = null,
+        private ?StrictRequiredTracker $strictRequiredTracker = null,
         private mixed $stderrWriter = null,
         private ?string $sidecarDir = null,
         private ?float $minEndpointCoverage = null,
@@ -148,6 +150,23 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         }
 
         return $token;
+    }
+
+    /**
+     * Resolve the {@see OpenApiCoverageTracker} this subscriber reports on.
+     * Falls back to {@see OpenApiCoverageTracker::current()} when constructed
+     * without an injected instance — keeps existing test fixtures that pre-date
+     * the DI wiring working unchanged while production code (the extension)
+     * always passes one in.
+     */
+    private function coverageTracker(): OpenApiCoverageTracker
+    {
+        return $this->coverageTracker ?? OpenApiCoverageTracker::current();
+    }
+
+    private function strictRequiredTracker(): StrictRequiredTracker
+    {
+        return $this->strictRequiredTracker ?? StrictRequiredTracker::current();
     }
 
     /**
@@ -337,8 +356,8 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         // independent of the worker's `strict_required` mode — the merge
         // CLI decides whether to assert (Issue #226).
         $envelope = CoverageSidecarEnvelope::build(
-            OpenApiCoverageTracker::exportState(),
-            StrictRequiredTracker::exportState(),
+            $this->coverageTracker()->exportStateOn(),
+            $this->strictRequiredTracker()->exportStateOn(),
         );
 
         try {
@@ -372,9 +391,11 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
      */
     private function computeAllResults(): array
     {
+        $tracker = $this->coverageTracker();
+
         $hasCoverage = false;
         foreach ($this->specs as $spec) {
-            if (OpenApiCoverageTracker::hasAnyCoverage($spec)) {
+            if ($tracker->hasAnyCoverageOn($spec)) {
                 $hasCoverage = true;
 
                 break;
@@ -389,7 +410,7 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
 
         foreach ($this->specs as $spec) {
             try {
-                $results[$spec] = OpenApiCoverageTracker::computeCoverage($spec);
+                $results[$spec] = $tracker->computeCoverageOn($spec);
             } catch (SpecFileNotFoundException $e) {
                 // Unlike bootstrap (which hard-fails missing files since
                 // issue #134), the subscriber runs after tests finished —

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -275,14 +275,18 @@ final class OpenApiCoverageExtension implements Extension
         // Issue #229: install fresh tracker instances for this run and route
         // the static facades (used by the Laravel trait that can't take DI)
         // through them. Replacing the locator instance gives us a clean
-        // start without depending on a process-global ::reset() — this
-        // mirrors what each unit-test fixture now does, just at suite scope.
-        // Worker observations are aggregated across paratest workers via the
-        // sidecar envelope (Issue #226); the run-level instances here are
-        // exactly what the merge CLI's tracker reconstructs from those
-        // sidecars.
+        // start without depending on a process-global ::reset(); the previous
+        // bootstrap-reset pattern is preserved by the fresh instances. Test
+        // seams that invoke setupExtension() multiple times in one PHP
+        // process re-install fresh instances each call, dropping any state
+        // accumulated since the previous bootstrap. Worker observations are
+        // aggregated across paratest workers via the sidecar envelope
+        // (Issue #226); the run-level instances installed here are exactly
+        // what the merge CLI's tracker reconstructs from those sidecars.
         $coverageTracker = new OpenApiCoverageTracker();
         $strictRequiredTracker = new StrictRequiredTracker();
+        OpenApiCoverageTracker::resetCurrent();
+        StrictRequiredTracker::resetCurrent();
         OpenApiCoverageTracker::setCurrent($coverageTracker);
         StrictRequiredTracker::setCurrent($strictRequiredTracker);
 

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -15,6 +15,7 @@ use PHPUnit\Runner\Extension\ParameterCollection;
 use PHPUnit\TextUI\Configuration\Configuration;
 use Studio\OpenApiContractTesting\Coverage\InvalidCoverageOutputPathException;
 use Studio\OpenApiContractTesting\Coverage\InvalidThresholdConfigurationException;
+use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\Exception\EnumBindingException;
 use Studio\OpenApiContractTesting\Exception\EnumBindingReason;
 use Studio\OpenApiContractTesting\Exception\EnumDriftException;
@@ -271,14 +272,24 @@ final class OpenApiCoverageExtension implements Extension
         $minEndpointCoverage = self::resolveThresholdParameter($parameters, 'min_endpoint_coverage', $minCoverageStrict);
         $minResponseCoverage = self::resolveThresholdParameter($parameters, 'min_response_coverage', $minCoverageStrict);
 
-        // Issue #224: schema under-description detection. Reset the tracker
-        // at bootstrap so observations from a previous PHPUnit process (or
-        // a leaked test-class static) do not contaminate this run's
-        // intersection — mirrors `OpenApiCoverageTracker::reset()`'s
-        // bootstrap-reset pattern. Worker observations are aggregated across
-        // paratest workers via the sidecar envelope (Issue #226).
+        // Issue #229: install fresh tracker instances for this run and route
+        // the static facades (used by the Laravel trait that can't take DI)
+        // through them. Replacing the locator instance gives us a clean
+        // start without depending on a process-global ::reset() — this
+        // mirrors what each unit-test fixture now does, just at suite scope.
+        // Worker observations are aggregated across paratest workers via the
+        // sidecar envelope (Issue #226); the run-level instances here are
+        // exactly what the merge CLI's tracker reconstructs from those
+        // sidecars.
+        $coverageTracker = new OpenApiCoverageTracker();
+        $strictRequiredTracker = new StrictRequiredTracker();
+        OpenApiCoverageTracker::setCurrent($coverageTracker);
+        StrictRequiredTracker::setCurrent($strictRequiredTracker);
+
+        // Issue #224: schema under-description detection mode is read from
+        // phpunit.xml here so a misspelled `strict_required=` value
+        // hard-fails bootstrap before any subscriber wiring.
         $strictRequiredMode = self::resolveStrictRequiredMode($parameters, $githubSummaryPath);
-        StrictRequiredTracker::reset();
 
         // Issue #228: per-call strict_required mode. Independent of the
         // run-level parameter above — both gates can be wired in the same
@@ -302,6 +313,8 @@ final class OpenApiCoverageExtension implements Extension
             outputFile: $outputFile,
             consoleOutput: $consoleOutput,
             githubSummaryPath: $githubSummaryPath,
+            coverageTracker: $coverageTracker,
+            strictRequiredTracker: $strictRequiredTracker,
             sidecarDir: $sidecarDir,
             minEndpointCoverage: $minEndpointCoverage,
             minResponseCoverage: $minResponseCoverage,

--- a/src/Validation/Strict/StrictRequiredTracker.php
+++ b/src/Validation/Strict/StrictRequiredTracker.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Validation\Strict;
 
+use const E_USER_WARNING;
+
 use InvalidArgumentException;
 use Studio\OpenApiContractTesting\Coverage\CoverageSidecarEnvelope;
 use Studio\OpenApiContractTesting\OpenApiResponseValidator;
@@ -22,10 +24,17 @@ use function ksort;
 use function sort;
 use function sprintf;
 use function strtoupper;
+use function trigger_error;
 
 /**
- * Static singleton that accumulates response body object-node observations
- * per `(spec, METHOD path, statusKey, contentTypeKey)` across a test run.
+ * Tracker that accumulates response body object-node observations per
+ * `(spec, METHOD path, statusKey, contentTypeKey)` across a test run.
+ * Exposed through a static facade (see {@see self::current()} /
+ * {@see self::setCurrent()}) so the Laravel `ValidatesOpenApiSchema` trait
+ * can still reach it without DI — the trait has no constructor and cannot
+ * receive an instance through injection. Production callers (the PHPUnit
+ * extension, the merge CLI, the validator) construct and use instances
+ * directly.
  *
  * Each observation feeds a JSON-Pointer-like map `pointer => list<string>`
  * (see {@see StrictRequiredBodyWalker}) describing the keys present at every
@@ -111,14 +120,43 @@ final class StrictRequiredTracker
     }
 
     /**
-     * Install the "current" tracker instance. Pass `null` to drop the slot
-     * (the next {@see self::current()} call will mint a fresh default).
+     * Install the "current" tracker instance. Called from the PHPUnit
+     * extension's bootstrap so the suite-wide tracker is the one wired into
+     * the subscriber. Drop the slot with {@see self::resetCurrent()} when
+     * you want the next {@see self::current()} call to mint a fresh default.
+     *
+     * Triggers `E_USER_WARNING` when overwriting an installed instance that
+     * already has recorded observations — that pattern almost always means
+     * a test forgot to call {@see self::resetCurrent()} before re-installing
+     * and is about to silently drop observations. Mirrors the same guard on
+     * {@see \Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker::setCurrent()}.
      *
      * @internal
      */
-    public static function setCurrent(?self $instance): void
+    public static function setCurrent(self $instance): void
     {
+        if (self::$current !== null && self::$current->recordedSpecsOn() !== []) {
+            trigger_error(
+                '[OpenAPI Strict Required] setCurrent() called while the '
+                . 'previous instance still holds recorded observations; '
+                . 'those observations will not contribute to drift '
+                . 'detection. Call resetCurrent() first if this is intentional.',
+                E_USER_WARNING,
+            );
+        }
         self::$current = $instance;
+    }
+
+    /**
+     * Drop the installed instance so the next {@see self::current()} call
+     * mints a fresh default. Symmetric with {@see self::setCurrent()};
+     * splitting the two intents keeps the type signatures honest.
+     *
+     * @internal
+     */
+    public static function resetCurrent(): void
+    {
+        self::$current = null;
     }
 
     /**

--- a/src/Validation/Strict/StrictRequiredTracker.php
+++ b/src/Validation/Strict/StrictRequiredTracker.php
@@ -75,6 +75,15 @@ final class StrictRequiredTracker
     public const STATE_FORMAT_VERSION = 2;
 
     /**
+     * Service-locator slot for the static facade (Issue #229). Symmetric with
+     * {@see OpenApiCoverageTracker::$current}: the Laravel trait and the
+     * {@see OpenApiResponseValidator} reach for the tracker via static call,
+     * and we route those to whichever instance the host installed via
+     * {@see self::setCurrent()}.
+     */
+    private static ?self $current = null;
+
+    /**
      * Per-(spec, endpoint, response key) observations.
      *
      * Endpoint key is `"{METHOD} {path}"` (method upper-cased). Response key
@@ -83,10 +92,34 @@ final class StrictRequiredTracker
      *
      * @var array<string, array<string, array<string, StrictRequiredRow>>>
      */
-    private static array $observations = [];
+    private array $observations = [];
 
-    /** Static-only utility — no instances. */
-    private function __construct() {}
+    public function __construct() {}
+
+    /**
+     * The "current" tracker instance — what the static facade methods
+     * delegate to. The PHPUnit extension installs a fresh instance at
+     * bootstrap so each test run starts clean; the lazy default exists for
+     * unit tests and other host-less call sites that hit the static facade
+     * before any setup ran.
+     *
+     * @internal Refactor seam for the static→instance migration in Issue #229.
+     */
+    public static function current(): self
+    {
+        return self::$current ??= new self();
+    }
+
+    /**
+     * Install the "current" tracker instance. Pass `null` to drop the slot
+     * (the next {@see self::current()} call will mint a fresh default).
+     *
+     * @internal
+     */
+    public static function setCurrent(?self $instance): void
+    {
+        self::$current = $instance;
+    }
 
     /**
      * Record one observed response body's pointer→keys map. The map is
@@ -134,25 +167,7 @@ final class StrictRequiredTracker
         string $contentTypeKey,
         array $pointers,
     ): void {
-        $endpointKey = strtoupper($method) . ' ' . $path;
-        $responseKey = $statusKey . ':' . $contentTypeKey;
-
-        $normalised = self::normalisePointers($specName, $endpointKey, $responseKey, $pointers);
-
-        $existing = self::$observations[$specName][$endpointKey][$responseKey] ?? null;
-        if ($existing === null) {
-            self::$observations[$specName][$endpointKey][$responseKey] = [
-                'hits' => 1,
-                'pointers' => $normalised,
-            ];
-
-            return;
-        }
-
-        self::$observations[$specName][$endpointKey][$responseKey] = [
-            'hits' => $existing['hits'] + 1,
-            'pointers' => self::mergePointers($existing['pointers'], $normalised),
-        ];
+        self::current()->recordOn($specName, $method, $path, $statusKey, $contentTypeKey, $pointers);
     }
 
     /**
@@ -163,7 +178,7 @@ final class StrictRequiredTracker
      */
     public static function reset(): void
     {
-        self::$observations = [];
+        self::current()->resetOn();
     }
 
     /**
@@ -182,7 +197,7 @@ final class StrictRequiredTracker
      */
     public static function getObservations(string $specName): array
     {
-        return self::$observations[$specName] ?? [];
+        return self::current()->getObservationsOn($specName);
     }
 
     /**
@@ -195,7 +210,7 @@ final class StrictRequiredTracker
      */
     public static function recordedSpecs(): array
     {
-        return array_keys(self::$observations);
+        return self::current()->recordedSpecsOn();
     }
 
     /**
@@ -210,10 +225,7 @@ final class StrictRequiredTracker
      */
     public static function exportState(): array
     {
-        return [
-            'version' => self::STATE_FORMAT_VERSION,
-            'observations' => self::$observations,
-        ];
+        return self::current()->exportStateOn();
     }
 
     /**
@@ -235,18 +247,109 @@ final class StrictRequiredTracker
      */
     public static function importState(array $state): void
     {
+        self::current()->importStateOn($state);
+    }
+
+    /**
+     * Instance counterpart of {@see self::record()} (Issue #229).
+     *
+     * @param array<mixed, mixed> $pointers
+     *
+     * @throws InvalidArgumentException when a pointer key or value is malformed
+     */
+    public function recordOn(
+        string $specName,
+        string $method,
+        string $path,
+        string $statusKey,
+        string $contentTypeKey,
+        array $pointers,
+    ): void {
+        $endpointKey = strtoupper($method) . ' ' . $path;
+        $responseKey = $statusKey . ':' . $contentTypeKey;
+
+        $normalised = self::normalisePointers($specName, $endpointKey, $responseKey, $pointers);
+
+        $existing = $this->observations[$specName][$endpointKey][$responseKey] ?? null;
+        if ($existing === null) {
+            $this->observations[$specName][$endpointKey][$responseKey] = [
+                'hits' => 1,
+                'pointers' => $normalised,
+            ];
+
+            return;
+        }
+
+        $this->observations[$specName][$endpointKey][$responseKey] = [
+            'hits' => $existing['hits'] + 1,
+            'pointers' => self::mergePointers($existing['pointers'], $normalised),
+        ];
+    }
+
+    /**
+     * Instance counterpart of {@see self::reset()} (Issue #229). Direct
+     * callers can also just drop the instance — there is no global state
+     * to clear.
+     */
+    public function resetOn(): void
+    {
+        $this->observations = [];
+    }
+
+    /**
+     * Instance counterpart of {@see self::getObservations()} (Issue #229).
+     *
+     * @return array<string, array<string, StrictRequiredRow>>
+     */
+    public function getObservationsOn(string $specName): array
+    {
+        return $this->observations[$specName] ?? [];
+    }
+
+    /**
+     * Instance counterpart of {@see self::recordedSpecs()} (Issue #229).
+     *
+     * @return list<string>
+     */
+    public function recordedSpecsOn(): array
+    {
+        return array_keys($this->observations);
+    }
+
+    /**
+     * Instance counterpart of {@see self::exportState()} (Issue #229).
+     *
+     * @return StrictRequiredStatePayload
+     */
+    public function exportStateOn(): array
+    {
+        return [
+            'version' => self::STATE_FORMAT_VERSION,
+            'observations' => $this->observations,
+        ];
+    }
+
+    /**
+     * Instance counterpart of {@see self::importState()} (Issue #229).
+     *
+     * @param array<string, mixed> $state
+     *
+     * @throws InvalidArgumentException when the payload shape or version is unrecognised
+     */
+    public function importStateOn(array $state): void
+    {
         $normalised = self::validateStatePayload($state);
 
         foreach ($normalised as $specName => $endpoints) {
             foreach ($endpoints as $endpointKey => $responses) {
                 foreach ($responses as $responseKey => $row) {
-                    $existing = self::$observations[$specName][$endpointKey][$responseKey] ?? null;
+                    $existing = $this->observations[$specName][$endpointKey][$responseKey] ?? null;
                     if ($existing === null) {
-                        self::$observations[$specName][$endpointKey][$responseKey] = $row;
+                        $this->observations[$specName][$endpointKey][$responseKey] = $row;
 
                         continue;
                     }
-                    self::$observations[$specName][$endpointKey][$responseKey] = [
+                    $this->observations[$specName][$endpointKey][$responseKey] = [
                         'hits' => $existing['hits'] + $row['hits'],
                         'pointers' => self::mergePointers($existing['pointers'], $row['pointers']),
                     ];

--- a/tests/Unit/Coverage/CoverageMergeCommandTest.php
+++ b/tests/Unit/Coverage/CoverageMergeCommandTest.php
@@ -62,8 +62,11 @@ class CoverageMergeCommandTest extends TestCase
             @rmdir(dirname($this->sidecarDir));
         }
 
-        OpenApiCoverageTracker::reset();
-        StrictRequiredTracker::reset();
+        // Issue #229 / S6: actively drop the process-global locator slot so
+        // the orphan instance run() installed does not leak into other
+        // tests that introspect ::current() between cases.
+        OpenApiCoverageTracker::resetCurrent();
+        StrictRequiredTracker::resetCurrent();
         OpenApiSpecLoader::reset();
         parent::tearDown();
     }
@@ -1511,6 +1514,82 @@ class CoverageMergeCommandTest extends TestCase
     {
         $opts = CoverageMergeCommand::parseArgv(['--strict-required=warn']);
         $this->assertSame('warn', $opts['strict_required'] ?? null);
+    }
+
+    #[Test]
+    public function run_isolates_from_a_pre_installed_locator_instance(): void
+    {
+        // Issue #229: the merge command constructs its own tracker
+        // instances in run() and installs them via setCurrent(). The
+        // computed report and the strict_required gate MUST read from
+        // those local instances, not from whatever was installed in the
+        // process-global locator before run() started. A regression that
+        // accidentally reuses ::current() (or skips the local install)
+        // would silently leak the orphan's state into the report.
+        //
+        // We pre-install a sentinel coverage tracker with a recording for
+        // a route that doesn't exist in the sidecars below, then assert
+        // the rendered report doesn't surface the sentinel route.
+        $sentinel = new OpenApiCoverageTracker();
+        $sentinel->recordResponseOn(
+            'petstore-3.0',
+            'DELETE',
+            '/v1/pets/{petId}',
+            '204',
+            null,
+            schemaValidated: true,
+        );
+        OpenApiCoverageTracker::resetCurrent();
+        OpenApiCoverageTracker::setCurrent($sentinel);
+
+        // Sidecar covers a completely different route.
+        $workerTracker = new OpenApiCoverageTracker();
+        $workerTracker->recordResponseOn(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        $envelope = CoverageSidecarEnvelope::build(
+            $workerTracker->exportStateOn(),
+            (new StrictRequiredTracker())->exportStateOn(),
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, 'iso', $envelope);
+
+        $stdout = '';
+        $command = new CoverageMergeCommand(
+            stdoutWriter: static function (string $msg) use (&$stdout): void {
+                $stdout .= $msg;
+            },
+        );
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'output_file' => $this->outputFile,
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $contents = (string) file_get_contents($this->outputFile);
+        $this->assertStringContainsString('GET /v1/pets', $contents);
+        // The sentinel's DELETE route must not appear as a covered row in
+        // the report (it would only appear if its state leaked through the
+        // merge command's tracker). Spec declares DELETE /v1/pets/{petId};
+        // when uncovered it has no row marked Validated. Assert: the row
+        // exists in the spec-declared rendering but no "covered" marker
+        // for it.
+        $this->assertStringNotContainsString(
+            'DELETE /v1/pets/{petId} | ✅',
+            $contents,
+            'sentinel observation must not be merged into the rendered report',
+        );
+
+        // Locator slot must point at the local instance the command
+        // installed, not the sentinel that pre-existed.
+        $this->assertNotSame($sentinel, OpenApiCoverageTracker::current());
     }
 
     /**

--- a/tests/Unit/Coverage/OpenApiCoverageTrackerInstanceIsolationTest.php
+++ b/tests/Unit/Coverage/OpenApiCoverageTrackerInstanceIsolationTest.php
@@ -102,8 +102,11 @@ final class OpenApiCoverageTrackerInstanceIsolationTest extends TestCase
     #[Test]
     public function static_facade_routes_to_the_current_instance(): void
     {
+        // resetCurrent() first so the setCurrent() overwrite-guard does not
+        // trip on a stateful slot left over from an earlier test in the same
+        // process.
+        OpenApiCoverageTracker::resetCurrent();
         $injected = new OpenApiCoverageTracker();
-        $previous = OpenApiCoverageTracker::current();
         OpenApiCoverageTracker::setCurrent($injected);
 
         try {
@@ -111,9 +114,48 @@ final class OpenApiCoverageTrackerInstanceIsolationTest extends TestCase
 
             $this->assertTrue($injected->hasAnyCoverageOn('petstore-3.0'));
         } finally {
-            // Restore so we don't leak the injected instance into other tests
-            // that share the process-global facade.
-            OpenApiCoverageTracker::setCurrent($previous);
+            // Drop the slot so the injected instance does not leak into
+            // other tests that share the process-global facade.
+            OpenApiCoverageTracker::resetCurrent();
         }
+    }
+
+    #[Test]
+    public function cold_slot_lazily_mints_default_for_static_facade(): void
+    {
+        // Production scenario: nothing has called setCurrent() and current()
+        // has never been touched. The first static-facade call must lazily
+        // mint a default rather than fail. Pinned because pre-Issue #229 the
+        // tracker was always populated; post-refactor we depend on the
+        // ??=  in current() for the host-less call path (CLI tools, unit
+        // tests that hit the facade before any setup).
+        OpenApiCoverageTracker::resetCurrent();
+
+        try {
+            OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets');
+
+            $minted = OpenApiCoverageTracker::current();
+            $this->assertTrue($minted->hasAnyCoverageOn('petstore-3.0'));
+        } finally {
+            OpenApiCoverageTracker::resetCurrent();
+        }
+    }
+
+    #[Test]
+    public function reset_current_drops_the_installed_instance(): void
+    {
+        // resetCurrent() must return the locator to the "cold" state so the
+        // next current() call mints a fresh default — pinning the documented
+        // contract on the two-method split.
+        OpenApiCoverageTracker::resetCurrent();
+        $first = new OpenApiCoverageTracker();
+        OpenApiCoverageTracker::setCurrent($first);
+        $this->assertSame($first, OpenApiCoverageTracker::current());
+
+        OpenApiCoverageTracker::resetCurrent();
+        $afterReset = OpenApiCoverageTracker::current();
+        $this->assertNotSame($first, $afterReset, 'resetCurrent must drop the previously installed slot');
+
+        OpenApiCoverageTracker::resetCurrent();
     }
 }

--- a/tests/Unit/Coverage/OpenApiCoverageTrackerInstanceIsolationTest.php
+++ b/tests/Unit/Coverage/OpenApiCoverageTrackerInstanceIsolationTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Coverage;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+
+/**
+ * Issue #229: structural guarantee that two independently-constructed
+ * {@see OpenApiCoverageTracker} instances do not share state. This is the
+ * invariant the refactor away from a static singleton buys us; a regression
+ * here would put us back in the world where test isolation depended on
+ * everyone remembering to call `::reset()` in `setUp`/`tearDown`.
+ *
+ * Spec loader still uses static configuration — only the tracker is
+ * instance-based here, mirroring the scope of the refactor.
+ */
+final class OpenApiCoverageTrackerInstanceIsolationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../../fixtures/specs');
+    }
+
+    protected function tearDown(): void
+    {
+        OpenApiSpecLoader::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function two_instances_do_not_share_recorded_requests(): void
+    {
+        $a = new OpenApiCoverageTracker();
+        $b = new OpenApiCoverageTracker();
+
+        $a->recordRequestOn('petstore-3.0', 'GET', '/v1/pets');
+
+        $this->assertTrue($a->hasAnyCoverageOn('petstore-3.0'));
+        $this->assertFalse($b->hasAnyCoverageOn('petstore-3.0'));
+    }
+
+    #[Test]
+    public function two_instances_do_not_share_recorded_responses(): void
+    {
+        $a = new OpenApiCoverageTracker();
+        $b = new OpenApiCoverageTracker();
+
+        $a->recordResponseOn(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        $this->assertNotSame([], $a->getCoveredOn());
+        $this->assertSame([], $b->getCoveredOn());
+    }
+
+    #[Test]
+    public function export_state_round_trips_through_a_second_instance(): void
+    {
+        $source = new OpenApiCoverageTracker();
+        $source->recordResponseOn(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        $sink = new OpenApiCoverageTracker();
+        $sink->importStateOn($source->exportStateOn());
+
+        $this->assertSame($source->getCoveredOn(), $sink->getCoveredOn());
+    }
+
+    #[Test]
+    public function reset_on_instance_does_not_affect_sibling_instance(): void
+    {
+        $a = new OpenApiCoverageTracker();
+        $b = new OpenApiCoverageTracker();
+
+        $a->recordRequestOn('petstore-3.0', 'GET', '/v1/pets');
+        $b->recordRequestOn('petstore-3.0', 'POST', '/v1/pets');
+
+        $a->resetOn();
+
+        $this->assertFalse($a->hasAnyCoverageOn('petstore-3.0'));
+        $this->assertTrue($b->hasAnyCoverageOn('petstore-3.0'));
+    }
+
+    #[Test]
+    public function static_facade_routes_to_the_current_instance(): void
+    {
+        $injected = new OpenApiCoverageTracker();
+        $previous = OpenApiCoverageTracker::current();
+        OpenApiCoverageTracker::setCurrent($injected);
+
+        try {
+            OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets');
+
+            $this->assertTrue($injected->hasAnyCoverageOn('petstore-3.0'));
+        } finally {
+            // Restore so we don't leak the injected instance into other tests
+            // that share the process-global facade.
+            OpenApiCoverageTracker::setCurrent($previous);
+        }
+    }
+}

--- a/tests/Unit/Coverage/OpenApiCoverageTrackerStateSerializationTest.php
+++ b/tests/Unit/Coverage/OpenApiCoverageTrackerStateSerializationTest.php
@@ -16,26 +16,29 @@ use function json_decode;
 use function json_encode;
 
 /**
- * Pins the JSON-safe state shape produced by {@see OpenApiCoverageTracker::exportState()}
- * and the union-merge semantics of {@see OpenApiCoverageTracker::importState()}.
+ * Pins the JSON-safe state shape produced by {@see OpenApiCoverageTracker::exportStateOn()}
+ * and the union-merge semantics of {@see OpenApiCoverageTracker::importStateOn()}.
  *
- * The merge CLI loads N worker sidecars by calling importState() N times, so
+ * The merge CLI loads N worker sidecars by calling importStateOn() N times, so
  * the merge rules MUST mirror the live recording rules: validated wins over
  * skipped, hits accumulate, and the latest non-null skipReason wins.
  */
 class OpenApiCoverageTrackerStateSerializationTest extends TestCase
 {
+    private OpenApiCoverageTracker $tracker;
+
     protected function setUp(): void
     {
         parent::setUp();
-        OpenApiCoverageTracker::reset();
+        // Issue #229: per-test tracker instance — no process-global reset
+        // dance needed at the class boundary.
+        $this->tracker = new OpenApiCoverageTracker();
         OpenApiSpecLoader::reset();
         OpenApiSpecLoader::configure(__DIR__ . '/../../fixtures/specs');
     }
 
     protected function tearDown(): void
     {
-        OpenApiCoverageTracker::reset();
         OpenApiSpecLoader::reset();
         parent::tearDown();
     }
@@ -43,7 +46,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
     #[Test]
     public function export_state_returns_empty_payload_when_nothing_recorded(): void
     {
-        $state = OpenApiCoverageTracker::exportState();
+        $state = $this->tracker->exportStateOn();
 
         $this->assertSame(['version' => 1, 'specs' => []], $state);
     }
@@ -51,9 +54,9 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
     #[Test]
     public function export_state_serializes_request_only_endpoint(): void
     {
-        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets');
+        $this->tracker->recordRequestOn('petstore-3.0', 'GET', '/v1/pets');
 
-        $state = OpenApiCoverageTracker::exportState();
+        $state = $this->tracker->exportStateOn();
 
         $this->assertSame([
             'version' => 1,
@@ -72,7 +75,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
     #[Test]
     public function export_state_serializes_validated_response(): void
     {
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'petstore-3.0',
             'GET',
             '/v1/pets',
@@ -81,7 +84,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
             schemaValidated: true,
         );
 
-        $state = OpenApiCoverageTracker::exportState();
+        $state = $this->tracker->exportStateOn();
 
         $this->assertSame([
             'version' => 1,
@@ -106,7 +109,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
     #[Test]
     public function export_state_serializes_skipped_response_with_reason(): void
     {
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'petstore-3.0',
             'GET',
             '/v1/pets',
@@ -116,7 +119,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
             skipReason: 'status 503 matched skip pattern 5\\d\\d',
         );
 
-        $state = OpenApiCoverageTracker::exportState();
+        $state = $this->tracker->exportStateOn();
 
         $this->assertSame([
             'version' => 1,
@@ -141,8 +144,8 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
     #[Test]
     public function export_state_round_trips_through_json(): void
     {
-        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets');
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordRequestOn('petstore-3.0', 'GET', '/v1/pets');
+        $this->tracker->recordResponseOn(
             'petstore-3.0',
             'GET',
             '/v1/pets',
@@ -150,7 +153,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
             'application/json',
             schemaValidated: true,
         );
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'petstore-3.0',
             'GET',
             '/v1/pets/{petId}',
@@ -160,21 +163,22 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
             skipReason: 'matched 5\\d\\d',
         );
 
-        $original = OpenApiCoverageTracker::exportState();
+        $original = $this->tracker->exportStateOn();
         $json = json_encode($original, JSON_THROW_ON_ERROR);
         $decoded = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
 
-        OpenApiCoverageTracker::reset();
-        OpenApiCoverageTracker::importState($decoded);
+        $sink = new OpenApiCoverageTracker();
+        $sink->importStateOn($decoded);
 
-        $this->assertSame($original, OpenApiCoverageTracker::exportState());
+        $this->assertSame($original, $sink->exportStateOn());
     }
 
     #[Test]
     public function import_state_is_additive_for_disjoint_specs(): void
     {
         // Worker A's state.
-        OpenApiCoverageTracker::recordResponse(
+        $workerATracker = new OpenApiCoverageTracker();
+        $workerATracker->recordResponseOn(
             'petstore-3.0',
             'GET',
             '/v1/pets',
@@ -182,11 +186,11 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
             'application/json',
             schemaValidated: true,
         );
-        $workerA = OpenApiCoverageTracker::exportState();
+        $workerA = $workerATracker->exportStateOn();
 
         // Worker B's state, captured from a fresh tracker.
-        OpenApiCoverageTracker::reset();
-        OpenApiCoverageTracker::recordResponse(
+        $workerBTracker = new OpenApiCoverageTracker();
+        $workerBTracker->recordResponseOn(
             'range-keys',
             'GET',
             '/widgets-default',
@@ -194,14 +198,13 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
             'application/json',
             schemaValidated: true,
         );
-        $workerB = OpenApiCoverageTracker::exportState();
+        $workerB = $workerBTracker->exportStateOn();
 
         // Merge both into one tracker.
-        OpenApiCoverageTracker::reset();
-        OpenApiCoverageTracker::importState($workerA);
-        OpenApiCoverageTracker::importState($workerB);
+        $this->tracker->importStateOn($workerA);
+        $this->tracker->importStateOn($workerB);
 
-        $merged = OpenApiCoverageTracker::exportState();
+        $merged = $this->tracker->exportStateOn();
         $this->assertArrayHasKey('petstore-3.0', $merged['specs']);
         $this->assertArrayHasKey('range-keys', $merged['specs']);
         $this->assertSame(
@@ -236,10 +239,10 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
             ],
         ];
 
-        OpenApiCoverageTracker::importState($worker);
-        OpenApiCoverageTracker::importState($worker);
+        $this->tracker->importStateOn($worker);
+        $this->tracker->importStateOn($worker);
 
-        $merged = OpenApiCoverageTracker::exportState();
+        $merged = $this->tracker->exportStateOn();
         $this->assertSame(
             2,
             $merged['specs']['petstore-3.0']['GET /v1/pets']['responses']['200:application/json']['hits'],
@@ -284,15 +287,15 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
             ],
         ];
 
-        OpenApiCoverageTracker::importState($skippedFirst);
-        OpenApiCoverageTracker::importState($validatedSecond);
+        $this->tracker->importStateOn($skippedFirst);
+        $this->tracker->importStateOn($validatedSecond);
 
-        $merged = OpenApiCoverageTracker::exportState();
+        $merged = $this->tracker->exportStateOn();
         $row = $merged['specs']['petstore-3.0']['GET /v1/pets']['responses']['200:application/json'];
         $this->assertSame('validated', $row['state']);
         $this->assertNull($row['skipReason']);
         // Bulk merge sums hits across both sources — matches sequential
-        // recordResponse() calls where hits++ runs unconditionally and
+        // recordResponseOn() calls where hits++ runs unconditionally and
         // state promotion does not roll the counter back.
         $this->assertSame(3, $row['hits']);
     }
@@ -335,10 +338,10 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
             ],
         ];
 
-        OpenApiCoverageTracker::importState($validatedFirst);
-        OpenApiCoverageTracker::importState($skippedSecond);
+        $this->tracker->importStateOn($validatedFirst);
+        $this->tracker->importStateOn($skippedSecond);
 
-        $merged = OpenApiCoverageTracker::exportState();
+        $merged = $this->tracker->exportStateOn();
         $row = $merged['specs']['petstore-3.0']['GET /v1/pets']['responses']['200:application/json'];
         $this->assertSame('validated', $row['state']);
         $this->assertNull($row['skipReason']);
@@ -383,10 +386,10 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
             ],
         ];
 
-        OpenApiCoverageTracker::importState($first);
-        OpenApiCoverageTracker::importState($second);
+        $this->tracker->importStateOn($first);
+        $this->tracker->importStateOn($second);
 
-        $merged = OpenApiCoverageTracker::exportState();
+        $merged = $this->tracker->exportStateOn();
         $row = $merged['specs']['petstore-3.0']['GET /v1/pets']['responses']['503:*'];
         $this->assertSame('skipped', $row['state']);
         $this->assertSame('new reason', $row['skipReason']);
@@ -425,10 +428,10 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
             ],
         ];
 
-        OpenApiCoverageTracker::importState($reached);
-        OpenApiCoverageTracker::importState($notReached);
+        $this->tracker->importStateOn($reached);
+        $this->tracker->importStateOn($notReached);
 
-        $merged = OpenApiCoverageTracker::exportState();
+        $merged = $this->tracker->exportStateOn();
         $endpoint = $merged['specs']['petstore-3.0']['GET /v1/pets'];
         $this->assertTrue($endpoint['requestReached']);
         $this->assertArrayHasKey('200:application/json', $endpoint['responses']);
@@ -440,7 +443,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('unsupported coverage state version');
 
-        OpenApiCoverageTracker::importState(['version' => 99, 'specs' => []]);
+        $this->tracker->importStateOn(['version' => 99, 'specs' => []]);
     }
 
     #[Test]
@@ -449,7 +452,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('missing "version"');
 
-        OpenApiCoverageTracker::importState(['specs' => []]);
+        $this->tracker->importStateOn(['specs' => []]);
     }
 
     #[Test]
@@ -458,7 +461,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('invalid response state');
 
-        OpenApiCoverageTracker::importState([
+        $this->tracker->importStateOn([
             'version' => 1,
             'specs' => [
                 'petstore-3.0' => [
@@ -483,7 +486,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('invalid spec entry');
 
-        OpenApiCoverageTracker::importState([
+        $this->tracker->importStateOn([
             'version' => 1,
             'specs' => [
                 42 => ['GET /v1/pets' => ['requestReached' => true, 'responses' => []]],
@@ -497,7 +500,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('invalid endpoint entry');
 
-        OpenApiCoverageTracker::importState([
+        $this->tracker->importStateOn([
             'version' => 1,
             'specs' => [
                 'petstore-3.0' => ['GET /v1/pets' => 'not an array'],
@@ -511,7 +514,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('invalid response entry');
 
-        OpenApiCoverageTracker::importState([
+        $this->tracker->importStateOn([
             'version' => 1,
             'specs' => [
                 'petstore-3.0' => [
@@ -530,7 +533,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('invalid response state');
 
-        OpenApiCoverageTracker::importState([
+        $this->tracker->importStateOn([
             'version' => 1,
             'specs' => [
                 'petstore-3.0' => [
@@ -554,7 +557,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
         // leaving the tracker inconsistent. Two-pass validate-then-apply
         // must roll back cleanly: nothing is mutated when validation
         // would eventually fail.
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'petstore-3.0',
             'GET',
             '/v1/pets',
@@ -562,10 +565,10 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
             'application/json',
             schemaValidated: true,
         );
-        $beforeSnapshot = OpenApiCoverageTracker::exportState();
+        $beforeSnapshot = $this->tracker->exportStateOn();
 
         try {
-            OpenApiCoverageTracker::importState([
+            $this->tracker->importStateOn([
                 'version' => 1,
                 'specs' => [
                     'petstore-3.0' => [
@@ -593,30 +596,30 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
             // Expected — the second endpoint's "bogus" state must abort.
         }
 
-        $this->assertSame($beforeSnapshot, OpenApiCoverageTracker::exportState());
+        $this->assertSame($beforeSnapshot, $this->tracker->exportStateOn());
     }
 
     #[Test]
     public function export_state_round_trip_preserves_request_skip_reason(): void
     {
-        // Issue #179: a recordRequest call with a skip reason (downgraded
+        // Issue #179: a recordRequestOn call with a skip reason (downgraded
         // failure on documented 4xx) must serialize round-trip cleanly so
         // paratest worker sidecars carry the field across to the merge CLI.
-        OpenApiCoverageTracker::recordRequest(
+        $this->tracker->recordRequestOn(
             'petstore-3.0',
             'POST',
             '/v1/pets',
             'request validation skipped: response 422 is documented (spec key 422)',
         );
 
-        $original = OpenApiCoverageTracker::exportState();
+        $original = $this->tracker->exportStateOn();
         $json = json_encode($original, JSON_THROW_ON_ERROR);
         $decoded = json_decode($json, true, flags: JSON_THROW_ON_ERROR);
 
-        OpenApiCoverageTracker::reset();
-        OpenApiCoverageTracker::importState($decoded);
+        $sink = new OpenApiCoverageTracker();
+        $sink->importStateOn($decoded);
 
-        $this->assertSame($original, OpenApiCoverageTracker::exportState());
+        $this->assertSame($original, $sink->exportStateOn());
         $endpoint = $original['specs']['petstore-3.0']['POST /v1/pets'];
         $this->assertTrue($endpoint['requestReached']);
         $this->assertSame(
@@ -632,7 +635,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
         // version (no `requestSkipReason` key) must still import cleanly. The
         // missing field defaults to null. This keeps the wire format
         // backward-compatible without a STATE_FORMAT_VERSION bump.
-        OpenApiCoverageTracker::importState([
+        $this->tracker->importStateOn([
             'version' => 1,
             'specs' => [
                 'petstore-3.0' => [
@@ -645,7 +648,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
             ],
         ]);
 
-        $state = OpenApiCoverageTracker::exportState();
+        $state = $this->tracker->exportStateOn();
         $endpoint = $state['specs']['petstore-3.0']['POST /v1/pets'];
         $this->assertTrue($endpoint['requestReached']);
         $this->assertNull($endpoint['requestSkipReason']);
@@ -661,7 +664,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('invalid requestSkipReason in coverage state payload');
 
-        OpenApiCoverageTracker::importState([
+        $this->tracker->importStateOn([
             'version' => 1,
             'specs' => [
                 'petstore-3.0' => [
@@ -679,18 +682,18 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
     public function reconcile_request_agrees_between_record_and_import_paths(): void
     {
         // Companion to reconcile_response_agrees_between_record_and_import_paths:
-        // the bulk-merge importState branch must produce the same final
-        // requestSkipReason as the sequential recordRequest branch when fed
+        // the bulk-merge importStateOn branch must produce the same final
+        // requestSkipReason as the sequential recordRequestOn branch when fed
         // equivalent observations. Pinned here so a future tweak to one
         // path and not the other is caught immediately.
-        OpenApiCoverageTracker::reset();
-        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets', 'reason-1');
-        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets', 'reason-2');
-        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets');
-        $sequential = OpenApiCoverageTracker::exportState();
+        $sequentialTracker = new OpenApiCoverageTracker();
+        $sequentialTracker->recordRequestOn('petstore-3.0', 'GET', '/v1/pets', 'reason-1');
+        $sequentialTracker->recordRequestOn('petstore-3.0', 'GET', '/v1/pets', 'reason-2');
+        $sequentialTracker->recordRequestOn('petstore-3.0', 'GET', '/v1/pets');
+        $sequential = $sequentialTracker->exportStateOn();
 
-        OpenApiCoverageTracker::reset();
-        OpenApiCoverageTracker::importState([
+        $bulkTracker = new OpenApiCoverageTracker();
+        $bulkTracker->importStateOn([
             'version' => 1,
             'specs' => ['petstore-3.0' => ['GET /v1/pets' => [
                 'requestReached' => true,
@@ -698,7 +701,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
                 'responses' => [],
             ]]],
         ]);
-        OpenApiCoverageTracker::importState([
+        $bulkTracker->importStateOn([
             'version' => 1,
             'specs' => ['petstore-3.0' => ['GET /v1/pets' => [
                 'requestReached' => true,
@@ -706,7 +709,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
                 'responses' => [],
             ]]],
         ]);
-        $bulk = OpenApiCoverageTracker::exportState();
+        $bulk = $bulkTracker->exportStateOn();
 
         $this->assertSame($sequential, $bulk);
     }
@@ -718,7 +721,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
         // for the request side. Once a worker recorded a clean request
         // validation, a later worker's downgrade for the same endpoint
         // must not flip it back to skipped.
-        OpenApiCoverageTracker::importState([
+        $this->tracker->importStateOn([
             'version' => 1,
             'specs' => ['petstore-3.0' => ['GET /v1/pets' => [
                 'requestReached' => true,
@@ -726,7 +729,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
                 'responses' => [],
             ]]],
         ]);
-        OpenApiCoverageTracker::importState([
+        $this->tracker->importStateOn([
             'version' => 1,
             'specs' => ['petstore-3.0' => ['GET /v1/pets' => [
                 'requestReached' => true,
@@ -735,7 +738,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
             ]]],
         ]);
 
-        $merged = OpenApiCoverageTracker::exportState();
+        $merged = $this->tracker->exportStateOn();
         $this->assertNull($merged['specs']['petstore-3.0']['GET /v1/pets']['requestSkipReason']);
     }
 
@@ -745,7 +748,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
         // C1 regression in the bulk-merge path: a worker A that wrote a
         // response-only sidecar must not erase the skipReason carried by
         // worker B's request-side payload when they merge.
-        OpenApiCoverageTracker::importState([
+        $this->tracker->importStateOn([
             'version' => 1,
             'specs' => ['petstore-3.0' => ['GET /v1/pets' => [
                 'requestReached' => false,
@@ -755,7 +758,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
                 ],
             ]]],
         ]);
-        OpenApiCoverageTracker::importState([
+        $this->tracker->importStateOn([
             'version' => 1,
             'specs' => ['petstore-3.0' => ['GET /v1/pets' => [
                 'requestReached' => true,
@@ -764,7 +767,7 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
             ]]],
         ]);
 
-        $merged = OpenApiCoverageTracker::exportState();
+        $merged = $this->tracker->exportStateOn();
         $endpoint = $merged['specs']['petstore-3.0']['GET /v1/pets'];
         $this->assertTrue($endpoint['requestReached']);
         $this->assertSame('downgraded after response', $endpoint['requestSkipReason']);
@@ -774,31 +777,31 @@ class OpenApiCoverageTrackerStateSerializationTest extends TestCase
     public function reconcile_response_agrees_between_record_and_import_paths(): void
     {
         // Sequential single-record path: 2 skip + 1 validated.
-        OpenApiCoverageTracker::reset();
-        OpenApiCoverageTracker::recordResponse('petstore-3.0', 'GET', '/v1/pets', '200', 'application/json', schemaValidated: false, skipReason: 'reason-1');
-        OpenApiCoverageTracker::recordResponse('petstore-3.0', 'GET', '/v1/pets', '200', 'application/json', schemaValidated: false, skipReason: 'reason-2');
-        OpenApiCoverageTracker::recordResponse('petstore-3.0', 'GET', '/v1/pets', '200', 'application/json', schemaValidated: true);
-        $sequential = OpenApiCoverageTracker::exportState();
+        $sequentialTracker = new OpenApiCoverageTracker();
+        $sequentialTracker->recordResponseOn('petstore-3.0', 'GET', '/v1/pets', '200', 'application/json', schemaValidated: false, skipReason: 'reason-1');
+        $sequentialTracker->recordResponseOn('petstore-3.0', 'GET', '/v1/pets', '200', 'application/json', schemaValidated: false, skipReason: 'reason-2');
+        $sequentialTracker->recordResponseOn('petstore-3.0', 'GET', '/v1/pets', '200', 'application/json', schemaValidated: true);
+        $sequential = $sequentialTracker->exportStateOn();
 
         // Bulk-merge path: equivalent observations split across two payloads.
         // First payload aggregates two skipped recordings into a single
         // entry of hits=2 with the latest skipReason.
-        OpenApiCoverageTracker::reset();
-        OpenApiCoverageTracker::importState([
+        $bulkTracker = new OpenApiCoverageTracker();
+        $bulkTracker->importStateOn([
             'version' => 1,
             'specs' => ['petstore-3.0' => ['GET /v1/pets' => [
                 'requestReached' => false,
                 'responses' => ['200:application/json' => ['state' => 'skipped', 'hits' => 2, 'skipReason' => 'reason-2']],
             ]]],
         ]);
-        OpenApiCoverageTracker::importState([
+        $bulkTracker->importStateOn([
             'version' => 1,
             'specs' => ['petstore-3.0' => ['GET /v1/pets' => [
                 'requestReached' => false,
                 'responses' => ['200:application/json' => ['state' => 'validated', 'hits' => 1, 'skipReason' => null]],
             ]]],
         ]);
-        $bulk = OpenApiCoverageTracker::exportState();
+        $bulk = $bulkTracker->exportStateOn();
 
         // The two paths must agree on the final reconciled state — pinned
         // here so a future tweak to one branch and not the other is caught.

--- a/tests/Unit/Coverage/OpenApiCoverageTrackerTest.php
+++ b/tests/Unit/Coverage/OpenApiCoverageTrackerTest.php
@@ -17,17 +17,20 @@ use function set_error_handler;
 
 class OpenApiCoverageTrackerTest extends TestCase
 {
+    private OpenApiCoverageTracker $tracker;
+
     protected function setUp(): void
     {
         parent::setUp();
-        OpenApiCoverageTracker::reset();
+        // Issue #229: each test gets its own tracker instance, so isolation
+        // no longer depends on a process-global ::reset() call.
+        $this->tracker = new OpenApiCoverageTracker();
         OpenApiSpecLoader::reset();
         OpenApiSpecLoader::configure(__DIR__ . '/../../fixtures/specs');
     }
 
     protected function tearDown(): void
     {
-        OpenApiCoverageTracker::reset();
         OpenApiSpecLoader::reset();
         parent::tearDown();
     }
@@ -35,9 +38,9 @@ class OpenApiCoverageTrackerTest extends TestCase
     #[Test]
     public function record_request_marks_endpoint_request_reached(): void
     {
-        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets');
+        $this->tracker->recordRequestOn('petstore-3.0', 'GET', '/v1/pets');
 
-        $this->assertTrue(OpenApiCoverageTracker::hasAnyCoverage('petstore-3.0'));
+        $this->assertTrue($this->tracker->hasAnyCoverageOn('petstore-3.0'));
     }
 
     #[Test]
@@ -45,7 +48,7 @@ class OpenApiCoverageTrackerTest extends TestCase
     {
         // /widgets-default has a single declared response (default:application/json)
         // so we can pin the resulting state without juggling other rows.
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'range-keys',
             'get',
             '/widgets-default',
@@ -62,7 +65,7 @@ class OpenApiCoverageTrackerTest extends TestCase
     public function record_response_increments_hits_per_pair(): void
     {
         for ($i = 0; $i < 3; $i++) {
-            OpenApiCoverageTracker::recordResponse(
+            $this->tracker->recordResponseOn(
                 'petstore-3.0',
                 'GET',
                 '/v1/pets',
@@ -81,7 +84,7 @@ class OpenApiCoverageTrackerTest extends TestCase
     #[Test]
     public function validated_promotes_prior_skipped_for_same_pair(): void
     {
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'petstore-3.0',
             'GET',
             '/v1/pets',
@@ -90,7 +93,7 @@ class OpenApiCoverageTrackerTest extends TestCase
             schemaValidated: false,
             skipReason: 'manually skipped',
         );
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'petstore-3.0',
             'GET',
             '/v1/pets',
@@ -108,7 +111,7 @@ class OpenApiCoverageTrackerTest extends TestCase
     #[Test]
     public function skipped_does_not_demote_validated_pair(): void
     {
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'petstore-3.0',
             'GET',
             '/v1/pets',
@@ -116,7 +119,7 @@ class OpenApiCoverageTrackerTest extends TestCase
             'application/json',
             schemaValidated: true,
         );
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'petstore-3.0',
             'GET',
             '/v1/pets',
@@ -135,7 +138,7 @@ class OpenApiCoverageTrackerTest extends TestCase
     #[Test]
     public function reset_clears_all_coverage(): void
     {
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'petstore-3.0',
             'GET',
             '/v1/pets',
@@ -144,9 +147,9 @@ class OpenApiCoverageTrackerTest extends TestCase
             schemaValidated: true,
         );
 
-        OpenApiCoverageTracker::reset();
+        $this->tracker->resetOn();
 
-        $this->assertFalse(OpenApiCoverageTracker::hasAnyCoverage('petstore-3.0'));
+        $this->assertFalse($this->tracker->hasAnyCoverageOn('petstore-3.0'));
     }
 
     #[Test]
@@ -154,7 +157,7 @@ class OpenApiCoverageTrackerTest extends TestCase
     {
         // GET /v1/pets declares 4 (status, content-type) pairs in the petstore
         // fixture: 200, 422, 500, 400. Hitting only 200 → partial.
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'petstore-3.0',
             'GET',
             '/v1/pets',
@@ -181,7 +184,7 @@ class OpenApiCoverageTrackerTest extends TestCase
                 ['400', 'application/problem+json'],
             ] as [$status, $contentType]
         ) {
-            OpenApiCoverageTracker::recordResponse(
+            $this->tracker->recordResponseOn(
                 'petstore-3.0',
                 'GET',
                 '/v1/pets',
@@ -210,7 +213,7 @@ class OpenApiCoverageTrackerTest extends TestCase
     #[Test]
     public function request_only_endpoint_has_request_only_state(): void
     {
-        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets');
+        $this->tracker->recordRequestOn('petstore-3.0', 'GET', '/v1/pets');
 
         $endpoint = $this->endpointSummary('petstore-3.0', 'GET /v1/pets');
         $this->assertSame(EndpointCoverageState::RequestOnly, $endpoint['state']);
@@ -224,14 +227,14 @@ class OpenApiCoverageTrackerTest extends TestCase
         // (because the response is a documented 4xx), it forwards the skip
         // reason so coverage can surface the downgrade rather than report a
         // clean validated request.
-        OpenApiCoverageTracker::recordRequest(
+        $this->tracker->recordRequestOn(
             'petstore-3.0',
             'GET',
             '/v1/pets',
             'request validation skipped: response 422 is documented',
         );
 
-        $state = OpenApiCoverageTracker::exportState();
+        $state = $this->tracker->exportStateOn();
         $endpoint = $state['specs']['petstore-3.0']['GET /v1/pets'];
         $this->assertTrue($endpoint['requestReached']);
         $this->assertSame(
@@ -247,15 +250,15 @@ class OpenApiCoverageTrackerTest extends TestCase
         // (no skipReason) wins over an earlier skipped one — same test
         // method may run a downgraded path first, then a non-downgraded
         // path, and the endpoint should end up as cleanly request-validated.
-        OpenApiCoverageTracker::recordRequest(
+        $this->tracker->recordRequestOn(
             'petstore-3.0',
             'GET',
             '/v1/pets',
             'first run: downgraded',
         );
-        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets');
+        $this->tracker->recordRequestOn('petstore-3.0', 'GET', '/v1/pets');
 
-        $state = OpenApiCoverageTracker::exportState();
+        $state = $this->tracker->exportStateOn();
         $endpoint = $state['specs']['petstore-3.0']['GET /v1/pets'];
         $this->assertTrue($endpoint['requestReached']);
         $this->assertNull(
@@ -271,15 +274,15 @@ class OpenApiCoverageTrackerTest extends TestCase
         // request-validated, a subsequent downgrade must NOT demote it back
         // to skipped. The "validated wins over skipped" rule is the
         // request-side mirror of the response-side promotion semantics.
-        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets');
-        OpenApiCoverageTracker::recordRequest(
+        $this->tracker->recordRequestOn('petstore-3.0', 'GET', '/v1/pets');
+        $this->tracker->recordRequestOn(
             'petstore-3.0',
             'GET',
             '/v1/pets',
             'late downgrade: should be ignored',
         );
 
-        $state = OpenApiCoverageTracker::exportState();
+        $state = $this->tracker->exportStateOn();
         $endpoint = $state['specs']['petstore-3.0']['GET /v1/pets'];
         $this->assertTrue($endpoint['requestReached']);
         $this->assertNull($endpoint['requestSkipReason']);
@@ -291,10 +294,10 @@ class OpenApiCoverageTrackerTest extends TestCase
         // Two different downgrade reasons against the same endpoint —
         // mirrors the response-side "latest non-null reason wins" rule so
         // per-test overrides aren't silently dropped.
-        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets', 'first reason');
-        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets', 'second reason');
+        $this->tracker->recordRequestOn('petstore-3.0', 'GET', '/v1/pets', 'first reason');
+        $this->tracker->recordRequestOn('petstore-3.0', 'GET', '/v1/pets', 'second reason');
 
-        $state = OpenApiCoverageTracker::exportState();
+        $state = $this->tracker->exportStateOn();
         $endpoint = $state['specs']['petstore-3.0']['GET /v1/pets'];
         $this->assertSame('second reason', $endpoint['requestSkipReason']);
     }
@@ -302,13 +305,13 @@ class OpenApiCoverageTrackerTest extends TestCase
     #[Test]
     public function record_request_after_record_response_preserves_skip_reason(): void
     {
-        // Regression guard for the C1 reconciliation bug: if recordResponse
+        // Regression guard for the C1 reconciliation bug: if recordResponseOn
         // initialises an entry first (creating requestReached=false +
-        // requestSkipReason=null), a subsequent recordRequest with a skip
+        // requestSkipReason=null), a subsequent recordRequestOn with a skip
         // reason must store that reason. Pre-fix, the reconciliation
         // treated the response-only entry as "already cleanly
         // request-validated" and silently dropped the incoming reason.
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'petstore-3.0',
             'GET',
             '/v1/pets',
@@ -316,21 +319,21 @@ class OpenApiCoverageTrackerTest extends TestCase
             'application/json',
             schemaValidated: true,
         );
-        OpenApiCoverageTracker::recordRequest(
+        $this->tracker->recordRequestOn(
             'petstore-3.0',
             'GET',
             '/v1/pets',
             'downgraded after response',
         );
 
-        $state = OpenApiCoverageTracker::exportState();
+        $state = $this->tracker->exportStateOn();
         $endpoint = $state['specs']['petstore-3.0']['GET /v1/pets'];
         $this->assertTrue($endpoint['requestReached']);
         $this->assertSame(
             'downgraded after response',
             $endpoint['requestSkipReason'],
             'first request-side recording must store the reason even when '
-            . 'recordResponse initialised the entry',
+            . 'recordResponseOn initialised the entry',
         );
     }
 
@@ -341,7 +344,7 @@ class OpenApiCoverageTrackerTest extends TestCase
         // (mixed case). A real response Content-Type is normalised to lower
         // case (`application/problem+json`). The reconciliation should still
         // recognise the recorded entry under the spec's casing.
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'petstore-3.0',
             'GET',
             '/v1/pets',
@@ -378,7 +381,7 @@ class OpenApiCoverageTrackerTest extends TestCase
     {
         // Spec declares `default` as a catch-all. A literal `418` recording
         // (validated) should mark it covered.
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'range-keys',
             'GET',
             '/widgets-default',
@@ -397,7 +400,7 @@ class OpenApiCoverageTrackerTest extends TestCase
     {
         // petstore-3.0 GET /v1/pets does not declare 418. Recording 418 surfaces
         // it as an unexpected observation rather than counting toward coverage.
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'petstore-3.0',
             'GET',
             '/v1/pets',
@@ -428,7 +431,7 @@ class OpenApiCoverageTrackerTest extends TestCase
     {
         // petstore-3.0 declares 31 (status, content-type) pairs across 24
         // endpoints. Pin the totals so future spec drift is caught.
-        $result = OpenApiCoverageTracker::computeCoverage('petstore-3.0');
+        $result = $this->tracker->computeCoverageOn('petstore-3.0');
 
         $this->assertSame(24, $result['endpointTotal']);
         $this->assertSame(31, $result['responseTotal']);
@@ -443,7 +446,7 @@ class OpenApiCoverageTrackerTest extends TestCase
     {
         // Trigger a no-content response (skipped 503 → `503:*`) alongside a
         // concrete content-type response, then verify the sub-row ordering.
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'range-keys',
             'GET',
             '/widgets',
@@ -451,7 +454,7 @@ class OpenApiCoverageTrackerTest extends TestCase
             'application/json',
             schemaValidated: true,
         );
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'range-keys',
             'GET',
             '/widgets',
@@ -477,7 +480,7 @@ class OpenApiCoverageTrackerTest extends TestCase
         // carry literal statuses, but external callers (and future skip-pattern
         // refactors) may pass spec range keys. The reverse direction must
         // reconcile too.
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'petstore-3.0',
             'GET',
             '/v1/pets',
@@ -499,7 +502,7 @@ class OpenApiCoverageTrackerTest extends TestCase
         // Edge case: caller passes the literal string "default" as statusKey.
         // statusKeyMatches() should resolve via the case-insensitive exact match
         // BEFORE falling through to the `default` wildcard branch.
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'range-keys',
             'GET',
             '/widgets-default',
@@ -519,7 +522,7 @@ class OpenApiCoverageTrackerTest extends TestCase
         // Pin the deriveEndpointState() $totalDeclared === 0 branch.
         // The fixture's GET /widgets-no-responses operation has no responses
         // block at all.
-        OpenApiCoverageTracker::recordRequest('range-keys', 'GET', '/widgets-no-responses');
+        $this->tracker->recordRequestOn('range-keys', 'GET', '/widgets-no-responses');
 
         $endpoint = $this->endpointSummary('range-keys', 'GET /widgets-no-responses');
         $this->assertSame(EndpointCoverageState::RequestOnly, $endpoint['state']);
@@ -538,9 +541,9 @@ class OpenApiCoverageTrackerTest extends TestCase
     {
         // Pin the hasAnyResponseObservation branch in deriveEndpointState():
         // a recording that doesn't reconcile to any declared spec entry
-        // (lands in unexpectedObservations) but no recordRequest call —
+        // (lands in unexpectedObservations) but no recordRequestOn call —
         // endpoint state must be `request-only`, not `uncovered`.
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'range-keys',
             'GET',
             '/widgets',
@@ -559,7 +562,7 @@ class OpenApiCoverageTrackerTest extends TestCase
     {
         // Two distinct recordings (`503` and `599`) both reconcile to spec `5XX`
         // via range matching. The validated row's `hits` should be the sum.
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'range-keys',
             'GET',
             '/widgets',
@@ -567,7 +570,7 @@ class OpenApiCoverageTrackerTest extends TestCase
             'application/json',
             schemaValidated: true,
         );
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'range-keys',
             'GET',
             '/widgets',
@@ -588,7 +591,7 @@ class OpenApiCoverageTrackerTest extends TestCase
         // Two skipped recordings followed by a validated one should NOT roll
         // the skipped hit count into the validated total — the displayed
         // "validated (N hits)" must reflect validations only.
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'range-keys',
             'GET',
             '/widgets',
@@ -597,7 +600,7 @@ class OpenApiCoverageTrackerTest extends TestCase
             schemaValidated: false,
             skipReason: 'first skip',
         );
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'range-keys',
             'GET',
             '/widgets',
@@ -606,7 +609,7 @@ class OpenApiCoverageTrackerTest extends TestCase
             schemaValidated: false,
             skipReason: 'second skip',
         );
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'range-keys',
             'GET',
             '/widgets',
@@ -624,7 +627,7 @@ class OpenApiCoverageTrackerTest extends TestCase
     #[Test]
     public function latest_skip_reason_wins_for_same_pair_recordings(): void
     {
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'range-keys',
             'GET',
             '/widgets',
@@ -633,7 +636,7 @@ class OpenApiCoverageTrackerTest extends TestCase
             schemaValidated: false,
             skipReason: 'reason A',
         );
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'range-keys',
             'GET',
             '/widgets',
@@ -654,7 +657,7 @@ class OpenApiCoverageTrackerTest extends TestCase
         // Two distinct skip recordings (different literal statuses) both
         // reconcile to the same spec `5XX:application/json` declaration.
         // Latest skipReason should win in buildResponseRows too.
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'range-keys',
             'GET',
             '/widgets',
@@ -663,7 +666,7 @@ class OpenApiCoverageTrackerTest extends TestCase
             schemaValidated: false,
             skipReason: 'reason A',
         );
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'range-keys',
             'GET',
             '/widgets',
@@ -687,7 +690,7 @@ class OpenApiCoverageTrackerTest extends TestCase
         // both rows validated and contributes to both counts. Spec authors are
         // unlikely to write both, but this pin documents the arithmetic so a
         // future refactor doesn't silently change the totals.
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'range-keys-overlap',
             'GET',
             '/widgets',
@@ -717,7 +720,7 @@ class OpenApiCoverageTrackerTest extends TestCase
         });
 
         try {
-            OpenApiCoverageTracker::computeCoverage('malformed-response');
+            $this->tracker->computeCoverageOn('malformed-response');
         } finally {
             restore_error_handler();
         }
@@ -730,10 +733,10 @@ class OpenApiCoverageTrackerTest extends TestCase
     #[Test]
     public function has_any_coverage_returns_true_for_request_only(): void
     {
-        OpenApiCoverageTracker::recordRequest('petstore-3.0', 'GET', '/v1/pets');
+        $this->tracker->recordRequestOn('petstore-3.0', 'GET', '/v1/pets');
 
-        $this->assertTrue(OpenApiCoverageTracker::hasAnyCoverage('petstore-3.0'));
-        $this->assertFalse(OpenApiCoverageTracker::hasAnyCoverage('other-spec'));
+        $this->assertTrue($this->tracker->hasAnyCoverageOn('petstore-3.0'));
+        $this->assertFalse($this->tracker->hasAnyCoverageOn('other-spec'));
     }
 
     /**
@@ -743,7 +746,7 @@ class OpenApiCoverageTrackerTest extends TestCase
      */
     private function recordCoverageForFakeSpec(): void
     {
-        OpenApiCoverageTracker::recordResponse(
+        $this->tracker->recordResponseOn(
             'range-keys',
             'GET',
             '/widgets',
@@ -771,7 +774,7 @@ class OpenApiCoverageTrackerTest extends TestCase
      */
     private function endpointSummary(string $specName, string $endpointKey): array
     {
-        $result = OpenApiCoverageTracker::computeCoverage($specName);
+        $result = $this->tracker->computeCoverageOn($specName);
         foreach ($result['endpoints'] as $summary) {
             if ($summary['endpoint'] === $endpointKey) {
                 return $summary;

--- a/tests/Unit/PHPUnit/CoverageReportSubscriberWorkerModeTest.php
+++ b/tests/Unit/PHPUnit/CoverageReportSubscriberWorkerModeTest.php
@@ -13,6 +13,7 @@ use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\PHPUnit\ConsoleOutput;
 use Studio\OpenApiContractTesting\PHPUnit\CoverageReportSubscriber;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredTracker;
 use Throwable;
 
 use function file_get_contents;
@@ -128,6 +129,74 @@ class CoverageReportSubscriberWorkerModeTest extends TestCase
         $this->assertSame(2, $loaded[0]['envelopeVersion']);
         $this->assertSame(1, $loaded[0]['coverage']['version']);
         $this->assertArrayHasKey('petstore-3.0', $loaded[0]['coverage']['specs']);
+    }
+
+    #[Test]
+    public function injected_trackers_drive_worker_sidecar_payload(): void
+    {
+        // Issue #229: when production code (the extension) injects tracker
+        // instances into the subscriber, the worker-mode sidecar must
+        // serialize THOSE instances — not whatever the process-global
+        // ::current() locator happens to point at. A regression that drops
+        // the field assignment would silently serialize the wrong state and
+        // the merge CLI would aggregate empty payloads.
+        $coverageTracker = new OpenApiCoverageTracker();
+        $coverageTracker->recordResponseOn(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            '201',
+            'application/json',
+            schemaValidated: true,
+        );
+        $strictRequiredTracker = new StrictRequiredTracker();
+        $strictRequiredTracker->recordOn(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            '201',
+            'application/json',
+            ['/' => ['id', 'name']],
+        );
+
+        // Process-global locator points at fresh, EMPTY trackers — if the
+        // subscriber ever read from current() instead of the injected refs,
+        // the sidecar would serialize this empty state.
+        OpenApiCoverageTracker::resetCurrent();
+        StrictRequiredTracker::resetCurrent();
+        OpenApiCoverageTracker::setCurrent(new OpenApiCoverageTracker());
+        StrictRequiredTracker::setCurrent(new StrictRequiredTracker());
+
+        putenv('TEST_TOKEN=9');
+
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            coverageTracker: $coverageTracker,
+            strictRequiredTracker: $strictRequiredTracker,
+            sidecarDir: $this->tmpDir,
+        );
+
+        ob_start();
+        $subscriber->notify($this->fakeExecutionFinished());
+        ob_get_clean();
+
+        $loaded = CoverageSidecarReader::readDir($this->tmpDir);
+        $this->assertCount(1, $loaded);
+        // Sidecar must contain the INJECTED coverage tracker's POST recording.
+        $this->assertArrayHasKey(
+            'POST /v1/pets',
+            $loaded[0]['coverage']['specs']['petstore-3.0'],
+            'sidecar must serialize the injected coverage tracker, not ::current()',
+        );
+        // And the injected strict_required tracker's observation.
+        $this->assertArrayHasKey(
+            'POST /v1/pets',
+            $loaded[0]['strictRequired']['observations']['petstore-3.0'],
+            'sidecar must serialize the injected strict_required tracker, not ::current()',
+        );
     }
 
     #[Test]

--- a/tests/Unit/Validation/Strict/StrictRequiredTrackerInstanceIsolationTest.php
+++ b/tests/Unit/Validation/Strict/StrictRequiredTrackerInstanceIsolationTest.php
@@ -8,6 +8,9 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredTracker;
 
+use function restore_error_handler;
+use function set_error_handler;
+
 /**
  * Issue #229: structural guarantee that two independently-constructed
  * {@see StrictRequiredTracker} instances do not share state. Mirrors the
@@ -70,8 +73,10 @@ final class StrictRequiredTrackerInstanceIsolationTest extends TestCase
     #[Test]
     public function static_facade_routes_to_the_current_instance(): void
     {
+        // resetCurrent() first so the setCurrent() overwrite-guard does not
+        // trip on a stateful slot left over from an earlier test.
+        StrictRequiredTracker::resetCurrent();
         $injected = new StrictRequiredTracker();
-        $previous = StrictRequiredTracker::current();
         StrictRequiredTracker::setCurrent($injected);
 
         try {
@@ -81,9 +86,73 @@ final class StrictRequiredTrackerInstanceIsolationTest extends TestCase
 
             $this->assertSame(['front'], $injected->recordedSpecsOn());
         } finally {
-            // Restore so we don't leak the injected instance into other tests
-            // that share the process-global facade.
-            StrictRequiredTracker::setCurrent($previous);
+            // Drop the slot so the injected instance does not leak.
+            StrictRequiredTracker::resetCurrent();
         }
+    }
+
+    #[Test]
+    public function cold_slot_lazily_mints_default_for_static_facade(): void
+    {
+        // Production scenario: nothing has called setCurrent() and current()
+        // has never been touched. The first static-facade call must lazily
+        // mint a default rather than fail.
+        StrictRequiredTracker::resetCurrent();
+
+        try {
+            StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', [
+                '/' => ['a'],
+            ]);
+
+            $minted = StrictRequiredTracker::current();
+            $this->assertSame(['front'], $minted->recordedSpecsOn());
+        } finally {
+            StrictRequiredTracker::resetCurrent();
+        }
+    }
+
+    #[Test]
+    public function reset_current_drops_the_installed_instance(): void
+    {
+        StrictRequiredTracker::resetCurrent();
+        $first = new StrictRequiredTracker();
+        StrictRequiredTracker::setCurrent($first);
+        $this->assertSame($first, StrictRequiredTracker::current());
+
+        StrictRequiredTracker::resetCurrent();
+        $afterReset = StrictRequiredTracker::current();
+        $this->assertNotSame($first, $afterReset, 'resetCurrent must drop the previously installed slot');
+
+        StrictRequiredTracker::resetCurrent();
+    }
+
+    #[Test]
+    public function set_current_warns_when_overwriting_stateful_slot(): void
+    {
+        // Hardening guard: if a caller forgets resetCurrent() between
+        // installations, observations accumulated on the outgoing tracker
+        // silently drop out of the report. The guard fires E_USER_WARNING
+        // exactly in that case so a test author sees what they're losing.
+        StrictRequiredTracker::resetCurrent();
+        $first = new StrictRequiredTracker();
+        $first->recordOn('front', 'GET', '/x', '200', 'application/json', ['/' => ['a']]);
+        StrictRequiredTracker::setCurrent($first);
+
+        $captured = null;
+        set_error_handler(static function (int $errno, string $message) use (&$captured): bool {
+            $captured = $message;
+
+            return true;
+        });
+
+        try {
+            StrictRequiredTracker::setCurrent(new StrictRequiredTracker());
+        } finally {
+            restore_error_handler();
+            StrictRequiredTracker::resetCurrent();
+        }
+
+        $this->assertNotNull($captured, 'overwriting a stateful slot must emit E_USER_WARNING');
+        $this->assertStringContainsString('still holds recorded observations', $captured);
     }
 }

--- a/tests/Unit/Validation/Strict/StrictRequiredTrackerInstanceIsolationTest.php
+++ b/tests/Unit/Validation/Strict/StrictRequiredTrackerInstanceIsolationTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Validation\Strict;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredTracker;
+
+/**
+ * Issue #229: structural guarantee that two independently-constructed
+ * {@see StrictRequiredTracker} instances do not share state. Mirrors the
+ * matching coverage-tracker isolation test — if either tracker regresses
+ * back to global mutable state, the suite catches it without depending on
+ * a test author remembering to call `::reset()` everywhere.
+ */
+final class StrictRequiredTrackerInstanceIsolationTest extends TestCase
+{
+    #[Test]
+    public function two_instances_do_not_share_observations(): void
+    {
+        $a = new StrictRequiredTracker();
+        $b = new StrictRequiredTracker();
+
+        $a->recordOn('front', 'GET', '/x', '200', 'application/json', [
+            '/' => ['a', 'b'],
+        ]);
+
+        $this->assertSame(['front'], $a->recordedSpecsOn());
+        $this->assertSame([], $b->recordedSpecsOn());
+    }
+
+    #[Test]
+    public function reset_on_instance_does_not_affect_sibling_instance(): void
+    {
+        $a = new StrictRequiredTracker();
+        $b = new StrictRequiredTracker();
+
+        $a->recordOn('front', 'GET', '/x', '200', 'application/json', [
+            '/' => ['a'],
+        ]);
+        $b->recordOn('back', 'GET', '/y', '200', 'application/json', [
+            '/' => ['b'],
+        ]);
+
+        $a->resetOn();
+
+        $this->assertSame([], $a->recordedSpecsOn());
+        $this->assertSame(['back'], $b->recordedSpecsOn());
+    }
+
+    #[Test]
+    public function export_state_round_trips_through_a_second_instance(): void
+    {
+        $source = new StrictRequiredTracker();
+        $source->recordOn('front', 'GET', '/x', '200', 'application/json', [
+            '/' => ['a', 'b'],
+        ]);
+
+        $sink = new StrictRequiredTracker();
+        $sink->importStateOn($source->exportStateOn());
+
+        $this->assertSame(
+            $source->getObservationsOn('front'),
+            $sink->getObservationsOn('front'),
+        );
+    }
+
+    #[Test]
+    public function static_facade_routes_to_the_current_instance(): void
+    {
+        $injected = new StrictRequiredTracker();
+        $previous = StrictRequiredTracker::current();
+        StrictRequiredTracker::setCurrent($injected);
+
+        try {
+            StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', [
+                '/' => ['a'],
+            ]);
+
+            $this->assertSame(['front'], $injected->recordedSpecsOn());
+        } finally {
+            // Restore so we don't leak the injected instance into other tests
+            // that share the process-global facade.
+            StrictRequiredTracker::setCurrent($previous);
+        }
+    }
+}

--- a/tests/Unit/Validation/Strict/StrictRequiredTrackerTest.php
+++ b/tests/Unit/Validation/Strict/StrictRequiredTrackerTest.php
@@ -11,26 +11,23 @@ use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredTracker;
 
 final class StrictRequiredTrackerTest extends TestCase
 {
+    private StrictRequiredTracker $tracker;
+
     protected function setUp(): void
     {
         parent::setUp();
-        StrictRequiredTracker::reset();
-    }
-
-    protected function tearDown(): void
-    {
-        StrictRequiredTracker::reset();
-        parent::tearDown();
+        // Issue #229: per-test tracker instance — no global reset needed.
+        $this->tracker = new StrictRequiredTracker();
     }
 
     #[Test]
     public function single_observation_keeps_full_pointer_map(): void
     {
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', [
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', [
             '/' => ['a', 'b', 'c'],
         ]);
 
-        $observations = StrictRequiredTracker::getObservations('front');
+        $observations = $this->tracker->getObservationsOn('front');
         $this->assertSame(
             [
                 'GET /x' => [
@@ -44,13 +41,13 @@ final class StrictRequiredTrackerTest extends TestCase
     #[Test]
     public function multiple_observations_intersect_keys_at_each_pointer(): void
     {
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', [
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', [
             '/' => ['a', 'b', 'c'],
         ]);
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', [
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', [
             '/' => ['a', 'b'],
         ]);
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', [
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', [
             '/' => ['a', 'b', 'd'],
         ]);
 
@@ -60,17 +57,17 @@ final class StrictRequiredTrackerTest extends TestCase
                     '200:application/json' => ['hits' => 3, 'pointers' => ['/' => ['a', 'b']]],
                 ],
             ],
-            StrictRequiredTracker::getObservations('front'),
+            $this->tracker->getObservationsOn('front'),
         );
     }
 
     #[Test]
     public function empty_body_observation_keeps_pointer_with_empty_key_list(): void
     {
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', [
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', [
             '/' => ['a', 'b'],
         ]);
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', [
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', [
             '/' => [],
         ]);
 
@@ -80,19 +77,19 @@ final class StrictRequiredTrackerTest extends TestCase
                     '200:application/json' => ['hits' => 2, 'pointers' => ['/' => []]],
                 ],
             ],
-            StrictRequiredTracker::getObservations('front'),
+            $this->tracker->getObservationsOn('front'),
         );
     }
 
     #[Test]
     public function nested_pointers_are_tracked_independently_per_pointer(): void
     {
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', [
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', [
             '/' => ['data'],
             '/data' => ['id', 'name', 'created_at'],
             '/data/tags[*]' => ['t'],
         ]);
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', [
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', [
             '/' => ['data'],
             '/data' => ['id', 'name', 'created_at', 'extra'],
             '/data/tags[*]' => ['t'],
@@ -111,7 +108,7 @@ final class StrictRequiredTrackerTest extends TestCase
                     ],
                 ],
             ],
-            StrictRequiredTracker::getObservations('front'),
+            $this->tracker->getObservationsOn('front'),
         );
     }
 
@@ -121,11 +118,11 @@ final class StrictRequiredTrackerTest extends TestCase
         // obs#1 has /items[*]; obs#2 has empty items array (no [*] pointer
         // emitted by the walker). The cross-observation rule must drop the
         // pointer entirely — "always observed" requires the pointer itself.
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', [
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', [
             '/' => ['items'],
             '/items[*]' => ['id', 'name'],
         ]);
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', [
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', [
             '/' => ['items'],
         ]);
 
@@ -138,17 +135,17 @@ final class StrictRequiredTrackerTest extends TestCase
                     ],
                 ],
             ],
-            StrictRequiredTracker::getObservations('front'),
+            $this->tracker->getObservationsOn('front'),
         );
     }
 
     #[Test]
     public function pointer_only_in_second_observation_is_dropped(): void
     {
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', [
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', [
             '/' => ['items'],
         ]);
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', [
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', [
             '/' => ['items'],
             '/items[*]' => ['id'],
         ]);
@@ -162,15 +159,15 @@ final class StrictRequiredTrackerTest extends TestCase
                     ],
                 ],
             ],
-            StrictRequiredTracker::getObservations('front'),
+            $this->tracker->getObservationsOn('front'),
         );
     }
 
     #[Test]
     public function different_status_keys_are_independent(): void
     {
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', ['/' => ['a']]);
-        StrictRequiredTracker::record('front', 'GET', '/x', '404', 'application/json', ['/' => ['error']]);
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', ['/' => ['a']]);
+        $this->tracker->recordOn('front', 'GET', '/x', '404', 'application/json', ['/' => ['error']]);
 
         $this->assertSame(
             [
@@ -179,15 +176,15 @@ final class StrictRequiredTrackerTest extends TestCase
                     '404:application/json' => ['hits' => 1, 'pointers' => ['/' => ['error']]],
                 ],
             ],
-            StrictRequiredTracker::getObservations('front'),
+            $this->tracker->getObservationsOn('front'),
         );
     }
 
     #[Test]
     public function different_content_types_are_independent(): void
     {
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', ['/' => ['a']]);
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/problem+json', ['/' => ['detail']]);
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', ['/' => ['a']]);
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/problem+json', ['/' => ['detail']]);
 
         $this->assertSame(
             [
@@ -196,81 +193,81 @@ final class StrictRequiredTrackerTest extends TestCase
                     '200:application/problem+json' => ['hits' => 1, 'pointers' => ['/' => ['detail']]],
                 ],
             ],
-            StrictRequiredTracker::getObservations('front'),
+            $this->tracker->getObservationsOn('front'),
         );
     }
 
     #[Test]
     public function different_specs_are_independent(): void
     {
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', ['/' => ['a']]);
-        StrictRequiredTracker::record('admin', 'GET', '/x', '200', 'application/json', ['/' => ['b']]);
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', ['/' => ['a']]);
+        $this->tracker->recordOn('admin', 'GET', '/x', '200', 'application/json', ['/' => ['b']]);
 
         $this->assertSame(
             ['GET /x' => ['200:application/json' => ['hits' => 1, 'pointers' => ['/' => ['a']]]]],
-            StrictRequiredTracker::getObservations('front'),
+            $this->tracker->getObservationsOn('front'),
         );
         $this->assertSame(
             ['GET /x' => ['200:application/json' => ['hits' => 1, 'pointers' => ['/' => ['b']]]]],
-            StrictRequiredTracker::getObservations('admin'),
+            $this->tracker->getObservationsOn('admin'),
         );
     }
 
     #[Test]
     public function record_normalises_method_to_uppercase(): void
     {
-        StrictRequiredTracker::record('front', 'get', '/x', '200', 'application/json', ['/' => ['a']]);
+        $this->tracker->recordOn('front', 'get', '/x', '200', 'application/json', ['/' => ['a']]);
 
-        $this->assertArrayHasKey('GET /x', StrictRequiredTracker::getObservations('front'));
+        $this->assertArrayHasKey('GET /x', $this->tracker->getObservationsOn('front'));
     }
 
     #[Test]
     public function record_normalises_pointer_lists_to_sorted_unique(): void
     {
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', [
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', [
             '/' => ['z', 'a', 'a', 'm'],
         ]);
 
         $this->assertSame(
             ['GET /x' => ['200:application/json' => ['hits' => 1, 'pointers' => ['/' => ['a', 'm', 'z']]]]],
-            StrictRequiredTracker::getObservations('front'),
+            $this->tracker->getObservationsOn('front'),
         );
     }
 
     #[Test]
     public function reset_clears_all_specs(): void
     {
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', ['/' => ['a']]);
-        StrictRequiredTracker::record('admin', 'GET', '/y', '200', 'application/json', ['/' => ['b']]);
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', ['/' => ['a']]);
+        $this->tracker->recordOn('admin', 'GET', '/y', '200', 'application/json', ['/' => ['b']]);
 
-        StrictRequiredTracker::reset();
+        $this->tracker->resetOn();
 
-        $this->assertSame([], StrictRequiredTracker::getObservations('front'));
-        $this->assertSame([], StrictRequiredTracker::getObservations('admin'));
+        $this->assertSame([], $this->tracker->getObservationsOn('front'));
+        $this->assertSame([], $this->tracker->getObservationsOn('admin'));
     }
 
     #[Test]
     public function export_and_import_round_trip_with_nested_pointers(): void
     {
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', [
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', [
             '/' => ['data'],
             '/data' => ['id', 'name'],
         ]);
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', [
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', [
             '/' => ['data'],
             '/data' => ['id', 'name', 'extra'],
         ]);
-        StrictRequiredTracker::record('front', 'POST', '/y', '201', 'application/json', [
+        $this->tracker->recordOn('front', 'POST', '/y', '201', 'application/json', [
             '/' => ['id'],
         ]);
 
-        $exported = StrictRequiredTracker::exportState();
+        $exported = $this->tracker->exportStateOn();
         $this->assertSame(2, $exported['version']);
 
-        StrictRequiredTracker::reset();
-        $this->assertSame([], StrictRequiredTracker::getObservations('front'));
+        $sink = new StrictRequiredTracker();
+        $this->assertSame([], $sink->getObservationsOn('front'));
 
-        StrictRequiredTracker::importState($exported);
+        $sink->importStateOn($exported);
 
         $this->assertSame(
             [
@@ -287,19 +284,19 @@ final class StrictRequiredTrackerTest extends TestCase
                     '201:application/json' => ['hits' => 1, 'pointers' => ['/' => ['id']]],
                 ],
             ],
-            StrictRequiredTracker::getObservations('front'),
+            $sink->getObservationsOn('front'),
         );
     }
 
     #[Test]
     public function import_unions_with_existing_via_intersection(): void
     {
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', [
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', [
             '/' => ['a', 'b', 'c'],
             '/nested' => ['x', 'y'],
         ]);
 
-        StrictRequiredTracker::importState([
+        $this->tracker->importStateOn([
             'version' => 2,
             'observations' => [
                 'front' => [
@@ -328,19 +325,19 @@ final class StrictRequiredTrackerTest extends TestCase
                     ],
                 ],
             ],
-            StrictRequiredTracker::getObservations('front'),
+            $this->tracker->getObservationsOn('front'),
         );
     }
 
     #[Test]
     public function import_drops_pointer_absent_on_one_side(): void
     {
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', [
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', [
             '/' => ['a'],
             '/items[*]' => ['id', 'name'],
         ]);
 
-        StrictRequiredTracker::importState([
+        $this->tracker->importStateOn([
             'version' => 2,
             'observations' => [
                 'front' => [
@@ -363,7 +360,7 @@ final class StrictRequiredTrackerTest extends TestCase
                     ],
                 ],
             ],
-            StrictRequiredTracker::getObservations('front'),
+            $this->tracker->getObservationsOn('front'),
         );
     }
 
@@ -373,7 +370,7 @@ final class StrictRequiredTrackerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unsupported strict_required state version');
 
-        StrictRequiredTracker::importState([
+        $this->tracker->importStateOn([
             'version' => 99,
             'observations' => [],
         ]);
@@ -388,7 +385,7 @@ final class StrictRequiredTrackerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unsupported strict_required state version: got 1, expected 2');
 
-        StrictRequiredTracker::importState([
+        $this->tracker->importStateOn([
             'version' => 1,
             'observations' => [
                 'front' => ['GET /x' => ['200:application/json' => ['hits' => 1, 'alwaysPresent' => ['a']]]],
@@ -402,7 +399,7 @@ final class StrictRequiredTrackerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('list<string>');
 
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', [
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', [
             '/' => ['a', 42, 'c'],
         ]);
     }
@@ -413,7 +410,7 @@ final class StrictRequiredTrackerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('non-empty string pointers');
 
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', [
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', [
             '' => ['a'],
         ]);
     }
@@ -424,7 +421,7 @@ final class StrictRequiredTrackerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('"observations" object');
 
-        StrictRequiredTracker::importState(['version' => 2]);
+        $this->tracker->importStateOn(['version' => 2]);
     }
 
     #[Test]
@@ -433,7 +430,7 @@ final class StrictRequiredTrackerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('integer hits >= 1');
 
-        StrictRequiredTracker::importState([
+        $this->tracker->importStateOn([
             'version' => 2,
             'observations' => [
                 'front' => ['GET /x' => ['200:application/json' => ['hits' => 0, 'pointers' => []]]],
@@ -447,7 +444,7 @@ final class StrictRequiredTrackerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('entries must be strings');
 
-        StrictRequiredTracker::importState([
+        $this->tracker->importStateOn([
             'version' => 2,
             'observations' => [
                 'front' => ['GET /x' => ['200:application/json' => [
@@ -466,7 +463,7 @@ final class StrictRequiredTrackerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('v1 "alwaysPresent" field');
 
-        StrictRequiredTracker::importState([
+        $this->tracker->importStateOn([
             'version' => 2,
             'observations' => [
                 'front' => ['GET /x' => ['200:application/json' => [
@@ -482,7 +479,7 @@ final class StrictRequiredTrackerTest extends TestCase
     {
         // Two-pass validation invariant: a malformed entry deep in the
         // payload must not leave the tracker in a partially-merged state.
-        StrictRequiredTracker::record('front', 'GET', '/x', '200', 'application/json', [
+        $this->tracker->recordOn('front', 'GET', '/x', '200', 'application/json', [
             '/' => ['a', 'b'],
         ]);
 
@@ -501,7 +498,7 @@ final class StrictRequiredTrackerTest extends TestCase
         ];
 
         try {
-            StrictRequiredTracker::importState($payload);
+            $this->tracker->importStateOn($payload);
             $this->fail('expected InvalidArgumentException');
         } catch (InvalidArgumentException) {
             // expected
@@ -513,8 +510,8 @@ final class StrictRequiredTrackerTest extends TestCase
                     '200:application/json' => ['hits' => 1, 'pointers' => ['/' => ['a', 'b']]],
                 ],
             ],
-            StrictRequiredTracker::getObservations('front'),
+            $this->tracker->getObservationsOn('front'),
         );
-        $this->assertSame([], StrictRequiredTracker::getObservations('admin'));
+        $this->assertSame([], $this->tracker->getObservationsOn('admin'));
     }
 }

--- a/tests/Unit/Validation/Strict/StrictRequiredValidatorIntegrationTest.php
+++ b/tests/Unit/Validation/Strict/StrictRequiredValidatorIntegrationTest.php
@@ -17,6 +17,7 @@ use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredPerCallChecker
 use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredPerCallMode;
 use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredTracker;
 
+use function array_keys;
 use function restore_error_handler;
 use function set_error_handler;
 
@@ -40,6 +41,34 @@ final class StrictRequiredValidatorIntegrationTest extends TestCase
         StrictRequiredPerCallChecker::reset();
         OpenApiSpecLoader::reset();
         parent::tearDown();
+    }
+
+    #[Test]
+    public function injected_tracker_receives_observations_instead_of_current_locator(): void
+    {
+        // Issue #229: the validator accepts an optional StrictRequiredTracker
+        // via ctor. When one is injected, observations must go to the
+        // injected instance, NOT the process-global current() locator. A
+        // regression that drops the field would silently route to current()
+        // and the suite-level intersection would absorb the test traffic.
+        $injected = new StrictRequiredTracker();
+        $validator = new OpenApiResponseValidator(strictRequiredTracker: $injected);
+
+        $result = $validator->validate(
+            'under-described',
+            'PUT',
+            '/signed-url',
+            200,
+            ['expires' => 3600, 'signed_url' => 's3://...', 'url' => 'https://...'],
+            'application/json',
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertSame(['PUT /signed-url'], array_keys($injected->getObservationsOn('under-described')));
+        // The process-global locator (which setUp reset()s) must NOT have
+        // absorbed the observation — the injection contract is "I asked
+        // for this tracker, only this tracker should record."
+        $this->assertSame([], StrictRequiredTracker::current()->getObservationsOn('under-described'));
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- Both `OpenApiCoverageTracker` and `StrictRequiredTracker` are now instance-based; the existing static methods stay as a thin facade routing to a process-global "current" instance the PHPUnit extension installs at bootstrap.
- The PHPUnit extension, `CoverageReportSubscriber`, `CoverageMergeCommand`, and `OpenApiResponseValidator` now own their trackers via construction (the merge CLI no longer relies on global `::reset()` to start clean).
- Tracker-unit tests migrated to a per-test instance fixture; new isolation tests pin the "two `new` instances don't share state" invariant the refactor buys us, plus the lazy-init, `resetCurrent()`, and `setCurrent()` overwrite-guard contracts.

## Why

Fixes #229. Both trackers had hit the limits of the static-singleton pattern:

- ~80 test files called `Tracker::reset()` in `setUp`/`tearDown` to avoid state leakage between tests.
- The `exportState` / `importState` / `reset` triplet exists purely because there was no instance to swap.
- Parallel-test safety relied on each paratest worker owning its own PHP process — implicit, never expressed in the type system.
- Statics could not be mocked / injected, only reset.

The Laravel `ValidatesOpenApiSchema` trait cannot take DI (PHP traits have no constructor), so the static methods remain as a SemVer-frozen facade. Instance API is suffixed `*On` (`recordResponseOn`, `exportStateOn`, etc.) to coexist with the static surface in the same class. Production call sites that can accept DI now do; the trait routes through the facade → `current()` → the same instance the extension installed at bootstrap.

The locator API is `setCurrent(self $instance)` + `resetCurrent(): void` — split into two methods so the type signature doesn't lie about `null` semantics, with an `E_USER_WARNING` guard when `setCurrent()` overwrites a stateful slot (matches the project's existing loud-on-suspicious-state style).

## Verification

- [x] `composer test` passes (1710 tests, 4019 assertions — 16 new behavioral tests + 1694 existing)
- [x] `composer stan` passes (level 6, no errors)
- [x] `composer cs-check` passes
- [x] Tracker-unit tests use `new Tracker()` per test; setUp/tearDown no longer call `Tracker::reset()`
- [x] Manual sanity check: existing tests that route through the static facade (the ~80 trait integration tests) keep passing unchanged
- [x] New tests cover: validator custom-tracker injection (subscriber + validator routes record to the injected instance, not `::current()`), merge CLI isolation from a pre-installed sentinel, cold-slot lazy-init, `resetCurrent()` drops the slot, `setCurrent()` overwrite-guard fires

## Notes for reviewers

- Migrating the ~80 trait integration tests away from static `::reset()` is **explicitly deferred** to a follow-up — they continue to work through the static facade, and bulk-rewriting them would balloon this PR without changing behavior. Happy to file follow-up issues per logical cluster if reviewers want.
- Adding `E_USER_DEPRECATED` to the static facade is also deferred. The issue mentions a deprecation cycle "before removal in a future major"; we are not in a major-bump window. Filed as a v2 tracking concern.
- `recordRequest` / `recordResponse` / `record` (the user-callable surface) are intentionally **not** marked deprecated — those route through the same facade and stay as the supported entrypoint for trait/external callers.
- Naming: instance methods take an `*On` suffix to avoid PHP's prohibition on same-name static + instance methods in one class. The alternative — renaming the statics — would have changed the SemVer-frozen public surface.

## Follow-up issues

- **#234** — `OpenApiResponseValidator::__construct()` の `?StrictRequiredTracker` を required にして locator fallback を排除（v2 release で対応予定 / SemVer-major のため PR #233 のスコープ外）。