### PR TITLE
fix(validation): guard spec traversal against malformed structural nodes (#259)

### DIFF
--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -129,6 +129,18 @@ final class OpenApiRequestValidator
 
         $version = OpenApiVersion::fromSpec($spec);
 
+        // A present-but-non-array `paths` is a malformed spec (stray scalar,
+        // e.g. a YAML/JSON node that decoded to the wrong type). `?? []`
+        // guards key *absence* only; a scalar value slips through to the
+        // `array_keys()` call below and raises an uncaught TypeError. Surface
+        // it as a loud spec error instead, mirroring the response-side
+        // traversal guards (issue #259).
+        if (isset($spec['paths']) && !is_array($spec['paths'])) {
+            return OpenApiValidationResult::failure([
+                "Malformed 'paths' for {$method} {$requestPath} in '{$specName}' spec: expected object, got scalar.",
+            ]);
+        }
+
         /** @var string[] $specPaths */
         $specPaths = array_keys($spec['paths'] ?? []);
         $matcher = $this->getPathMatcher($specName, $specPaths);
@@ -144,17 +156,39 @@ final class OpenApiRequestValidator
         $pathVariables = $matched['variables'];
 
         $lowerMethod = strtolower($method);
-        /** @var array<string, mixed> $pathSpec */
         $pathSpec = $spec['paths'][$matchedPath] ?? [];
 
+        // A present-but-non-array path item is a malformed spec; without this
+        // guard a scalar `$pathSpec` produces a misleading "method not
+        // defined" diagnostic (the `isset()` below is false for a scalar) and
+        // would otherwise reach `ParameterCollector::collect()`'s `array
+        // $pathSpec` parameter. Surface it loudly instead (issue #259).
+        if (!is_array($pathSpec)) {
+            return OpenApiValidationResult::failure([
+                "Malformed 'paths[\"{$matchedPath}\"]' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+            ], $matchedPath);
+        }
+
+        /** @var array<string, mixed> $pathSpec */
         if (!isset($pathSpec[$lowerMethod])) {
             return OpenApiValidationResult::failure([
                 PathDiagnosticsFormatter::methodNotDefined($specName, $method, $matchedPath, $spec),
             ], $matchedPath);
         }
 
-        /** @var array<string, mixed> $operation */
         $operation = $pathSpec[$lowerMethod];
+
+        // A present-but-non-array operation is a malformed spec; a scalar here
+        // would reach the `array $operation` parameters of
+        // `ParameterCollector::collect()` / `RequestBodyValidator::validate()`
+        // and raise an uncaught TypeError (issue #259).
+        if (!is_array($operation)) {
+            return OpenApiValidationResult::failure([
+                "Malformed 'paths[\"{$matchedPath}\"].{$lowerMethod}' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+            ], $matchedPath);
+        }
+
+        /** @var array<string, mixed> $operation */
 
         // Collect merged path/operation parameters once so path + query + header
         // validation share a single view of the spec and malformed-entry errors

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -20,7 +20,9 @@ use Studio\OpenApiContractTesting\Validation\Support\SpecResponseKeyResolver;
 use Studio\OpenApiContractTesting\Validation\Support\StatusCodePatternSet;
 use Studio\OpenApiContractTesting\Validation\Support\ValidatorErrorBoundary;
 
+use function array_key_exists;
 use function array_keys;
+use function get_debug_type;
 use function is_array;
 use function sprintf;
 use function strtolower;
@@ -129,15 +131,24 @@ final class OpenApiRequestValidator
 
         $version = OpenApiVersion::fromSpec($spec);
 
-        // A present-but-non-array `paths` is a malformed spec (stray scalar,
-        // e.g. a YAML/JSON node that decoded to the wrong type). `?? []`
-        // guards key *absence* only; a scalar value slips through to the
-        // `array_keys()` call below and raises an uncaught TypeError. Surface
-        // it as a loud spec error instead, mirroring the response-side
-        // traversal guards (issue #259).
-        if (isset($spec['paths']) && !is_array($spec['paths'])) {
+        // A present-but-non-array `paths` is a malformed spec — a stray
+        // scalar or an explicit `null` (a YAML `paths:` left empty, or a node
+        // that decoded to the wrong type). `array_key_exists` (not `isset`)
+        // is deliberate: `isset` is false for `null`, which would let a
+        // present-but-`null` `paths` slip through to `?? []` below and be
+        // silently coalesced to an empty map. A non-array value otherwise
+        // reaches the `array_keys()` call and raises an uncaught TypeError.
+        // Surface it as a loud spec error instead, mirroring the
+        // response-side traversal guards (issue #259).
+        if (array_key_exists('paths', $spec) && !is_array($spec['paths'])) {
             return OpenApiValidationResult::failure([
-                "Malformed 'paths' for {$method} {$requestPath} in '{$specName}' spec: expected object, got scalar.",
+                sprintf(
+                    "Malformed 'paths' for %s %s in '%s' spec: expected object, got %s.",
+                    $method,
+                    $requestPath,
+                    $specName,
+                    get_debug_type($spec['paths']),
+                ),
             ]);
         }
 
@@ -156,21 +167,35 @@ final class OpenApiRequestValidator
         $pathVariables = $matched['variables'];
 
         $lowerMethod = strtolower($method);
-        $pathSpec = $spec['paths'][$matchedPath] ?? [];
+        // `$matchedPath` is always a key of `$spec['paths']` (the matcher was
+        // built from its `array_keys()`), so `?? null` here only fires for an
+        // explicit `null` *value* — which the guard below then treats as
+        // malformed, exactly like a scalar path item.
+        $pathSpec = $spec['paths'][$matchedPath] ?? null;
 
         // A present-but-non-array path item is a malformed spec; without this
-        // guard a scalar `$pathSpec` produces a misleading "method not
-        // defined" diagnostic (the `isset()` below is false for a scalar) and
-        // would otherwise reach `ParameterCollector::collect()`'s `array
-        // $pathSpec` parameter. Surface it loudly instead (issue #259).
+        // guard a scalar/`null` `$pathSpec` reaches the `array_key_exists()`
+        // method lookup below (and `ParameterCollector::collect()`'s `array
+        // $pathSpec` parameter) and raises an uncaught TypeError. Surface it
+        // loudly instead (issue #259).
         if (!is_array($pathSpec)) {
             return OpenApiValidationResult::failure([
-                "Malformed 'paths[\"{$matchedPath}\"]' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+                sprintf(
+                    "Malformed 'paths[\"%s\"]' for %s %s in '%s' spec: expected object, got %s.",
+                    $matchedPath,
+                    $method,
+                    $matchedPath,
+                    $specName,
+                    get_debug_type($pathSpec),
+                ),
             ], $matchedPath);
         }
 
         /** @var array<string, mixed> $pathSpec */
-        if (!isset($pathSpec[$lowerMethod])) {
+        // `array_key_exists` (not `isset`) so an explicit `{method}: null`
+        // reaches the operation guard below as malformed rather than being
+        // misreported as an undefined method.
+        if (!array_key_exists($lowerMethod, $pathSpec)) {
             return OpenApiValidationResult::failure([
                 PathDiagnosticsFormatter::methodNotDefined($specName, $method, $matchedPath, $spec),
             ], $matchedPath);
@@ -178,21 +203,28 @@ final class OpenApiRequestValidator
 
         $operation = $pathSpec[$lowerMethod];
 
-        // A present-but-non-array operation is a malformed spec; a scalar here
-        // would reach the `array $operation` parameters of
-        // `ParameterCollector::collect()` / `RequestBodyValidator::validate()`
-        // and raise an uncaught TypeError (issue #259).
+        // A present-but-non-array operation is a malformed spec; a scalar or
+        // `null` here would reach `ParameterCollector::collect()`'s `array
+        // $operation` parameter (the first scalar-typed sink) and raise an
+        // uncaught TypeError (issue #259).
         if (!is_array($operation)) {
             return OpenApiValidationResult::failure([
-                "Malformed 'paths[\"{$matchedPath}\"].{$lowerMethod}' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+                sprintf(
+                    "Malformed 'paths[\"%s\"].%s' for %s %s in '%s' spec: expected object, got %s.",
+                    $matchedPath,
+                    $lowerMethod,
+                    $method,
+                    $matchedPath,
+                    $specName,
+                    get_debug_type($operation),
+                ),
             ], $matchedPath);
         }
-
-        /** @var array<string, mixed> $operation */
 
         // Collect merged path/operation parameters once so path + query + header
         // validation share a single view of the spec and malformed-entry errors
         // are surfaced only once.
+        /** @var array<string, mixed> $operation */
         $collected = ParameterCollector::collect($method, $matchedPath, $pathSpec, $operation);
 
         // Each sub-validator is wrapped in ValidatorErrorBoundary::safely() so a

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -14,6 +14,7 @@ use Studio\OpenApiContractTesting\Validation\Request\QueryParameterValidator;
 use Studio\OpenApiContractTesting\Validation\Request\RequestBodyValidationResult;
 use Studio\OpenApiContractTesting\Validation\Request\RequestBodyValidator;
 use Studio\OpenApiContractTesting\Validation\Request\SecurityValidator;
+use Studio\OpenApiContractTesting\Validation\Support\MalformedSpecNode;
 use Studio\OpenApiContractTesting\Validation\Support\PathDiagnosticsFormatter;
 use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
 use Studio\OpenApiContractTesting\Validation\Support\SpecResponseKeyResolver;
@@ -22,7 +23,6 @@ use Studio\OpenApiContractTesting\Validation\Support\ValidatorErrorBoundary;
 
 use function array_key_exists;
 use function array_keys;
-use function get_debug_type;
 use function is_array;
 use function sprintf;
 use function strtolower;
@@ -131,23 +131,22 @@ final class OpenApiRequestValidator
 
         $version = OpenApiVersion::fromSpec($spec);
 
-        // A present-but-non-array `paths` is a malformed spec — a stray
-        // scalar or an explicit `null` (a YAML `paths:` left empty, or a node
-        // that decoded to the wrong type). `array_key_exists` (not `isset`)
-        // is deliberate: `isset` is false for `null`, which would let a
-        // present-but-`null` `paths` slip through to `?? []` below and be
-        // silently coalesced to an empty map. A non-array value otherwise
-        // reaches the `array_keys()` call and raises an uncaught TypeError.
-        // Surface it as a loud spec error instead, mirroring the
+        // The root `paths` must decode to a JSON object; a scalar, `null`, or
+        // a JSON list is a malformed spec ({@see MalformedSpecNode}).
+        // Unguarded, a non-array reaches the `array_keys()` call below
+        // (uncaught TypeError) and a list mis-resolves silently. The presence
+        // test uses `array_key_exists` (not `isset`) so a present-but-`null`
+        // `paths` is caught here rather than coalesced to an empty map by
+        // `?? []`. Surface it as a loud spec error instead, mirroring the
         // response-side traversal guards (issue #259).
-        if (array_key_exists('paths', $spec) && !is_array($spec['paths'])) {
+        if (array_key_exists('paths', $spec) && MalformedSpecNode::isMalformed($spec['paths'])) {
             return OpenApiValidationResult::failure([
                 sprintf(
                     "Malformed 'paths' for %s %s in '%s' spec: expected object, got %s.",
                     $method,
                     $requestPath,
                     $specName,
-                    get_debug_type($spec['paths']),
+                    MalformedSpecNode::describe($spec['paths']),
                 ),
             ]);
         }
@@ -173,12 +172,13 @@ final class OpenApiRequestValidator
         // malformed, exactly like a scalar path item.
         $pathSpec = $spec['paths'][$matchedPath] ?? null;
 
-        // A present-but-non-array path item is a malformed spec; without this
-        // guard a scalar/`null` `$pathSpec` reaches the `array_key_exists()`
-        // method lookup below (and `ParameterCollector::collect()`'s `array
-        // $pathSpec` parameter) and raises an uncaught TypeError. Surface it
-        // loudly instead (issue #259).
-        if (!is_array($pathSpec)) {
+        // A path item must decode to a JSON object; a scalar, `null`, or a
+        // JSON list is malformed ({@see MalformedSpecNode}). Unguarded, a
+        // non-array reaches the `array_key_exists()` method lookup below (and
+        // `ParameterCollector::collect()`'s `array $pathSpec` parameter),
+        // raising an uncaught TypeError, and a list mis-resolves silently.
+        // Surface it loudly instead (issue #259).
+        if (MalformedSpecNode::isMalformed($pathSpec)) {
             return OpenApiValidationResult::failure([
                 sprintf(
                     "Malformed 'paths[\"%s\"]' for %s %s in '%s' spec: expected object, got %s.",
@@ -186,7 +186,7 @@ final class OpenApiRequestValidator
                     $method,
                     $matchedPath,
                     $specName,
-                    get_debug_type($pathSpec),
+                    MalformedSpecNode::describe($pathSpec),
                 ),
             ], $matchedPath);
         }
@@ -203,11 +203,12 @@ final class OpenApiRequestValidator
 
         $operation = $pathSpec[$lowerMethod];
 
-        // A present-but-non-array operation is a malformed spec; a scalar or
-        // `null` here would reach `ParameterCollector::collect()`'s `array
-        // $operation` parameter (the first scalar-typed sink) and raise an
-        // uncaught TypeError (issue #259).
-        if (!is_array($operation)) {
+        // An operation must decode to a JSON object; a scalar, `null`, or a
+        // JSON list is malformed ({@see MalformedSpecNode}). A non-array
+        // would reach `ParameterCollector::collect()`'s `array $operation`
+        // parameter (the first scalar-typed sink) and raise an uncaught
+        // TypeError; a list mis-resolves silently (issue #259).
+        if (MalformedSpecNode::isMalformed($operation)) {
             return OpenApiValidationResult::failure([
                 sprintf(
                     "Malformed 'paths[\"%s\"].%s' for %s %s in '%s' spec: expected object, got %s.",
@@ -216,7 +217,7 @@ final class OpenApiRequestValidator
                     $method,
                     $matchedPath,
                     $specName,
-                    get_debug_type($operation),
+                    MalformedSpecNode::describe($operation),
                 ),
             ], $matchedPath);
         }

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -108,6 +108,18 @@ final class OpenApiResponseValidator
 
         $version = OpenApiVersion::fromSpec($spec);
 
+        // A present-but-non-array `paths` is a malformed spec (stray scalar,
+        // e.g. a YAML/JSON node that decoded to the wrong type). `?? []`
+        // guards key *absence* only; a scalar value slips through to the
+        // `array_keys()` call below and raises an uncaught TypeError. Surface
+        // it as a loud spec error instead — the traversal-level sibling of
+        // the per-response content/schema guards (issue #259).
+        if (isset($spec['paths']) && !is_array($spec['paths'])) {
+            return OpenApiValidationResult::failure([
+                "Malformed 'paths' for {$method} {$requestPath} in '{$specName}' spec: expected object, got scalar.",
+            ]);
+        }
+
         /** @var string[] $specPaths */
         $specPaths = array_keys($spec['paths'] ?? []);
         $matcher = $this->getPathMatcher($specName, $specPaths);
@@ -122,14 +134,51 @@ final class OpenApiResponseValidator
         $lowerMethod = strtolower($method);
         $pathSpec = $spec['paths'][$matchedPath] ?? [];
 
+        // A present-but-non-array path item is a malformed spec; without this
+        // guard a scalar `$pathSpec` produces a misleading "method not
+        // defined" diagnostic (the `isset()` below is false for a scalar) and
+        // hides the real fault. Surface it loudly instead (issue #259).
+        if (!is_array($pathSpec)) {
+            return OpenApiValidationResult::failure([
+                "Malformed 'paths[\"{$matchedPath}\"]' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+            ], $matchedPath);
+        }
+
         if (!isset($pathSpec[$lowerMethod])) {
             return OpenApiValidationResult::failure([
                 PathDiagnosticsFormatter::methodNotDefined($specName, $method, $matchedPath, $spec),
             ], $matchedPath);
         }
 
+        $operation = $pathSpec[$lowerMethod];
+
+        // A present-but-non-array operation is a malformed spec; without this
+        // guard a scalar operation produces a misleading "status code not
+        // defined" diagnostic (the `responses` lookup `?? []`-falls-back to an
+        // empty map for a scalar) and hides the real fault (issue #259).
+        if (!is_array($operation)) {
+            return OpenApiValidationResult::failure([
+                "Malformed 'paths[\"{$matchedPath}\"].{$lowerMethod}' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+            ], $matchedPath);
+        }
+
+        /** @var array<string, mixed> $operation */
         $statusCodeStr = (string) $statusCode;
-        $responses = $pathSpec[$lowerMethod]['responses'] ?? [];
+        $responses = $operation['responses'] ?? [];
+
+        // A present-but-non-array `responses` map is a malformed spec; a
+        // scalar here would reach `SpecResponseKeyResolver::resolve()`'s
+        // `array $responses` parameter and raise an uncaught TypeError. The
+        // guard runs BEFORE the skip-by-status-code check below: a malformed
+        // `responses` map is a structural spec error, not a status-code-level
+        // failure mode, so a configured skip pattern must not hide it. This
+        // is the traversal-level sibling of the #258 `responses[$status]`
+        // per-entry guard (issue #259).
+        if (!is_array($responses)) {
+            return OpenApiValidationResult::failure([
+                "Malformed 'paths[\"{$matchedPath}\"].{$lowerMethod}.responses' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+            ], $matchedPath);
+        }
 
         // Skip-by-status-code: applied before the "Status code not defined"
         // branch so a configured skip suppresses both status-code-level failure

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -21,6 +21,7 @@ use Studio\OpenApiContractTesting\Validation\Support\SpecResponseKeyResolver;
 use Studio\OpenApiContractTesting\Validation\Support\StatusCodePatternSet;
 use Studio\OpenApiContractTesting\Validation\Support\ValidatorErrorBoundary;
 
+use function array_key_exists;
 use function array_keys;
 use function array_merge;
 use function get_debug_type;
@@ -108,15 +109,24 @@ final class OpenApiResponseValidator
 
         $version = OpenApiVersion::fromSpec($spec);
 
-        // A present-but-non-array `paths` is a malformed spec (stray scalar,
-        // e.g. a YAML/JSON node that decoded to the wrong type). `?? []`
-        // guards key *absence* only; a scalar value slips through to the
-        // `array_keys()` call below and raises an uncaught TypeError. Surface
-        // it as a loud spec error instead — the traversal-level sibling of
-        // the per-response content/schema guards (issue #259).
-        if (isset($spec['paths']) && !is_array($spec['paths'])) {
+        // A present-but-non-array `paths` is a malformed spec — a stray
+        // scalar or an explicit `null` (a YAML `paths:` left empty, or a node
+        // that decoded to the wrong type). `array_key_exists` (not `isset`)
+        // is deliberate: `isset` is false for `null`, which would let a
+        // present-but-`null` `paths` slip through to `?? []` below and be
+        // silently coalesced to an empty map. A non-array value otherwise
+        // reaches the `array_keys()` call and raises an uncaught TypeError.
+        // Surface it as a loud spec error instead — the traversal-level
+        // sibling of the per-response content/schema guards (issue #259).
+        if (array_key_exists('paths', $spec) && !is_array($spec['paths'])) {
             return OpenApiValidationResult::failure([
-                "Malformed 'paths' for {$method} {$requestPath} in '{$specName}' spec: expected object, got scalar.",
+                sprintf(
+                    "Malformed 'paths' for %s %s in '%s' spec: expected object, got %s.",
+                    $method,
+                    $requestPath,
+                    $specName,
+                    get_debug_type($spec['paths']),
+                ),
             ]);
         }
 
@@ -132,19 +142,33 @@ final class OpenApiResponseValidator
         }
 
         $lowerMethod = strtolower($method);
-        $pathSpec = $spec['paths'][$matchedPath] ?? [];
+        // `$matchedPath` is always a key of `$spec['paths']` (the matcher was
+        // built from its `array_keys()`), so `?? null` here only fires for an
+        // explicit `null` *value* — which the guard below then treats as
+        // malformed, exactly like a scalar path item.
+        $pathSpec = $spec['paths'][$matchedPath] ?? null;
 
         // A present-but-non-array path item is a malformed spec; without this
-        // guard a scalar `$pathSpec` produces a misleading "method not
-        // defined" diagnostic (the `isset()` below is false for a scalar) and
-        // hides the real fault. Surface it loudly instead (issue #259).
+        // guard a scalar/`null` `$pathSpec` reaches the `array_key_exists()`
+        // method lookup below and raises an uncaught TypeError. Surface it
+        // loudly instead (issue #259).
         if (!is_array($pathSpec)) {
             return OpenApiValidationResult::failure([
-                "Malformed 'paths[\"{$matchedPath}\"]' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+                sprintf(
+                    "Malformed 'paths[\"%s\"]' for %s %s in '%s' spec: expected object, got %s.",
+                    $matchedPath,
+                    $method,
+                    $matchedPath,
+                    $specName,
+                    get_debug_type($pathSpec),
+                ),
             ], $matchedPath);
         }
 
-        if (!isset($pathSpec[$lowerMethod])) {
+        // `array_key_exists` (not `isset`) so an explicit `{method}: null`
+        // reaches the operation guard below as malformed rather than being
+        // misreported as an undefined method.
+        if (!array_key_exists($lowerMethod, $pathSpec)) {
             return OpenApiValidationResult::failure([
                 PathDiagnosticsFormatter::methodNotDefined($specName, $method, $matchedPath, $spec),
             ], $matchedPath);
@@ -153,21 +177,33 @@ final class OpenApiResponseValidator
         $operation = $pathSpec[$lowerMethod];
 
         // A present-but-non-array operation is a malformed spec; without this
-        // guard a scalar operation produces a misleading "status code not
-        // defined" diagnostic (the `responses` lookup `?? []`-falls-back to an
-        // empty map for a scalar) and hides the real fault (issue #259).
+        // guard a scalar/`null` operation reaches the `array_key_exists()`
+        // `responses` lookup below and raises an uncaught TypeError
+        // (issue #259).
         if (!is_array($operation)) {
             return OpenApiValidationResult::failure([
-                "Malformed 'paths[\"{$matchedPath}\"].{$lowerMethod}' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+                sprintf(
+                    "Malformed 'paths[\"%s\"].%s' for %s %s in '%s' spec: expected object, got %s.",
+                    $matchedPath,
+                    $lowerMethod,
+                    $method,
+                    $matchedPath,
+                    $specName,
+                    get_debug_type($operation),
+                ),
             ], $matchedPath);
         }
 
         /** @var array<string, mixed> $operation */
         $statusCodeStr = (string) $statusCode;
-        $responses = $operation['responses'] ?? [];
+        // `array_key_exists` (not `?? []`) so a present-but-`null` `responses`
+        // is caught by the guard below as malformed, while a genuinely absent
+        // `responses` key still falls back to an empty map (resolved later as
+        // "status code not defined").
+        $responses = array_key_exists('responses', $operation) ? $operation['responses'] : [];
 
         // A present-but-non-array `responses` map is a malformed spec; a
-        // scalar here would reach `SpecResponseKeyResolver::resolve()`'s
+        // scalar/`null` here would reach `SpecResponseKeyResolver::resolve()`'s
         // `array $responses` parameter and raise an uncaught TypeError. The
         // guard runs BEFORE the skip-by-status-code check below: a malformed
         // `responses` map is a structural spec error, not a status-code-level
@@ -176,7 +212,15 @@ final class OpenApiResponseValidator
         // per-entry guard (issue #259).
         if (!is_array($responses)) {
             return OpenApiValidationResult::failure([
-                "Malformed 'paths[\"{$matchedPath}\"].{$lowerMethod}.responses' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+                sprintf(
+                    "Malformed 'paths[\"%s\"].%s.responses' for %s %s in '%s' spec: expected object, got %s.",
+                    $matchedPath,
+                    $lowerMethod,
+                    $method,
+                    $matchedPath,
+                    $specName,
+                    get_debug_type($responses),
+                ),
             ], $matchedPath);
         }
 

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -15,6 +15,7 @@ use Studio\OpenApiContractTesting\Validation\Response\ResponseHeaderValidator;
 use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredBodyWalker;
 use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredPerCallChecker;
 use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredTracker;
+use Studio\OpenApiContractTesting\Validation\Support\MalformedSpecNode;
 use Studio\OpenApiContractTesting\Validation\Support\PathDiagnosticsFormatter;
 use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
 use Studio\OpenApiContractTesting\Validation\Support\SpecResponseKeyResolver;
@@ -109,23 +110,23 @@ final class OpenApiResponseValidator
 
         $version = OpenApiVersion::fromSpec($spec);
 
-        // A present-but-non-array `paths` is a malformed spec — a stray
-        // scalar or an explicit `null` (a YAML `paths:` left empty, or a node
-        // that decoded to the wrong type). `array_key_exists` (not `isset`)
-        // is deliberate: `isset` is false for `null`, which would let a
-        // present-but-`null` `paths` slip through to `?? []` below and be
-        // silently coalesced to an empty map. A non-array value otherwise
-        // reaches the `array_keys()` call and raises an uncaught TypeError.
-        // Surface it as a loud spec error instead — the traversal-level
-        // sibling of the per-response content/schema guards (issue #259).
-        if (array_key_exists('paths', $spec) && !is_array($spec['paths'])) {
+        // The root `paths` must decode to a JSON object; a scalar, `null`, or
+        // a JSON list is a malformed spec ({@see MalformedSpecNode}).
+        // Unguarded, a non-array reaches the `array_keys()` call below
+        // (uncaught TypeError) and a list mis-resolves silently. The presence
+        // test uses `array_key_exists` (not `isset`) so a present-but-`null`
+        // `paths` is caught here rather than coalesced to an empty map by
+        // `?? []`. Surface it as a loud spec error instead — the
+        // traversal-level sibling of the per-response content/schema guards
+        // (issue #259).
+        if (array_key_exists('paths', $spec) && MalformedSpecNode::isMalformed($spec['paths'])) {
             return OpenApiValidationResult::failure([
                 sprintf(
                     "Malformed 'paths' for %s %s in '%s' spec: expected object, got %s.",
                     $method,
                     $requestPath,
                     $specName,
-                    get_debug_type($spec['paths']),
+                    MalformedSpecNode::describe($spec['paths']),
                 ),
             ]);
         }
@@ -148,11 +149,12 @@ final class OpenApiResponseValidator
         // malformed, exactly like a scalar path item.
         $pathSpec = $spec['paths'][$matchedPath] ?? null;
 
-        // A present-but-non-array path item is a malformed spec; without this
-        // guard a scalar/`null` `$pathSpec` reaches the `array_key_exists()`
-        // method lookup below and raises an uncaught TypeError. Surface it
+        // A path item must decode to a JSON object; a scalar, `null`, or a
+        // JSON list is malformed ({@see MalformedSpecNode}). Unguarded, a
+        // non-array reaches the `array_key_exists()` method lookup below
+        // (uncaught TypeError) and a list mis-resolves silently. Surface it
         // loudly instead (issue #259).
-        if (!is_array($pathSpec)) {
+        if (MalformedSpecNode::isMalformed($pathSpec)) {
             return OpenApiValidationResult::failure([
                 sprintf(
                     "Malformed 'paths[\"%s\"]' for %s %s in '%s' spec: expected object, got %s.",
@@ -160,7 +162,7 @@ final class OpenApiResponseValidator
                     $method,
                     $matchedPath,
                     $specName,
-                    get_debug_type($pathSpec),
+                    MalformedSpecNode::describe($pathSpec),
                 ),
             ], $matchedPath);
         }
@@ -176,11 +178,11 @@ final class OpenApiResponseValidator
 
         $operation = $pathSpec[$lowerMethod];
 
-        // A present-but-non-array operation is a malformed spec; without this
-        // guard a scalar/`null` operation reaches the `array_key_exists()`
-        // `responses` lookup below and raises an uncaught TypeError
-        // (issue #259).
-        if (!is_array($operation)) {
+        // An operation must decode to a JSON object; a scalar, `null`, or a
+        // JSON list is malformed ({@see MalformedSpecNode}). Unguarded, a
+        // non-array reaches the `array_key_exists()` `responses` lookup below
+        // (uncaught TypeError) and a list mis-resolves silently (issue #259).
+        if (MalformedSpecNode::isMalformed($operation)) {
             return OpenApiValidationResult::failure([
                 sprintf(
                     "Malformed 'paths[\"%s\"].%s' for %s %s in '%s' spec: expected object, got %s.",
@@ -189,7 +191,7 @@ final class OpenApiResponseValidator
                     $method,
                     $matchedPath,
                     $specName,
-                    get_debug_type($operation),
+                    MalformedSpecNode::describe($operation),
                 ),
             ], $matchedPath);
         }
@@ -202,15 +204,16 @@ final class OpenApiResponseValidator
         // "status code not defined").
         $responses = array_key_exists('responses', $operation) ? $operation['responses'] : [];
 
-        // A present-but-non-array `responses` map is a malformed spec; a
-        // scalar/`null` here would reach `SpecResponseKeyResolver::resolve()`'s
-        // `array $responses` parameter and raise an uncaught TypeError. The
-        // guard runs BEFORE the skip-by-status-code check below: a malformed
-        // `responses` map is a structural spec error, not a status-code-level
-        // failure mode, so a configured skip pattern must not hide it. This
-        // is the traversal-level sibling of the #258 `responses[$status]`
-        // per-entry guard (issue #259).
-        if (!is_array($responses)) {
+        // The `responses` map must decode to a JSON object; a scalar, `null`,
+        // or a JSON list is malformed ({@see MalformedSpecNode}). Unguarded,
+        // a non-array reaches `SpecResponseKeyResolver::resolve()`'s `array
+        // $responses` parameter (uncaught TypeError) and a list mis-resolves
+        // silently. The guard runs BEFORE the skip-by-status-code check
+        // below: a malformed `responses` map is a structural spec error, not
+        // a status-code-level failure mode, so a configured skip pattern must
+        // not hide it. This is the traversal-level sibling of the #258
+        // `responses[$status]` per-entry guard (issue #259).
+        if (MalformedSpecNode::isMalformed($responses)) {
             return OpenApiValidationResult::failure([
                 sprintf(
                     "Malformed 'paths[\"%s\"].%s.responses' for %s %s in '%s' spec: expected object, got %s.",
@@ -219,7 +222,7 @@ final class OpenApiResponseValidator
                     $method,
                     $matchedPath,
                     $specName,
-                    get_debug_type($responses),
+                    MalformedSpecNode::describe($responses),
                 ),
             ], $matchedPath);
         }
@@ -282,17 +285,25 @@ final class OpenApiResponseValidator
         $statusCodeStr = $matchedResponseKey;
         $responseSpec = $responses[$matchedResponseKey];
 
-        // A present-but-non-array response entry is a malformed spec (stray
-        // scalar, e.g. an unresolved $ref); surface it as a loud spec error
-        // (issue #258). Without this guard the scalar reaches the
-        // `array $responseSpec` parameters of validateBody() / validateHeaders()
-        // and raises an uncaught TypeError (TypeError extends Error, not
-        // RuntimeException, so validateBody()'s catch would not see it). This
-        // mirrors the content-level guards in validateBody() and
-        // RequestBodyValidator's `requestBody` guard.
-        if (!is_array($responseSpec)) {
+        // A response entry must decode to a JSON object; a scalar, `null`, or
+        // a JSON list is a malformed spec ({@see MalformedSpecNode}) — e.g.
+        // an unresolved $ref. Surface it as a loud spec error (issue #258).
+        // Without this guard the bad value reaches the `array $responseSpec`
+        // parameters of validateBody() / validateHeaders() and raises an
+        // uncaught TypeError (TypeError extends Error, not RuntimeException,
+        // so validateBody()'s catch would not see it). This mirrors the
+        // content-level guards in validateBody() and RequestBodyValidator's
+        // `requestBody` guard.
+        if (MalformedSpecNode::isMalformed($responseSpec)) {
             return OpenApiValidationResult::failure([
-                "Malformed 'responses[{$matchedResponseKey}]' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+                sprintf(
+                    "Malformed 'responses[%s]' for %s %s in '%s' spec: expected object, got %s.",
+                    $matchedResponseKey,
+                    $method,
+                    $matchedPath,
+                    $specName,
+                    MalformedSpecNode::describe($responseSpec),
+                ),
             ], $matchedPath, $statusCodeStr);
         }
 
@@ -520,15 +531,24 @@ final class OpenApiResponseValidator
             return new ResponseBodyValidationResult([], null);
         }
 
-        // A present-but-non-array `content` is a malformed spec (stray scalar,
-        // e.g. an unresolved $ref). Surface it before it reaches
-        // ResponseBodyValidator::validate()'s `array $content` parameter, where
-        // it would raise an uncaught TypeError (TypeError extends Error, not
-        // RuntimeException, so the catch below would not see it). Mirrors
-        // RequestBodyValidator's `requestBody.content` guard (issue #256).
-        if (!is_array($responseSpec['content'])) {
+        // A `content` block must decode to a JSON object; a scalar or a JSON
+        // list is a malformed spec ({@see MalformedSpecNode}) — e.g. an
+        // unresolved $ref. Surface it before it reaches
+        // ResponseBodyValidator::validate()'s `array $content` parameter,
+        // where a non-array would raise an uncaught TypeError (TypeError
+        // extends Error, not RuntimeException, so the catch below would not
+        // see it). Mirrors RequestBodyValidator's `requestBody.content` guard
+        // (issue #256).
+        if (MalformedSpecNode::isMalformed($responseSpec['content'])) {
             return new ResponseBodyValidationResult([
-                "Malformed 'responses[{$statusCode}].content' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+                sprintf(
+                    "Malformed 'responses[%s].content' for %s %s in '%s' spec: expected object, got %s.",
+                    $statusCode,
+                    $method,
+                    $matchedPath,
+                    $specName,
+                    MalformedSpecNode::describe($responseSpec['content']),
+                ),
             ], null);
         }
 

--- a/src/Validation/Request/RequestBodyValidator.php
+++ b/src/Validation/Request/RequestBodyValidator.php
@@ -10,6 +10,7 @@ use Studio\OpenApiContractTesting\OpenApiVersion;
 use Studio\OpenApiContractTesting\SchemaContext;
 use Studio\OpenApiContractTesting\Spec\OpenApiSchemaConverter;
 use Studio\OpenApiContractTesting\Validation\Support\ContentTypeMatcher;
+use Studio\OpenApiContractTesting\Validation\Support\MalformedSpecNode;
 use Studio\OpenApiContractTesting\Validation\Support\ObjectConverter;
 use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
 
@@ -58,11 +59,18 @@ final class RequestBodyValidator
             return new RequestBodyValidationResult([]);
         }
 
-        // A present-but-non-array requestBody signals a malformed spec (stray scalar).
+        // A `requestBody` must decode to a JSON object; a scalar or a JSON
+        // list signals a malformed spec ({@see MalformedSpecNode}).
         // Contract-testing tools should surface this, not mask it as "no body".
-        if (!is_array($operation['requestBody'])) {
+        if (MalformedSpecNode::isMalformed($operation['requestBody'])) {
             return new RequestBodyValidationResult([
-                "Malformed 'requestBody' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+                sprintf(
+                    "Malformed 'requestBody' for %s %s in '%s' spec: expected object, got %s.",
+                    $method,
+                    $matchedPath,
+                    $specName,
+                    MalformedSpecNode::describe($operation['requestBody']),
+                ),
             ]);
         }
 
@@ -75,9 +83,15 @@ final class RequestBodyValidator
             return new RequestBodyValidationResult([]);
         }
 
-        if (!is_array($requestBodySpec['content'])) {
+        if (MalformedSpecNode::isMalformed($requestBodySpec['content'])) {
             return new RequestBodyValidationResult([
-                "Malformed 'requestBody.content' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+                sprintf(
+                    "Malformed 'requestBody.content' for %s %s in '%s' spec: expected object, got %s.",
+                    $method,
+                    $matchedPath,
+                    $specName,
+                    MalformedSpecNode::describe($requestBodySpec['content']),
+                ),
             ]);
         }
 
@@ -89,9 +103,18 @@ final class RequestBodyValidator
             // runtime — a malformed spec like `content: {"application/json": "oops"}`
             // would TypeError on downstream array accesses. Surface it as a loud spec
             // error instead, matching the sibling guard on `requestBody.content` above.
-            if (!is_array($mediaTypeSpec)) {
+            // A JSON list written for the entry is rejected the same way
+            // ({@see MalformedSpecNode}).
+            if (MalformedSpecNode::isMalformed($mediaTypeSpec)) {
                 return new RequestBodyValidationResult([
-                    "Malformed 'requestBody.content[\"{$mediaType}\"]' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+                    sprintf(
+                        "Malformed 'requestBody.content[\"%s\"]' for %s %s in '%s' spec: expected object, got %s.",
+                        $mediaType,
+                        $method,
+                        $matchedPath,
+                        $specName,
+                        MalformedSpecNode::describe($mediaTypeSpec),
+                    ),
                 ]);
             }
 
@@ -100,9 +123,16 @@ final class RequestBodyValidator
             // OpenApiSchemaConverter::convert() as a scalar, producing a confusing
             // TypeError instead of a spec-level error. array_key_exists rather than
             // isset so an explicit `schema: null` is also flagged.
-            if (array_key_exists('schema', $mediaTypeSpec) && !is_array($mediaTypeSpec['schema'])) {
+            if (array_key_exists('schema', $mediaTypeSpec) && MalformedSpecNode::isMalformed($mediaTypeSpec['schema'])) {
                 return new RequestBodyValidationResult([
-                    "Malformed 'requestBody.content[\"{$mediaType}\"].schema' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+                    sprintf(
+                        "Malformed 'requestBody.content[\"%s\"].schema' for %s %s in '%s' spec: expected object, got %s.",
+                        $mediaType,
+                        $method,
+                        $matchedPath,
+                        $specName,
+                        MalformedSpecNode::describe($mediaTypeSpec['schema']),
+                    ),
                 ]);
             }
         }

--- a/src/Validation/Response/ResponseBodyValidator.php
+++ b/src/Validation/Response/ResponseBodyValidator.php
@@ -12,6 +12,7 @@ use Studio\OpenApiContractTesting\OpenApiVersion;
 use Studio\OpenApiContractTesting\SchemaContext;
 use Studio\OpenApiContractTesting\Spec\OpenApiSchemaConverter;
 use Studio\OpenApiContractTesting\Validation\Support\ContentTypeMatcher;
+use Studio\OpenApiContractTesting\Validation\Support\MalformedSpecNode;
 use Studio\OpenApiContractTesting\Validation\Support\ObjectConverter;
 use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
 
@@ -67,25 +68,43 @@ final class ResponseBodyValidator
     ): ResponseBodyValidationResult {
         // Pre-scan the content map for malformed media-type entries before any
         // content negotiation runs. This mirrors RequestBodyValidator's
-        // per-media-type guards: a scalar entry would slip past the downstream
-        // `isset(...['schema'])` checks as a silent pass, and a non-array
-        // `schema` on a JSON media type would reach OpenApiSchemaConverter as a
-        // scalar and raise a confusing TypeError. Surface both as loud
-        // spec-level errors (issue #256). `matchedContentType` is null: no
-        // content-type lookup succeeded.
+        // per-media-type guards: a media-type entry and its `schema` must each
+        // decode to a JSON object — a scalar entry would slip past the
+        // downstream `isset(...['schema'])` checks as a silent pass, a non-array
+        // `schema` on a JSON media type would reach OpenApiSchemaConverter and
+        // raise a confusing TypeError, and a JSON list mis-resolves silently.
+        // Surface all of them as loud spec-level errors via
+        // {@see MalformedSpecNode} (issue #256). `matchedContentType` is null:
+        // no content-type lookup succeeded.
         foreach ($content as $mediaType => $mediaTypeSpec) {
-            if (!is_array($mediaTypeSpec)) {
+            if (MalformedSpecNode::isMalformed($mediaTypeSpec)) {
                 return new ResponseBodyValidationResult([
-                    "Malformed 'responses[{$statusCode}].content[\"{$mediaType}\"]' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+                    sprintf(
+                        "Malformed 'responses[%s].content[\"%s\"]' for %s %s in '%s' spec: expected object, got %s.",
+                        $statusCode,
+                        $mediaType,
+                        $method,
+                        $matchedPath,
+                        $specName,
+                        MalformedSpecNode::describe($mediaTypeSpec),
+                    ),
                 ], null);
             }
 
             // array_key_exists rather than isset so an explicit `schema: null`
             // is also flagged — otherwise it falls through the downstream
             // presence check as a silent "no schema" pass.
-            if (array_key_exists('schema', $mediaTypeSpec) && !is_array($mediaTypeSpec['schema'])) {
+            if (array_key_exists('schema', $mediaTypeSpec) && MalformedSpecNode::isMalformed($mediaTypeSpec['schema'])) {
                 return new ResponseBodyValidationResult([
-                    "Malformed 'responses[{$statusCode}].content[\"{$mediaType}\"].schema' for {$method} {$matchedPath} in '{$specName}' spec: expected object, got scalar.",
+                    sprintf(
+                        "Malformed 'responses[%s].content[\"%s\"].schema' for %s %s in '%s' spec: expected object, got %s.",
+                        $statusCode,
+                        $mediaType,
+                        $method,
+                        $matchedPath,
+                        $specName,
+                        MalformedSpecNode::describe($mediaTypeSpec['schema']),
+                    ),
                 ], null);
             }
         }

--- a/src/Validation/Support/MalformedSpecNode.php
+++ b/src/Validation/Support/MalformedSpecNode.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Validation\Support;
+
+use function array_is_list;
+use function get_debug_type;
+use function is_array;
+
+/**
+ * Shared shape check for OpenAPI structural nodes that MUST decode to a JSON
+ * object — `paths`, a path item, an operation, the `responses` map, a
+ * `responses[$status]` entry, a `content` map, a media-type entry, a
+ * `schema`, and so on.
+ *
+ * A spec authored in YAML/JSON can decode such a node to the wrong PHP type
+ * in two ways, both malformed:
+ *
+ *  - a scalar or `null` — a stray value, an empty YAML key, or an unresolved
+ *    `$ref`; left unguarded it reaches an `array`-typed sink and raises an
+ *    uncaught `TypeError`;
+ *  - a JSON array (`[...]`) written where an object (`{...}`) was meant;
+ *    left unguarded it passes `is_array()` and then mis-resolves silently
+ *    (integer keys never match a path / method / status).
+ *
+ * The validators route every such guard through this class so the two
+ * failure modes surface as one consistent, loud spec error.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+final class MalformedSpecNode
+{
+    /**
+     * True when `$node` is NOT a usable JSON object for a structural spec
+     * position.
+     *
+     * Rejects every non-array value (scalar / `null`) and every non-empty
+     * list array (a JSON `[...]` where an object was expected). An empty
+     * array is accepted: `{}` and `[]` both decode to `[]` in PHP, so an
+     * empty node is treated as an empty object — harmless, and the
+     * downstream "not found / not defined" diagnostics handle it.
+     *
+     * @phpstan-assert-if-false array<array-key, mixed> $node
+     */
+    public static function isMalformed(mixed $node): bool
+    {
+        if (!is_array($node)) {
+            return true;
+        }
+
+        return $node !== [] && array_is_list($node);
+    }
+
+    /**
+     * Human-readable type of a malformed node for the
+     * "expected object, got X" diagnostic. Only meaningful when
+     * {@see self::isMalformed()} returned true.
+     *
+     * A malformed array is always a non-empty list, reported as `list`;
+     * anything else is a scalar / `null`, reported via `get_debug_type()`
+     * (`string`, `int`, `float`, `bool`, `null`).
+     */
+    public static function describe(mixed $node): string
+    {
+        return is_array($node) ? 'list' : get_debug_type($node);
+    }
+}

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -586,6 +586,76 @@ class OpenApiRequestValidatorTest extends TestCase
         );
     }
 
+    #[Test]
+    public function malformed_paths_node_returns_failure(): void
+    {
+        // The spec's root `paths` is a scalar. `?? []` guards key absence
+        // only — a scalar slips through to `array_keys()` and raises an
+        // uncaught TypeError. The traversal guard surfaces a loud spec error
+        // instead, mirroring the response-side traversal guards (issue #259).
+        $result = $this->validator->validate(
+            'malformed-paths',
+            'POST',
+            '/things',
+            [],
+            [],
+            ['foo' => 'bar'],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString("Malformed 'paths'", $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function malformed_path_item_returns_failure(): void
+    {
+        // `paths["/scalar-path-item"]` is a scalar. Without the guard the
+        // scalar reaches `ParameterCollector::collect()`'s `array $pathSpec`
+        // parameter (after a misleading "method not defined" diagnostic).
+        // The guard surfaces a loud spec error instead (issue #259).
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/scalar-path-item',
+            [],
+            [],
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "Malformed 'paths[\"/scalar-path-item\"]'",
+            $result->errors()[0],
+        );
+        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function malformed_operation_returns_failure(): void
+    {
+        // `paths["/scalar-operation"].get` is a scalar. Without the guard the
+        // scalar reaches the `array $operation` parameters of
+        // `ParameterCollector::collect()` / `RequestBodyValidator::validate()`
+        // and raises an uncaught TypeError (issue #259).
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/scalar-operation',
+            [],
+            [],
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "Malformed 'paths[\"/scalar-operation\"].get'",
+            $result->errors()[0],
+        );
+        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+    }
+
     // ========================================
     // Constructor validation (mirrors response validator)
     // ========================================

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -589,10 +589,10 @@ class OpenApiRequestValidatorTest extends TestCase
     #[Test]
     public function malformed_paths_node_returns_failure(): void
     {
-        // The spec's root `paths` is a scalar. `?? []` guards key absence
-        // only — a scalar slips through to `array_keys()` and raises an
-        // uncaught TypeError. The traversal guard surfaces a loud spec error
-        // instead, mirroring the response-side traversal guards (issue #259).
+        // The spec's root `paths` is a scalar. The traversal guard surfaces a
+        // loud spec error before it reaches `array_keys()` (which would raise
+        // an uncaught TypeError), mirroring the response-side traversal
+        // guards (issue #259).
         $result = $this->validator->validate(
             'malformed-paths',
             'POST',
@@ -605,16 +605,40 @@ class OpenApiRequestValidatorTest extends TestCase
 
         $this->assertFalse($result->isValid());
         $this->assertStringContainsString("Malformed 'paths'", $result->errors()[0]);
-        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got string', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function null_paths_node_returns_failure(): void
+    {
+        // The spec's root `paths` is an explicit `null` (a YAML `paths:` left
+        // empty). The guard uses `array_key_exists` (not `isset`, which is
+        // false for `null`), so a present-but-`null` `paths` surfaces as a
+        // malformed spec rather than being coalesced to an empty paths map
+        // (issue #259).
+        $result = $this->validator->validate(
+            'malformed-paths-null',
+            'POST',
+            '/things',
+            [],
+            [],
+            ['foo' => 'bar'],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString("Malformed 'paths'", $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got null', $result->errors()[0]);
     }
 
     #[Test]
     public function malformed_path_item_returns_failure(): void
     {
         // `paths["/scalar-path-item"]` is a scalar. Without the guard the
-        // scalar reaches `ParameterCollector::collect()`'s `array $pathSpec`
-        // parameter (after a misleading "method not defined" diagnostic).
-        // The guard surfaces a loud spec error instead (issue #259).
+        // scalar reaches the `array_key_exists()` method lookup (and
+        // `ParameterCollector::collect()`'s `array $pathSpec` parameter) and
+        // raises an uncaught TypeError. The guard surfaces a loud spec error
+        // instead (issue #259).
         $result = $this->validator->validate(
             'malformed',
             'GET',
@@ -629,16 +653,40 @@ class OpenApiRequestValidatorTest extends TestCase
             "Malformed 'paths[\"/scalar-path-item\"]'",
             $result->errors()[0],
         );
-        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got string', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function null_path_item_returns_failure(): void
+    {
+        // `paths["/null-path-item"]` is an explicit `null`. The `?? null`
+        // fallback on the path-item lookup keeps the `null` value flowing
+        // into the `!is_array()` guard rather than coalescing it to an empty
+        // path item — so a null path item surfaces as malformed (issue #259).
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/null-path-item',
+            [],
+            [],
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "Malformed 'paths[\"/null-path-item\"]'",
+            $result->errors()[0],
+        );
+        $this->assertStringContainsString('expected object, got null', $result->errors()[0]);
     }
 
     #[Test]
     public function malformed_operation_returns_failure(): void
     {
         // `paths["/scalar-operation"].get` is a scalar. Without the guard the
-        // scalar reaches the `array $operation` parameters of
-        // `ParameterCollector::collect()` / `RequestBodyValidator::validate()`
-        // and raises an uncaught TypeError (issue #259).
+        // scalar reaches the `array_key_exists()` method lookup and
+        // `ParameterCollector::collect()`'s `array $operation` parameter,
+        // raising an uncaught TypeError (issue #259).
         $result = $this->validator->validate(
             'malformed',
             'GET',
@@ -653,7 +701,31 @@ class OpenApiRequestValidatorTest extends TestCase
             "Malformed 'paths[\"/scalar-operation\"].get'",
             $result->errors()[0],
         );
-        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got string', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function null_operation_returns_failure(): void
+    {
+        // `paths["/null-operation"].get` is an explicit `null`. The method
+        // lookup uses `array_key_exists` (not `isset`), so a `get: null`
+        // entry reaches the operation guard as malformed rather than being
+        // misreported as an undefined method (issue #259).
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/null-operation',
+            [],
+            [],
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "Malformed 'paths[\"/null-operation\"].get'",
+            $result->errors()[0],
+        );
+        $this->assertStringContainsString('expected object, got null', $result->errors()[0]);
     }
 
     // ========================================

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -501,7 +501,7 @@ class OpenApiRequestValidatorTest extends TestCase
 
         $this->assertFalse($result->isValid());
         $this->assertStringContainsString("Malformed 'requestBody'", $result->errors()[0]);
-        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got string', $result->errors()[0]);
     }
 
     #[Test]
@@ -536,7 +536,7 @@ class OpenApiRequestValidatorTest extends TestCase
 
         $this->assertFalse($result->isValid());
         $this->assertStringContainsString("Malformed 'requestBody.content[\"application/json\"]'", $result->errors()[0]);
-        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got string', $result->errors()[0]);
     }
 
     #[Test]
@@ -557,7 +557,7 @@ class OpenApiRequestValidatorTest extends TestCase
             "Malformed 'requestBody.content[\"application/json\"].schema'",
             $result->errors()[0],
         );
-        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got string', $result->errors()[0]);
     }
 
     /**
@@ -726,6 +726,70 @@ class OpenApiRequestValidatorTest extends TestCase
             $result->errors()[0],
         );
         $this->assertStringContainsString('expected object, got null', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function list_paths_node_returns_failure(): void
+    {
+        // The spec's root `paths` is a JSON list (`[...]`). A list passes
+        // `is_array()` but is not an object — the guard surfaces it as a loud
+        // malformed-spec error rather than letting integer keys mis-resolve
+        // (issue #259).
+        $result = $this->validator->validate(
+            'malformed-paths-list',
+            'POST',
+            '/things',
+            [],
+            [],
+            ['foo' => 'bar'],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString("Malformed 'paths'", $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got list', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function list_path_item_returns_failure(): void
+    {
+        // `paths["/list-path-item"]` is a JSON list (issue #259).
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/list-path-item',
+            [],
+            [],
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "Malformed 'paths[\"/list-path-item\"]'",
+            $result->errors()[0],
+        );
+        $this->assertStringContainsString('expected object, got list', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function list_operation_returns_failure(): void
+    {
+        // `paths["/list-operation"].get` is a JSON list (issue #259).
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/list-operation',
+            [],
+            [],
+            null,
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "Malformed 'paths[\"/list-operation\"].get'",
+            $result->errors()[0],
+        );
+        $this->assertStringContainsString('expected object, got list', $result->errors()[0]);
     }
 
     // ========================================

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -2204,4 +2204,123 @@ class OpenApiResponseValidatorTest extends TestCase
         );
         $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
     }
+
+    #[Test]
+    public function malformed_paths_node_returns_failure(): void
+    {
+        // The spec's root `paths` is a scalar. `?? []` guards key absence
+        // only — a scalar slips through to `array_keys()` and raises an
+        // uncaught TypeError. The traversal guard surfaces a loud spec error
+        // instead, extending the #256/#258 per-response guards to the spec
+        // walk itself (issue #259).
+        $result = $this->validator->validate(
+            'malformed-paths',
+            'GET',
+            '/things',
+            200,
+            ['id' => 1],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString("Malformed 'paths'", $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function malformed_path_item_returns_failure(): void
+    {
+        // `paths["/scalar-path-item"]` is a scalar. Without the guard the
+        // scalar yields a misleading "method not defined" diagnostic (the
+        // `isset()` lookup is false for a scalar) or a TypeError further
+        // down. The guard surfaces a loud spec error instead (issue #259).
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/scalar-path-item',
+            200,
+            ['id' => 1],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "Malformed 'paths[\"/scalar-path-item\"]'",
+            $result->errors()[0],
+        );
+        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function malformed_operation_returns_failure(): void
+    {
+        // `paths["/scalar-operation"].get` is a scalar. Without the guard the
+        // scalar reaches the `['responses']` offset access and raises an
+        // uncaught TypeError (issue #259).
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/scalar-operation',
+            200,
+            ['id' => 1],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "Malformed 'paths[\"/scalar-operation\"].get'",
+            $result->errors()[0],
+        );
+        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function malformed_responses_map_returns_failure(): void
+    {
+        // `paths["/scalar-responses-map"].get.responses` is a scalar. Without
+        // the guard the scalar reaches `SpecResponseKeyResolver::resolve()`'s
+        // `array $responses` parameter and raises an uncaught TypeError. The
+        // guard surfaces a loud spec error — the traversal-level sibling of
+        // the #258 `responses[$status]` per-entry guard (issue #259).
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/scalar-responses-map',
+            200,
+            ['id' => 1],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "Malformed 'paths[\"/scalar-responses-map\"].get.responses'",
+            $result->errors()[0],
+        );
+        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function malformed_responses_map_surfaces_even_for_skip_status(): void
+    {
+        // A malformed `responses` map is a structural spec error, not a
+        // status-code-level failure mode — so the guard fires BEFORE the
+        // skip-by-status-code check. A 503 (which matches the default
+        // `5\d\d` skip pattern) must still surface the malformed map loudly
+        // rather than be silently skipped (issue #259).
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/scalar-responses-map',
+            503,
+            ['id' => 1],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertFalse($result->isSkipped());
+        $this->assertStringContainsString(
+            "Malformed 'paths[\"/scalar-responses-map\"].get.responses'",
+            $result->errors()[0],
+        );
+    }
 }

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -2208,11 +2208,10 @@ class OpenApiResponseValidatorTest extends TestCase
     #[Test]
     public function malformed_paths_node_returns_failure(): void
     {
-        // The spec's root `paths` is a scalar. `?? []` guards key absence
-        // only — a scalar slips through to `array_keys()` and raises an
-        // uncaught TypeError. The traversal guard surfaces a loud spec error
-        // instead, extending the #256/#258 per-response guards to the spec
-        // walk itself (issue #259).
+        // The spec's root `paths` is a scalar. The traversal guard surfaces a
+        // loud spec error before it reaches `array_keys()` (which would raise
+        // an uncaught TypeError), extending the #256/#258 per-response guards
+        // to the spec walk itself (issue #259).
         $result = $this->validator->validate(
             'malformed-paths',
             'GET',
@@ -2224,16 +2223,38 @@ class OpenApiResponseValidatorTest extends TestCase
 
         $this->assertFalse($result->isValid());
         $this->assertStringContainsString("Malformed 'paths'", $result->errors()[0]);
-        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got string', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function null_paths_node_returns_failure(): void
+    {
+        // The spec's root `paths` is an explicit `null` (a YAML `paths:` left
+        // empty). `isset()` would be false for `null`, so the guard uses
+        // `array_key_exists`: a present-but-`null` `paths` must surface as a
+        // malformed spec, not be silently coalesced to an empty paths map
+        // (issue #259). `get_debug_type` reports the concrete `null` type.
+        $result = $this->validator->validate(
+            'malformed-paths-null',
+            'GET',
+            '/things',
+            200,
+            ['id' => 1],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString("Malformed 'paths'", $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got null', $result->errors()[0]);
     }
 
     #[Test]
     public function malformed_path_item_returns_failure(): void
     {
         // `paths["/scalar-path-item"]` is a scalar. Without the guard the
-        // scalar yields a misleading "method not defined" diagnostic (the
-        // `isset()` lookup is false for a scalar) or a TypeError further
-        // down. The guard surfaces a loud spec error instead (issue #259).
+        // scalar reaches the `array_key_exists()` method lookup and raises an
+        // uncaught TypeError. The guard surfaces a loud spec error instead
+        // (issue #259).
         $result = $this->validator->validate(
             'malformed',
             'GET',
@@ -2248,15 +2269,39 @@ class OpenApiResponseValidatorTest extends TestCase
             "Malformed 'paths[\"/scalar-path-item\"]'",
             $result->errors()[0],
         );
-        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got string', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function null_path_item_returns_failure(): void
+    {
+        // `paths["/null-path-item"]` is an explicit `null`. The `?? null`
+        // fallback on the path-item lookup keeps the `null` value flowing
+        // into the `!is_array()` guard rather than coalescing it to an empty
+        // path item — so a null path item surfaces as malformed (issue #259).
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/null-path-item',
+            200,
+            ['id' => 1],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "Malformed 'paths[\"/null-path-item\"]'",
+            $result->errors()[0],
+        );
+        $this->assertStringContainsString('expected object, got null', $result->errors()[0]);
     }
 
     #[Test]
     public function malformed_operation_returns_failure(): void
     {
         // `paths["/scalar-operation"].get` is a scalar. Without the guard the
-        // scalar reaches the `['responses']` offset access and raises an
-        // uncaught TypeError (issue #259).
+        // scalar reaches the `array_key_exists()` `responses` lookup and
+        // raises an uncaught TypeError (issue #259).
         $result = $this->validator->validate(
             'malformed',
             'GET',
@@ -2271,7 +2316,56 @@ class OpenApiResponseValidatorTest extends TestCase
             "Malformed 'paths[\"/scalar-operation\"].get'",
             $result->errors()[0],
         );
-        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got string', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function null_operation_returns_failure(): void
+    {
+        // `paths["/null-operation"].get` is an explicit `null`. The method
+        // lookup uses `array_key_exists` (not `isset`), so a `get: null`
+        // entry reaches the operation guard as malformed rather than being
+        // misreported as an undefined method (issue #259).
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/null-operation',
+            200,
+            ['id' => 1],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "Malformed 'paths[\"/null-operation\"].get'",
+            $result->errors()[0],
+        );
+        $this->assertStringContainsString('expected object, got null', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function malformed_operation_message_keys_off_matched_spec_path(): void
+    {
+        // The malformed operation lives under a templated path
+        // (`/scalar-operation-template/{id}`); the request hits a concrete
+        // `/scalar-operation-template/42`. The guard message must name the
+        // matched spec key (the `{id}` template), not the wire request path
+        // — mirroring `malformed_response_status_entry_keys_message_off_matched_spec_key`.
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/scalar-operation-template/42',
+            200,
+            ['id' => 1],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "Malformed 'paths[\"/scalar-operation-template/{id}\"].get'",
+            $result->errors()[0],
+        );
+        $this->assertStringNotContainsString('/scalar-operation-template/42', $result->errors()[0]);
     }
 
     #[Test]
@@ -2296,7 +2390,32 @@ class OpenApiResponseValidatorTest extends TestCase
             "Malformed 'paths[\"/scalar-responses-map\"].get.responses'",
             $result->errors()[0],
         );
-        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got string', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function null_responses_map_returns_failure(): void
+    {
+        // `paths["/null-responses-map"].get.responses` is an explicit `null`.
+        // The `responses` lookup uses `array_key_exists` (not `?? []`), so a
+        // present-but-`null` `responses` reaches the guard as malformed while
+        // a genuinely absent `responses` key still falls back to an empty map
+        // (issue #259).
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/null-responses-map',
+            200,
+            ['id' => 1],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "Malformed 'paths[\"/null-responses-map\"].get.responses'",
+            $result->errors()[0],
+        );
+        $this->assertStringContainsString('expected object, got null', $result->errors()[0]);
     }
 
     #[Test]

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -2083,7 +2083,7 @@ class OpenApiResponseValidatorTest extends TestCase
             "Malformed 'responses[200].content'",
             $result->errors()[0],
         );
-        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got string', $result->errors()[0]);
     }
 
     #[Test]
@@ -2106,7 +2106,7 @@ class OpenApiResponseValidatorTest extends TestCase
             'Malformed \'responses[200].content["application/json"]\'',
             $result->errors()[0],
         );
-        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got string', $result->errors()[0]);
     }
 
     #[Test]
@@ -2129,7 +2129,7 @@ class OpenApiResponseValidatorTest extends TestCase
             'Malformed \'responses[200].content["application/json"].schema\'',
             $result->errors()[0],
         );
-        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got string', $result->errors()[0]);
     }
 
     #[Test]
@@ -2177,7 +2177,7 @@ class OpenApiResponseValidatorTest extends TestCase
             "Malformed 'responses[200]'",
             $result->errors()[0],
         );
-        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got string', $result->errors()[0]);
     }
 
     #[Test]
@@ -2202,7 +2202,7 @@ class OpenApiResponseValidatorTest extends TestCase
             "Malformed 'responses[default]'",
             $result->errors()[0],
         );
-        $this->assertStringContainsString('expected object, got scalar', $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got string', $result->errors()[0]);
     }
 
     #[Test]
@@ -2441,5 +2441,118 @@ class OpenApiResponseValidatorTest extends TestCase
             "Malformed 'paths[\"/scalar-responses-map\"].get.responses'",
             $result->errors()[0],
         );
+    }
+
+    #[Test]
+    public function list_paths_node_returns_failure(): void
+    {
+        // The spec's root `paths` is a JSON list (`[...]`). A list passes
+        // `is_array()` but is not an object: `array_keys()` would yield
+        // integer keys that mis-resolve silently against every request path.
+        // The guard surfaces it as a loud malformed-spec error (issue #259).
+        $result = $this->validator->validate(
+            'malformed-paths-list',
+            'GET',
+            '/things',
+            200,
+            ['id' => 1],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString("Malformed 'paths'", $result->errors()[0]);
+        $this->assertStringContainsString('expected object, got list', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function list_path_item_returns_failure(): void
+    {
+        // `paths["/list-path-item"]` is a JSON list. A list path item passes
+        // `is_array()` but has no method keys, so it would mis-resolve to a
+        // misleading "method not defined" — the guard surfaces it as
+        // malformed instead (issue #259).
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/list-path-item',
+            200,
+            ['id' => 1],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "Malformed 'paths[\"/list-path-item\"]'",
+            $result->errors()[0],
+        );
+        $this->assertStringContainsString('expected object, got list', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function list_operation_returns_failure(): void
+    {
+        // `paths["/list-operation"].get` is a JSON list (issue #259).
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/list-operation',
+            200,
+            ['id' => 1],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "Malformed 'paths[\"/list-operation\"].get'",
+            $result->errors()[0],
+        );
+        $this->assertStringContainsString('expected object, got list', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function list_responses_map_returns_failure(): void
+    {
+        // `paths["/list-responses-map"].get.responses` is a JSON list. A list
+        // passes `is_array()` and would reach `SpecResponseKeyResolver` with
+        // integer keys that never match a status — the guard surfaces it as
+        // malformed instead (issue #259).
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/list-responses-map',
+            200,
+            ['id' => 1],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "Malformed 'paths[\"/list-responses-map\"].get.responses'",
+            $result->errors()[0],
+        );
+        $this->assertStringContainsString('expected object, got list', $result->errors()[0]);
+    }
+
+    #[Test]
+    public function list_response_status_entry_returns_failure(): void
+    {
+        // `responses["200"]` is a JSON list. The per-entry guard (issue #258)
+        // now routes through MalformedSpecNode, so a list response entry is
+        // surfaced with the same loud diagnostic as a scalar one.
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/list-response-status',
+            200,
+            ['id' => 1],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "Malformed 'responses[200]'",
+            $result->errors()[0],
+        );
+        $this->assertStringContainsString('expected object, got list', $result->errors()[0]);
     }
 }

--- a/tests/Unit/Validation/Request/RequestBodyValidatorTest.php
+++ b/tests/Unit/Validation/Request/RequestBodyValidatorTest.php
@@ -279,7 +279,58 @@ class RequestBodyValidatorTest extends TestCase
 
         $this->assertCount(1, $result->errors);
         $this->assertStringContainsString('.schema\'', $result->errors[0]);
-        $this->assertStringContainsString('expected object, got scalar', $result->errors[0]);
+        $this->assertStringContainsString('expected object, got string', $result->errors[0]);
+    }
+
+    #[Test]
+    public function validate_flags_list_request_body(): void
+    {
+        // A `requestBody` written as a JSON list passes `is_array()` but is
+        // not an object. The shared MalformedSpecNode guard surfaces it with
+        // the same loud diagnostic as a scalar `requestBody` (issue #256).
+        $operation = ['requestBody' => ['this should have been an object']];
+
+        $result = $this->validator->validate(
+            'spec',
+            'POST',
+            '/pets',
+            $operation,
+            DecodedBody::absent(),
+            null,
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertCount(1, $result->errors);
+        $this->assertStringContainsString("Malformed 'requestBody'", $result->errors[0]);
+        $this->assertStringContainsString('expected object, got list', $result->errors[0]);
+    }
+
+    #[Test]
+    public function validate_flags_list_media_type_schema(): void
+    {
+        // A `schema` written as a JSON list is malformed the same way — a
+        // list is not a JSON Schema object (issue #256).
+        $operation = [
+            'requestBody' => [
+                'content' => [
+                    'application/json' => ['schema' => ['this should have been an object']],
+                ],
+            ],
+        ];
+
+        $result = $this->validator->validate(
+            'spec',
+            'POST',
+            '/pets',
+            $operation,
+            DecodedBody::absent(),
+            null,
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertCount(1, $result->errors);
+        $this->assertStringContainsString('.schema\'', $result->errors[0]);
+        $this->assertStringContainsString('expected object, got list', $result->errors[0]);
     }
 
     #[Test]

--- a/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
+++ b/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
@@ -541,7 +541,7 @@ class ResponseBodyValidatorTest extends TestCase
             'Malformed \'responses[200].content["application/json"]\'',
             $result->errors[0],
         );
-        $this->assertStringContainsString('expected object, got scalar', $result->errors[0]);
+        $this->assertStringContainsString('expected object, got string', $result->errors[0]);
         $this->assertNull($result->matchedContentType);
     }
 
@@ -569,8 +569,61 @@ class ResponseBodyValidatorTest extends TestCase
             'Malformed \'responses[200].content["application/json"].schema\'',
             $result->errors[0],
         );
-        $this->assertStringContainsString('expected object, got scalar', $result->errors[0]);
+        $this->assertStringContainsString('expected object, got string', $result->errors[0]);
         $this->assertNull($result->matchedContentType);
+    }
+
+    #[Test]
+    public function validate_flags_list_media_type_entry(): void
+    {
+        // A media-type entry written as a JSON list passes `is_array()` but is
+        // not an object. The shared MalformedSpecNode guard surfaces it with
+        // the same loud diagnostic as a scalar entry (issue #256).
+        $content = ['application/json' => ['this should have been an object']];
+
+        $result = $this->validator->validate(
+            'spec',
+            'GET',
+            '/pets',
+            200,
+            $content,
+            DecodedBody::present(['id' => 1]),
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertCount(1, $result->errors);
+        $this->assertStringContainsString(
+            'Malformed \'responses[200].content["application/json"]\'',
+            $result->errors[0],
+        );
+        $this->assertStringContainsString('expected object, got list', $result->errors[0]);
+    }
+
+    #[Test]
+    public function validate_flags_list_media_type_schema(): void
+    {
+        // A `schema` written as a JSON list is malformed the same way
+        // (issue #256).
+        $content = ['application/json' => ['schema' => ['this should have been an object']]];
+
+        $result = $this->validator->validate(
+            'spec',
+            'GET',
+            '/pets',
+            200,
+            $content,
+            DecodedBody::present(['id' => 1]),
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertCount(1, $result->errors);
+        $this->assertStringContainsString(
+            'Malformed \'responses[200].content["application/json"].schema\'',
+            $result->errors[0],
+        );
+        $this->assertStringContainsString('expected object, got list', $result->errors[0]);
     }
 
     #[Test]

--- a/tests/Unit/Validation/Support/MalformedSpecNodeTest.php
+++ b/tests/Unit/Validation/Support/MalformedSpecNodeTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Validation\Support;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Validation\Support\MalformedSpecNode;
+
+class MalformedSpecNodeTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{mixed}>
+     */
+    public static function provideIs_malformed_rejects_scalars_null_and_listsCases(): iterable
+    {
+        yield 'string scalar' => ['this should have been an object'];
+        yield 'int scalar' => [42];
+        yield 'float scalar' => [3.14];
+        yield 'bool scalar' => [true];
+        yield 'null' => [null];
+        yield 'non-empty list' => [['a', 'b']];
+        yield 'single-element list' => [['only']];
+        yield 'nested list' => [[['a']]];
+    }
+
+    /**
+     * @return iterable<string, array{mixed}>
+     */
+    public static function provideIs_malformed_accepts_objects_and_the_empty_nodeCases(): iterable
+    {
+        yield 'map with string keys' => [['get' => [], 'post' => []]];
+        yield 'single-key map' => [['200' => ['description' => 'OK']]];
+        // `{}` and `[]` both decode to `[]` in PHP: an empty node is
+        // ambiguous and treated as an (empty) object, never malformed.
+        yield 'empty array' => [[]];
+    }
+
+    #[Test]
+    #[DataProvider('provideIs_malformed_rejects_scalars_null_and_listsCases')]
+    public function is_malformed_rejects_scalars_null_and_lists(mixed $node): void
+    {
+        $this->assertTrue(MalformedSpecNode::isMalformed($node));
+    }
+
+    #[Test]
+    #[DataProvider('provideIs_malformed_accepts_objects_and_the_empty_nodeCases')]
+    public function is_malformed_accepts_objects_and_the_empty_node(mixed $node): void
+    {
+        $this->assertFalse(MalformedSpecNode::isMalformed($node));
+    }
+
+    #[Test]
+    public function describe_reports_scalar_and_null_types_via_get_debug_type(): void
+    {
+        $this->assertSame('string', MalformedSpecNode::describe('x'));
+        $this->assertSame('int', MalformedSpecNode::describe(42));
+        $this->assertSame('float', MalformedSpecNode::describe(3.14));
+        $this->assertSame('bool', MalformedSpecNode::describe(true));
+        $this->assertSame('null', MalformedSpecNode::describe(null));
+    }
+
+    #[Test]
+    public function describe_reports_a_non_empty_list_as_list(): void
+    {
+        $this->assertSame('list', MalformedSpecNode::describe(['a', 'b']));
+    }
+}

--- a/tests/fixtures/specs/malformed-paths-list.json
+++ b/tests/fixtures/specs/malformed-paths-list.json
@@ -1,0 +1,8 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Malformed Paths Fixture (JSON list)",
+    "version": "0.1.0"
+  },
+  "paths": ["this should have been an object, not a list"]
+}

--- a/tests/fixtures/specs/malformed-paths-null.json
+++ b/tests/fixtures/specs/malformed-paths-null.json
@@ -1,0 +1,8 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Malformed Paths Fixture (explicit null)",
+    "version": "0.1.0"
+  },
+  "paths": null
+}

--- a/tests/fixtures/specs/malformed-paths.json
+++ b/tests/fixtures/specs/malformed-paths.json
@@ -1,0 +1,8 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Malformed Paths Fixture",
+    "version": "0.1.0"
+  },
+  "paths": "this should have been an object, not a scalar"
+}

--- a/tests/fixtures/specs/malformed.json
+++ b/tests/fixtures/specs/malformed.json
@@ -186,6 +186,17 @@
                 }
             }
         },
+        "/scalar-path-item": "this should have been an object",
+        "/scalar-operation": {
+            "get": "this should have been an object"
+        },
+        "/scalar-responses-map": {
+            "get": {
+                "summary": "responses map is a scalar (not an object)",
+                "operationId": "scalarResponsesMap",
+                "responses": "this should have been an object"
+            }
+        },
         "/path-scalar-parameter/{id}": {
             "parameters": [
                 "this should have been an object"

--- a/tests/fixtures/specs/malformed.json
+++ b/tests/fixtures/specs/malformed.json
@@ -197,6 +197,20 @@
                 "responses": "this should have been an object"
             }
         },
+        "/null-path-item": null,
+        "/null-operation": {
+            "get": null
+        },
+        "/null-responses-map": {
+            "get": {
+                "summary": "responses map is an explicit null (not an object)",
+                "operationId": "nullResponsesMap",
+                "responses": null
+            }
+        },
+        "/scalar-operation-template/{id}": {
+            "get": "this should have been an object"
+        },
         "/path-scalar-parameter/{id}": {
             "parameters": [
                 "this should have been an object"

--- a/tests/fixtures/specs/malformed.json
+++ b/tests/fixtures/specs/malformed.json
@@ -208,6 +208,26 @@
                 "responses": null
             }
         },
+        "/list-path-item": ["this should have been an object, not a list"],
+        "/list-operation": {
+            "get": ["this should have been an object, not a list"]
+        },
+        "/list-responses-map": {
+            "get": {
+                "summary": "responses map is a JSON list (not an object)",
+                "operationId": "listResponsesMap",
+                "responses": ["this should have been an object, not a list"]
+            }
+        },
+        "/list-response-status": {
+            "get": {
+                "summary": "responses[200] entry is a JSON list (not an object)",
+                "operationId": "listResponseStatus",
+                "responses": {
+                    "200": ["this should have been an object, not a list"]
+                }
+            }
+        },
         "/scalar-operation-template/{id}": {
             "get": "this should have been an object"
         },


### PR DESCRIPTION
# 概要

malformed spec の構造ノード（非配列スカラー）が spec 走査経路で未捕捉 `TypeError` を出す問題を修正し、`RequestBodyValidator` と同じ粒度の loud な spec エラーとして surface するようにしました。

## 変更内容

`OpenApiResponseValidator::validate()` / `OpenApiRequestValidator::validate()` は spec を段階的に走査しますが、各段階で構造ノードが非配列スカラーのケースをガードしていませんでした。`?? []` は**キー不在**には効くものの、**スカラー値が存在する**場合は素通しし、`array_keys()` や `array` 型ヒント、`SpecResponseKeyResolver::resolve()` に到達して未捕捉 `TypeError`（`TypeError extends Error`）でクラッシュしていました。#256（content/schema）・#258（responses[$status]）が確立した per-response の malformed ガードを、その上位の走査経路にも広げます。

- `OpenApiResponseValidator::validate()` に 4 段の `is_array()` ガードを追加（`paths` / path item / operation / `responses` マップ）。operation を `$operation` 変数として抽出
- `responses` マップのガードは skip-by-status-code チェックより**前**に配置。malformed な `responses` マップは構造エラーであり status-code-level の失敗ではないため、skip パターン（5xx 等）に隠さず常に loud に surface する
- `OpenApiRequestValidator::validate()` に 3 段の `is_array()` ガードを追加（`paths` / path item / operation）。`responses` マップは既存の `is_array() ? : []` ガードがあるため対象外
- エラー文言は #256/#258 と対称（`Malformed 'paths[...]...' for {METHOD} {path} in '{spec}' spec: expected object, got scalar.`）
- fixture: `malformed.json` に `/scalar-path-item`・`/scalar-operation`・`/scalar-responses-map` を追加、ルート `paths` がスカラーの新規 `malformed-paths.json` を追加
- TDD で 8 テストを追加（response 5 / request 3、skip-status 経路でも surface する不変条件の固定を含む）

## 関連情報

- Closes #259
- PR #257（#256 / #258）の multi-agent レビューにおける silent-failure-hunter 指摘から派生
- #256 — `ResponseBodyValidator` の非配列 `content`/`schema` ガード
- #258 — 非配列 `responses[$status]` エントリのガード（本 PR の直下階層）
