### PR TITLE
feat(extension): add default_testsuite_as_full to neutralize partial-run for defaultTestSuite-resolved selection

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -131,3 +131,31 @@ subset data. Re-run the full suite to refresh.
 Paratest workers (`TEST_TOKEN` set) are unaffected — they always write
 their sidecar so the merge CLI can aggregate. The persistent-write skip
 only fires on the sequential (or merge) rendering path.
+
+### `defaultTestSuite` と partial 判定の opt-in 解除
+
+`phpunit.xml` で `defaultTestSuite` を宣言しているプロジェクトでは、引数なしの
+`phpunit` 実行でも PHPUnit が `Configuration::includeTestSuites()` にその名前を
+詰める。結果として、ユーザーから見れば "canonical full run" のはずの実行が
+`--testsuite` 由来の partial と判定され、`strict_required` ゲート等が
+スキップされる (issue #236)。
+
+これがユーザー側のワークフローに合致しているなら、`default_testsuite_as_full`
+を立てて partial 判定を解除できる:
+
+```xml
+<bootstrap class="Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension">
+    <parameter name="default_testsuite_as_full" value="true"/>
+    <parameter name="strict_required" value="warn"/>
+</bootstrap>
+```
+
+挙動:
+
+- `includeTestSuites` が `[defaultTestSuite]` と完全一致するときだけ
+  `--testsuite` 由来の partial signal を打ち消す。`--testsuite=Other` のように
+  default を越える選択をした場合や、他の partial signal (`--filter`, path 引数, …)
+  が立っている場合は引き続き partial。
+- 副作用として `output_file` / `junit_output` 等の persistent 書き込みも実行される。
+  defaultTestSuite に含まれないテストスイート (例: 別 job で動かす Integration suite)
+  が抜けた状態のレポートが書かれる点を許容できる場合のみ有効化する。

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -132,7 +132,7 @@ Paratest workers (`TEST_TOKEN` set) are unaffected — they always write
 their sidecar so the merge CLI can aggregate. The persistent-write skip
 only fires on the sequential (or merge) rendering path.
 
-### `defaultTestSuite` と partial 判定の opt-in 解除
+### default_testsuite_as_full opt-in
 
 `phpunit.xml` で `defaultTestSuite` を宣言しているプロジェクトでは、引数なしの
 `phpunit` 実行でも PHPUnit が `Configuration::includeTestSuites()` にその名前を
@@ -159,3 +159,8 @@ only fires on the sequential (or merge) rendering path.
 - 副作用として `output_file` / `junit_output` 等の persistent 書き込みも実行される。
   defaultTestSuite に含まれないテストスイート (例: 別 job で動かす Integration suite)
   が抜けた状態のレポートが書かれる点を許容できる場合のみ有効化する。
+- 設定ミス検知: `default_testsuite_as_full=true` だが `defaultTestSuite` 属性が
+  未設定 (`<phpunit defaultTestSuite="...">` 不在) や空文字 (`defaultTestSuite=""`)
+  の場合、opt-in が黙って no-op になるのを避けるため bootstrap で stderr に
+  WARNING を出す (FATAL ではない — 設計上 opt-in を立てたまま XML を直さなくても
+  実行可能なため)。

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -57,6 +57,7 @@ Add the coverage extension to your `phpunit.xml`:
 | `html_output` | No | — | File path to write self-contained HTML coverage report (PR comments, CI artifact preview, offline review). See [`coverage-html-output.md`](coverage-html-output.md) |
 | `console_output` | No | `default` | Console output mode: `default`, `all`, `uncovered_only`, or `active_only` (overridden by `OPENAPI_CONSOLE_OUTPUT` env var) |
 | `sidecar_dir` | No | `sys_get_temp_dir()/openapi-coverage-sidecars` | Directory paratest workers drop per-worker JSON sidecars into. Used only under parallel test runners — see [Parallel test runners](parallel.md) |
+| `default_testsuite_as_full` | No | `false` | Opt-in. When `true` and PHPUnit's `includeTestSuites` resolves exactly to the configured `defaultTestSuite`, treat the run as full instead of partial (so `strict_required` and coverage outputs aren't suppressed). See [Partial test runs](ci.md#partial-test-runs-filter-testsuite-path-args-) for trade-offs |
 
 *Not required if you call `OpenApiSpecLoader::configure()` manually.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -57,7 +57,7 @@ Add the coverage extension to your `phpunit.xml`:
 | `html_output` | No | — | File path to write self-contained HTML coverage report (PR comments, CI artifact preview, offline review). See [`coverage-html-output.md`](coverage-html-output.md) |
 | `console_output` | No | `default` | Console output mode: `default`, `all`, `uncovered_only`, or `active_only` (overridden by `OPENAPI_CONSOLE_OUTPUT` env var) |
 | `sidecar_dir` | No | `sys_get_temp_dir()/openapi-coverage-sidecars` | Directory paratest workers drop per-worker JSON sidecars into. Used only under parallel test runners — see [Parallel test runners](parallel.md) |
-| `default_testsuite_as_full` | No | `false` | Opt-in. When `true` and PHPUnit's `includeTestSuites` resolves exactly to the configured `defaultTestSuite`, treat the run as full instead of partial (so `strict_required` and coverage outputs aren't suppressed). See [Partial test runs](ci.md#partial-test-runs-filter-testsuite-path-args-) for trade-offs |
+| `default_testsuite_as_full` | No | `false` | Opt-in. When `true` and PHPUnit's `includeTestSuites` resolves exactly to the configured `defaultTestSuite`, treat the run as full instead of partial (so `strict_required` and coverage outputs aren't suppressed). See [default_testsuite_as_full opt-in](ci.md#default_testsuite_as_full-opt-in) for trade-offs |
 
 *Not required if you call `OpenApiSpecLoader::configure()` manually.
 

--- a/docs/strict-required.md
+++ b/docs/strict-required.md
@@ -226,6 +226,16 @@ The diagnostic block is rendered after the coverage report (Markdown, JUnit, JSO
 
 **Per-call mode is worker-local.** `strict_required_per_call=warn` fires `E_USER_WARNING` inside the worker process. PHPUnit's `failOnWarning="true"` converts those warnings into per-worker test failures, which paratest aggregates into its own non-zero exit code — the gate works correctly under paratest. The `strict_required_per_call` parameter is **not** consumed by the merge CLI; there is no `--strict-required-per-call` flag because the per-call decision is made entirely inside the worker. NOTEs (see [Per-call silent paths](#per-call-silent-paths-and-note-channel)) are also per-worker, so the same condition may produce multiple NOTEs across a paratest run.
 
+## Partial-run skipping
+
+`strict_required` の intersection は "全 suite が走った結果" を前提とする。`--filter` / `--testsuite` / 位置引数等で部分実行されたときは、誤検知 (broader suite では時々欠ける key を "always present" と扱う) を避けるためゲートをスキップし、stderr に NOTE を 1 行出すだけにしている (issue #221 / #225)。
+
+```text
+[OpenAPI Strict Required] NOTE: strict_required is skipped on partial runs (--filter / --testsuite / etc.) ...
+```
+
+`phpunit.xml` で `defaultTestSuite` を宣言しているプロジェクトでは引数なしの `phpunit` 実行でも partial 判定が立つため、このゲートが常にスキップされて到達不能になる場合がある。`default_testsuite_as_full` opt-in でこの挙動を解除できる — トレードオフを含めて [`ci.md` の Partial test runs 節](ci.md#defaulttestsuite-と-partial-判定の-opt-in-解除) を参照。
+
 ## Known limitations
 
 - **Mixed sidecar versions.** Workers running an older library version write a v1 (coverage-only) sidecar. The merge CLI still accepts those and merges their coverage, but their strict_required contribution is empty. Upgrade all workers to share the gate fully.

--- a/docs/strict-required.md
+++ b/docs/strict-required.md
@@ -234,7 +234,7 @@ The diagnostic block is rendered after the coverage report (Markdown, JUnit, JSO
 [OpenAPI Strict Required] NOTE: strict_required is skipped on partial runs (--filter / --testsuite / etc.) ...
 ```
 
-`phpunit.xml` で `defaultTestSuite` を宣言しているプロジェクトでは引数なしの `phpunit` 実行でも partial 判定が立つため、このゲートが常にスキップされて到達不能になる場合がある。`default_testsuite_as_full` opt-in でこの挙動を解除できる — トレードオフを含めて [`ci.md` の Partial test runs 節](ci.md#defaulttestsuite-と-partial-判定の-opt-in-解除) を参照。
+`phpunit.xml` で `defaultTestSuite` を宣言しているプロジェクトでは引数なしの `phpunit` 実行でも partial 判定が立つため、このゲートが常にスキップされて到達不能になる場合がある。`default_testsuite_as_full` opt-in でこの挙動を解除できる — トレードオフを含めて [`default_testsuite_as_full` opt-in](ci.md#default_testsuite_as_full-opt-in) 節を参照。
 
 ## Known limitations
 

--- a/src/Internal/PartialRunDecision.php
+++ b/src/Internal/PartialRunDecision.php
@@ -62,6 +62,16 @@ final readonly class PartialRunDecision
      * `null` / non-null — there is no separate `isPartial` flag,
      * so by construction "partial" and "has reason" are the same fact.
      *
+     * Issue #236: `$defaultTestSuite` + `$treatDefaultTestSuiteAsFull` let
+     * callers opt the `--testsuite` signal out when `$includeTestSuites`
+     * was filled by PHPUnit's `defaultTestSuite` xml attribute rather
+     * than a CLI selection — e.g. `phpunit` with no args resolves to
+     * `[defaultTestSuite()]`, which the user considers the canonical
+     * full run. The override is scoped to the `--testsuite` reason only;
+     * every other signal (`--filter`, path args, `--group`, …) keeps
+     * its partial verdict so the escape hatch can't silently relax
+     * unrelated selections. Default `false` preserves pre-#236 behavior.
+     *
      * @param list<non-empty-string> $includeTestSuites
      * @param list<non-empty-string> $excludeTestSuites
      */
@@ -76,6 +86,8 @@ final readonly class PartialRunDecision
         bool $hasTestsCovering,
         bool $hasTestsUsing,
         bool $hasTestsRequiringPhpExtension,
+        ?string $defaultTestSuite = null,
+        bool $treatDefaultTestSuiteAsFull = false,
     ): ?self {
         // Reason fragments emitted in declaration order so output is
         // stable across runs and tests can rely on substring assertions
@@ -98,7 +110,12 @@ final readonly class PartialRunDecision
             $reasons[] = '--exclude-group';
         }
         if ($includeTestSuites !== []) {
-            $reasons[] = '--testsuite';
+            $matchesDefault = $treatDefaultTestSuiteAsFull &&
+                $defaultTestSuite !== null &&
+                $includeTestSuites === [$defaultTestSuite];
+            if (!$matchesDefault) {
+                $reasons[] = '--testsuite';
+            }
         }
         if ($excludeTestSuites !== []) {
             $reasons[] = '--exclude-testsuite';

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -145,7 +145,7 @@ final class OpenApiCoverageExtension implements Extension
                 $facade,
                 $parameters,
                 getenv('GITHUB_STEP_SUMMARY') ?: null,
-                self::detectPartialRun($configuration),
+                self::detectPartialRun($configuration, $parameters),
             );
         } catch (EnumBindingException|EnumDriftException|InvalidCoverageOutputPathException|InvalidOpenApiSpecException|InvalidStrictRequiredConfigurationException|InvalidThresholdConfigurationException|SpecFileNotFoundException) {
             // setupExtension() has already written a FATAL line to stderr and
@@ -337,9 +337,18 @@ final class OpenApiCoverageExtension implements Extension
      * writes on partial runs. The signal set, rationale, and why the
      * `TestSuite\Filtered` event is not used are documented on
      * {@see PartialRunDecision} — keeping that explanation in one place.
+     *
+     * Issue #236: the `default_testsuite_as_full` xml parameter is forwarded
+     * here together with `Configuration::defaultTestSuite()` so the
+     * `defaultTestSuite`-resolved `includeTestSuites` payload can be treated
+     * as a canonical full run when the user opts in.
      */
-    private static function detectPartialRun(Configuration $configuration): ?PartialRunDecision
-    {
+    private static function detectPartialRun(
+        Configuration $configuration,
+        ParameterCollection $parameters,
+    ): ?PartialRunDecision {
+        $treatDefaultAsFull = self::resolveBooleanFlag($parameters, 'default_testsuite_as_full', false);
+
         return PartialRunDecision::fromSignals(
             hasCliArguments: $configuration->hasCliArguments(),
             hasFilter: $configuration->hasFilter(),
@@ -351,7 +360,30 @@ final class OpenApiCoverageExtension implements Extension
             hasTestsCovering: $configuration->hasTestsCovering(),
             hasTestsUsing: $configuration->hasTestsUsing(),
             hasTestsRequiringPhpExtension: $configuration->hasTestsRequiringPhpExtension(),
+            defaultTestSuite: self::readDefaultTestSuite($configuration),
+            treatDefaultTestSuiteAsFull: $treatDefaultAsFull,
         );
+    }
+
+    /**
+     * Read the `defaultTestSuite` xml attribute via PHPUnit's
+     * {@see Configuration} accessors. Both `hasDefaultTestSuite()` and
+     * `defaultTestSuite()` exist on PHPUnit 11/12/13, so a direct call is
+     * safe across the CI matrix (unlike {@see readTestSuiteList()}, which
+     * needs the dynamic dispatch because PHPUnit 13 dropped the singular
+     * `includeTestSuite()` accessor). The `hasDefaultTestSuite()` guard is
+     * mandatory: `defaultTestSuite()` throws `NoDefaultTestSuiteException`
+     * when the xml attribute is absent.
+     */
+    private static function readDefaultTestSuite(Configuration $configuration): ?string
+    {
+        if (!$configuration->hasDefaultTestSuite()) {
+            return null;
+        }
+
+        $value = $configuration->defaultTestSuite();
+
+        return $value !== '' ? $value : null;
     }
 
     /**

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -360,7 +360,7 @@ final class OpenApiCoverageExtension implements Extension
             hasTestsCovering: $configuration->hasTestsCovering(),
             hasTestsUsing: $configuration->hasTestsUsing(),
             hasTestsRequiringPhpExtension: $configuration->hasTestsRequiringPhpExtension(),
-            defaultTestSuite: self::readDefaultTestSuite($configuration),
+            defaultTestSuite: self::readDefaultTestSuite($configuration, warnOnInertOptIn: $treatDefaultAsFull),
             treatDefaultTestSuiteAsFull: $treatDefaultAsFull,
         );
     }
@@ -374,16 +374,46 @@ final class OpenApiCoverageExtension implements Extension
      * `includeTestSuite()` accessor). The `hasDefaultTestSuite()` guard is
      * mandatory: `defaultTestSuite()` throws `NoDefaultTestSuiteException`
      * when the xml attribute is absent.
+     *
+     * `$warnOnInertOptIn` surfaces the two misconfigurations that make
+     * `default_testsuite_as_full=true` a silent no-op: (1) the user opted
+     * in but never set `<phpunit defaultTestSuite="...">`, and (2) the
+     * attribute is present but empty. The WARN is gated on the opt-in
+     * itself so it never fires for callers that did not request the
+     * neutralisation (the same path the rest of the extension uses).
      */
-    private static function readDefaultTestSuite(Configuration $configuration): ?string
-    {
+    private static function readDefaultTestSuite(
+        Configuration $configuration,
+        bool $warnOnInertOptIn,
+    ): ?string {
         if (!$configuration->hasDefaultTestSuite()) {
+            if ($warnOnInertOptIn) {
+                self::writeStderr(
+                    '[OpenAPI Coverage] WARNING: default_testsuite_as_full=true but phpunit.xml does not declare '
+                    . 'a `defaultTestSuite` attribute on <phpunit>. The opt-in will be inert; partial-run '
+                    . 'detection remains active. Either set `defaultTestSuite="..."` on <phpunit> or remove '
+                    . "`default_testsuite_as_full`.\n",
+                );
+            }
+
             return null;
         }
 
         $value = $configuration->defaultTestSuite();
 
-        return $value !== '' ? $value : null;
+        if ($value === '') {
+            if ($warnOnInertOptIn) {
+                self::writeStderr(
+                    '[OpenAPI Coverage] WARNING: default_testsuite_as_full=true but phpunit.xml declares an '
+                    . 'empty `defaultTestSuite=""` attribute. The opt-in cannot match an empty default and '
+                    . "will be inert. Set a non-empty `defaultTestSuite` or remove `default_testsuite_as_full`.\n",
+                );
+            }
+
+            return null;
+        }
+
+        return $value;
     }
 
     /**

--- a/tests/Integration/OpenApiCoverageExtensionBootstrapTest.php
+++ b/tests/Integration/OpenApiCoverageExtensionBootstrapTest.php
@@ -74,6 +74,82 @@ class OpenApiCoverageExtensionBootstrapTest extends TestCase
         $this->assertStringContainsString('Action:', $stderr);
     }
 
+    #[Test]
+    public function default_testsuite_as_full_warns_when_no_default_configured(): void
+    {
+        // Issue #236: opting in without declaring `defaultTestSuite` makes
+        // the flag silently inert otherwise — the partial detection still
+        // suppresses `strict_required` and coverage outputs, and the user
+        // can't tell why their gate isn't firing. Bootstrap must surface
+        // the misconfiguration. This also pins the configuration→bootstrap
+        // wiring: the WARN only fires if `default_testsuite_as_full=true`
+        // is read off the ParameterCollection AND `hasDefaultTestSuite()`
+        // is consulted on the Configuration in the same path.
+        $output = $this->runPhpunitWithDefaultTestSuite(
+            defaultTestSuite: null,
+            optInValue: 'true',
+            outputFile: null,
+        );
+
+        $this->assertStringContainsString('default_testsuite_as_full=true', $output);
+        $this->assertStringContainsString('does not declare', $output);
+    }
+
+    #[Test]
+    public function default_testsuite_as_full_warns_when_default_is_empty_string(): void
+    {
+        // `<phpunit defaultTestSuite="">` is valid XML but makes the
+        // opt-in inert (no possible match). Same WARN policy as above.
+        // Verifies the empty-string branch of `readDefaultTestSuite()`
+        // end-to-end (the unit branch is exercised through `fromSignals`'s
+        // `defaultTestSuite: null` parameterisation; this is the only place
+        // the extension's empty-string normalisation is observable).
+        $output = $this->runPhpunitWithDefaultTestSuite(
+            defaultTestSuite: '',
+            optInValue: 'true',
+            outputFile: null,
+        );
+
+        $this->assertStringContainsString('default_testsuite_as_full=true', $output);
+        $this->assertStringContainsString('empty', $output);
+    }
+
+    #[Test]
+    public function default_testsuite_as_full_does_not_warn_for_matching_default_testsuite(): void
+    {
+        // Positive case: opt-in + matching defaultTestSuite is a valid
+        // configuration and must not emit either of the inert-WARN lines.
+        // Pins that the WARN paths are gated on the misconfiguration, not
+        // on the opt-in itself. The subscriber's persistent-write WARN
+        // ("Skipping output_file ...") is exercised by
+        // `CoverageReportSubscriberPartialRunTest`; reaching it from
+        // bootstrap requires the test to actually record coverage, which
+        // is out of scope for this integration check.
+        $output = $this->runPhpunitWithDefaultTestSuite(
+            defaultTestSuite: 'Unit',
+            optInValue: 'true',
+            outputFile: null,
+        );
+
+        $this->assertStringNotContainsString('default_testsuite_as_full=true but', $output);
+    }
+
+    #[Test]
+    public function default_testsuite_as_full_warn_does_not_fire_when_opt_in_is_absent(): void
+    {
+        // Negative case: when the user hasn't opted in, the WARN paths
+        // must stay silent even if the rest of the configuration would
+        // otherwise trip them (here: matching defaultTestSuite, but no
+        // opt-in). Pins that the warn gate is bound to the opt-in.
+        $output = $this->runPhpunitWithDefaultTestSuite(
+            defaultTestSuite: 'Unit',
+            optInValue: null,
+            outputFile: null,
+        );
+
+        $this->assertStringNotContainsString('default_testsuite_as_full=true', $output);
+    }
+
     /**
      * @return array{0: int, 1: string} [exit code, combined stderr]
      */
@@ -128,5 +204,84 @@ class OpenApiCoverageExtensionBootstrapTest extends TestCase
         // Both streams may carry the FATAL/WARNING line depending on where
         // PHP flushes; the caller only cares about the combined text.
         return [$exit, $stdout . $stderr];
+    }
+
+    /**
+     * Run a subprocess phpunit with a custom `defaultTestSuite` attribute
+     * and (optionally) the `default_testsuite_as_full` opt-in. Targets
+     * `tests/Unit/Internal/PartialRunDecisionTest.php` only so the
+     * subscriber's `ExecutionFinished` hook fires (a `--filter` to no
+     * matches would early-exit before that) while keeping the run cheap.
+     * The testsuite name `Unit` matches the `defaultTestSuite` attribute
+     * we set on the synthetic `<phpunit>`, which is the contract we want
+     * to pin.
+     */
+    private function runPhpunitWithDefaultTestSuite(
+        ?string $defaultTestSuite,
+        ?string $optInValue,
+        ?string $outputFile,
+    ): string {
+        $defaultAttr = $defaultTestSuite === null
+            ? ''
+            : sprintf(' defaultTestSuite="%s"', $defaultTestSuite);
+
+        $optInParam = $optInValue === null
+            ? ''
+            : sprintf('<parameter name="default_testsuite_as_full" value="%s"/>', $optInValue);
+
+        $outputFileParam = $outputFile === null
+            ? ''
+            : sprintf('<parameter name="output_file" value="%s"/>', $outputFile);
+
+        $xml = sprintf(
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            . '<phpunit bootstrap="%s/vendor/autoload.php" cacheDirectory="%s/.phpunit.cache" '
+            . 'colors="false" failOnEmptyTestSuite="false"%s>'
+            . '<testsuites><testsuite name="Unit"><file>%s/tests/Unit/Internal/PartialRunDecisionTest.php</file></testsuite></testsuites>'
+            . '<extensions><bootstrap class="Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension">'
+            . '<parameter name="spec_base_path" value="%s/tests/fixtures/specs"/>'
+            . '<parameter name="specs" value="composition"/>'
+            . '%s%s'
+            . '</bootstrap></extensions>'
+            . '</phpunit>',
+            $this->repoRoot,
+            $this->repoRoot,
+            $defaultAttr,
+            $this->repoRoot,
+            $this->repoRoot,
+            $optInParam,
+            $outputFileParam,
+        );
+
+        $tmp = tempnam(sys_get_temp_dir(), 'openapi-ext-integration-') ?: null;
+        if ($tmp === null) {
+            $this->fail('Could not create temp phpunit config');
+        }
+        $this->configPath = $tmp;
+        file_put_contents($tmp, $xml);
+
+        $cmd = sprintf(
+            '%s/vendor/bin/phpunit -c %s',
+            escapeshellarg($this->repoRoot),
+            escapeshellarg($tmp),
+        );
+
+        $descriptors = [
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+        $process = proc_open($cmd, $descriptors, $pipes, $this->repoRoot);
+        if (!is_resource($process)) {
+            $this->fail('Could not spawn phpunit subprocess');
+        }
+
+        $stdout = (string) stream_get_contents($pipes[1]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        foreach ($pipes as $pipe) {
+            fclose($pipe);
+        }
+        proc_close($process);
+
+        return $stdout . $stderr;
     }
 }

--- a/tests/Unit/Internal/PartialRunDecisionTest.php
+++ b/tests/Unit/Internal/PartialRunDecisionTest.php
@@ -138,4 +138,121 @@ final class PartialRunDecisionTest extends TestCase
 
         $this->assertSame('--filter', $decision->reason);
     }
+
+    #[Test]
+    public function default_testsuite_match_neutralises_testsuite_signal_when_opted_in(): void
+    {
+        // Issue #236: `defaultTestSuite` 経由で includeTestSuites が埋まったケースは,
+        // ユーザーが opt-in したときだけ "canonical full run" として扱う。
+        $decision = PartialRunDecision::fromSignals(
+            hasCliArguments: false,
+            hasFilter: false,
+            hasExcludeFilter: false,
+            hasGroups: false,
+            hasExcludeGroups: false,
+            includeTestSuites: ['ApplicationTest'],
+            excludeTestSuites: [],
+            hasTestsCovering: false,
+            hasTestsUsing: false,
+            hasTestsRequiringPhpExtension: false,
+            defaultTestSuite: 'ApplicationTest',
+            treatDefaultTestSuiteAsFull: true,
+        );
+
+        $this->assertNull($decision);
+    }
+
+    #[Test]
+    public function default_testsuite_opt_in_does_not_match_when_extra_suites_selected(): void
+    {
+        // CLI で `--testsuite=ApplicationTest,Other` のように defaultTestSuite を越えた
+        // 選択を渡したケースは, opt-in 中でも partial のまま扱う (canonical run の範囲を逸脱)。
+        $decision = PartialRunDecision::fromSignals(
+            hasCliArguments: false,
+            hasFilter: false,
+            hasExcludeFilter: false,
+            hasGroups: false,
+            hasExcludeGroups: false,
+            includeTestSuites: ['ApplicationTest', 'StripeIntegration'],
+            excludeTestSuites: [],
+            hasTestsCovering: false,
+            hasTestsUsing: false,
+            hasTestsRequiringPhpExtension: false,
+            defaultTestSuite: 'ApplicationTest',
+            treatDefaultTestSuiteAsFull: true,
+        );
+
+        $this->assertNotNull($decision);
+        $this->assertStringContainsString('--testsuite', $decision->reason);
+    }
+
+    #[Test]
+    public function default_testsuite_opt_in_is_inert_without_configured_default(): void
+    {
+        // phpunit.xml で defaultTestSuite が未設定なら flag を立てても意味を持たない。
+        $decision = PartialRunDecision::fromSignals(
+            hasCliArguments: false,
+            hasFilter: false,
+            hasExcludeFilter: false,
+            hasGroups: false,
+            hasExcludeGroups: false,
+            includeTestSuites: ['ApplicationTest'],
+            excludeTestSuites: [],
+            hasTestsCovering: false,
+            hasTestsUsing: false,
+            hasTestsRequiringPhpExtension: false,
+            defaultTestSuite: null,
+            treatDefaultTestSuiteAsFull: true,
+        );
+
+        $this->assertNotNull($decision);
+        $this->assertStringContainsString('--testsuite', $decision->reason);
+    }
+
+    #[Test]
+    public function default_testsuite_match_does_not_neutralise_when_opt_out(): void
+    {
+        // 既定 (flag=false) では既存挙動を維持: defaultTestSuite 経由でも partial。
+        $decision = PartialRunDecision::fromSignals(
+            hasCliArguments: false,
+            hasFilter: false,
+            hasExcludeFilter: false,
+            hasGroups: false,
+            hasExcludeGroups: false,
+            includeTestSuites: ['ApplicationTest'],
+            excludeTestSuites: [],
+            hasTestsCovering: false,
+            hasTestsUsing: false,
+            hasTestsRequiringPhpExtension: false,
+            defaultTestSuite: 'ApplicationTest',
+            treatDefaultTestSuiteAsFull: false,
+        );
+
+        $this->assertNotNull($decision);
+        $this->assertStringContainsString('--testsuite', $decision->reason);
+    }
+
+    #[Test]
+    public function default_testsuite_opt_in_only_neutralises_testsuite_signal(): void
+    {
+        // flag が無効化するのは `--testsuite` reason だけ。他の partial signal は素通り。
+        $decision = PartialRunDecision::fromSignals(
+            hasCliArguments: false,
+            hasFilter: true,
+            hasExcludeFilter: false,
+            hasGroups: false,
+            hasExcludeGroups: false,
+            includeTestSuites: ['ApplicationTest'],
+            excludeTestSuites: [],
+            hasTestsCovering: false,
+            hasTestsUsing: false,
+            hasTestsRequiringPhpExtension: false,
+            defaultTestSuite: 'ApplicationTest',
+            treatDefaultTestSuiteAsFull: true,
+        );
+
+        $this->assertNotNull($decision);
+        $this->assertStringContainsString('--filter', $decision->reason);
+        $this->assertStringNotContainsString('--testsuite', $decision->reason);
+    }
 }


### PR DESCRIPTION
## Summary

`OpenApiCoverageExtension` に opt-in パラメータ `default_testsuite_as_full` を追加。`true` かつ `Configuration::includeTestSuites()` が `Configuration::defaultTestSuite()` と完全一致するときだけ `--testsuite` 由来の partial 判定を解除し、`strict_required` ゲート等が defaultTestSuite ベースの canonical full run でも到達可能になるようにする。

## Why

`phpunit.xml` に `defaultTestSuite` を宣言しているプロジェクトでは、引数なしの `phpunit` 実行でも PHPUnit が `Configuration::includeTestSuites()` にその名前を埋める。結果として #221 の partial 判定が常に立ち、`strict_required` ゲート (#225) はユーザーの default workflow からは決して評価されない (常に `[OpenAPI Strict Required] NOTE: skipped on partial runs ...` のみ)。

複数 suite を切っているプロジェクト (`make test` で Stripe 統合だけ別 job に分離する等) は `defaultTestSuite` を外せず、phpunit-override 等の二重 config を強いられる状況だった。

#236 で議論した 3 案のうち短期推奨の opt-in パラメータ案 (A) を採用。`--testsuite` signal のみを打ち消す scoped escape hatch にすることで、`--filter` / path args 等の他 partial signal は引き続き保護する。

Fixes #236

## Verification

- 失敗テストを先に追加 (`tests/Unit/Internal/PartialRunDecisionTest.php` の新規 5 ケース) し、`PartialRunDecision::fromSignals` / `OpenApiCoverageExtension::detectPartialRun` を実装して green に。
- `composer ci` (PHPUnit 1715 / 4029 assertions + PHPStan level 6 + PHP-CS-Fixer dry) すべて pass。
- 手元の studio-api 構成での再現は本 PR では未実施 (本リポジトリの単体テストに反映済み)。Reviewer 側で必要なら issue #236 の再現プロジェクトで `default_testsuite_as_full=true` を設定し、`[OpenAPI Strict Required] NOTE: skipped on partial runs` が出なくなることを確認できます。

- [x] `composer test` passes
- [x] `composer stan` passes
- [x] `composer cs-check` passes

## Notes for reviewers

- `PartialRunDecision::fromSignals` は internal クラスなので、optional 引数 2 つの追加は SemVer 上問題なし (UPGRADING.md の Frozen に該当しない)。既存呼び出しは引数の名前付きで指定されているため、追加位置 (末尾) で破壊しないことを確認済み。
- `default_testsuite_as_full=true` を立てると output_file 等の persistent 書き込みも実行される。defaultTestSuite に含まれない suite (例: 別 job で動かす Integration suite) が抜けた状態のレポートが書かれる点はユーザー側のトレードオフ。`docs/ci.md` の新節と `docs/strict-required.md` の Partial-run skipping 節に明記。
- issue #236 の中期案 (C: PartialRunDecision を output-persistence と gate で 2 系統に分離) は本 PR の範囲外。需要があれば follow-up issue を起票。
- `Configuration::hasDefaultTestSuite()` / `defaultTestSuite()` は PHPUnit 11/12/13 すべてに存在するため `readTestSuiteList()` のような dynamic dispatch は不要。`hasDefaultTestSuite()` の guard は `NoDefaultTestSuiteException` の throw を避けるために必須。