### PR TITLE
fix(adapters): align adapter JSON content-type detection with ContentTypeMatcher

### DIFF
--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -1130,9 +1130,11 @@ trait ValidatesOpenApiSchema
      * an empty body, or a non-JSON Content-Type, yields an absent envelope.
      *
      * A non-JSON body is left undecoded rather than guessed at: the Content-Type
-     * is forwarded to the validator separately, and its content negotiation
-     * delivers the contract verdict — a loud "Content-Type is not defined" when
-     * the spec does not declare that media type, acceptance when it does. The
+     * is forwarded to the validator separately, which resolves non-JSON media
+     * types through content negotiation. When the operation declares a
+     * `requestBody` content map, a media type missing from it is reported as
+     * "Content-Type is not defined" and one it declares is accepted without
+     * body-schema validation (the validator's schema engine is JSON-only). The
      * JSON-ness test uses {@see ContentTypeMatcher::isJsonContentType()} so this
      * adapter and the validator agree on exactly which media types count as
      * JSON (issue #251).

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -28,6 +28,7 @@ use Studio\OpenApiContractTesting\Spec\OpenApiPathMatcher;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecResolver;
 use Studio\OpenApiContractTesting\Validation\Request\SecuritySchemeIntrospector;
+use Studio\OpenApiContractTesting\Validation\Support\ContentTypeMatcher;
 use Studio\OpenApiContractTesting\Validation\Support\HeaderNormalizer;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -44,7 +45,6 @@ use function is_numeric;
 use function is_string;
 use function json_decode;
 use function sprintf;
-use function str_contains;
 use function strtolower;
 use function strtoupper;
 use function trigger_error;
@@ -1125,10 +1125,17 @@ trait ValidatesOpenApiSchema
 
     /**
      * Extract the request body in the shape OpenApiRequestValidator expects.
-     * Mirrors {@see self::extractJsonBody()} for the request side: parse JSON
-     * only when the Content-Type claims it (or is absent), report an absent
-     * body on empty or non-JSON content so the validator decides whether the
-     * spec required one.
+     * Mirrors {@see self::extractJsonBody()} for the request side: the body is
+     * JSON-decoded only when the Content-Type is a JSON media type (or absent);
+     * an empty body, or a non-JSON Content-Type, yields an absent envelope.
+     *
+     * A non-JSON body is left undecoded rather than guessed at: the Content-Type
+     * is forwarded to the validator separately, and its content negotiation
+     * delivers the contract verdict — a loud "Content-Type is not defined" when
+     * the spec does not declare that media type, acceptance when it does. The
+     * JSON-ness test uses {@see ContentTypeMatcher::isJsonContentType()} so this
+     * adapter and the validator agree on exactly which media types count as
+     * JSON (issue #251).
      *
      * Issues #246 / #248: a non-empty body that decodes to the literal JSON
      * `null` is returned as a present {@see DecodedBody} carrying `null`, so
@@ -1142,7 +1149,12 @@ trait ValidatesOpenApiSchema
             return DecodedBody::absent();
         }
 
-        if ($contentType !== '' && !str_contains(strtolower($contentType), 'json')) {
+        // Non-JSON Content-Type: leave the body undecoded and report it absent.
+        // The validator receives the Content-Type separately and decides the
+        // contract verdict from it (issue #251).
+        if ($contentType !== '' && !ContentTypeMatcher::isJsonContentType(
+            ContentTypeMatcher::normalizeMediaType($contentType),
+        )) {
             return DecodedBody::absent();
         }
 
@@ -1164,10 +1176,12 @@ trait ValidatesOpenApiSchema
 
     /**
      * Extract the response body in the shape OpenApiResponseValidator expects.
-     * Mirrors {@see self::extractRequestBody()}: parse JSON only when the
-     * Content-Type claims it (or is absent), report an absent body on empty
-     * or non-JSON content so the validator decides whether the spec required
-     * one.
+     * Mirrors {@see self::extractRequestBody()}: the body is JSON-decoded only
+     * when the Content-Type is a JSON media type (or absent); an empty body, or
+     * a non-JSON Content-Type, yields an absent envelope. The JSON-ness test
+     * uses {@see ContentTypeMatcher::isJsonContentType()} so this adapter and
+     * the validator agree on exactly which media types count as JSON (issue
+     * #251).
      *
      * Issues #246 / #248: decoding goes through `json_decode()` rather than
      * `TestResponse::json()` so a body of the literal JSON `null` is not
@@ -1183,9 +1197,12 @@ trait ValidatesOpenApiSchema
             return DecodedBody::absent();
         }
 
-        // Non-JSON Content-Type: report an absent body so the validator can
-        // decide whether the spec requires a JSON body for this endpoint.
-        if ($contentType !== '' && !str_contains(strtolower($contentType), 'json')) {
+        // Non-JSON Content-Type: leave the body undecoded and report it absent.
+        // The validator receives the Content-Type separately and decides the
+        // contract verdict from it (issue #251).
+        if ($contentType !== '' && !ContentTypeMatcher::isJsonContentType(
+            ContentTypeMatcher::normalizeMediaType($contentType),
+        )) {
             return DecodedBody::absent();
         }
 

--- a/src/Symfony/OpenApiAssertions.php
+++ b/src/Symfony/OpenApiAssertions.php
@@ -17,6 +17,7 @@ use Studio\OpenApiContractTesting\OpenApiRequestValidator;
 use Studio\OpenApiContractTesting\OpenApiResponseValidator;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecResolver;
+use Studio\OpenApiContractTesting\Validation\Support\ContentTypeMatcher;
 use Symfony\Component\BrowserKit\Exception\BadMethodCallException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,7 +26,6 @@ use Symfony\Component\HttpKernel\HttpKernelBrowser;
 use function array_merge;
 use function json_decode;
 use function sprintf;
-use function str_contains;
 use function strtolower;
 use function strtoupper;
 use function var_export;
@@ -329,9 +329,11 @@ trait OpenApiAssertions
 
     /**
      * Decode a JSON request / response body in the shape the validators
-     * expect. Mirrors the Laravel adapter: parse only when the Content-Type
-     * claims JSON (or is absent), report an absent body on empty or non-JSON
-     * content so the validator decides whether the spec required one.
+     * expect. Mirrors the Laravel adapter: the body is JSON-decoded only when
+     * the Content-Type is a JSON media type (or absent); an empty body, or a
+     * non-JSON Content-Type, yields an absent envelope. The JSON-ness test uses
+     * {@see ContentTypeMatcher::isJsonContentType()} so this adapter and the
+     * validator agree on exactly which media types count as JSON (issue #251).
      *
      * Issues #246 / #248: when the raw content is non-empty but decodes to the
      * literal JSON `null`, a present {@see DecodedBody} carrying `null` is
@@ -348,7 +350,12 @@ trait OpenApiAssertions
             return DecodedBody::absent();
         }
 
-        if ($contentType !== '' && !str_contains(strtolower($contentType), 'json')) {
+        // Non-JSON Content-Type: leave the body undecoded and report it absent.
+        // The validator receives the Content-Type separately and decides the
+        // contract verdict from it (issue #251).
+        if ($contentType !== '' && !ContentTypeMatcher::isJsonContentType(
+            ContentTypeMatcher::normalizeMediaType($contentType),
+        )) {
             return DecodedBody::absent();
         }
 

--- a/tests/Unit/Symfony/OpenApiAssertionsTest.php
+++ b/tests/Unit/Symfony/OpenApiAssertionsTest.php
@@ -250,6 +250,31 @@ final class OpenApiAssertionsTest extends TestCase
     }
 
     #[Test]
+    public function content_type_containing_json_substring_is_not_decoded_as_json(): void
+    {
+        // Issue #251: a Content-Type that merely contains the substring "json"
+        // (e.g. application/jsonsomethingweird) is NOT a JSON media type. The
+        // adapter defers to ContentTypeMatcher::isJsonContentType() — the same
+        // strict check the validator uses — so a non-JSON body is left
+        // undecoded and the validator surfaces its clean "Content-Type is not
+        // defined" diagnostic instead of a misleading "could not be parsed as
+        // JSON" parse error.
+        $request = Request::create('/v1/pets', 'GET');
+        $response = new Response(
+            'not json at all',
+            200,
+            ['Content-Type' => 'application/jsonsomethingweird'],
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage(
+            "Response Content-Type 'application/jsonsomethingweird' is not defined",
+        );
+
+        $this->assertResponseMatchesOpenApiSchema($request, $response);
+    }
+
+    #[Test]
     public function json_content_type_with_charset_is_validated(): void
     {
         $request = Request::create('/v1/pets', 'GET');

--- a/tests/Unit/ValidatesOpenApiSchemaAutoValidateRequestTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaAutoValidateRequestTest.php
@@ -395,6 +395,36 @@ class ValidatesOpenApiSchemaAutoValidateRequestTest extends TestCase
     }
 
     #[Test]
+    public function content_type_containing_json_substring_is_not_decoded_as_json(): void
+    {
+        // Issue #251: a Content-Type that merely contains the substring "json"
+        // (e.g. application/jsonsomethingweird) is NOT a JSON media type. The
+        // adapter defers to ContentTypeMatcher::isJsonContentType() — the same
+        // strict check the validator uses — so a non-JSON body is left
+        // undecoded and the validator surfaces its clean "Content-Type is not
+        // defined" diagnostic instead of a misleading "could not be parsed as
+        // JSON" parse error.
+        $GLOBALS['__openapi_testing_config']['openapi-contract-testing.auto_validate_request'] = true;
+
+        $request = Request::create(
+            '/v1/pets',
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/jsonsomethingweird'],
+            'not json at all',
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage(
+            "Request Content-Type 'application/jsonsomethingweird' is not defined",
+        );
+
+        $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/v1/pets');
+    }
+
+    #[Test]
     public function non_json_content_type_body_is_treated_as_null(): void
     {
         // Regression guard: a form-urlencoded body must not be handed to the

--- a/tests/Unit/ValidatesOpenApiSchemaTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaTest.php
@@ -287,6 +287,34 @@ class ValidatesOpenApiSchemaTest extends TestCase
     }
 
     #[Test]
+    public function content_type_containing_json_substring_is_not_decoded_as_json(): void
+    {
+        // Issue #251: a Content-Type that merely contains the substring "json"
+        // (e.g. application/jsonsomethingweird) is NOT a JSON media type. The
+        // adapter defers to ContentTypeMatcher::isJsonContentType() — the same
+        // strict check the validator uses — so a non-JSON body is left
+        // undecoded and the validator surfaces its clean "Content-Type is not
+        // defined" diagnostic instead of a misleading "could not be parsed as
+        // JSON" parse error.
+        $response = $this->makeTestResponse(
+            'not json at all',
+            200,
+            ['Content-Type' => 'application/jsonsomethingweird'],
+        );
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage(
+            "Response Content-Type 'application/jsonsomethingweird' is not defined",
+        );
+
+        $this->assertResponseMatchesOpenApiSchema(
+            $response,
+            HttpMethod::GET,
+            '/v1/pets',
+        );
+    }
+
+    #[Test]
     public function missing_content_type_header_still_parses_json(): void
     {
         $body = (string) json_encode(

--- a/tests/Unit/Validation/Support/ContentTypeMatcherTest.php
+++ b/tests/Unit/Validation/Support/ContentTypeMatcherTest.php
@@ -31,6 +31,19 @@ class ContentTypeMatcherTest extends TestCase
     }
 
     #[Test]
+    public function is_json_content_type_rejects_media_types_that_merely_contain_json(): void
+    {
+        // Issue #251: only an exact `application/json` or a `+json` structured
+        // syntax suffix counts as JSON. Media types that merely contain the
+        // substring "json" are NOT JSON — pinning this is what lets the
+        // framework adapters safely delegate their JSON-decode decision here
+        // instead of a loose `str_contains($ct, 'json')` check.
+        $this->assertFalse(ContentTypeMatcher::isJsonContentType('text/json'));
+        $this->assertFalse(ContentTypeMatcher::isJsonContentType('application/jsonp'));
+        $this->assertFalse(ContentTypeMatcher::isJsonContentType('application/jsonsomethingweird'));
+    }
+
+    #[Test]
     public function find_json_content_type_returns_first_json_key(): void
     {
         $content = [


### PR DESCRIPTION
## Summary

The three adapter body-extraction methods (Laravel `extractRequestBody` / `extractJsonBody`, Symfony `extractSymfonyJsonBody`) decided whether to JSON-decode a body using a loose `str_contains(strtolower($contentType), 'json')` check. They now use the strict `ContentTypeMatcher::isJsonContentType()` — the same check the body validators already use — so the adapter and validator agree on which media types count as JSON.

## Why

Fixes #251.

The loose check treats borderline media types such as `application/jsonsomethingweird` as JSON, so the adapter would attempt `json_decode()` on a non-JSON body and fail with a misleading **"could not be parsed as JSON"** parse error, when the real issue is the Content-Type. After the change the non-JSON body is left undecoded and reported absent, and the validator's content negotiation surfaces its clean **"Content-Type is not defined"** diagnostic instead.

**Scope note (investigation finding):** Issue #251 describes a "silent pass" for non-empty non-JSON bodies. On close inspection that scenario no longer reproduces — the content negotiation introduced in #246 already makes the body validators decide non-JSON handling from the separately-forwarded `$contentType` (loud "Content-Type is not defined" when the spec does not declare the type; correctly accepted when it does). The body envelope's absent-vs-present bit is never consulted for non-JSON types, so **extending `DecodedBody` with a third state was deliberately not done** — it would be a dead state nothing reads. The remaining, actionable gap was the adapter/validator JSON-detection inconsistency addressed here.

**Behavior change (minor, intentional):** non-standard JSON-ish content types (`application/jsonsomethingweird`, `text/json`, `application/jsonp`) are now treated as non-JSON by the adapters, matching the validators. Standard types (`application/json`, `application/*+json`, `application/json; charset=utf-8`) are unaffected.

## Verification

Failing tests were added first (TDD), confirmed red, then made green by the fix. Each asserts the failure message is the clean `Content-Type ... is not defined` diagnostic rather than `could not be parsed as JSON`:

- `ValidatesOpenApiSchemaTest::content_type_containing_json_substring_is_not_decoded_as_json` (Laravel response)
- `ValidatesOpenApiSchemaAutoValidateRequestTest::content_type_containing_json_substring_is_not_decoded_as_json` (Laravel request)
- `OpenApiAssertionsTest::content_type_containing_json_substring_is_not_decoded_as_json` (Symfony)

- [x] `composer test` passes (1788 tests, 4201 assertions)
- [x] `composer stan` passes (no errors)
- [x] `composer cs-check` passes (no violations)

## Notes for reviewers

- `ContentTypeMatcher` is `@internal`; intra-package use from the adapters mirrors how `RequestBodyValidator` / `ResponseBodyValidator` already consume it.
- Misleading docblock/inline comments on the three methods ("report an absent body so the validator decides whether the spec required one") were clarified — the validator decides via Content-Type negotiation on the separately-passed Content-Type, not via the body envelope.