### PR TITLE
chore: remove discussions link from issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Question
-    url: https://github.com/studio-design/openapi-contract-testing/discussions/new?category=q-a
-    about: Use Discussions for usage questions and design conversations.
   - name: Security report
     url: https://github.com/studio-design/openapi-contract-testing/security/advisories/new
     about: Report a security vulnerability privately. See SECURITY.md.


### PR DESCRIPTION
## Summary

Remove the `Question → Discussions` contact link from `.github/ISSUE_TEMPLATE/config.yml` so the issue creation page no longer routes users to a Discussions tab that is being disabled at the repo level.

## Why

The project currently has 1 GitHub Star, 557 monthly Packagist downloads, and no organic Q&A traffic. An empty Discussions tab projects a "ghost town" signal that hurts more than it helps, and splits maintainer attention between two channels. The existing `question` label on issues already covers the Q&A use case at this scale.

Discussions will be re-enabled if organic Q&A volume picks up (rule of thumb: ~30+ Q&A items per month, or recurring "is this a bug or expected" patterns).

## Verification

- [x] `composer ci` not run — config.yml is consumed by GitHub UI only.
- [x] The remaining `Security report` contact link continues to route to the private advisory form.

## Notes for reviewers

The repo-level `Discussions` feature will be disabled out-of-band after this PR merges. The order matters: link removed first, feature off second, so users who hit the link in the window between never see a 404.