### PR TITLE
chore(static-analysis): type coverage results as CoverageResult for PHPStan 2.2

### DIFF
--- a/src/Coverage/CoverageMergeCommand.php
+++ b/src/Coverage/CoverageMergeCommand.php
@@ -505,7 +505,7 @@ final class CoverageMergeCommand
      * caller decides what to do with the return value (only `strict=true`
      * misses propagate to a non-zero exit).
      *
-     * @param array<string, array<string, mixed>> $results
+     * @param array<string, CoverageResult> $results
      */
     private function evaluateThresholdGate(
         array $results,
@@ -517,7 +517,6 @@ final class CoverageMergeCommand
             return false;
         }
 
-        /** @var array<string, array{endpoints: list<mixed>, endpointTotal: int, endpointFullyCovered: int, endpointPartial: int, endpointUncovered: int, endpointRequestOnly: int, responseTotal: int, responseCovered: int, responseSkipped: int, responseUncovered: int}> $results */
         $evaluation = CoverageThresholdEvaluator::evaluate($results, $minEndpointPct, $minResponsePct, $strict);
 
         if ($evaluation['passed']) {
@@ -654,7 +653,7 @@ final class CoverageMergeCommand
     /**
      * @param list<string> $specs
      *
-     * @return array<string, array<string, mixed>>
+     * @return array<string, CoverageResult>
      */
     private function computeResults(array $specs, OpenApiCoverageTracker $tracker): array
     {

--- a/tests/Unit/Coverage/CoverageThresholdEvaluatorTest.php
+++ b/tests/Unit/Coverage/CoverageThresholdEvaluatorTest.php
@@ -7,12 +7,16 @@ namespace Studio\OpenApiContractTesting\Tests\Unit\Coverage;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\Coverage\CoverageThresholdEvaluator;
+use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
 
 use function explode;
 use function str_repeat;
 use function substr;
 use function trim;
 
+/**
+ * @phpstan-import-type CoverageResult from OpenApiCoverageTracker
+ */
 class CoverageThresholdEvaluatorTest extends TestCase
 {
     #[Test]
@@ -240,7 +244,7 @@ class CoverageThresholdEvaluatorTest extends TestCase
      * defaults match the empty/zero shape so a typo can't accidentally inflate
      * a metric.
      *
-     * @return array<string, mixed>
+     * @return CoverageResult
      */
     private static function counts(
         int $endpointFullyCovered,

--- a/tests/Unit/Coverage/HtmlCoverageRendererTest.php
+++ b/tests/Unit/Coverage/HtmlCoverageRendererTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\Coverage\EndpointCoverageState;
 use Studio\OpenApiContractTesting\Coverage\HtmlCoverageRenderer;
+use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\Coverage\ResponseCoverageState;
 
 use function array_unique;
@@ -16,6 +17,9 @@ use function preg_match_all;
 use function sort;
 use function substr_count;
 
+/**
+ * @phpstan-import-type EndpointSummary from OpenApiCoverageTracker
+ */
 class HtmlCoverageRendererTest extends TestCase
 {
     #[Test]
@@ -560,7 +564,7 @@ class HtmlCoverageRendererTest extends TestCase
     }
 
     /**
-     * @param array<string, mixed> $endpoint
+     * @param EndpointSummary $endpoint
      */
     private function renderOne(
         string $specName,

--- a/tests/Unit/Coverage/JUnitCoverageRendererTest.php
+++ b/tests/Unit/Coverage/JUnitCoverageRendererTest.php
@@ -9,11 +9,15 @@ use PHPUnit\Framework\TestCase;
 use SimpleXMLElement;
 use Studio\OpenApiContractTesting\Coverage\EndpointCoverageState;
 use Studio\OpenApiContractTesting\Coverage\JUnitCoverageRenderer;
+use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\Coverage\ResponseCoverageState;
 
 use function explode;
 use function simplexml_load_string;
 
+/**
+ * @phpstan-import-type EndpointSummary from OpenApiCoverageTracker
+ */
 class JUnitCoverageRendererTest extends TestCase
 {
     #[Test]
@@ -388,7 +392,7 @@ class JUnitCoverageRendererTest extends TestCase
     /**
      * Convenience: render a single-endpoint coverage result for a single spec.
      *
-     * @param array<string, mixed> $endpoint
+     * @param EndpointSummary $endpoint
      */
     private function renderOne(
         string $specName,

--- a/tests/Unit/Coverage/JsonCoverageRendererTest.php
+++ b/tests/Unit/Coverage/JsonCoverageRendererTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\Coverage\EndpointCoverageState;
 use Studio\OpenApiContractTesting\Coverage\JsonCoverageRenderer;
+use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\Coverage\ResponseCoverageState;
 
 use function array_keys;
@@ -17,6 +18,9 @@ use function explode;
 use function is_array;
 use function json_decode;
 
+/**
+ * @phpstan-import-type CoverageResult from OpenApiCoverageTracker
+ */
 class JsonCoverageRendererTest extends TestCase
 {
     private const FIXED_TIMESTAMP = '2026-05-11T12:34:56+00:00';
@@ -442,7 +446,7 @@ class JsonCoverageRendererTest extends TestCase
     }
 
     /**
-     * @return array<string, array<string, mixed>>
+     * @return array<string, CoverageResult>
      */
     private function oneSpecResults(): array
     {

--- a/tests/Unit/Coverage/MarkdownCoverageRendererLintTest.php
+++ b/tests/Unit/Coverage/MarkdownCoverageRendererLintTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\Coverage\EndpointCoverageState;
 use Studio\OpenApiContractTesting\Coverage\MarkdownCoverageRenderer;
+use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\Coverage\ResponseCoverageState;
 
 use function dirname;
@@ -23,6 +24,10 @@ use function sys_get_temp_dir;
 use function tempnam;
 use function unlink;
 
+/**
+ * @phpstan-import-type CoverageResult from OpenApiCoverageTracker
+ * @phpstan-import-type EndpointSummary from OpenApiCoverageTracker
+ */
 final class MarkdownCoverageRendererLintTest extends TestCase
 {
     #[Test]
@@ -38,7 +43,7 @@ final class MarkdownCoverageRendererLintTest extends TestCase
     }
 
     /**
-     * @return array<string, array<string, mixed>>
+     * @return array<string, CoverageResult>
      */
     private static function standardFixture(): array
     {
@@ -88,7 +93,7 @@ final class MarkdownCoverageRendererLintTest extends TestCase
     }
 
     /**
-     * @return array<string, array<string, mixed>>
+     * @return array<string, CoverageResult>
      */
     private static function edgeCasesFixture(): array
     {
@@ -137,7 +142,7 @@ final class MarkdownCoverageRendererLintTest extends TestCase
      * @param list<array{statusKey: string, contentTypeKey: string, state: ResponseCoverageState, hits: int, skipReason: ?string}> $responses
      * @param list<array{statusKey: string, contentTypeKey: string}> $unexpectedObservations
      *
-     * @return array<string, mixed>
+     * @return EndpointSummary
      */
     private static function endpoint(
         string $endpoint,
@@ -187,7 +192,7 @@ final class MarkdownCoverageRendererLintTest extends TestCase
     }
 
     /**
-     * @param array<string, array<string, mixed>> $results
+     * @param array<string, CoverageResult> $results
      */
     private function assertRenderedMarkdownPassesLint(array $results): void
     {


### PR DESCRIPTION
# 概要

PHPStan 2.2 で sealed array shape のチェックが厳格化され、`array<string, mixed>` を sealed な `CoverageResult` / `EndpointSummary` 期待箇所へ渡すコードが新たにエラー化しました。`composer.lock` が gitignore されているため CI は毎回 PHPStan を最新解決しており、この厳格版を取り込んで **19 件**のエラーで CI（PHPStan ジョブ / PHP 8.3）が落ちています。`main` でも同一エラーを再現します（既存問題で、特定機能 PR とは無関係）。

## 変更内容

カバレッジ系の renderer/evaluator 呼び出し箇所の緩い `array<string, mixed>` 注釈を、`OpenApiCoverageTracker` で定義済みの `CoverageResult` / `EndpointSummary` エイリアスへ置き換え（ヘルパは既に完全な shape を構築済み）。**型注釈のみでランタイム挙動の変更なし。**

- `src/Coverage/CoverageMergeCommand.php`: `computeResults()` の `@return` を `array<string, CoverageResult>` に是正（`computeCoverageOn()` の実戻り値どおり）。`evaluateThresholdGate()` の `@param` も同様に是正し、不要なインライン `@var` を撤去。
- `tests/Unit/Coverage/CoverageThresholdEvaluatorTest.php`: `counts()` の `@return` を `CoverageResult` に（`@phpstan-import-type` 追加）。
- `tests/Unit/Coverage/{Html,JUnit}CoverageRendererTest.php`: `renderOne()` の `$endpoint` を `EndpointSummary` に。
- `tests/Unit/Coverage/JsonCoverageRendererTest.php`: `oneSpecResults()` の `@return` を `array<string, CoverageResult>` に。
- `tests/Unit/Coverage/MarkdownCoverageRendererLintTest.php`: `endpoint()` を `EndpointSummary`、`*Fixture()` / lint ヘルパを `array<string, CoverageResult>` に。

## 検証

PHP 8.3（CI と同条件、`composer install` で最新依存を解決 → PHPStan 2.2.1）で:

- `vendor/bin/phpstan analyse` → **No errors**（19 → 0）
- `vendor/bin/phpunit` → 1856 tests グリーン
- `php-cs-fixer --dry-run` → クリーン

## 関連情報

- PR #263 の CI も本問題でブロックされていました（#263 は discriminator 機能のみで本問題とは無関係）。本 PR マージ後に #263 を再実行すれば green になります。
- 根本原因: `composer.lock` の gitignore により CI が PHPStan を最新解決する設計（= 最新ツールでの継続検証）のため、ツール側の厳格化がそのまま顕在化したもの。