### PR TITLE
fix(validation): guard response validation against malformed content and response specs

### DIFF
--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -190,12 +190,13 @@ final class OpenApiResponseValidator
         $responseSpec = $responses[$matchedResponseKey];
 
         // A present-but-non-array response entry is a malformed spec (stray
-        // scalar, e.g. an unresolved $ref). Surface it before it reaches the
-        // `array $responseSpec` parameters of validateBody() / validateHeaders(),
-        // where it would raise an uncaught TypeError (TypeError extends Error,
-        // not RuntimeException, so validateBody()'s catch would not see it).
-        // Mirrors the content-level guards in validateBody() and
-        // RequestBodyValidator's `requestBody` guard (issue #258).
+        // scalar, e.g. an unresolved $ref); surface it as a loud spec error
+        // (issue #258). Without this guard the scalar reaches the
+        // `array $responseSpec` parameters of validateBody() / validateHeaders()
+        // and raises an uncaught TypeError (TypeError extends Error, not
+        // RuntimeException, so validateBody()'s catch would not see it). This
+        // mirrors the content-level guards in validateBody() and
+        // RequestBodyValidator's `requestBody` guard.
         if (!is_array($responseSpec)) {
             return OpenApiValidationResult::failure([
                 "Malformed 'responses[{$matchedResponseKey}]' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -189,6 +189,20 @@ final class OpenApiResponseValidator
         $statusCodeStr = $matchedResponseKey;
         $responseSpec = $responses[$matchedResponseKey];
 
+        // A present-but-non-array response entry is a malformed spec (stray
+        // scalar, e.g. an unresolved $ref). Surface it before it reaches the
+        // `array $responseSpec` parameters of validateBody() / validateHeaders(),
+        // where it would raise an uncaught TypeError (TypeError extends Error,
+        // not RuntimeException, so validateBody()'s catch would not see it).
+        // Mirrors the content-level guards in validateBody() and
+        // RequestBodyValidator's `requestBody` guard (issue #258).
+        if (!is_array($responseSpec)) {
+            return OpenApiValidationResult::failure([
+                "Malformed 'responses[{$matchedResponseKey}]' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+            ], $matchedPath, $statusCodeStr);
+        }
+
+        /** @var array<string, mixed> $responseSpec */
         $bodyResult = $this->validateBody(
             $specName,
             $method,

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -412,7 +412,19 @@ final class OpenApiResponseValidator
             return new ResponseBodyValidationResult([], null);
         }
 
-        /** @var array<string, array<string, mixed>> $content */
+        // A present-but-non-array `content` is a malformed spec (stray scalar,
+        // e.g. an unresolved $ref). Surface it before it reaches
+        // ResponseBodyValidator::validate()'s `array $content` parameter, where
+        // it would raise an uncaught TypeError (TypeError extends Error, not
+        // RuntimeException, so the catch below would not see it). Mirrors
+        // RequestBodyValidator's `requestBody.content` guard (issue #256).
+        if (!is_array($responseSpec['content'])) {
+            return new ResponseBodyValidationResult([
+                "Malformed 'responses[{$statusCode}].content' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+            ], null);
+        }
+
+        /** @var array<string, mixed> $content */
         $content = $responseSpec['content'];
 
         // Inlined try/catch mirrors ValidatorErrorBoundary::safely() for the

--- a/src/Validation/Response/ResponseBodyValidator.php
+++ b/src/Validation/Response/ResponseBodyValidator.php
@@ -15,6 +15,7 @@ use Studio\OpenApiContractTesting\Validation\Support\ContentTypeMatcher;
 use Studio\OpenApiContractTesting\Validation\Support\ObjectConverter;
 use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
 
+use function array_key_exists;
 use function array_keys;
 use function implode;
 use function in_array;
@@ -49,7 +50,10 @@ final class ResponseBodyValidator
      * {@see OpenApiResponseValidator::validate()} — when the response spec
      * has no `content` key, this validator is never invoked.
      *
-     * @param array<string, array<string, mixed>> $content the `responses[$status].content` map
+     * @param array<string, mixed> $content the `responses[$status].content` map.
+     *                                      Values are media-type objects, but a malformed spec can
+     *                                      carry a scalar — the guard loop below rejects those loudly
+     *                                      before any value is dereferenced as an array.
      */
     public function validate(
         string $specName,
@@ -61,6 +65,31 @@ final class ResponseBodyValidator
         ?string $responseContentType,
         OpenApiVersion $version,
     ): ResponseBodyValidationResult {
+        // Pre-scan the content map for malformed media-type entries before any
+        // content negotiation runs. This mirrors RequestBodyValidator's
+        // per-media-type guards: a scalar entry would slip past the downstream
+        // `isset(...['schema'])` checks as a silent pass, and a non-array
+        // `schema` on a JSON media type would reach OpenApiSchemaConverter as a
+        // scalar and raise a confusing TypeError. Surface both as loud
+        // spec-level errors (issue #256). `matchedContentType` is null: no
+        // content-type lookup succeeded.
+        foreach ($content as $mediaType => $mediaTypeSpec) {
+            if (!is_array($mediaTypeSpec)) {
+                return new ResponseBodyValidationResult([
+                    "Malformed 'responses[{$statusCode}].content[\"{$mediaType}\"]' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+                ], null);
+            }
+
+            // array_key_exists rather than isset so an explicit `schema: null`
+            // is also flagged — otherwise it falls through the downstream
+            // presence check as a silent "no schema" pass.
+            if (array_key_exists('schema', $mediaTypeSpec) && !is_array($mediaTypeSpec['schema'])) {
+                return new ResponseBodyValidationResult([
+                    "Malformed 'responses[{$statusCode}].content[\"{$mediaType}\"].schema' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+                ], null);
+            }
+        }
+
         // When the actual response Content-Type is provided, handle content negotiation:
         // non-JSON types are checked for spec presence only, while JSON-compatible types
         // fall through to schema validation. For JSON-flavoured response Content-Types
@@ -84,11 +113,11 @@ final class ResponseBodyValidator
                     // with no `schema` has nothing to validate — stay
                     // silently successful, as before.
                     //
-                    // `isset` treats a degenerate `schema: null` as "no
-                    // schema" (silent success). Unlike the request validator,
-                    // this validator has no upstream malformed-schema guard,
-                    // so a non-array `schema` is not surfaced as a loud spec
-                    // error here — tracked separately (see #256).
+                    // `isset` (not `array_key_exists`) is deliberate: an
+                    // explicit `schema: null` is a degenerate entry, and the
+                    // per-media-type malformed-schema guard above already
+                    // rejected it loudly before this point — so it never
+                    // reaches here as a silent "no schema" case.
                     if (isset($content[$matchedKey]['schema'])) {
                         return new ResponseBodyValidationResult(
                             [],

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -2160,9 +2160,9 @@ class OpenApiResponseValidatorTest extends TestCase
         // `responses["200"]` is a scalar instead of a response object. Without
         // the guard the scalar reaches validateBody()/validateHeaders()' `array
         // $responseSpec` parameter and raises an uncaught TypeError (TypeError
-        // extends Error, not RuntimeException). The guard surfaces a loud spec
-        // error, mirroring the content-level guards and RequestBodyValidator's
-        // `requestBody` guard (issue #258).
+        // extends Error, not RuntimeException). The guard added for issue #258
+        // surfaces a loud spec error, mirroring the content-level guards and
+        // RequestBodyValidator's `requestBody` guard.
         $result = $this->validator->validate(
             'malformed-response',
             'GET',
@@ -2175,6 +2175,31 @@ class OpenApiResponseValidatorTest extends TestCase
         $this->assertFalse($result->isValid());
         $this->assertStringContainsString(
             "Malformed 'responses[200]'",
+            $result->errors()[0],
+        );
+        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function malformed_response_status_entry_keys_message_off_matched_spec_key(): void
+    {
+        // The spec declares only `default`; a wire status of 200 resolves to
+        // the `default` key (SpecResponseKeyResolver runs before the guard).
+        // The guard's error message must name the matched spec key
+        // (`responses[default]`), not the wire status — `responses[200]` would
+        // point at a map entry the spec author never wrote (issue #258).
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/response-default-status-scalar',
+            200,
+            ['id' => 1],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "Malformed 'responses[default]'",
             $result->errors()[0],
         );
         $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -2085,4 +2085,72 @@ class OpenApiResponseValidatorTest extends TestCase
         );
         $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
     }
+
+    #[Test]
+    public function malformed_response_content_media_type_entry_returns_failure(): void
+    {
+        // `responses.200.content["application/json"]` is a scalar. The
+        // per-media-type guard in ResponseBodyValidator surfaces it as a spec
+        // error, which the orchestrator turns into a Failure (issue #256).
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/response-scalar-content-media-type',
+            200,
+            ['id' => 1],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            'Malformed \'responses[200].content["application/json"]\'',
+            $result->errors()[0],
+        );
+        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function malformed_response_content_schema_returns_failure(): void
+    {
+        // `responses.200.content["application/json"].schema` is a scalar.
+        // Without the guard the scalar would reach OpenApiSchemaConverter and
+        // raise a TypeError; the orchestrator now reports a clean spec error.
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/response-scalar-content-schema',
+            200,
+            ['id' => 1],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            'Malformed \'responses[200].content["application/json"].schema\'',
+            $result->errors()[0],
+        );
+        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function null_response_content_schema_returns_failure(): void
+    {
+        // Locks `array_key_exists` over `isset` at the orchestrator level: an
+        // explicit `schema: null` must surface a Failure, not slip through the
+        // downstream presence check as a silent pass.
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/response-null-content-schema',
+            200,
+            ['id' => 1],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            'Malformed \'responses[200].content["application/json"].schema\'',
+            $result->errors()[0],
+        );
+    }
 }

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -2153,4 +2153,30 @@ class OpenApiResponseValidatorTest extends TestCase
             $result->errors()[0],
         );
     }
+
+    #[Test]
+    public function malformed_response_status_entry_returns_failure(): void
+    {
+        // `responses["200"]` is a scalar instead of a response object. Without
+        // the guard the scalar reaches validateBody()/validateHeaders()' `array
+        // $responseSpec` parameter and raises an uncaught TypeError (TypeError
+        // extends Error, not RuntimeException). The guard surfaces a loud spec
+        // error, mirroring the content-level guards and RequestBodyValidator's
+        // `requestBody` guard (issue #258).
+        $result = $this->validator->validate(
+            'malformed-response',
+            'GET',
+            '/things',
+            200,
+            ['id' => 1],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "Malformed 'responses[200]'",
+            $result->errors()[0],
+        );
+        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+    }
 }

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -2059,4 +2059,30 @@ class OpenApiResponseValidatorTest extends TestCase
         $this->assertFalse($result->isValid());
         $this->assertStringContainsString('Response body is empty', $result->errorMessage());
     }
+
+    #[Test]
+    public function malformed_response_content_block_returns_failure(): void
+    {
+        // `responses.200.content` is a scalar. Without the guard the scalar
+        // reaches ResponseBodyValidator::validate()'s `array $content`
+        // parameter and raises an uncaught TypeError (TypeError extends Error,
+        // not RuntimeException, so validateBody()'s catch does not see it).
+        // The guard surfaces a loud spec error instead, mirroring the
+        // request-side `Malformed 'requestBody.content'` guard (issue #256).
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/response-scalar-content',
+            200,
+            ['id' => 1],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "Malformed 'responses[200].content'",
+            $result->errors()[0],
+        );
+        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+    }
 }

--- a/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
+++ b/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
@@ -627,4 +627,63 @@ class ResponseBodyValidatorTest extends TestCase
         );
         $this->assertNull($result->skipReason);
     }
+
+    #[Test]
+    public function validate_flags_malformed_media_type_schema_for_non_json_content_type(): void
+    {
+        // A non-null scalar `schema` (the natural shape of an unresolved $ref
+        // that decoded to a string) on a non-JSON media type. Like the
+        // `schema: null` case, the guard runs before content negotiation, so
+        // it is flagged regardless of the actual response Content-Type.
+        $content = ['text/plain' => ['schema' => 'oops']];
+
+        $result = $this->validator->validate(
+            'spec',
+            'GET',
+            '/pets',
+            200,
+            $content,
+            DecodedBody::present('blob'),
+            'text/plain',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertCount(1, $result->errors);
+        $this->assertStringContainsString(
+            'Malformed \'responses[200].content["text/plain"].schema\'',
+            $result->errors[0],
+        );
+        $this->assertNull($result->skipReason);
+    }
+
+    #[Test]
+    public function validate_flags_malformed_entry_even_when_not_the_negotiated_content_type(): void
+    {
+        // The guard loop pre-scans every media-type entry before content
+        // negotiation runs. A malformed `text/plain` entry must be flagged
+        // even though the JSON response Content-Type would negotiate the
+        // well-formed `application/json` entry — a malformed spec is surfaced
+        // regardless of which entry the request would have matched.
+        $content = [
+            'application/json' => ['schema' => ['type' => 'object']],
+            'text/plain' => 'oops',
+        ];
+
+        $result = $this->validator->validate(
+            'spec',
+            'GET',
+            '/pets',
+            200,
+            $content,
+            DecodedBody::present(['id' => 1]),
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertCount(1, $result->errors);
+        $this->assertStringContainsString(
+            'Malformed \'responses[200].content["text/plain"]\'',
+            $result->errors[0],
+        );
+    }
 }

--- a/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
+++ b/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
@@ -510,4 +510,121 @@ class ResponseBodyValidatorTest extends TestCase
         $this->assertStringContainsString('/id', $result->errors[0]);
         $this->assertSame('application/json', $result->matchedContentType);
     }
+
+    // ========================================
+    // Malformed-spec guards (issue #256) — symmetric with RequestBodyValidator
+    // ========================================
+
+    #[Test]
+    public function validate_flags_malformed_media_type_entry(): void
+    {
+        // `content: {"application/json": "oops"}` — a scalar where a media
+        // type object was expected. Without the guard the scalar slips past
+        // the downstream `isset(...['schema'])` presence check and the body
+        // is silently recorded as a clean pass. Surface a loud spec error,
+        // mirroring RequestBodyValidator's sibling guard.
+        $content = ['application/json' => 'oops'];
+
+        $result = $this->validator->validate(
+            'spec',
+            'GET',
+            '/pets',
+            200,
+            $content,
+            DecodedBody::present(['id' => 1]),
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertCount(1, $result->errors);
+        $this->assertStringContainsString(
+            'Malformed \'responses[200].content["application/json"]\'',
+            $result->errors[0],
+        );
+        $this->assertStringContainsString('expected object, got scalar', $result->errors[0]);
+        $this->assertNull($result->matchedContentType);
+    }
+
+    #[Test]
+    public function validate_flags_malformed_media_type_schema_for_json_content_type(): void
+    {
+        // A non-array `schema` on a JSON media type would reach
+        // OpenApiSchemaConverter::convert() as a scalar and raise a confusing
+        // TypeError. The guard turns it into a spec-level error instead.
+        $content = ['application/json' => ['schema' => 'oops']];
+
+        $result = $this->validator->validate(
+            'spec',
+            'GET',
+            '/pets',
+            200,
+            $content,
+            DecodedBody::present(['id' => 1]),
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertCount(1, $result->errors);
+        $this->assertStringContainsString(
+            'Malformed \'responses[200].content["application/json"].schema\'',
+            $result->errors[0],
+        );
+        $this->assertStringContainsString('expected object, got scalar', $result->errors[0]);
+        $this->assertNull($result->matchedContentType);
+    }
+
+    #[Test]
+    public function validate_flags_null_media_type_schema_for_json_content_type(): void
+    {
+        // Locks in `array_key_exists` over `isset`: an explicit `schema: null`
+        // must be flagged. With `isset` it would fall through the downstream
+        // presence check and accept any body — a silent pass.
+        $content = ['application/json' => ['schema' => null]];
+
+        $result = $this->validator->validate(
+            'spec',
+            'GET',
+            '/pets',
+            200,
+            $content,
+            DecodedBody::present(['id' => 1]),
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertCount(1, $result->errors);
+        $this->assertStringContainsString(
+            'Malformed \'responses[200].content["application/json"].schema\'',
+            $result->errors[0],
+        );
+    }
+
+    #[Test]
+    public function validate_flags_null_media_type_schema_for_non_json_content_type(): void
+    {
+        // Before the guard, a non-JSON entry with `schema: null` slipped
+        // through the `isset(...['schema'])` skip check (issue #254) as a
+        // silent success — asymmetric with the request validator, which
+        // rejects the same `schema: null` loudly. The guard runs before
+        // content negotiation, so request and response now agree.
+        $content = ['text/plain' => ['schema' => null]];
+
+        $result = $this->validator->validate(
+            'spec',
+            'GET',
+            '/pets',
+            200,
+            $content,
+            DecodedBody::present('blob'),
+            'text/plain',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertCount(1, $result->errors);
+        $this->assertStringContainsString(
+            'Malformed \'responses[200].content["text/plain"].schema\'',
+            $result->errors[0],
+        );
+        $this->assertNull($result->skipReason);
+    }
 }

--- a/tests/fixtures/specs/malformed.json
+++ b/tests/fixtures/specs/malformed.json
@@ -131,6 +131,52 @@
                 }
             }
         },
+        "/response-scalar-content-media-type": {
+            "get": {
+                "summary": "responses[200].content[mediaType] is a scalar (not an object)",
+                "operationId": "responseScalarContentMediaType",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": "this should have been an object"
+                        }
+                    }
+                }
+            }
+        },
+        "/response-scalar-content-schema": {
+            "get": {
+                "summary": "responses[200].content[mediaType].schema is a scalar (not an object)",
+                "operationId": "responseScalarContentSchema",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": "this should have been an object"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/response-null-content-schema": {
+            "get": {
+                "summary": "responses[200].content[mediaType].schema is null (explicitly absent value)",
+                "operationId": "responseNullContentSchema",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": null
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/path-scalar-parameter/{id}": {
             "parameters": [
                 "this should have been an object"

--- a/tests/fixtures/specs/malformed.json
+++ b/tests/fixtures/specs/malformed.json
@@ -177,6 +177,15 @@
                 }
             }
         },
+        "/response-default-status-scalar": {
+            "get": {
+                "summary": "responses[default] entry is a scalar — declares only `default`, so a wire status resolves to the `default` spec key",
+                "operationId": "responseDefaultStatusScalar",
+                "responses": {
+                    "default": "this should have been an object"
+                }
+            }
+        },
         "/path-scalar-parameter/{id}": {
             "parameters": [
                 "this should have been an object"

--- a/tests/fixtures/specs/malformed.json
+++ b/tests/fixtures/specs/malformed.json
@@ -119,6 +119,18 @@
                 }
             }
         },
+        "/response-scalar-content": {
+            "get": {
+                "summary": "responses[200].content is a scalar (not an object)",
+                "operationId": "responseScalarContent",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": "this should have been an object"
+                    }
+                }
+            }
+        },
         "/path-scalar-parameter/{id}": {
             "parameters": [
                 "this should have been an object"


### PR DESCRIPTION
## Summary

`ResponseBodyValidator` and `OpenApiResponseValidator` lacked the
malformed-schema guards that `RequestBodyValidator` already had, so the two
sides of the contract behaved asymmetrically on a broken spec. This adds
symmetric guards at every level of the response spec so a non-array
`responses[$status]` entry, a non-array `content` block, a non-array
`content[mediaType]` entry, or a non-array `schema` is surfaced as a loud
spec-level error.

## Why

Fixes #256. Fixes #258.

With no guard, a malformed `responses` map produced one of two bad outcomes on
the response side:

- **Uncaught `TypeError`** — a non-array `responses[$status]` entry, a non-array
  `content` block, or a non-array `schema` on a JSON media type reached an
  `array`-typed parameter (`validateBody()` / `validateHeaders()` /
  `ResponseBodyValidator::validate()`) or `OpenApiSchemaConverter::convert()`.
  `TypeError` extends `Error`, not `RuntimeException`, so `validateBody()`'s
  catch never saw it — the run crashed with a stack trace instead of a readable
  spec error.
- **Diagnostic-free silent pass** — a non-JSON media type's `schema: null` was
  read as "no schema" by the `isset(...['schema'])` skip check (issue #254) and
  slipped through as a clean success. The request side rejects the same
  `schema: null` loudly, so request and response disagreed.

Both contradict the contract-testing principle of surfacing malformed specs
rather than masking them, and broke parity with `RequestBodyValidator`'s guards.

#258 (the non-array `responses[$status]` entry) was originally split out as a
follow-up; it is the same logical change one level up, so it is folded into this
PR.

## Verification

Failing tests were added first (each reproducing a `TypeError` or a silent
pass), then the guards were implemented. `array_key_exists` (not `isset`) is used
so an explicit `schema: null` is also flagged.

A multi-agent review (`/pr-review-toolkit:review-pr`) prompted additional tests:
orchestrator-level tests for the malformed media-type-entry and malformed/null
`schema` guards (for parity with the request-side `OpenApiRequestValidatorTest`),
a non-JSON non-null scalar `schema` case, and a test pinning that the guard
pre-scans every media-type entry regardless of content negotiation.

- [x] `composer test` passes (1815 tests)
- [x] `composer stan` passes
- [x] `composer cs-check` passes

## Notes for reviewers

- The guards live at the level each malformed shape first becomes reachable: the
  `responses[$status]` and `content`-block guards in
  `OpenApiResponseValidator::validate()` / `validateBody()` (their `array`-typed
  parameters are the crash site), and the per-entry / per-`schema` guards in
  `ResponseBodyValidator::validate()`, mirroring `RequestBodyValidator`.
- The `responses[...]` status in the error message uses the matched spec key for
  the `responses[$status]` guard (a literal spec pointer) and the wire status
  code for the `content`-level guards (consistent with the validator's existing
  `(status N)` messages). When the matched key is a range (`5XX`) or `default`,
  the wire-status form is not a literal pointer but is enough to locate the
  malformed `content`.
- Out of scope and tracked as #259: a malformed (non-array) structural node
  *above* `responses[$status]` — a non-array `paths`, path item, operation, or
  `responses` map — still raises an uncaught `TypeError` in the spec-traversal
  path of `validate()`. Hardening that traversal is a separate concern from the
  per-response malformed guards this PR adds.
