### PR TITLE
fix(deps): require patched Guzzle versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.94",
-        "guzzlehttp/psr7": "^2.0",
+        "guzzlehttp/guzzle": "^7.12.1",
+        "guzzlehttp/psr7": "^2.12.1",
         "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
         "phpstan/phpstan": "^2.1.13",
         "symfony/browser-kit": "^6.4 || ^7.0 || ^8.0",

--- a/tests/Integration/OpenApiCoverageExtensionBootstrapTest.php
+++ b/tests/Integration/OpenApiCoverageExtensionBootstrapTest.php
@@ -99,11 +99,9 @@ class OpenApiCoverageExtensionBootstrapTest extends TestCase
     public function default_testsuite_as_full_warns_when_default_is_empty_string(): void
     {
         // `<phpunit defaultTestSuite="">` is valid XML but makes the
-        // opt-in inert (no possible match). Same WARN policy as above.
-        // Verifies the empty-string branch of `readDefaultTestSuite()`
-        // end-to-end (the unit branch is exercised through `fromSignals`'s
-        // `defaultTestSuite: null` parameterisation; this is the only place
-        // the extension's empty-string normalisation is observable).
+        // opt-in inert (no possible match). PHPUnit 13.2 normalises the empty
+        // attribute to "not declared", while older supported versions expose
+        // the empty string. Both paths must surface the same inert-opt-in WARN.
         $output = $this->runPhpunitWithDefaultTestSuite(
             defaultTestSuite: '',
             optInValue: 'true',
@@ -111,7 +109,7 @@ class OpenApiCoverageExtensionBootstrapTest extends TestCase
         );
 
         $this->assertStringContainsString('default_testsuite_as_full=true', $output);
-        $this->assertStringContainsString('empty', $output);
+        $this->assertStringContainsString('will be inert', $output);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- declare `guzzlehttp/guzzle` as a direct development dependency because the test suite directly uses `GuzzleHttp\Client`
- require the first patched release or newer for both affected packages:
  - `guzzlehttp/guzzle:^7.12.1`
  - `guzzlehttp/psr7:^2.12.1`
- keep the package-library convention of not committing `composer.lock`
- make the empty `defaultTestSuite` warning assertion compatible with PHPUnit 13.2's normalization behavior

## Rationale

The root `composer.lock` is intentionally ignored, so there is no tracked lock-file update to commit. Fresh Composer resolution currently selects patched releases, but the previous manifest still allowed affected releases in contributor and lowest-dependency environments.

Making Guzzle an explicit `require-dev` dependency also reflects its direct use in `OpenApiSpecLoaderTest`, instead of relying on Testbench to provide it transitively. This does not add a production dependency for library consumers.

Renovate did not miss a configured patch update: `guzzlehttp/psr7:^2.0` already allowed newer 2.x releases, and there is no tracked root lock file for Renovate to refresh. No Renovate policy change is needed.

The first CI run also exposed a PHPUnit 13.2 compatibility issue unrelated to Guzzle: an empty `defaultTestSuite` attribute is now normalized as not declared. Both states correctly produce the inert-opt-in warning, so the integration assertion now checks that stable semantic contract instead of version-specific wording.

## Verification

- `composer validate --strict`
- `composer audit --abandoned=fail` — no advisories
- `composer update --prefer-lowest --prefer-dist --no-interaction --no-progress --dry-run` — resolves Guzzle 7.12.1 and PSR-7 2.12.1 with no advisories
- HTTP `$ref` tests — 76 tests, 157 assertions
- full PHPUnit suite — 1,880 non-lint tests passed; the two Markdown lint tests initially hit sandbox DNS restrictions, then passed separately with network access
- PHPUnit 13.2 compatibility regression test — passed locally on PHPUnit 13.1 and covered by the CI matrix on 13.2
- PHPStan — no errors
- PHP-CS-Fixer dry-run — both standard and Pest configurations passed

Closes #284
