### PR TITLE
test(validation): pin the DecodedBody envelope unwrap on the strict-required path

### DIFF
--- a/tests/Unit/Validation/Strict/StrictRequiredValidatorIntegrationTest.php
+++ b/tests/Unit/Validation/Strict/StrictRequiredValidatorIntegrationTest.php
@@ -9,6 +9,7 @@ use const E_USER_WARNING;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use Studio\OpenApiContractTesting\DecodedBody;
 use Studio\OpenApiContractTesting\OpenApiResponseValidator;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredAsserter;
@@ -197,6 +198,63 @@ final class StrictRequiredValidatorIntegrationTest extends TestCase
         );
 
         $this->assertSame([], StrictRequiredTracker::getObservations('under-described'));
+    }
+
+    #[Test]
+    public function present_literal_null_body_records_no_strict_required_pointer(): void
+    {
+        // Issues #246 / #248 / #249: a literal JSON `null` body reaches the
+        // validator as DecodedBody::present(null) — distinct from an absent
+        // body. /nullable-object declares a `nullable: true` object schema,
+        // so the null body passes conformance and the validator hits the
+        // Success path where maybeRecordStrictRequired() runs. The strict-
+        // required walker must observe the unwrapped real `null`
+        // (OpenApiResponseValidator passes `$body->value`, not the envelope),
+        // which collectPointers() maps to an empty pointer map — so nothing
+        // is recorded. A regression that fed the walker a non-null marker /
+        // envelope would still record `[]` here, but the present-object
+        // sibling test below pins the unwrap with teeth.
+        $result = $this->validator->validate(
+            'under-described',
+            'GET',
+            '/nullable-object',
+            200,
+            DecodedBody::present(null),
+            'application/json',
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertSame([], StrictRequiredTracker::getObservations('under-described'));
+    }
+
+    #[Test]
+    public function decoded_body_envelope_is_unwrapped_before_strict_required_walk(): void
+    {
+        // Issue #249: the framework adapters pass a DecodedBody envelope to
+        // validate(); maybeRecordStrictRequired() must hand the strict-
+        // required walker the *unwrapped* decoded value (`$body->value`),
+        // not the DecodedBody object itself. If the unwrap were dropped, the
+        // walker would receive a DecodedBody instance — neither stdClass nor
+        // array — and collectPointers() would return `[]`, silently recording
+        // no observation. Asserting the `/` pointer carries the inner array's
+        // keys pins the unwrap: this test fails the moment `$body->value`
+        // becomes `$body`.
+        $result = $this->validator->validate(
+            'under-described',
+            'PUT',
+            '/signed-url',
+            200,
+            DecodedBody::present(['expires' => 3600, 'signed_url' => 's3://...', 'url' => 'https://...']),
+            'application/json',
+        );
+
+        $this->assertTrue($result->isValid());
+
+        $observations = StrictRequiredTracker::getObservations('under-described');
+        $this->assertSame(
+            ['hits' => 1, 'pointers' => ['/' => ['expires', 'signed_url', 'url']]],
+            $observations['PUT /signed-url']['200:application/json'],
+        );
     }
 
     #[Test]

--- a/tests/Unit/Validation/Strict/StrictRequiredValidatorIntegrationTest.php
+++ b/tests/Unit/Validation/Strict/StrictRequiredValidatorIntegrationTest.php
@@ -203,17 +203,21 @@ final class StrictRequiredValidatorIntegrationTest extends TestCase
     #[Test]
     public function present_literal_null_body_records_no_strict_required_pointer(): void
     {
-        // Issues #246 / #248 / #249: a literal JSON `null` body reaches the
-        // validator as DecodedBody::present(null) — distinct from an absent
-        // body. /nullable-object declares a `nullable: true` object schema,
-        // so the null body passes conformance and the validator hits the
-        // Success path where maybeRecordStrictRequired() runs. The strict-
-        // required walker must observe the unwrapped real `null`
-        // (OpenApiResponseValidator passes `$body->value`, not the envelope),
-        // which collectPointers() maps to an empty pointer map — so nothing
-        // is recorded. A regression that fed the walker a non-null marker /
-        // envelope would still record `[]` here, but the present-object
-        // sibling test below pins the unwrap with teeth.
+        // Issues #248 / #249: a literal JSON `null` body reaches the
+        // validator as DecodedBody::present(null) — the envelope introduced
+        // in #248, distinct from an absent body. /nullable-object declares a
+        // `nullable: true` object schema, so the null body passes conformance
+        // and the validator reaches the Success path where
+        // maybeRecordStrictRequired() runs. This test pins that path: a
+        // present literal-null body validates (isValid true) and records no
+        // strict-required observation, because collectPointers() maps a real
+        // `null` to an empty pointer map.
+        //
+        // This is a characterization test for the literal-null Success path,
+        // not the unwrap guard: feeding the walker the DecodedBody envelope
+        // instead of `$body->value` would also yield `[]` here (a DecodedBody
+        // is neither array nor stdClass). The unwrap itself is pinned with
+        // teeth by the sibling test below.
         $result = $this->validator->validate(
             'under-described',
             'GET',
@@ -235,10 +239,13 @@ final class StrictRequiredValidatorIntegrationTest extends TestCase
         // required walker the *unwrapped* decoded value (`$body->value`),
         // not the DecodedBody object itself. If the unwrap were dropped, the
         // walker would receive a DecodedBody instance — neither stdClass nor
-        // array — and collectPointers() would return `[]`, silently recording
-        // no observation. Asserting the `/` pointer carries the inner array's
-        // keys pins the unwrap: this test fails the moment `$body->value`
-        // becomes `$body`.
+        // array — and collectPointers() would return `[]`, silently skipping
+        // the observation entirely (recordOn() is never reached). Asserting
+        // the `/` pointer carries the body's keys pins the unwrap: this test
+        // fails the moment `$body->value` becomes `$body`.
+        //
+        // The expected pointer keys come from this test's input body, not
+        // from the /signed-url spec schema (which declares no `required`).
         $result = $this->validator->validate(
             'under-described',
             'PUT',

--- a/tests/Unit/Validation/Strict/StrictRequiredValidatorIntegrationTest.php
+++ b/tests/Unit/Validation/Strict/StrictRequiredValidatorIntegrationTest.php
@@ -232,6 +232,55 @@ final class StrictRequiredValidatorIntegrationTest extends TestCase
     }
 
     #[Test]
+    public function present_literal_null_body_on_oas31_nullable_schema_records_no_pointer(): void
+    {
+        // The literal-null Success path is version-specific: OAS 3.0 spells a
+        // nullable object `nullable: true`, OAS 3.1 spells it
+        // `type: ["object", "null"]`, and OpenApiSchemaConverter routes the
+        // two through different branches. The sibling test above pins the 3.0
+        // form; this one pins the 3.1 form against under-described-3.1, so a
+        // converter regression on 3.1 type arrays — which would stop a null
+        // body from passing conformance — surfaces here.
+        $result = $this->validator->validate(
+            'under-described-3.1',
+            'GET',
+            '/nullable-object',
+            200,
+            DecodedBody::present(null),
+            'application/json',
+        );
+
+        $this->assertTrue($result->isValid());
+        $this->assertSame([], StrictRequiredTracker::getObservations('under-described-3.1'));
+    }
+
+    #[Test]
+    public function absent_decoded_body_against_json_schema_fails_and_records_nothing(): void
+    {
+        // Issues #248 / #249: the framework adapters build the envelope
+        // directly, so the production path for a missing body is an explicit
+        // DecodedBody::absent() reaching validate() — not a bare null routed
+        // through fromLegacy() (the path null_body_is_not_recorded covers).
+        // Passing absent() against /nullable-object, which declares a JSON
+        // schema, must fail conformance ("empty body") and therefore record
+        // no strict-required observation — the mirror of the present-literal-
+        // null case above: present(null) validates, absent() does not. This
+        // pins the absent/present distinction the DecodedBody envelope exists
+        // to carry, on the direct adapter path.
+        $result = $this->validator->validate(
+            'under-described',
+            'GET',
+            '/nullable-object',
+            200,
+            DecodedBody::absent(),
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertSame([], StrictRequiredTracker::getObservations('under-described'));
+    }
+
+    #[Test]
     public function decoded_body_envelope_is_unwrapped_before_strict_required_walk(): void
     {
         // Issue #249: the framework adapters pass a DecodedBody envelope to

--- a/tests/fixtures/specs/under-described-3.1.json
+++ b/tests/fixtures/specs/under-described-3.1.json
@@ -1,0 +1,25 @@
+{
+  "openapi": "3.1.0",
+  "info": { "title": "Strict required fixture (OAS 3.1)", "version": "1.0.0" },
+  "paths": {
+    "/nullable-object": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok; OAS 3.1 nullable object (type: [object, null]) — a literal JSON null body validates",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": ["object", "null"],
+                  "properties": {
+                    "id": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/specs/under-described.json
+++ b/tests/fixtures/specs/under-described.json
@@ -317,6 +317,27 @@
           }
         }
       }
+    },
+    "/nullable-object": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok; nullable object — a literal JSON null body validates",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "nullable": true,
+                  "required": ["id"],
+                  "properties": {
+                    "id": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/tests/fixtures/specs/under-described.json
+++ b/tests/fixtures/specs/under-described.json
@@ -328,7 +328,6 @@
                 "schema": {
                   "type": "object",
                   "nullable": true,
-                  "required": ["id"],
                   "properties": {
                     "id": { "type": "string" }
                   }


### PR DESCRIPTION
## Summary

`OpenApiResponseValidator` の strict-required 記録経路に、`DecodedBody` envelope を unwrap してから walker へ渡す挙動を固定する回帰テストを追加します。

## Why

PR #247 は、strict-required walker が present-literal-null マーカーではなく decoded body の実値を観測するよう unwrap を1行追加しました。#248 でそのマーカーが `DecodedBody` envelope に置き換わったため、現在の unwrap は `OpenApiResponseValidator::maybeRecordStrictRequired()` に渡す `$body->value` です。この経路を直接固定するテストが無いと #247 の pr-test レビューで指摘されていました（severity 6）。

Fixes #249

## Verification

`tests/Unit/Validation/Strict/StrictRequiredValidatorIntegrationTest.php` に回帰テストを4本追加:

- **`present_literal_null_body_records_no_strict_required_pointer`** — literal JSON null body（`DecodedBody::present(null)`）を OAS 3.0 `nullable: true` schema で検証し、validation success かつ strict-required observation 無記録（walker が実 `null` を観測）であることを assert。literal-null Success 経路の characterization テスト。
- **`present_literal_null_body_on_oas31_nullable_schema_records_no_pointer`** — 同じ挙動を OAS 3.1 `type: ["object","null"]` schema で固定（`OpenApiSchemaConverter` は 3.0 / 3.1 を別経路で処理するため、3.1 type 配列の converter 回帰を捕捉）。
- **`absent_decoded_body_against_json_schema_fails_and_records_nothing`** — アダプタが直接生成する `DecodedBody::absent()` を JSON schema エンドポイントへ渡すと conformance 失敗し observation 無記録であることを assert（`present(null)` は success / `absent()` は failure という envelope の本質的区別を直接経路で固定）。
- **`decoded_body_envelope_is_unwrapped_before_strict_required_walk`** — present な object body を `DecodedBody` envelope として渡し、walker が envelope ではなく内側の配列を観測すること（`/` ポインタにキーが記録される）を assert。`$body->value` を `$body` に変えると `collectPointers()` が `DecodedBody` を受け取り空マップを返すため、このテストが落ちる ＝ Issue の「ゴール」を満たす teeth テスト。

fixture追加:
- `under-described.json` に OAS 3.0 `nullable: true` の `/nullable-object` エンドポイント
- `under-described-3.1.json`（新規）に OAS 3.1 `type: ["object","null"]` の `/nullable-object` エンドポイント

ゴール検証として `src/OpenApiResponseValidator.php` の `$body->value` を一時的に `$body` へ書き換え、teeth テストが fail することを確認済み（変更は revert 済み）。

- [x] `composer test` passes（1785 tests, 4192 assertions）
- [x] `composer stan` passes（PHPStan level 6, No errors）
- [x] `composer cs-check` passes

## Notes for reviewers

- Issue #249 本文は #247 当時の `instanceof PresentJsonNull` ternary を unwrap 対象として記述していますが、#248 でそのマーカーが廃止されたため、回帰対象を `DecodedBody` envelope の `$body->value` 経路に読み替えています（#250 のレビューでも明記済み）。
- literal-null 単体では unwrap 削除を捕捉できません（walker は `null` も `DecodedBody` object もどちらも非 array として空マップを返すため）。そのため `decoded_body_envelope_is_unwrapped_before_strict_required_walk` が unwrap を実際に固定する teeth テストで、literal-null 系2本は Success 経路の characterization テストです。
- `pr-review-toolkit:review-pr` のマルチエージェントレビューを実施し、指摘（#246 引用誤り・comment 表現・inert fixture フィールド）を反映済み。さらに pr-test レビューが挙げた `DecodedBody::absent()` 直接経路 / OAS 3.1 variant のカバレッジ gap も本 PR で対応しています。