### PR TITLE
chore(renovate): adopt config:best-practices and pin actions to SHA

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,15 +1,22 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:best-practices"
   ],
   "labels": ["dependencies"],
-  "schedule": ["before 9am on Monday"],
   "timezone": "Asia/Tokyo",
+  "schedule": ["before 9am on Monday"],
+  "minimumReleaseAge": "7 days",
   "packageRules": [
     {
-      "description": "Group GitHub Actions updates",
+      "description": "Skip the example's path-linked self reference (resolved from the working tree, not Packagist)",
+      "matchPackageNames": ["studio-design/openapi-contract-testing"],
+      "enabled": false
+    },
+    {
+      "description": "Automerge GitHub Actions digest + minor/patch bumps; majors stay manual review",
       "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "digest", "pin", "pinDigest"],
       "groupName": "GitHub Actions",
       "automerge": true
     },


### PR DESCRIPTION
# 概要

`renovate.json` を Renovate 公式の `config:best-practices` に揃え、GitHub Actions の SHA(ダイジェスト)固定・自動マージ前の cool-down・major アクション更新の手動レビュー化を導入します。サプライチェーン対策と自動マージ運用の安全性を強化する設定変更で、ライブラリ機能には影響しません。

## 変更内容

`config:recommended` から `config:best-practices` へ切り替え、自動マージ構成に不足していた安全策（リリース熟成待ち・major 除外）を補い、example の自己参照を更新対象から除外しました。`composer.lock` 未コミット（ライブラリ配布）のため `rangeStrategy` は `auto`（`type: library` 判別で広いレンジ維持）のまま据え置きます。

- **preset**: `config:recommended` → `config:best-practices`。実効するのは `helpers:pinGitHubActionDigests`（全 GitHub Actions を SHA 固定 / OpenSSF Scorecard 推奨）・`:configMigration`・`abandonments:recommended`。`docker:pinDigests` / `:pinDevDependencies` / `:maintainLockFilesWeekly` / `security:minimumReleaseAgeNpm` は本リポジトリでは no-op
- **cool-down**: `minimumReleaseAge: "7 days"` を追加。yank / 改ざんされた公開を即マージしないためのサプライチェーン対策（週次スケジュールと合わせ安定した週次バッチで更新）
- **GitHub Actions 自動マージの限定**: `matchUpdateTypes` を `minor/patch/digest/pin/pinDigest` に限定し、**major は手動レビュー**へ。従来は updateType 無制限で major も自動マージ対象だったギャップを是正
- **自己参照の除外**: `examples/pest/composer.json` の path リンク自己参照 `studio-design/openapi-contract-testing` を `enabled: false` で更新対象外に
- **据え置き**: `rangeStrategy`（`auto` のまま）/ `require`・`require-dev` の patch・minor 自動マージルール / `labels`・`timezone`・`schedule`

### 検証

- `npx renovate-config-validator renovate.json` → `Config validated successfully`
- JSON 妥当性 → `No error`

### レビュー時の注意

- 初回実行で全 workflow の `@v6` → `@<sha> # v6` 変換 PR が1本生成されます（`pinDigest` で自動マージ対象。気になる場合は初回のみ手動マージでも可）
- PR タイトルチェック（`pr-title.yml`）は `renovate[bot]` を除外しませんが、Renovate デフォルトの `chore(deps):` / `fix(deps):` 出力は規約を満たすため互換です

## 関連情報

- ベストプラクティス出典: Renovate 公式 `config:best-practices`（Upgrade Best Practices）
- 関連: 現在 open の major アクション更新 PR #261（本変更後は major が自動マージされなくなります）
