### PR TITLE
fix(spec): reject unsupported OpenAPI versions

### DIFF
--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -14,7 +14,11 @@ This is a contract-testing tool: where we can't enforce a constraint precisely, 
 
 ## OpenAPI 3.0 vs 3.1
 
-The package auto-detects the OAS version from the `openapi` field and handles schema conversion accordingly:
+The package accepts OpenAPI `3.0.x` and `3.1.x`. The root `openapi` field must be a string in explicit `major.minor.patch` form (for example, `3.0.4` or `3.1.2`). Patch releases within a supported minor use the same feature set, following the [OpenAPI version policy](https://spec.openapis.org/oas/latest.html#versions-and-deprecation).
+
+Missing, empty, non-string, malformed, and unsupported values fail spec loading with `InvalidOpenApiSpecException`. This includes Swagger / OpenAPI 2.x, OpenAPI 3.2.x, and unknown future versions. They are never interpreted as 3.0. OpenAPI 3.2 requires dedicated support before it can be accepted because minor releases may change the OAS feature set.
+
+For supported versions, the package detects the OAS feature family from the `openapi` field and handles schema conversion accordingly:
 
 | Feature | 3.0 handling | 3.1 handling |
 |---|---|---|

--- a/src/Exception/InvalidOpenApiSpecReason.php
+++ b/src/Exception/InvalidOpenApiSpecReason.php
@@ -49,5 +49,6 @@ enum InvalidOpenApiSpecReason
     case NonMappingRoot;
     case YamlLibraryMissing;
     case UnsupportedExtension;
+    case UnsupportedVersion;
     case BasePathNotConfigured;
 }

--- a/src/OpenApiVersion.php
+++ b/src/OpenApiVersion.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting;
 
+use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecException;
+use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecReason;
+
+use function array_key_exists;
+use function get_debug_type;
 use function is_string;
-use function str_starts_with;
+use function preg_match;
+use function sprintf;
+use function var_export;
 
 enum OpenApiVersion: string
 {
@@ -16,15 +23,35 @@ enum OpenApiVersion: string
      * Detect OAS version from a parsed spec array.
      *
      * @param array<string, mixed> $spec
+     *
+     * @throws InvalidOpenApiSpecException when the version is absent, malformed, or unsupported
      */
     public static function fromSpec(array $spec): self
     {
-        $version = $spec['openapi'] ?? '';
+        $version = $spec['openapi'] ?? null;
 
-        if (is_string($version) && str_starts_with($version, '3.1')) {
-            return self::V3_1;
+        if (is_string($version) &&
+            preg_match('/\A(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)\z/D', $version, $matches) === 1
+        ) {
+            $family = $matches['major'] . '.' . $matches['minor'];
+
+            if ($family === self::V3_0->value) {
+                return self::V3_0;
+            }
+
+            if ($family === self::V3_1->value) {
+                return self::V3_1;
+            }
         }
 
-        return self::V3_0;
+        $received = array_key_exists('openapi', $spec)
+            ? sprintf('%s (%s)', var_export($version, true), get_debug_type($version))
+            : '<missing>';
+
+        throw new InvalidOpenApiSpecException(
+            InvalidOpenApiSpecReason::UnsupportedVersion,
+            "Unsupported OpenAPI version: {$received}. The required `openapi` field must be a "
+            . 'major.minor.patch string in a supported version family: 3.0.x or 3.1.x.',
+        );
     }
 }

--- a/src/Spec/OpenApiSpecLoader.php
+++ b/src/Spec/OpenApiSpecLoader.php
@@ -14,6 +14,7 @@ use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecReason;
 use Studio\OpenApiContractTesting\Exception\SpecFileNotFoundException;
 use Studio\OpenApiContractTesting\Internal\YamlAvailability;
+use Studio\OpenApiContractTesting\OpenApiVersion;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
@@ -191,6 +192,16 @@ final class OpenApiSpecLoader
                 specName: $specName,
             ),
         };
+
+        // Version selection changes schema semantics, so reject an absent,
+        // malformed, or unsupported `openapi` value before resolving refs or
+        // running any endpoint assertions. This also makes PHPUnit extension
+        // bootstrap fail while eagerly loading its configured specs.
+        try {
+            OpenApiVersion::fromSpec($decoded);
+        } catch (InvalidOpenApiSpecException $e) {
+            throw $e->withSpecName($specName);
+        }
 
         // Canonicalize the source path so the resolver's cycle detection
         // sees the same key for this file whether it's reached as the

--- a/tests/Integration/Laravel/AutoAssertIntegrationTest.php
+++ b/tests/Integration/Laravel/AutoAssertIntegrationTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Studio\OpenApiContractTesting\Attribute\OpenApiSpec;
 use Studio\OpenApiContractTesting\Attribute\SkipOpenApi;
 use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\Laravel\OpenApiContractTestingServiceProvider;
 use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
@@ -57,6 +58,18 @@ class AutoAssertIntegrationTest extends TestCase
         $covered = OpenApiCoverageTracker::getCovered();
         $this->assertArrayHasKey('petstore-3.0', $covered);
         $this->assertArrayHasKey('GET /v1/pets', $covered['petstore-3.0']);
+    }
+
+    #[Test]
+    public function auto_assert_rejects_unsupported_openapi_version(): void
+    {
+        config()->set('openapi-contract-testing.default_spec', 'unsupported-version');
+        config()->set('openapi-contract-testing.auto_assert', true);
+
+        $this->expectException(InvalidOpenApiSpecException::class);
+        $this->expectExceptionMessage("Unsupported OpenAPI version: '3.2.0' (string)");
+
+        $this->get('/v1/pets');
     }
 
     #[Test]

--- a/tests/Integration/OpenApiCoverageExtensionBootstrapTest.php
+++ b/tests/Integration/OpenApiCoverageExtensionBootstrapTest.php
@@ -59,6 +59,17 @@ class OpenApiCoverageExtensionBootstrapTest extends TestCase
     }
 
     #[Test]
+    public function phpunit_exits_non_zero_when_registered_spec_has_unsupported_version(): void
+    {
+        [$exit, $stderr] = $this->runPhpunit('unsupported-version', '--filter=DoesNotMatchAnyTest');
+
+        $this->assertNotSame(0, $exit, "Expected non-zero exit; stderr was:\n" . $stderr);
+        $this->assertStringContainsString('FATAL', $stderr);
+        $this->assertStringContainsString("Unsupported OpenAPI version: '3.2.0' (string)", $stderr);
+        $this->assertStringContainsString('3.0.x or 3.1.x', $stderr);
+    }
+
+    #[Test]
     public function phpunit_exits_non_zero_when_registered_spec_file_is_missing(): void
     {
         // issue #134 contract pinned end-to-end: the unit test covers the

--- a/tests/Unit/Fuzz/OpenApiEndpointExplorerTest.php
+++ b/tests/Unit/Fuzz/OpenApiEndpointExplorerTest.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use Opis\JsonSchema\Validator;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\Fuzz\ExplorationCases;
 use Studio\OpenApiContractTesting\Fuzz\ExploredCase;
 use Studio\OpenApiContractTesting\Fuzz\OpenApiEndpointExplorer;
@@ -38,6 +39,15 @@ class OpenApiEndpointExplorerTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
 
         OpenApiEndpointExplorer::explore('petstore-3.0', 'POST', '/v1/pets', cases: 0);
+    }
+
+    #[Test]
+    public function rejects_unsupported_openapi_version(): void
+    {
+        $this->expectException(InvalidOpenApiSpecException::class);
+        $this->expectExceptionMessage("Unsupported OpenAPI version: '3.2.0' (string)");
+
+        OpenApiEndpointExplorer::explore('unsupported-version', 'GET', '/v1/pets', cases: 1);
     }
 
     #[Test]

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Studio\OpenApiContractTesting\DecodedBody;
+use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\OpenApiRequestValidator;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\Validation\Request\SecurityValidator;
@@ -54,6 +55,15 @@ class OpenApiRequestValidatorTest extends TestCase
     // ========================================
     // Acceptance criteria: valid / invalid / spec 未定義
     // ========================================
+
+    #[Test]
+    public function rejects_unsupported_openapi_version(): void
+    {
+        $this->expectException(InvalidOpenApiSpecException::class);
+        $this->expectExceptionMessage("Unsupported OpenAPI version: '3.2.0' (string)");
+
+        $this->validator->validate('unsupported-version', 'GET', '/v1/pets', [], [], null);
+    }
 
     #[Test]
     public function validates_request_body_against_ref_backed_schema(): void

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Studio\OpenApiContractTesting\DecodedBody;
+use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\OpenApiResponseValidator;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 
@@ -66,6 +67,15 @@ class OpenApiResponseValidatorTest extends TestCase
     // ========================================
     // OAS 3.0 tests
     // ========================================
+
+    #[Test]
+    public function rejects_unsupported_openapi_version(): void
+    {
+        $this->expectException(InvalidOpenApiSpecException::class);
+        $this->expectExceptionMessage("Unsupported OpenAPI version: '3.2.0' (string)");
+
+        $this->validator->validate('unsupported-version', 'GET', '/v1/pets', 200, null);
+    }
 
     #[Test]
     public function v30_valid_response_passes(): void

--- a/tests/Unit/OpenApiVersionTest.php
+++ b/tests/Unit/OpenApiVersionTest.php
@@ -7,6 +7,8 @@ namespace Studio\OpenApiContractTesting\Tests\Unit;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecException;
+use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecReason;
 use Studio\OpenApiContractTesting\OpenApiVersion;
 
 class OpenApiVersionTest extends TestCase
@@ -17,11 +19,26 @@ class OpenApiVersionTest extends TestCase
         return [
             '3.0.0' => [['openapi' => '3.0.0'], OpenApiVersion::V3_0],
             '3.0.3' => [['openapi' => '3.0.3'], OpenApiVersion::V3_0],
+            '3.0 future patch' => [['openapi' => '3.0.999'], OpenApiVersion::V3_0],
             '3.1.0' => [['openapi' => '3.1.0'], OpenApiVersion::V3_1],
             '3.1.1' => [['openapi' => '3.1.1'], OpenApiVersion::V3_1],
-            'missing field' => [[], OpenApiVersion::V3_0],
-            'empty string' => [['openapi' => ''], OpenApiVersion::V3_0],
-            'non-string value' => [['openapi' => 3], OpenApiVersion::V3_0],
+            '3.1 future patch' => [['openapi' => '3.1.999'], OpenApiVersion::V3_1],
+        ];
+    }
+
+    /** @return array<string, array{array<string, mixed>, string}> */
+    public static function provideRejects_invalid_or_unsupported_versionCases(): iterable
+    {
+        return [
+            'missing field' => [[], '<missing>'],
+            'empty string' => [['openapi' => ''], "'' (string)"],
+            'non-string value' => [['openapi' => 3], '3 (int)'],
+            'Swagger 2.0' => [['openapi' => '2.0.0'], "'2.0.0' (string)"],
+            'unsupported 3.2' => [['openapi' => '3.2.0'], "'3.2.0' (string)"],
+            'unsupported 3.10' => [['openapi' => '3.10.0'], "'3.10.0' (string)"],
+            'unknown future version' => [['openapi' => '4.0.0'], "'4.0.0' (string)"],
+            'missing patch' => [['openapi' => '3.1'], "'3.1' (string)"],
+            'malformed version' => [['openapi' => 'not-a-version'], "'not-a-version' (string)"],
         ];
     }
 
@@ -31,5 +48,20 @@ class OpenApiVersionTest extends TestCase
     public function detects_version_from_spec(array $spec, OpenApiVersion $expected): void
     {
         $this->assertSame($expected, OpenApiVersion::fromSpec($spec));
+    }
+
+    /** @param array<string, mixed> $spec */
+    #[Test]
+    #[DataProvider('provideRejects_invalid_or_unsupported_versionCases')]
+    public function rejects_invalid_or_unsupported_version(array $spec, string $received): void
+    {
+        try {
+            OpenApiVersion::fromSpec($spec);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::UnsupportedVersion, $e->reason);
+            $this->assertStringContainsString($received, $e->getMessage());
+            $this->assertStringContainsString('3.0.x or 3.1.x', $e->getMessage());
+        }
     }
 }

--- a/tests/Unit/Spec/OpenApiSpecLoaderTest.php
+++ b/tests/Unit/Spec/OpenApiSpecLoaderTest.php
@@ -155,6 +155,22 @@ class OpenApiSpecLoaderTest extends TestCase
     }
 
     #[Test]
+    public function load_rejects_unsupported_openapi_version_with_spec_context(): void
+    {
+        OpenApiSpecLoader::configure(__DIR__ . '/../../fixtures/specs');
+
+        try {
+            OpenApiSpecLoader::load('unsupported-version');
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::UnsupportedVersion, $e->reason);
+            $this->assertSame('unsupported-version', $e->specName);
+            $this->assertStringContainsString("'3.2.0' (string)", $e->getMessage());
+            $this->assertStringContainsString('3.0.x or 3.1.x', $e->getMessage());
+        }
+    }
+
+    #[Test]
     public function load_caches_result(): void
     {
         $fixturesPath = __DIR__ . '/../../fixtures/specs';

--- a/tests/Unit/Symfony/OpenApiAssertionsTest.php
+++ b/tests/Unit/Symfony/OpenApiAssertionsTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\Attribute\OpenApiSpec;
 use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecException;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\Symfony\OpenApiAssertions;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -41,6 +42,19 @@ final class OpenApiAssertionsTest extends TestCase
     {
         $request = Request::create('/v1/pets', 'GET');
         $response = new JsonResponse(['data' => [['id' => 1, 'name' => 'Fido', 'tag' => null]]]);
+
+        $this->assertResponseMatchesOpenApiSchema($request, $response);
+    }
+
+    #[Test]
+    #[OpenApiSpec('unsupported-version')]
+    public function unsupported_openapi_version_fails_before_response_assertion(): void
+    {
+        $request = Request::create('/v1/pets', 'GET');
+        $response = new Response('', 200);
+
+        $this->expectException(InvalidOpenApiSpecException::class);
+        $this->expectExceptionMessage("Unsupported OpenAPI version: '3.2.0' (string)");
 
         $this->assertResponseMatchesOpenApiSchema($request, $response);
     }

--- a/tests/fixtures/specs/unsupported-version.json
+++ b/tests/fixtures/specs/unsupported-version.json
@@ -1,0 +1,18 @@
+{
+  "openapi": "3.2.0",
+  "info": {
+    "title": "Unsupported OpenAPI version",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/v1/pets": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Parse the required `openapi` field as an explicit `major.minor.patch` value and accept only the implemented `3.0.x` and `3.1.x` families.
- Reject missing, malformed, non-string, and unsupported versions with `InvalidOpenApiSpecException` / `UnsupportedVersion`, including the received value and supported families.
- Validate the version during `OpenApiSpecLoader::load()` so Laravel, Symfony, direct validators, fuzzing, and the PHPUnit extension fail before endpoint assertions run.
- Document the version policy and add entry-point regression coverage for OpenAPI 3.2.

## Why

Every value other than a string beginning with `3.1` previously fell back to OpenAPI 3.0 semantics. That could make missing fields, Swagger 2.0 documents, OpenAPI 3.2 documents, and malformed/future versions produce false-positive contract tests.

OpenAPI defines `major.minor` as the feature set and patch releases as compatible within that feature set: https://spec.openapis.org/oas/latest.html#versions-and-deprecation

Fixes #272

## Verification

- [x] `composer test` coverage completed: 1,894 tests passed in the full run; the 2 npm-backed markdownlint tests were blocked only by sandbox DNS and passed when rerun with network access. The final version-boundary tests also pass (57 tests, 138 assertions).
- [x] `composer stan` equivalent: `vendor/bin/phpstan analyse` passed with no errors.
- [x] `composer cs-check` equivalent: both PHP-CS-Fixer configurations passed in sequential dry-run mode.
- [x] `composer validate --strict` passed.
- [x] Laravel, Symfony, request/response validator, fuzzing, loader, and PHPUnit bootstrap version-error paths are covered.

## Notes for reviewers

- OpenAPI 3.2 is intentionally rejected until its distinct feature set is implemented; it never falls through to 3.0 behavior.
- Local Pest execution was unavailable because Pest 3 is intentionally omitted from the main PHPUnit 12/13 dependency set. The dedicated CI job installs Pest 3 and exercises that integration.
- No production dependency was added.
