### PR TITLE
feat(schema): warn when dependentSchemas / dependentRequired is encountered

### DIFF
--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -65,6 +65,7 @@ Detection looks at each property schema's own top-level `readOnly` / `writeOnly`
 - **Stripped**: `discriminator` (including `mapping`), `xml`, `externalDocs`, `example` / `examples`, `deprecated`, OAS-only `nullable`/`readOnly`/`writeOnly` after enforcement (3.0), and Draft 2020-12 keys `$dynamicRef` / `$dynamicAnchor` / `contentSchema` (3.1).
 - **Validated via opis (Draft 06+)**: `patternProperties`, `contentMediaType`, `contentEncoding`. These are JSON Schema keywords that opis implements natively, so your constraints are enforced.
 - **Not supported (loud E_USER_WARNING when first encountered)**: `unevaluatedProperties`, `unevaluatedItems`. These are 2019-09 keywords with no Draft 07 equivalent — opis silently ignores them, so the warning surfaces specs that depend on them. Rewrite using `additionalProperties: false` plus explicit `properties` to enforce object closure.
+- **Advisory-only (loud E_USER_WARNING when first encountered)**: `dependentSchemas`, `dependentRequired`. These 2019-09 property-dependency keywords are not registered by opis Draft 07, so the constraint is dropped wholesale — a payload carrying the trigger property without its dependents passes silently. Rewrite as a Draft 07 conditional with `if` / `then` / `else` (the `if` clause tests for the trigger property, the `then` clause carries the dependent requirement).
 - **`discriminator`**: the keyword is dropped; the underlying `oneOf` / `anyOf` is still validated as a union, but `discriminator.mapping` does not steer validation toward a single branch. When `mapping` is non-empty the converter emits a one-shot `E_USER_WARNING` so polymorphic specs with serialiser bugs surface as a loud signal rather than silently passing through any valid branch.
 - **`readOnly` / `writeOnly`**: enforced at the property's own top level only (see [readOnly / writeOnly enforcement](#readonly--writeonly-enforcement)).
 
@@ -81,7 +82,7 @@ The library uses PHP's native `trigger_error(..., E_USER_WARNING)` as the loud-s
 | Category prefix | Source | Dedup key |
 |---|---|---|
 | `[security]` | `SecurityValidator` (`oauth2`, `openIdConnect`, `mutualTLS`, `http-basic`, `http-digest`) | scheme name |
-| `[OpenAPI Schema]` | `OpenApiSchemaConverter` (`unevaluatedProperties` / `unevaluatedItems`, `discriminator.mapping`, unknown / malformed `format`) | per-keyword / per-format-value |
+| `[OpenAPI Schema]` | `OpenApiSchemaConverter` (`unevaluatedProperties` / `unevaluatedItems`, `dependentSchemas` / `dependentRequired`, `discriminator.mapping`, unknown / malformed `format`) | per-keyword / per-format-value |
 
 **How to consume:**
 

--- a/src/Spec/OpenApiSchemaConverter.php
+++ b/src/Spec/OpenApiSchemaConverter.php
@@ -188,6 +188,7 @@ final class OpenApiSchemaConverter
         // emit. `format` is not in OPENAPI_COMMON_KEYS so its order is
         // independent.
         self::warnIfDiscriminatorMappingPresent($schema);
+        self::warnIfDependentKeywordsPresent($schema);
         self::warnIfUnknownFormat($schema);
 
         self::removeKeys($schema, self::OPENAPI_COMMON_KEYS);
@@ -494,6 +495,44 @@ final class OpenApiSchemaConverter
             "[OpenAPI Schema] 'discriminator.mapping' is silently stripped — the underlying oneOf/anyOf is still validated as a plain union, but the mapping does not steer validation toward a single branch. A body with the wrong discriminator value passes as long as it satisfies any branch, masking serialiser bugs. See README \"Schema features\" for the full limitation note.",
             E_USER_WARNING,
         );
+    }
+
+    /**
+     * Issue a one-shot E_USER_WARNING when a schema declares the 2019-09
+     * keywords `dependentSchemas` or `dependentRequired`. opis Draft 07 does
+     * not register either keyword (they are introduced in Draft 2019-09 —
+     * see vendor/opis/json-schema/src/Parsers/Drafts/Draft201909.php), so
+     * the property-dependency constraint is dropped wholesale: a payload
+     * carrying the trigger property without its dependents passes silently.
+     *
+     * The converter still recurses into `dependentSchemas` value subschemas
+     * for keyword hygiene (#214), but that does not restore the outer
+     * keyword's intended validation — hence this separate observability
+     * warning. The Draft 07 equivalent (`if` / `then` / `else`) differs from
+     * the `additionalProperties` / `required` advice in
+     * {@see warnIfUsesUnsupportedKeywords()}, so the copy lives here rather
+     * than folding these keywords into `DRAFT_2020_12_UNSUPPORTED_KEYS`.
+     *
+     * Warns once per keyword per process; dedup shares `$warnedKeywords`.
+     *
+     * @param array<string, mixed> $schema
+     */
+    private static function warnIfDependentKeywordsPresent(array $schema): void
+    {
+        foreach (['dependentSchemas', 'dependentRequired'] as $keyword) {
+            if (!array_key_exists($keyword, $schema) || isset(self::$warnedKeywords[$keyword])) {
+                continue;
+            }
+
+            self::$warnedKeywords[$keyword] = true;
+            trigger_error(
+                sprintf(
+                    "[OpenAPI Schema] '%s' is a Draft 2019-09 keyword that the JSON Schema Draft 07 validator opis uses internally does not register. The keyword will be ignored — your spec's property-dependency constraint is NOT being enforced. Rewrite it as a Draft 07 conditional using if/then/else (the `if` clause tests for the trigger property, the `then` clause carries the dependent requirement).",
+                    $keyword,
+                ),
+                E_USER_WARNING,
+            );
+        }
     }
 
     /**

--- a/src/Spec/OpenApiSchemaConverter.php
+++ b/src/Spec/OpenApiSchemaConverter.php
@@ -505,13 +505,19 @@ final class OpenApiSchemaConverter
      * the property-dependency constraint is dropped wholesale: a payload
      * carrying the trigger property without its dependents passes silently.
      *
-     * The converter still recurses into `dependentSchemas` value subschemas
-     * for keyword hygiene (#214), but that does not restore the outer
-     * keyword's intended validation — hence this separate observability
+     * The converter still recurses into `dependentSchemas` map-shaped value
+     * subschemas for keyword hygiene (#214), but that does not restore the
+     * outer keyword's intended validation — hence this separate observability
      * warning. The Draft 07 equivalent (`if` / `then` / `else`) differs from
      * the `additionalProperties` / `required` advice in
      * {@see warnIfUsesUnsupportedKeywords()}, so the copy lives here rather
      * than folding these keywords into `DRAFT_2020_12_UNSUPPORTED_KEYS`.
+     *
+     * Called from `convertInPlace()`, so the warning fires for every schema
+     * node the converter recurses into. A keyword buried inside a position
+     * `convertInPlace()` deliberately does not visit — notably a list-shaped
+     * `dependentSchemas` value, itself a spec defect skipped at the recursion
+     * site — is not surfaced; that residual gap is defect-on-defect only.
      *
      * Warns once per keyword per process; dedup shares `$warnedKeywords`.
      *

--- a/tests/Unit/Spec/OpenApiSchemaConverterTest.php
+++ b/tests/Unit/Spec/OpenApiSchemaConverterTest.php
@@ -1216,6 +1216,99 @@ class OpenApiSchemaConverterTest extends TestCase
     }
 
     // ========================================
+    // dependentSchemas / dependentRequired silent-ignore warning (#216)
+    // opis Draft 07 does not register either 2019-09 keyword, so the
+    // property-dependency constraint is dropped wholesale and no error
+    // surfaces. The warning makes that silent bypass loud.
+    // ========================================
+
+    #[Test]
+    public function dependent_schemas_emits_warning(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => ['creditCard' => ['type' => 'string']],
+            'dependentSchemas' => [
+                'creditCard' => [
+                    'type' => 'object',
+                    'required' => ['cvv'],
+                ],
+            ],
+        ];
+
+        $warnings = $this->captureWarnings(static function () use ($schema): void {
+            OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+        });
+
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString('dependentSchemas', $warnings[0]);
+    }
+
+    #[Test]
+    public function dependent_required_emits_warning(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'creditCard' => ['type' => 'string'],
+                'cvv' => ['type' => 'string'],
+            ],
+            'dependentRequired' => ['creditCard' => ['cvv']],
+        ];
+
+        $warnings = $this->captureWarnings(static function () use ($schema): void {
+            OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+        });
+
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString('dependentRequired', $warnings[0]);
+    }
+
+    #[Test]
+    public function dependent_keywords_emit_warning_for_oas_3_0_too(): void
+    {
+        // Both keywords are 2019-09 but can appear in hand-rolled or
+        // generated 3.0 specs that mix dialects. The warning must run for
+        // both versions, mirroring the unevaluated* handling.
+        $schema = [
+            'type' => 'object',
+            'dependentRequired' => ['creditCard' => ['cvv']],
+        ];
+
+        $warnings = $this->captureWarnings(static function () use ($schema): void {
+            OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_0);
+        });
+
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString('dependentRequired', $warnings[0]);
+    }
+
+    #[Test]
+    public function dependent_keywords_warn_independently_and_point_to_if_then_else(): void
+    {
+        // Per-keyword dedup: a schema declaring both keywords at once must
+        // surface two distinct warnings, each pointing the user at the
+        // Draft 07 equivalent (if/then/else).
+        $schema = [
+            'type' => 'object',
+            'dependentSchemas' => [
+                'creditCard' => ['type' => 'object', 'required' => ['cvv']],
+            ],
+            'dependentRequired' => ['billingAddress' => ['country']],
+        ];
+
+        $warnings = $this->captureWarnings(static function () use ($schema): void {
+            OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+        });
+
+        $this->assertCount(2, $warnings);
+        $joined = implode("\n", $warnings);
+        $this->assertStringContainsString('dependentSchemas', $joined);
+        $this->assertStringContainsString('dependentRequired', $joined);
+        $this->assertStringContainsString('if/then/else', $joined);
+    }
+
+    // ========================================
     // discriminator.mapping silent-strip warning (#147)
     // ========================================
 
@@ -1857,7 +1950,12 @@ class OpenApiSchemaConverterTest extends TestCase
             ],
         ];
 
-        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+        // The outer `dependentSchemas` keyword triggers the #216 silent-ignore
+        // warning; this test is about inner-subschema lowering, so swallow it.
+        $result = null;
+        $this->captureWarnings(static function () use ($schema, &$result): void {
+            $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+        });
 
         $this->assertArrayNotHasKey(
             'const',
@@ -2124,7 +2222,11 @@ class OpenApiSchemaConverterTest extends TestCase
         ];
         $original = $schema;
 
-        OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+        // `dependentSchemas` triggers the #216 warning; this test asserts the
+        // input array is not mutated, so swallow the unrelated warning.
+        $this->captureWarnings(static function () use ($schema): void {
+            OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+        });
 
         $this->assertSame($original, $schema);
     }
@@ -2146,7 +2248,12 @@ class OpenApiSchemaConverterTest extends TestCase
             'dependentSchemas' => ['k' => true],
         ];
 
-        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+        // The `dependentSchemas` key triggers the #216 warning; this test is
+        // about boolean-subschema preservation, so swallow it.
+        $result = null;
+        $this->captureWarnings(static function () use ($schema, &$result): void {
+            $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+        });
 
         $this->assertSame($schema, $result);
     }
@@ -2166,7 +2273,12 @@ class OpenApiSchemaConverterTest extends TestCase
             ],
         ];
 
-        $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+        // The `dependentSchemas` key triggers the #216 warning; this test is
+        // about list-shaped-value skipping, so swallow it.
+        $result = null;
+        $this->captureWarnings(static function () use ($schema, &$result): void {
+            $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+        });
 
         $this->assertSame($schema, $result);
     }

--- a/tests/Unit/Spec/OpenApiSchemaConverterTest.php
+++ b/tests/Unit/Spec/OpenApiSchemaConverterTest.php
@@ -1308,6 +1308,76 @@ class OpenApiSchemaConverterTest extends TestCase
         $this->assertStringContainsString('if/then/else', $joined);
     }
 
+    #[Test]
+    public function dependent_keyword_warns_only_once_across_repeated_calls(): void
+    {
+        // Core "one-shot per keyword per process" contract: three convert()
+        // calls must still surface only one warning. A single-call test
+        // cannot tell correct dedup apart from no dedup at all.
+        // (setUp() already reset the seen-set.)
+        $schema = [
+            'type' => 'object',
+            'dependentRequired' => ['creditCard' => ['cvv']],
+        ];
+
+        $warnings = $this->captureWarnings(static function () use ($schema): void {
+            OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+            OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+            OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+        });
+
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString('dependentRequired', $warnings[0]);
+    }
+
+    #[Test]
+    public function dependent_keyword_nested_below_root_emits_warning(): void
+    {
+        // The warning fires from convertInPlace(), which recurses into every
+        // subschema position. Real specs almost always carry these keywords
+        // on nested model definitions, not the root — pin that the warning
+        // reaches a keyword buried inside `properties`.
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'payment' => [
+                    'type' => 'object',
+                    'dependentSchemas' => [
+                        'creditCard' => ['type' => 'object', 'required' => ['cvv']],
+                    ],
+                ],
+            ],
+        ];
+
+        $warnings = $this->captureWarnings(static function () use ($schema): void {
+            OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+        });
+
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString('dependentSchemas', $warnings[0]);
+    }
+
+    #[Test]
+    public function schema_without_dependent_keywords_emits_no_warning(): void
+    {
+        // Guard against a false positive: a schema declaring neither keyword
+        // must stay silent, so the warning keeps signalling something real.
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'creditCard' => ['type' => 'string'],
+                'cvv' => ['type' => 'string'],
+            ],
+            'required' => ['creditCard'],
+        ];
+
+        $warnings = $this->captureWarnings(static function () use ($schema): void {
+            OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
+        });
+
+        $this->assertSame([], $warnings);
+    }
+
     // ========================================
     // discriminator.mapping silent-strip warning (#147)
     // ========================================
@@ -1951,12 +2021,15 @@ class OpenApiSchemaConverterTest extends TestCase
         ];
 
         // The outer `dependentSchemas` keyword triggers the #216 silent-ignore
-        // warning; this test is about inner-subschema lowering, so swallow it.
+        // warning; this test is about inner-subschema lowering. Capture the
+        // warning and assert its exact count so an unexpected extra warning
+        // fails the test instead of being silently absorbed.
         $result = null;
-        $this->captureWarnings(static function () use ($schema, &$result): void {
+        $warnings = $this->captureWarnings(static function () use ($schema, &$result): void {
             $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
         });
 
+        $this->assertCount(1, $warnings, 'only the #216 dependentSchemas warning is expected');
         $this->assertArrayNotHasKey(
             'const',
             $result['dependentSchemas']['creditCard']['properties']['currency'],
@@ -2223,11 +2296,13 @@ class OpenApiSchemaConverterTest extends TestCase
         $original = $schema;
 
         // `dependentSchemas` triggers the #216 warning; this test asserts the
-        // input array is not mutated, so swallow the unrelated warning.
-        $this->captureWarnings(static function () use ($schema): void {
+        // input array is not mutated. Assert the exact warning count so an
+        // unexpected extra warning fails instead of being silently absorbed.
+        $warnings = $this->captureWarnings(static function () use ($schema): void {
             OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
         });
 
+        $this->assertCount(1, $warnings, 'only the #216 dependentSchemas warning is expected');
         $this->assertSame($original, $schema);
     }
 
@@ -2249,12 +2324,15 @@ class OpenApiSchemaConverterTest extends TestCase
         ];
 
         // The `dependentSchemas` key triggers the #216 warning; this test is
-        // about boolean-subschema preservation, so swallow it.
+        // about boolean-subschema preservation. Assert the exact warning
+        // count so an unexpected extra warning fails instead of being
+        // silently absorbed.
         $result = null;
-        $this->captureWarnings(static function () use ($schema, &$result): void {
+        $warnings = $this->captureWarnings(static function () use ($schema, &$result): void {
             $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
         });
 
+        $this->assertCount(1, $warnings, 'only the #216 dependentSchemas warning is expected');
         $this->assertSame($schema, $result);
     }
 
@@ -2274,12 +2352,15 @@ class OpenApiSchemaConverterTest extends TestCase
         ];
 
         // The `dependentSchemas` key triggers the #216 warning; this test is
-        // about list-shaped-value skipping, so swallow it.
+        // about list-shaped-value skipping. Assert the exact warning count so
+        // an unexpected extra warning fails instead of being silently
+        // absorbed.
         $result = null;
-        $this->captureWarnings(static function () use ($schema, &$result): void {
+        $warnings = $this->captureWarnings(static function () use ($schema, &$result): void {
             $result = OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1);
         });
 
+        $this->assertCount(1, $warnings, 'only the #216 dependentSchemas warning is expected');
         $this->assertSame($schema, $result);
     }
 


### PR DESCRIPTION
## Summary

`dependentSchemas` and `dependentRequired` (Draft 2019-09 keywords) reach
the validator unchanged but opis Draft 07 does not register either, so the
property-dependency constraint is dropped wholesale and a payload missing
the dependent properties passes silently. This PR emits a one-shot
`E_USER_WARNING` per keyword so the silent bypass becomes a loud signal.

## Why

Fixes #216.

The same silent-bypass class was already closed for `discriminator.mapping`
(#147) and unknown `format` values (#151): a contract test that does not
actually enforce the contract is the worst possible failure mode. #214 (PR
#215) made `convertInPlace()` recurse into `dependentSchemas` value
subschemas for keyword hygiene, but that does not restore the *outer*
keyword's intended validation — it is still silently ignored. This issue
closes that observability gap for both `dependentSchemas` and its 2019-09
sibling `dependentRequired`.

## Verification

New TDD tests in `tests/Unit/Spec/OpenApiSchemaConverterTest.php` (written
failing first, then made green):

- `dependent_schemas_emits_warning` / `dependent_required_emits_warning`
- `dependent_keywords_emit_warning_for_oas_3_0_too` — both keywords are
  2019-09 but can appear in hand-rolled / mixed-dialect 3.0 specs, so the
  warning runs for both versions (mirrors the `unevaluated*` handling)
- `dependent_keywords_warn_independently_and_point_to_if_then_else` — pins
  per-keyword dedup and that the copy points at the Draft 07 equivalent

- [x] `composer test` passes (1723 tests, 4045 assertions)
- [x] `composer stan` passes (level 6)
- [x] `composer cs-check` passes

## Notes for reviewers

- **Dedicated helper, not `DRAFT_2020_12_UNSUPPORTED_KEYS`.** The issue
  offered both options. The generic channel's copy advises rewriting with
  `additionalProperties` / `required`, which is wrong for these conditional
  keywords — the correct Draft 07 equivalent is `if` / `then` / `else`.
  Keyword-specific copy → a dedicated `warnIfDependentKeywordsPresent()`
  mirroring `warnIfDiscriminatorMappingPresent()`. Dedup still shares the
  `$warnedKeywords` set, so the one-shot-per-keyword-per-process guarantee
  is unchanged.
- **Four pre-existing #214 tests now incidentally trigger the new warning**
  (`v31_const_lowered_inside_dependent_schemas`,
  `convert_does_not_mutate_input_schema_with_multi_entry_dependent_schemas`,
  `boolean_schemas_at_new_recursion_sites_are_preserved`,
  `dependent_schemas_list_shaped_value_is_skipped`). They are wrapped in the
  existing `captureWarnings()` helper so they keep focus on their actual
  subject (recursion / lowering / no-mutation), with an inline comment
  explaining why the warning is swallowed.
- `docs/supported-features.md` updated: new advisory-only bullet and the
  warning-channel table entry.