### PR TITLE
fix(adapters): type-check literal JSON null / scalar request & response bodies

### DIFF
--- a/src/Internal/PresentJsonNull.php
+++ b/src/Internal/PresentJsonNull.php
@@ -17,8 +17,12 @@ namespace Studio\OpenApiContractTesting\Internal;
  * in this marker so the request / response body validators type-check it
  * against the schema instead of short-circuiting as "no body".
  *
- * A single-case enum is used as a value-less singleton: callers compare with
- * `$body instanceof PresentJsonNull` (or `=== PresentJsonNull::Body`).
+ * A single-case enum is used as a value-less singleton: callers detect it
+ * with `$body instanceof PresentJsonNull` (an explicit `=== PresentJsonNull::Body`
+ * is equivalent). Every code path that reads a decoded body value MUST unwrap
+ * this marker — treat it as the value `null` — before passing the value on to
+ * schema conversion or the strict-required walker; the marker itself must
+ * never reach `opis/json-schema` or user code.
  *
  * @internal Not part of the package's public API. Do not use from user code.
  */

--- a/src/Internal/PresentJsonNull.php
+++ b/src/Internal/PresentJsonNull.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Internal;
+
+/**
+ * Marker for "the wire carried a body whose decoded JSON value is the literal
+ * `null`" — distinct from a plain PHP `null`, which the body validators read
+ * as "no body was present at all".
+ *
+ * Issue #246: the framework adapters decode request / response bodies with
+ * `json_decode()`. A body of the four bytes `null` decodes to PHP `null`,
+ * indistinguishable from an absent body once it reaches the validators —
+ * letting a malformed `null` / scalar body be silently classified as "empty".
+ * An adapter that knows the raw content was non-empty wraps a decoded `null`
+ * in this marker so the request / response body validators type-check it
+ * against the schema instead of short-circuiting as "no body".
+ *
+ * A single-case enum is used as a value-less singleton: callers compare with
+ * `$body instanceof PresentJsonNull` (or `=== PresentJsonNull::Body`).
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+enum PresentJsonNull
+{
+    case Body;
+}

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -1126,8 +1126,9 @@ trait ValidatesOpenApiSchema
     /**
      * Extract the request body in the shape OpenApiRequestValidator expects.
      * Mirrors {@see self::extractJsonBody()} for the request side: parse JSON
-     * only when the Content-Type claims it, stay `null` on empty or non-JSON
-     * bodies so the validator decides whether the spec required one.
+     * only when the Content-Type claims it (or is absent), stay `null` on
+     * empty or non-JSON bodies so the validator decides whether the spec
+     * required one.
      *
      * Issue #246: a non-empty body that decodes to the literal JSON `null`
      * yields a {@see PresentJsonNull} marker so the validator type-checks the
@@ -1144,17 +1145,20 @@ trait ValidatesOpenApiSchema
             return null;
         }
 
+        // The return lives inside the try so its dependence on a successful
+        // decode is local and explicit: failOpenApi() is `: never`, so the
+        // catch cannot fall through to a use of an undefined $decoded.
         try {
             /** @var mixed $decoded */
             $decoded = json_decode($content, true, flags: JSON_THROW_ON_ERROR);
+
+            return $decoded ?? PresentJsonNull::Body;
         } catch (JsonException $e) {
             $this->failOpenApi(
                 'Request body could not be parsed as JSON: ' . $e->getMessage()
                 . ($contentType === '' ? ' (no Content-Type header was present on the request)' : ''),
             );
         }
-
-        return $decoded ?? PresentJsonNull::Body;
     }
 
     /**
@@ -1183,16 +1187,18 @@ trait ValidatesOpenApiSchema
             return null;
         }
 
+        // See extractRequestBody(): the return is inside the try so its
+        // dependence on a successful decode is local and explicit.
         try {
             /** @var mixed $decoded */
             $decoded = json_decode($content, true, flags: JSON_THROW_ON_ERROR);
+
+            return $decoded ?? PresentJsonNull::Body;
         } catch (JsonException $e) {
             $this->failOpenApi(
                 'Response body could not be parsed as JSON: ' . $e->getMessage()
                 . ($contentType === '' ? ' (no Content-Type header was present on the response)' : ''),
             );
         }
-
-        return $decoded ?? PresentJsonNull::Body;
     }
 }

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -19,6 +19,7 @@ use RuntimeException;
 use Studio\OpenApiContractTesting\Attribute\SkipOpenApi;
 use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\HttpMethod;
+use Studio\OpenApiContractTesting\Internal\PresentJsonNull;
 use Studio\OpenApiContractTesting\Internal\StackTraceFilter;
 use Studio\OpenApiContractTesting\OpenApiRequestValidator;
 use Studio\OpenApiContractTesting\OpenApiResponseValidator;
@@ -520,7 +521,7 @@ trait ValidatesOpenApiSchema
             $resolvedMethod,
             $resolvedPath,
             $response->getStatusCode(),
-            $this->extractJsonBody($response, $content, $contentType),
+            $this->extractJsonBody($content, $contentType),
             $contentType !== '' ? $contentType : null,
             // HeaderNormalizer is idempotent; HeaderBag's already-lower-cased
             // keys pass through unchanged.
@@ -1127,6 +1128,10 @@ trait ValidatesOpenApiSchema
      * Mirrors {@see self::extractJsonBody()} for the request side: parse JSON
      * only when the Content-Type claims it, stay `null` on empty or non-JSON
      * bodies so the validator decides whether the spec required one.
+     *
+     * Issue #246: a non-empty body that decodes to the literal JSON `null`
+     * yields a {@see PresentJsonNull} marker so the validator type-checks the
+     * value against the schema instead of mistaking it for an absent body.
      */
     private function extractRequestBody(Request $request, string $contentType): mixed
     {
@@ -1149,11 +1154,24 @@ trait ValidatesOpenApiSchema
             );
         }
 
-        return $decoded;
+        return $decoded ?? PresentJsonNull::Body;
     }
 
-    /** @return null|array<string, mixed> */
-    private function extractJsonBody(TestResponse $response, string $content, string $contentType): ?array
+    /**
+     * Extract the response body in the shape OpenApiResponseValidator expects.
+     * Mirrors {@see self::extractRequestBody()}: parse JSON only when the
+     * Content-Type claims it (or is absent), stay `null` on empty or non-JSON
+     * bodies so the validator decides whether the spec required one.
+     *
+     * Issue #246: decoding goes through `json_decode()` rather than
+     * `TestResponse::json()` so a body of the literal JSON `null` is not
+     * tripped up by Laravel's "null decode == invalid JSON" heuristic, and a
+     * scalar body is returned as-is for schema type-checking instead of being
+     * forced into an array. A present literal `null` yields a
+     * {@see PresentJsonNull} marker so it is type-checked rather than read as
+     * an absent body — keeping this adapter aligned with the Symfony one.
+     */
+    private function extractJsonBody(string $content, string $contentType): mixed
     {
         if ($content === '') {
             return null;
@@ -1166,12 +1184,15 @@ trait ValidatesOpenApiSchema
         }
 
         try {
-            return $response->json();
+            /** @var mixed $decoded */
+            $decoded = json_decode($content, true, flags: JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {
             $this->failOpenApi(
                 'Response body could not be parsed as JSON: ' . $e->getMessage()
                 . ($contentType === '' ? ' (no Content-Type header was present on the response)' : ''),
             );
         }
+
+        return $decoded ?? PresentJsonNull::Body;
     }
 }

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -6,6 +6,7 @@ namespace Studio\OpenApiContractTesting;
 
 use InvalidArgumentException;
 use RuntimeException;
+use Studio\OpenApiContractTesting\Internal\PresentJsonNull;
 use Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension;
 use Studio\OpenApiContractTesting\Spec\OpenApiPathMatcher;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
@@ -235,7 +236,10 @@ final class OpenApiResponseValidator
                 $matchedPath,
                 $statusCodeStr,
                 $bodyResult->matchedContentType,
-                $responseBody,
+                // Issue #246: unwrap the present-literal-null marker so the
+                // strict-required walker observes the real `null` value
+                // rather than the marker object.
+                $responseBody instanceof PresentJsonNull ? null : $responseBody,
             );
 
             return OpenApiValidationResult::success(

--- a/src/Symfony/OpenApiAssertions.php
+++ b/src/Symfony/OpenApiAssertions.php
@@ -330,8 +330,8 @@ trait OpenApiAssertions
     /**
      * Decode a JSON request / response body in the shape the validators
      * expect. Mirrors the Laravel adapter: parse only when the Content-Type
-     * claims JSON, stay `null` on empty or non-JSON bodies so the validator
-     * decides whether the spec required one.
+     * claims JSON (or is absent), stay `null` on empty or non-JSON bodies so
+     * the validator decides whether the spec required one.
      *
      * Issue #246: when the raw content is non-empty but decodes to the literal
      * JSON `null`, a {@see PresentJsonNull} marker is returned instead of a
@@ -352,9 +352,14 @@ trait OpenApiAssertions
             return null;
         }
 
+        // The return is inside the try so its dependence on a successful
+        // decode is local and explicit: failOpenApi() is `: never`, so the
+        // catch cannot fall through to a use of an undefined $decoded.
         try {
             /** @var mixed $decoded */
             $decoded = json_decode($content, true, flags: JSON_THROW_ON_ERROR);
+
+            return $decoded ?? PresentJsonNull::Body;
         } catch (JsonException $e) {
             $this->failOpenApi(sprintf(
                 '%s body could not be parsed as JSON: %s%s',
@@ -365,8 +370,6 @@ trait OpenApiAssertions
                     : '',
             ));
         }
-
-        return $decoded ?? PresentJsonNull::Body;
     }
 
     /** Like Assert::fail() but with vendor frames stripped from the trace. */

--- a/src/Symfony/OpenApiAssertions.php
+++ b/src/Symfony/OpenApiAssertions.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\AssertionFailedError;
 use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\HttpMethod;
+use Studio\OpenApiContractTesting\Internal\PresentJsonNull;
 use Studio\OpenApiContractTesting\Internal\StackTraceFilter;
 use Studio\OpenApiContractTesting\OpenApiRequestValidator;
 use Studio\OpenApiContractTesting\OpenApiResponseValidator;
@@ -332,6 +333,12 @@ trait OpenApiAssertions
      * claims JSON, stay `null` on empty or non-JSON bodies so the validator
      * decides whether the spec required one.
      *
+     * Issue #246: when the raw content is non-empty but decodes to the literal
+     * JSON `null`, a {@see PresentJsonNull} marker is returned instead of a
+     * bare `null` so the validator type-checks the value against the schema
+     * rather than mistaking it for an absent body. Non-null decoded values
+     * (scalars, arrays) pass through unchanged.
+     *
      * @param string $subject either `Request` or `Response`, used only for the
      *                        error message when the body is not valid JSON
      */
@@ -359,7 +366,7 @@ trait OpenApiAssertions
             ));
         }
 
-        return $decoded;
+        return $decoded ?? PresentJsonNull::Body;
     }
 
     /** Like Assert::fail() but with vendor frames stripped from the trace. */

--- a/src/Validation/Request/RequestBodyValidator.php
+++ b/src/Validation/Request/RequestBodyValidator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio\OpenApiContractTesting\Validation\Request;
 
 use stdClass;
+use Studio\OpenApiContractTesting\Internal\PresentJsonNull;
 use Studio\OpenApiContractTesting\OpenApiVersion;
 use Studio\OpenApiContractTesting\SchemaContext;
 use Studio\OpenApiContractTesting\Spec\OpenApiSchemaConverter;
@@ -141,7 +142,17 @@ final class RequestBodyValidator
             return [];
         }
 
-        if ($requestBody === null) {
+        // Issue #246: see the matching comment in ResponseBodyValidator. A
+        // PresentJsonNull marker means the wire carried a literal JSON `null`
+        // body; unwrap it and flag the body as present so it is type-checked
+        // against the schema instead of taking the empty-body branch.
+        $bodyWasPresent = false;
+        if ($requestBody instanceof PresentJsonNull) {
+            $requestBody = null;
+            $bodyWasPresent = true;
+        }
+
+        if ($requestBody === null && !$bodyWasPresent) {
             if (!$required) {
                 return [];
             }

--- a/src/Validation/Response/ResponseBodyValidator.php
+++ b/src/Validation/Response/ResponseBodyValidator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio\OpenApiContractTesting\Validation\Response;
 
 use stdClass;
+use Studio\OpenApiContractTesting\Internal\PresentJsonNull;
 use Studio\OpenApiContractTesting\OpenApiResponseValidator;
 use Studio\OpenApiContractTesting\OpenApiValidationResult;
 use Studio\OpenApiContractTesting\OpenApiVersion;
@@ -106,7 +107,18 @@ final class ResponseBodyValidator
             return new ResponseBodyValidationResult([], $jsonContentType);
         }
 
-        if ($responseBody === null) {
+        // Issue #246: an adapter that saw non-empty raw content but decoded a
+        // literal JSON `null` passes the PresentJsonNull marker so the null is
+        // type-checked against the schema below, rather than short-circuiting
+        // as an absent body. Unwrap it to a real null and remember the body
+        // WAS present so the empty-body branch is bypassed.
+        $bodyWasPresent = false;
+        if ($responseBody instanceof PresentJsonNull) {
+            $responseBody = null;
+            $bodyWasPresent = true;
+        }
+
+        if ($responseBody === null && !$bodyWasPresent) {
             return new ResponseBodyValidationResult(
                 [
                     "Response body is empty but {$method} {$matchedPath} (status {$statusCode}) defines a JSON-compatible response schema in '{$specName}' spec.",

--- a/tests/Unit/Symfony/OpenApiAssertionsTest.php
+++ b/tests/Unit/Symfony/OpenApiAssertionsTest.php
@@ -191,6 +191,56 @@ final class OpenApiAssertionsTest extends TestCase
     }
 
     #[Test]
+    public function literal_null_response_body_without_content_type_fails_loudly(): void
+    {
+        // Issue #246: a response body of the literal JSON `null` with no
+        // Content-Type is type-checked against the schema, not silently read
+        // as an absent body. GET /v1/pets declares a `type: object` 200
+        // schema, so a null body is a contract violation surfaced as a schema
+        // type error rather than the misleading "Response body is empty".
+        $request = Request::create('/v1/pets', 'GET');
+        $response = new Response('null', 200);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('must match the type');
+
+        $this->assertResponseMatchesOpenApiSchema($request, $response);
+    }
+
+    #[Test]
+    public function scalar_response_body_without_content_type_is_type_checked(): void
+    {
+        // Issue #246: a scalar JSON body (here the integer `123`) is decoded
+        // and type-checked against the schema rather than being treated as no
+        // body. Regression guard — the Symfony adapter's `mixed` body shape
+        // already handled scalars; this pins that the #246 fix keeps it so.
+        $request = Request::create('/v1/pets', 'GET');
+        $response = new Response('123', 200);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('must match the type');
+
+        $this->assertResponseMatchesOpenApiSchema($request, $response);
+    }
+
+    #[Test]
+    public function literal_null_request_body_without_content_type_fails_loudly(): void
+    {
+        // Issue #246: a request body of the literal JSON `null` with no
+        // Content-Type is type-checked against the requestBody schema. POST
+        // /v1/pets requires a `type: object` body, so a null body fails
+        // loudly. Request::create() forces a Content-Type on POST bodies;
+        // drop it so the no-Content-Type path runs.
+        $request = Request::create('/v1/pets', 'POST', [], [], [], [], 'null');
+        $request->headers->remove('Content-Type');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('must match the type');
+
+        $this->assertRequestMatchesOpenApiSchema($request);
+    }
+
+    #[Test]
     public function non_json_response_body_passes_as_null_body(): void
     {
         $request = Request::create('/v1/pets/123', 'DELETE');

--- a/tests/Unit/ValidatesOpenApiSchemaAutoValidateRequestTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaAutoValidateRequestTest.php
@@ -128,6 +128,26 @@ class ValidatesOpenApiSchemaAutoValidateRequestTest extends TestCase
     }
 
     #[Test]
+    public function auto_validate_request_type_checks_literal_null_body(): void
+    {
+        // Issue #246: a request body of the literal JSON `null` with no
+        // Content-Type is type-checked against the requestBody schema instead
+        // of being read as an absent body. POST /v1/pets requires a
+        // `type: object` body, so a null body fails loudly with a schema type
+        // error — before the fix the decoded `null` was misreported as an
+        // empty body.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = true;
+
+        $request = Request::create('/v1/pets', 'POST', [], [], [], [], 'null');
+        $request->headers->remove('Content-Type');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('must match the type');
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/v1/pets');
+    }
+
+    #[Test]
     public function auto_validate_request_true_raises_on_missing_bearer(): void
     {
         // Without auto-inject, a bearer-protected endpoint called without any

--- a/tests/Unit/ValidatesOpenApiSchemaTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaTest.php
@@ -166,6 +166,25 @@ class ValidatesOpenApiSchemaTest extends TestCase
     }
 
     #[Test]
+    public function literal_null_response_body_with_json_content_type_is_type_checked(): void
+    {
+        // Issue #246: the literal-null fix applies on the explicit-Content-Type
+        // path too, not only when the header is absent. A response with
+        // `Content-Type: application/json` and a `null` body is type-checked
+        // against GET /v1/pets' `type: object` 200 schema and fails.
+        $response = $this->makeTestResponse('null', 200, ['Content-Type' => 'application/json']);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('must match the type');
+
+        $this->assertResponseMatchesOpenApiSchema(
+            $response,
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+    }
+
+    #[Test]
     public function scalar_response_body_is_type_checked(): void
     {
         // Issue #246: a scalar JSON body (the integer `123`) reaches the

--- a/tests/Unit/ValidatesOpenApiSchemaTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaTest.php
@@ -145,6 +145,46 @@ class ValidatesOpenApiSchemaTest extends TestCase
     }
 
     #[Test]
+    public function literal_null_response_body_is_type_checked(): void
+    {
+        // Issue #246: a response body of the literal JSON `null` is
+        // type-checked against the schema instead of being read as an absent
+        // body. GET /v1/pets declares a `type: object` 200 schema, so a null
+        // body fails with a schema type error. Before the fix the Laravel
+        // adapter decoded through TestResponse::json(), whose "null decode ==
+        // invalid JSON" heuristic raised a misleading framework failure.
+        $response = $this->makeTestResponse('null', 200);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('must match the type');
+
+        $this->assertResponseMatchesOpenApiSchema(
+            $response,
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+    }
+
+    #[Test]
+    public function scalar_response_body_is_type_checked(): void
+    {
+        // Issue #246: a scalar JSON body (the integer `123`) reaches the
+        // validator and is type-checked. Before the fix the body extractor's
+        // `?array` return type raised a TypeError on a non-array decoded
+        // body; the Laravel and Symfony adapters now behave identically.
+        $response = $this->makeTestResponse('123', 200);
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('must match the type');
+
+        $this->assertResponseMatchesOpenApiSchema(
+            $response,
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+    }
+
+    #[Test]
     public function non_json_html_body_passes_as_null_body(): void
     {
         $response = $this->makeTestResponse(

--- a/tests/Unit/Validation/Request/RequestBodyValidatorTest.php
+++ b/tests/Unit/Validation/Request/RequestBodyValidatorTest.php
@@ -152,6 +152,36 @@ class RequestBodyValidatorTest extends TestCase
     }
 
     #[Test]
+    public function validate_accepts_present_literal_null_body_against_oas_30_nullable_schema(): void
+    {
+        // OAS 3.0 expresses a nullable body with `nullable: true`;
+        // OpenApiSchemaConverter lowers it to a `["object", "null"]` type
+        // array for Draft 07. A present literal `null` validates cleanly
+        // against it — distinct conversion branch from the OAS 3.1 type-array
+        // form covered above.
+        $operation = [
+            'requestBody' => [
+                'required' => true,
+                'content' => [
+                    'application/json' => ['schema' => ['type' => 'object', 'nullable' => true]],
+                ],
+            ],
+        ];
+
+        $errors = $this->validator->validate(
+            'spec',
+            'POST',
+            '/pets',
+            $operation,
+            PresentJsonNull::Body,
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
     public function validate_still_treats_plain_null_as_absent_body(): void
     {
         // Regression guard for issue #246: a plain PHP `null` (absent body,

--- a/tests/Unit/Validation/Request/RequestBodyValidatorTest.php
+++ b/tests/Unit/Validation/Request/RequestBodyValidatorTest.php
@@ -6,6 +6,7 @@ namespace Studio\OpenApiContractTesting\Tests\Unit\Validation\Request;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Internal\PresentJsonNull;
 use Studio\OpenApiContractTesting\OpenApiVersion;
 use Studio\OpenApiContractTesting\Validation\Request\RequestBodyValidator;
 use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
@@ -60,6 +61,123 @@ class RequestBodyValidatorTest extends TestCase
 
         $this->assertCount(1, $errors);
         $this->assertStringContainsString('Request body is empty', $errors[0]);
+    }
+
+    #[Test]
+    public function validate_flags_present_literal_null_body_against_object_schema_when_optional(): void
+    {
+        // Issue #246 — the core silent-pass bug. A request body of the literal
+        // JSON `null` against an OPTIONAL `type: object` body must NOT pass:
+        // before the fix the validator read the decoded `null` as "no body"
+        // and, because the body was optional, returned no errors — letting a
+        // malformed `null` body slip through unchecked. A present `null` is
+        // now type-checked against the schema and fails loudly.
+        $operation = [
+            'requestBody' => [
+                'required' => false,
+                'content' => [
+                    'application/json' => ['schema' => ['type' => 'object']],
+                ],
+            ],
+        ];
+
+        $errors = $this->validator->validate(
+            'spec',
+            'POST',
+            '/pets',
+            $operation,
+            PresentJsonNull::Body,
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertNotEmpty($errors);
+        $this->assertStringContainsString('must match the type', $errors[0]);
+    }
+
+    #[Test]
+    public function validate_flags_present_literal_null_body_against_object_schema_when_required(): void
+    {
+        // A present literal `null` against a REQUIRED object body fails with a
+        // schema type error, not the "Request body is empty" message — the
+        // body WAS present on the wire, it is simply the wrong type.
+        $operation = [
+            'requestBody' => [
+                'required' => true,
+                'content' => [
+                    'application/json' => ['schema' => ['type' => 'object']],
+                ],
+            ],
+        ];
+
+        $errors = $this->validator->validate(
+            'spec',
+            'POST',
+            '/pets',
+            $operation,
+            PresentJsonNull::Body,
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertNotEmpty($errors);
+        $this->assertStringContainsString('must match the type', $errors[0]);
+        $this->assertStringNotContainsString('Request body is empty', $errors[0]);
+    }
+
+    #[Test]
+    public function validate_accepts_present_literal_null_body_against_oas_31_nullable_schema(): void
+    {
+        // OAS 3.1 `type: ["object", "null"]` explicitly permits a null body.
+        $operation = [
+            'requestBody' => [
+                'required' => true,
+                'content' => [
+                    'application/json' => ['schema' => ['type' => ['object', 'null']]],
+                ],
+            ],
+        ];
+
+        $errors = $this->validator->validate(
+            'spec',
+            'POST',
+            '/pets',
+            $operation,
+            PresentJsonNull::Body,
+            'application/json',
+            OpenApiVersion::V3_1,
+        );
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function validate_still_treats_plain_null_as_absent_body(): void
+    {
+        // Regression guard for issue #246: a plain PHP `null` (absent body,
+        // raw content was empty) keeps the historical "no body" semantics —
+        // it is NOT type-checked. An optional absent body still passes; the
+        // PresentJsonNull marker is the ONLY value whose handling changed.
+        $operation = [
+            'requestBody' => [
+                'required' => false,
+                'content' => [
+                    'application/json' => ['schema' => ['type' => 'object']],
+                ],
+            ],
+        ];
+
+        $errors = $this->validator->validate(
+            'spec',
+            'POST',
+            '/pets',
+            $operation,
+            null,
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertSame([], $errors);
     }
 
     #[Test]

--- a/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
+++ b/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
@@ -129,6 +129,33 @@ class ResponseBodyValidatorTest extends TestCase
     }
 
     #[Test]
+    public function validate_accepts_present_literal_null_body_against_oas_30_nullable_schema(): void
+    {
+        // OAS 3.0 expresses a nullable body with `nullable: true`;
+        // OpenApiSchemaConverter lowers it to a `["object", "null"]` type
+        // array for Draft 07. A present literal `null` must validate cleanly
+        // against it — distinct conversion branch from the OAS 3.1 type-array
+        // form covered above.
+        $content = [
+            'application/json' => ['schema' => ['type' => 'object', 'nullable' => true]],
+        ];
+
+        $result = $this->validator->validate(
+            'spec',
+            'GET',
+            '/pets',
+            200,
+            $content,
+            PresentJsonNull::Body,
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertSame([], $result->errors);
+        $this->assertSame('application/json', $result->matchedContentType);
+    }
+
+    #[Test]
     public function validate_accepts_non_json_content_type_when_defined_in_spec(): void
     {
         $content = [

--- a/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
+++ b/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
@@ -6,6 +6,7 @@ namespace Studio\OpenApiContractTesting\Tests\Unit\Validation\Response;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Internal\PresentJsonNull;
 use Studio\OpenApiContractTesting\OpenApiVersion;
 use Studio\OpenApiContractTesting\Validation\Response\ResponseBodyValidator;
 use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
@@ -68,6 +69,62 @@ class ResponseBodyValidatorTest extends TestCase
 
         $this->assertCount(1, $result->errors);
         $this->assertStringContainsString('Response body is empty', $result->errors[0]);
+        $this->assertSame('application/json', $result->matchedContentType);
+    }
+
+    #[Test]
+    public function validate_type_checks_present_literal_null_body_against_object_schema(): void
+    {
+        // Issue #246: a response body of the literal JSON `null` (the four
+        // bytes `null` on the wire) is type-checked against the schema, not
+        // short-circuited as an absent body. Against `type: object` it is a
+        // contract violation and must surface a schema type error — NOT the
+        // "Response body is empty" message reserved for a genuinely absent
+        // body. The PresentJsonNull marker is how an adapter signals "the
+        // wire carried a body and its decoded value is null".
+        $content = [
+            'application/json' => ['schema' => ['type' => 'object']],
+        ];
+
+        $result = $this->validator->validate(
+            'spec',
+            'GET',
+            '/pets',
+            200,
+            $content,
+            PresentJsonNull::Body,
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertNotEmpty($result->errors);
+        $this->assertStringContainsString('must match the type', $result->errors[0]);
+        $this->assertStringNotContainsString('Response body is empty', $result->errors[0]);
+        $this->assertSame('application/json', $result->matchedContentType);
+    }
+
+    #[Test]
+    public function validate_accepts_present_literal_null_body_against_oas_31_nullable_schema(): void
+    {
+        // OAS 3.1 `type: ["object", "null"]` explicitly permits a null body.
+        // A present literal `null` validates cleanly against it — the pre-#246
+        // "body is empty" short-circuit would have wrongly rejected it.
+        $content = [
+            'application/json' => ['schema' => ['type' => ['object', 'null']]],
+        ];
+
+        $result = $this->validator->validate(
+            'spec',
+            'GET',
+            '/pets',
+            200,
+            $content,
+            PresentJsonNull::Body,
+            'application/json',
+            OpenApiVersion::V3_1,
+        );
+
+        $this->assertSame([], $result->errors);
         $this->assertSame('application/json', $result->matchedContentType);
     }
 


### PR DESCRIPTION
## Summary

リクエスト / レスポンスボディが JSON リテラルの `null`（あるいは JSON スカラー）だった場合、`json_decode` の結果が PHP の `null` となり、ボディ validator が「ボディ無し」と区別できませんでした。本 PR は内部マーカー `PresentJsonNull` を導入し、非空の生ボディが `null` にデコードされたケースをアダプタがマーカーで包むことで、validator がスキーマと型照合するようにします。

## Why

Content-Type 無し + ボディが literal `null`（4バイト）等の不正な内容のとき、`json_decode('null')` → `null` が「ボディ無し」と同一視されていました。その結果:

- **リクエスト側**: ボディが optional のエンドポイントで、不正な `null` ボディが型照合されず **silent pass**（contract テストの「不正は loud に落とす」原則に反する）
- **レスポンス側**: literal `null` が「Response body is empty」という不正確なメッセージで失敗
- **Laravel アダプタ**: スカラーレスポンスボディが `extractJsonBody` の戻り値型 `?array` で `TypeError` クラッシュ（Symfony アダプタは `mixed` のため正常）

Closes #246

## Verification

実装前に失敗テストを先に書き（TDD: RED 8件）、実装後 GREEN を確認しました。デグレ防止として、素の `null`（空ボディ）が従来通り absent 扱いされること、スカラーボディが型照合されることも回帰テストで固定しています。

- [x] `composer test` passes（1768 tests）
- [x] `composer stan` passes（PHPStan level 6）
- [x] `composer cs-check` passes

## Notes for reviewers

- **後方互換性**: validator の `null` =「ボディ無し」セマンティクスは不変。マーカーを渡すのは更新済みアダプタのみで、`OpenApiResponseValidator::validate()` / `OpenApiRequestValidator::validate()` の公開シグネチャ・引数も変更なし → SemVer 凍結 API に非抵触。直接呼び出し側の挙動は変わりません。
- `extractJsonBody`（Laravel）を `TestResponse::json()` から直接 `json_decode()` へ変更しました。Laravel の「`null` decode = Invalid JSON」ヒューリスティックを回避し、Symfony アダプタと完全に挙動を揃えるためです（両アダプタとも `json_decode(..., JSON_THROW_ON_ERROR)` に統一）。private メソッドのため外部影響はありません。
- OAS 3.1 の `type: ["object", "null"]` に対しては literal `null` ボディが正しく通過するようになります（修正前は「body is empty」で誤って reject）。これは意図した挙動改善です。

## フォローアップ Issue

multi-agent レビュー（`/pr-review-toolkit:review-pr`）で挙がった、本 PR のスコープ外として切り出した項目:

- #248 — decoded body の `mixed` を absent/present を表現する envelope 型に置き換える（type-design 指摘。公開シグネチャ変更のため v2 メジャーバンプ案件）
- #249 — `OpenApiResponseValidator` の `PresentJsonNull` unwrap 経路の回帰テスト追加（pr-test 指摘）