### PR TITLE
feat(spec): add OpenAPI 3.2 support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ vendor/bin/php-cs-fixer fix --dry-run --diff
 
 ## Architecture
 
-This is a PHP library (`studio-design/openapi-contract-testing`) that validates API responses against OpenAPI 3.0/3.1 specs during PHPUnit tests and tracks endpoint coverage.
+This is a PHP library (`studio-design/openapi-contract-testing`) that validates API responses against OpenAPI 3.0/3.1/3.2 specs during PHPUnit tests and tracks endpoint coverage.
 
 ### Validation Flow
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@
 [![PHP Version Require](https://poser.pugx.org/studio-design/openapi-contract-testing/require/php)](https://packagist.org/packages/studio-design/openapi-contract-testing)
 [![License](https://poser.pugx.org/studio-design/openapi-contract-testing/license)](https://packagist.org/packages/studio-design/openapi-contract-testing)
 
-Framework-agnostic OpenAPI 3.0/3.1 contract testing for PHPUnit **with endpoint coverage tracking**.
+Framework-agnostic OpenAPI 3.0/3.1/3.2 contract testing for PHPUnit **with endpoint coverage tracking**.
 
 Validate your API responses against your OpenAPI specification during testing, and get a coverage report showing which endpoints have been tested.
 
 ## Features
 
-- **OpenAPI 3.0 & 3.1 support** — Automatic version detection from the `openapi` field
+- **OpenAPI 3.0, 3.1 & 3.2 support** — Explicit version detection, including 3.2 `QUERY`, custom `additionalOperations`, form `querystring`, `discriminator.defaultMapping`, and observable streaming limitations
 - **Response & request validation** — JSON Schema (Draft 07 via opis/json-schema) for body, parameters, and security schemes; `application/json` and any `+json` content type
 - **Endpoint coverage tracking** — Unique PHPUnit extension that reports which spec endpoints are covered by tests, at `(method, path, status, content-type)` granularity
 - **Schema-driven request fuzzing** — `ExploresOpenApiEndpoint` trait generates N happy-path inputs straight from the spec (Schemathesis-style)
@@ -33,7 +33,7 @@ Validate your API responses against your OpenAPI specification during testing, a
 
 ## Why this library?
 
-This library fills a gap left by existing PHP OpenAPI testing tools: **endpoint coverage tracking** and **first-class OpenAPI 3.1 support**, combined with Laravel auto-assert DX. If you already use Spectator and don't need coverage reports, this library won't offer much. If you want to see which endpoints your test suite actually exercises, or you're writing OpenAPI 3.1 specs, this is likely the best choice today.
+This library fills a gap left by existing PHP OpenAPI testing tools: **endpoint coverage tracking** and explicit **OpenAPI 3.2 support**, combined with Laravel auto-assert DX. If you already use Spectator and don't need coverage reports, this library won't offer much. If you want to see which endpoints your test suite actually exercises, or you are adopting OpenAPI 3.1/3.2, this is likely the best choice today.
 
 ### Feature comparison (as of 2026-04)
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "studio-design/openapi-contract-testing",
-    "description": "Framework-agnostic OpenAPI 3.0/3.1 contract testing for PHPUnit with endpoint coverage tracking",
+    "description": "Framework-agnostic OpenAPI 3.0/3.1/3.2 contract testing for PHPUnit with endpoint coverage tracking",
     "keywords": ["openapi", "contract-testing", "phpunit", "api-testing", "coverage"],
     "license": "MIT",
     "type": "library",

--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -2,7 +2,7 @@
 
 This is a contract-testing tool: where we can't enforce a constraint precisely, we prefer a loud failure or an explicit "skipped" outcome over silently accepting non-compliant data. The list below pins down what does and does not get checked so you can decide whether the gaps matter for your spec.
 
-- [OpenAPI 3.0 vs 3.1](#openapi-30-vs-31)
+- [OpenAPI 3.0, 3.1, and 3.2](#openapi-30-31-and-32)
   - [`readOnly` / `writeOnly` enforcement](#readonly--writeonly-enforcement)
 - [Body validation](#body-validation)
 - [Parameter styles](#parameter-styles)
@@ -12,15 +12,15 @@ This is a contract-testing tool: where we can't enforce a constraint precisely, 
 - [Spec features not consulted](#spec-features-not-consulted)
 - [Warning channel (`E_USER_WARNING` contract)](#warning-channel-e_user_warning-contract)
 
-## OpenAPI 3.0 vs 3.1
+## OpenAPI 3.0, 3.1, and 3.2
 
-The package accepts OpenAPI `3.0.x` and `3.1.x`. The root `openapi` field must be a string in explicit `major.minor.patch` form (for example, `3.0.4` or `3.1.2`). Patch releases within a supported minor use the same feature set, following the [OpenAPI version policy](https://spec.openapis.org/oas/latest.html#versions-and-deprecation).
+The package accepts OpenAPI `3.0.x`, `3.1.x`, and `3.2.x`. The root `openapi` field must be a string in explicit `major.minor.patch` form (for example, `3.0.4`, `3.1.2`, or `3.2.0`). Patch releases within a supported minor use the same feature set, following the [OpenAPI version policy](https://spec.openapis.org/oas/latest.html#versions-and-deprecation).
 
-Missing, empty, non-string, malformed, and unsupported values fail spec loading with `InvalidOpenApiSpecException`. This includes Swagger / OpenAPI 2.x, OpenAPI 3.2.x, and unknown future versions. They are never interpreted as 3.0. OpenAPI 3.2 requires dedicated support before it can be accepted because minor releases may change the OAS feature set.
+Missing, empty, non-string, malformed, and unsupported values fail spec loading with `InvalidOpenApiSpecException`. This includes Swagger / OpenAPI 2.x, OpenAPI 3.3.x, and unknown future versions. They are never interpreted as 3.0.
 
 For supported versions, the package detects the OAS feature family from the `openapi` field and handles schema conversion accordingly:
 
-| Feature | 3.0 handling | 3.1 handling |
+| Feature | 3.0 handling | 3.1 / 3.2 handling |
 |---|---|---|
 | `nullable: true` | Converted to type array `["string", "null"]`; `null` appended to `enum` if present | Not applicable (uses type arrays natively) |
 | `prefixItems` | N/A | Converted to `items` array (Draft 07 tuple) |
@@ -28,6 +28,15 @@ For supported versions, the package detects the OAS feature family from the `ope
 | `examples` (array) | Removed (Draft 2020-12 keyword, not Draft 07) | Removed (Draft 2020-12 keyword, not Draft 07) |
 | `const` | N/A | Lowered to `enum: [value]` so opis Draft 07 enforces it |
 | `readOnly` / `writeOnly` | Semantic enforcement (see below). Forbidden properties become boolean `false` subschemas; the keyword is dropped as OAS-only on surviving properties | Semantic enforcement (see below). Forbidden properties become boolean `false` subschemas; the keyword is preserved on surviving properties (valid in Draft 07) |
+
+OpenAPI 3.2 is backward compatible with 3.1, so ordinary 3.2 operations use the tested 3.1 conversion pipeline. The behavior below follows the official [OpenAPI 3.2 specification](https://spec.openapis.org/oas/v3.2.0.html) and [3.1-to-3.2 upgrade guide](https://learn.openapis.org/upgrading/v3.1-to-v3.2.html). The contract-relevant 3.2 additions have explicit behavior:
+
+- `QUERY` works in direct validators, Laravel, Symfony, Pest, fuzz exploration, and coverage reports.
+- Custom methods under `additionalOperations` resolve in direct request/response validators and appear in coverage. The enum-based framework and fuzz adapters accept `QUERY` but not arbitrary custom method tokens.
+- One `in: querystring` parameter with `application/x-www-form-urlencoded` content validates the entire framework-parsed query map against its schema. Mixing it with `in: query`, declaring it more than once, or omitting its schema fails loudly. Other query-string media types emit `[OpenAPI 3.2 querystring]` because the public validator receives a parsed map rather than the original serialized query string.
+- `discriminator.defaultMapping` is enforced for missing and unknown values when an explicit `mapping` is also present. With implicit mappings only, missing values use the fallback while unknown present values rely on the underlying `oneOf` / `anyOf`; `[OpenAPI 3.2 discriminator]` makes that residual limitation observable.
+- `itemSchema` streaming bodies are returned as `Skipped` with a reason and matched content type. The current adapters buffer a complete body and cannot safely apply a schema independently to each SSE, JSON Lines, JSON Text Sequence, or multipart stream item.
+- A root `$self` emits `[OpenAPI 3.2 $self]`: relative references still resolve from the retrieved file path, so specs depending on a different `$self` base URI must be pre-bundled.
 
 ### `readOnly` / `writeOnly` enforcement
 
@@ -42,14 +51,16 @@ Detection looks at each property schema's own top-level `readOnly` / `writeOnly`
 - **Validated**: `application/json` and any `+json` structured-syntax suffix (RFC 6838), and content keys using ranges (`application/*`, `*/*`) — the matcher tries exact match first, then `<type>/*`, then `*/*`.
 - **Multi-JSON-per-status specs** (e.g. `application/json` + `application/problem+json` for the same status): when the actual response Content-Type is supplied, schema validation prefers the spec key that exactly matches the response Content-Type before falling back to the first JSON key. A problem-details body served as `application/problem+json` is judged against its own schema, not the success-shape `application/json` schema. Vendor `+json` suffixes the spec doesn't enumerate (e.g. `application/vnd.example.v1+json`) still fall through to the first JSON key, preserving the legacy interchangeable-JSON behaviour for that case.
 - **Presence-only** (no schema validation): every other media type, including `application/xml`, `multipart/form-data`, `application/x-www-form-urlencoded`, `text/plain`, and `application/octet-stream`. The validator confirms the spec declares the content type but does not check the body. When the matched media-type entry declares a `schema` (OpenAPI permits a schema on any media type, but this JSON Schema engine cannot evaluate a non-JSON one), the orchestrator marks the response/request as `Skipped` with a `skipReason` so the unvalidated body is surfaced in coverage rather than counted as a clean pass. A non-JSON entry with no `schema` has nothing to validate and stays a plain success.
+- **OpenAPI 3.2 streaming `itemSchema`**: explicitly `Skipped`, never counted as a clean validation. `prefixEncoding` / `itemEncoding` are therefore not enforced either.
 - **Multipart `encoding` object**: per-part `contentType` / `headers` / `style` / `explode` are not consulted.
 - **Cascading `additionalProperties: false` errors** are stripped automatically. opis's `PropertiesKeyword` skips its `addCheckedProperties()` call whenever any sub-property fails its schema, leaving `$checked` empty in the validation context. The follow-on `additionalProperties: false` keyword then reports every property the data carries — including ones explicitly declared in the schema's `properties` — as "additional". The validator walks opis's `ValidationError` tree, reads the raw list of "additional" property names from `args()['properties']`, and filters out names that ARE declared in the schema's `properties` keyword at that path. A single failure shows as one error, not a paired pseudo-error naming declared properties as not-allowed. Genuine additional properties still surface; mixed cases keep only the real extras in the message. The property-name comparison is fully structural (raw arrays + raw path segments — no string parsing of the rendered message for the names), so property names containing commas, whitespace, empty strings, or JSON-Pointer-escape-worthy characters survive correctly. The walker also descends through `items` for array-element segments, so cascades through `{ data: [Item] }`-shaped envelopes (single-schema items and Draft 07 tuple-form items, including the shape `OpenApiSchemaConverter` lowers OAS 3.1 `prefixItems` to) collapse the same way. The walker recognises only `properties.<name>` and `items` transitions and treats every other shape as unresolvable — composition keywords (`oneOf` / `allOf` / `anyOf`), `additionalProperties: <schema>`, `patternProperties`, `additionalItems`, and boolean schemas at item level all fall through to keeping the original message untouched, so a real additional-property violation is never silently swallowed.
 
 ## Parameter styles
 - **Query**: only `style: form` + `explode: true` (the OAS default). Specs declaring `pipeDelimited`, `spaceDelimited`, `deepObject`, or `form` + `explode: false` are not parsed; type-mismatch errors will surface but they will point at the wrong cause.
+- **Query string (3.2)**: `in: querystring` with `application/x-www-form-urlencoded` validates the whole parsed query map. Other media types emit a categorized warning and skip query-string validation.
 - **Header / Path**: only `style: simple` for scalar values. `type: array` and `type: object` parameters are not parsed (the raw string is fed to the schema, which then mismatches). `style: matrix` and `style: label` for path parameters are not handled — the prefix is not stripped before validation.
 - **Cookie parameters** (`apiKey` security scheme aside): not validated.
-- **`parameters[].content`**: only `parameters[].schema` is read.
+- **`parameters[].content`**: read only for OpenAPI 3.2 `in: querystring`; other parameter locations still use `parameters[].schema` only.
 
 ## Security schemes
 - **Validated**: `apiKey` (in `header` / `query` / `cookie`) and `http` + `bearer` — presence checks for the named header/query/cookie / RFC 6750 `Bearer` token.
@@ -65,7 +76,7 @@ Detection looks at each property schema's own top-level `readOnly` / `writeOnly`
 - **Validated** (delegated to opis Draft 07): `type`, `enum`, `multipleOf`, `minimum`/`maximum`/`exclusiveMinimum`/`exclusiveMaximum`, `minLength`/`maxLength`/`pattern`, `minItems`/`maxItems`/`uniqueItems`, `minProperties`/`maxProperties`/`required`, `additionalProperties` (`true` / `false` / schema), `allOf` / `oneOf` / `anyOf` / `not`.
 - **`format`** (validated by opis Draft 06+): the canonical 19-entry set (`email`, `uuid`, `date`, `date-time`, `uri`, `ipv4`, `ipv6`, `hostname`, `regex`, `json-pointer`, …). The full list is the authoritative `KNOWN_OPIS_FORMATS` constant in `src/Spec/OpenApiSchemaConverter.php` — keeping it in one place avoids drift when opis adds formats. Unknown values (e.g. `format: emial` typo for `email`) emit a one-shot `E_USER_WARNING` per format value, since opis silently accepts any value for unrecognised formats. Non-string `format` values fire a separate malformed-spec warning.
 - **Advisory `format`** (deliberately not enforced, no warning): `int32`, `int64`, `float`, `double`, `byte`, `binary`, `password`. Treated as documentation hints per OAS conventions; see `ADVISORY_FORMATS` constant.
-- **Lowered**: `const` → `enum: [value]` (3.1); `discriminator` + `mapping` → an `allOf` of `if`/`then` conditionals (default; see `discriminator` below).
+- **Lowered**: `const` → `enum: [value]` (3.1/3.2); `discriminator` + `mapping` / `defaultMapping` → an `allOf` of `if`/`then` conditionals (default; see `discriminator` below).
 - **Stripped**: `xml`, `externalDocs`, `example` / `examples`, `deprecated`, OAS-only `nullable`/`readOnly`/`writeOnly` after enforcement (3.0), and Draft 2020-12 keys `$dynamicRef` / `$dynamicAnchor` / `contentSchema` (3.1). `discriminator` is also stripped when enforcement is turned off (`enforce_discriminator: false`).
 - **Validated via opis (Draft 06+)**: `patternProperties`, `contentMediaType`, `contentEncoding`. These are JSON Schema keywords that opis implements natively, so your constraints are enforced.
 - **Not supported (loud E_USER_WARNING when first encountered)**: `unevaluatedProperties`, `unevaluatedItems`. These are 2019-09 keywords with no Draft 07 equivalent — opis silently ignores them, so the warning surfaces specs that depend on them. Rewrite using `additionalProperties: false` plus explicit `properties` to enforce object closure.
@@ -73,15 +84,16 @@ Detection looks at each property schema's own top-level `readOnly` / `writeOnly`
 - **`discriminator`** (enforced by default, #262): when a schema declares `discriminator` with a non-empty `mapping`, the converter lowers it into an `allOf` of an unknown-value guard (the discriminator property must be present and one of the mapping keys) plus one `if`/`then` per mapping value, where `then` is the resolved subtype schema. The discriminator value therefore steers validation toward a single branch — a body that lies about its type (e.g. `kty: RSA` carrying EC-only fields) fails instead of passing the underlying `oneOf` / `anyOf` union. This is stricter than the OAS spec strictly requires (the discriminator is officially a tooling hint), which is exactly what a contract-testing tool wants. No `E_USER_WARNING` is emitted.
   - **Opt out**: set `enforce_discriminator: false` (Laravel config) or `<parameter name="enforce_discriminator" value="false"/>` (the PHPUnit extension; `0` / `no` also work) to restore the historical behaviour — `discriminator` is stripped and the mapping is not enforced (and no warning is emitted).
   - **Malformed blocks**: with enforcement on, a structurally invalid `discriminator` (missing/non-string `propertyName`, non-array `mapping`, non-string mapping value, an unresolvable mapping pointer, or a pointer to a non-object) surfaces as a loud validation failure rather than silently passing.
+  - **OpenAPI 3.2 `defaultMapping`**: with explicit mapping keys, absent and unknown discriminator values validate against the fallback schema. Without explicit keys, only the absent-value fallback can be reconstructed after eager `$ref` resolution; a categorized warning exposes the unknown-value limitation.
   - **Known limitation**: a self-referential discriminator chain (a subtype that, via `allOf` + `$ref`, re-contains the *same* base discriminator — the inheritance idiom) is enforced at the first recursion level; the inner re-appearance of that same discriminator is stripped without re-lowering (the outer branch already routes to and enforces that exact subtype). This terminates the lowering and avoids combinatorial blow-up while still enforcing the outer branch selection. Subtype-specific constraints (e.g. `required`) are unaffected — they live in the outer `then`.
   - **`nullable` + `discriminator`** (3.0): a `null` body fails the discriminated-object branch (the lowered guard requires the discriminator property). Model a null-tolerant polymorphic field with an explicit `oneOf` including `{type: 'null'}` if needed.
 - **`readOnly` / `writeOnly`**: enforced at the property's own top level only (see [readOnly / writeOnly enforcement](#readonly--writeonly-enforcement)).
 
 ## HTTP methods
-The PHPUnit coverage report counts `GET`, `POST`, `PUT`, `PATCH`, `DELETE`. Operations under `HEAD`, `OPTIONS`, and `TRACE` are not part of the coverage allowlist, and the Laravel auto-validation hook silently skips them (it normalises the request method through `HttpMethod::tryFrom()`, which returns `null` for these). Direct calls to `OpenApiResponseValidator::validate()` with one of these method strings will resolve against the spec — but if you depend on coverage tracking or the Laravel trait, treat HEAD / OPTIONS / TRACE as out of scope today.
+The PHPUnit coverage report counts `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, OpenAPI 3.2 `QUERY`, and every custom method declared under `additionalOperations`. Laravel, Symfony, Pest, and the fuzz explorer accept the six named enum methods including `QUERY`; arbitrary custom tokens are supported by the direct validators and coverage tracker. Operations under `HEAD`, `OPTIONS`, and `TRACE` are still outside the coverage allowlist and enum-based adapters, although direct validator calls resolve them.
 
 ## Spec features not consulted
-Webhooks (3.1), Callbacks, Response `Links`, Server URL templating (`servers` with `variables`), Examples (`examples` blocks at parameter / requestBody / response level — not used for fuzzing or validation), `tags`, `externalDocs`, vendor extensions (`x-*` keys, ignored harmlessly).
+Webhooks (3.1+), Callbacks, Response `Links`, Server URL templating (`servers` with `variables`), Examples (`example` / `examples`, including 3.2 `dataValue` / `serializedValue` — not used for fuzzing or validation), 3.2 tag hierarchy (`summary` / `parent` / `kind`), `externalDocs`, and vendor extensions (`x-*` keys, ignored harmlessly). OAuth2 device authorization and other OAuth/OpenID schemes remain on the existing `[security]` warning path.
 
 ## Warning channel (`E_USER_WARNING` contract)
 
@@ -91,6 +103,9 @@ The library uses PHP's native `trigger_error(..., E_USER_WARNING)` as the loud-s
 |---|---|---|
 | `[security]` | `SecurityValidator` (`oauth2`, `openIdConnect`, `mutualTLS`, `http-basic`, `http-digest`) | scheme name |
 | `[OpenAPI Schema]` | `OpenApiSchemaConverter` (`unevaluatedProperties` / `unevaluatedItems`, `dependentSchemas` / `dependentRequired`, unknown / malformed `format`) | per-keyword / per-format-value |
+| `[OpenAPI 3.2 querystring]` | `QueryParameterValidator` (serialized query media type cannot be reconstructed) | declared media-type set |
+| `[OpenAPI 3.2 discriminator]` | `OpenApiSchemaConverter` (`defaultMapping` with implicit mappings only) | process-wide limitation key |
+| `[OpenAPI 3.2 $self]` | `OpenApiSpecLoader` (`$self` base URI is not applied) | spec load/cache |
 
 **How to consume:**
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -16,7 +16,7 @@ This library follows [Semantic Versioning 2.0](https://semver.org/). v1.0.0 is t
 - The CLI surface of `bin/openapi-coverage-merge` (flags, exit codes, sidecar JSON wire format via `STATE_FORMAT_VERSION`)
 - The `OpenApiCoverageExtension` PHPUnit configuration parameters (`spec_base_path`, `strip_prefixes`, `specs`, `output_file`, `console_output`, …)
 - The Laravel `ValidatesOpenApiSchema` trait's public methods
-- The category prefixes used in `E_USER_WARNING` messages (`[security]`, `[OpenAPI Schema]`)
+- The category prefixes used in `E_USER_WARNING` messages (`[security]`, `[OpenAPI Schema]`, and the `[OpenAPI 3.2 ...]` categories)
 
 ## What's NOT covered by SemVer
 

--- a/src/Coverage/OpenApiCoverageTracker.php
+++ b/src/Coverage/OpenApiCoverageTracker.php
@@ -27,7 +27,6 @@ use function str_starts_with;
 use function strcasecmp;
 use function strcmp;
 use function strpos;
-use function strtoupper;
 use function substr;
 use function trigger_error;
 use function usort;
@@ -788,7 +787,7 @@ final class OpenApiCoverageTracker
 
     private static function endpointKey(string $method, string $path): string
     {
-        return strtoupper($method) . ' ' . $path;
+        return OpenApiOperationResolver::normalizeMethodForKey($method) . ' ' . $path;
     }
 
     /**

--- a/src/Coverage/OpenApiCoverageTracker.php
+++ b/src/Coverage/OpenApiCoverageTracker.php
@@ -7,8 +7,10 @@ namespace Studio\OpenApiContractTesting\Coverage;
 use const E_USER_WARNING;
 
 use InvalidArgumentException;
+use Studio\OpenApiContractTesting\Spec\OpenApiOperationResolver;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredTracker;
+use Studio\OpenApiContractTesting\Validation\Support\MalformedSpecNode;
 
 use function array_key_exists;
 use function array_keys;
@@ -21,6 +23,7 @@ use function is_int;
 use function is_string;
 use function preg_match;
 use function sprintf;
+use function str_starts_with;
 use function strcasecmp;
 use function strcmp;
 use function strpos;
@@ -840,13 +843,20 @@ final class OpenApiCoverageTracker
                 continue;
             }
 
-            foreach ($methods as $method => $operation) {
-                $upper = strtoupper((string) $method);
-                if (!in_array($upper, ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'], true)) {
+            if (array_key_exists('additionalOperations', $methods) && MalformedSpecNode::isMalformed($methods['additionalOperations'])) {
+                self::warnMalformed($specName, sprintf('path %s additionalOperations is not an object (got %s); omitted from coverage', (string) $path, MalformedSpecNode::describe($methods['additionalOperations'])));
+            }
+
+            foreach (OpenApiOperationResolver::declaredOperations($methods) as $declaredOperation) {
+                $upper = $declaredOperation['method'];
+                $operation = $declaredOperation['operation'];
+                $isBaselineMethod = in_array($upper, ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'QUERY'], true);
+                $isAdditionalOperation = str_starts_with($declaredOperation['location'], 'additionalOperations[');
+                if (!$isBaselineMethod && !$isAdditionalOperation) {
                     continue;
                 }
-                if (!is_array($operation)) {
-                    self::warnMalformed($specName, sprintf('operation %s %s is not an object (got %s); omitted from coverage', $upper, (string) $path, get_debug_type($operation)));
+                if (MalformedSpecNode::isMalformed($operation)) {
+                    self::warnMalformed($specName, sprintf('operation %s %s (%s) is not an object (got %s); omitted from coverage', $upper, (string) $path, $declaredOperation['location'], MalformedSpecNode::describe($operation)));
 
                     continue;
                 }

--- a/src/Fuzz/OpenApiEndpointExplorer.php
+++ b/src/Fuzz/OpenApiEndpointExplorer.php
@@ -9,6 +9,7 @@ use InvalidArgumentException;
 use Studio\OpenApiContractTesting\HttpMethod;
 use Studio\OpenApiContractTesting\OpenApiVersion;
 use Studio\OpenApiContractTesting\SchemaContext;
+use Studio\OpenApiContractTesting\Spec\OpenApiOperationResolver;
 use Studio\OpenApiContractTesting\Spec\OpenApiPathMatcher;
 use Studio\OpenApiContractTesting\Spec\OpenApiSchemaConverter;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
@@ -64,7 +65,6 @@ final class OpenApiEndpointExplorer
         }
 
         $methodUpper = strtoupper($method);
-        $methodLower = strtolower($method);
 
         try {
             $methodEnum = HttpMethod::from($methodUpper);
@@ -91,8 +91,9 @@ final class OpenApiEndpointExplorer
 
         /** @var array<string, mixed> $pathSpec */
         $pathSpec = is_array($paths[$matchedPath] ?? null) ? $paths[$matchedPath] : [];
-        $operation = $pathSpec[$methodLower] ?? null;
-        if (!is_array($operation)) {
+        $resolvedOperation = OpenApiOperationResolver::resolve($pathSpec, $methodUpper);
+        $operation = $resolvedOperation['operation'];
+        if (!$resolvedOperation['found'] || !is_array($operation)) {
             throw new InvalidArgumentException(sprintf(
                 "Operation %s '%s' is not declared in OpenAPI spec '%s'.",
                 $methodUpper,

--- a/src/HttpMethod.php
+++ b/src/HttpMethod.php
@@ -14,10 +14,11 @@ enum HttpMethod: string
     case PUT = 'PUT';
     case PATCH = 'PATCH';
     case DELETE = 'DELETE';
+    case QUERY = 'QUERY';
 
     /**
      * Comma-separated list of supported method values for use in error
-     * messages (e.g. "Allowed: GET, POST, PUT, PATCH, DELETE").
+     * messages (e.g. "Allowed: GET, POST, PUT, PATCH, DELETE, QUERY").
      *
      * Centralised so the Pest dispatcher and the Laravel trait error
      * surfaces stay in sync when a new case is added to the enum.

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -24,6 +24,7 @@ use Studio\OpenApiContractTesting\Internal\StackTraceFilter;
 use Studio\OpenApiContractTesting\OpenApiRequestValidator;
 use Studio\OpenApiContractTesting\OpenApiResponseValidator;
 use Studio\OpenApiContractTesting\SkipOpenApiResolver;
+use Studio\OpenApiContractTesting\Spec\OpenApiOperationResolver;
 use Studio\OpenApiContractTesting\Spec\OpenApiPathMatcher;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecResolver;
@@ -889,9 +890,10 @@ trait ValidatesOpenApiSchema
             return null;
         }
 
-        $operation = $pathSpec[strtolower($method)] ?? null;
+        $resolved = OpenApiOperationResolver::resolve($pathSpec, $method);
+        $operation = $resolved['operation'];
 
-        return is_array($operation) ? $operation : null;
+        return $resolved['found'] && is_array($operation) ? $operation : null;
     }
 
     private function getOrCreateValidator(): OpenApiResponseValidator

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio\OpenApiContractTesting;
 
 use RuntimeException;
+use Studio\OpenApiContractTesting\Spec\OpenApiOperationResolver;
 use Studio\OpenApiContractTesting\Spec\OpenApiPathMatcher;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\Validation\Request\HeaderParameterValidator;
@@ -27,7 +28,6 @@ use function array_key_exists;
 use function array_keys;
 use function is_array;
 use function sprintf;
-use function strtolower;
 
 final class OpenApiRequestValidator
 {
@@ -167,7 +167,6 @@ final class OpenApiRequestValidator
         $matchedPath = $matched['path'];
         $pathVariables = $matched['variables'];
 
-        $lowerMethod = strtolower($method);
         // `$matchedPath` is always a key of `$spec['paths']` (the matcher was
         // built from its `array_keys()`), so `?? null` here only fires for an
         // explicit `null` *value* — which the guard below then treats as
@@ -194,16 +193,15 @@ final class OpenApiRequestValidator
         }
 
         /** @var array<string, mixed> $pathSpec */
-        // `array_key_exists` (not `isset`) so an explicit `{method}: null`
-        // reaches the operation guard below as malformed rather than being
-        // misreported as an undefined method.
-        if (!array_key_exists($lowerMethod, $pathSpec)) {
+        $resolvedOperation = OpenApiOperationResolver::resolve($pathSpec, $method);
+        if (!$resolvedOperation['found']) {
             return OpenApiValidationResult::failure([
                 PathDiagnosticsFormatter::methodNotDefined($specName, $method, $matchedPath, $spec),
             ], $matchedPath);
         }
 
-        $operation = $pathSpec[$lowerMethod];
+        $operation = $resolvedOperation['operation'];
+        $operationLocation = $resolvedOperation['location'];
 
         // An operation must decode to a JSON object; a scalar, `null`, or a
         // JSON list is malformed ({@see MalformedSpecNode}). A non-array
@@ -215,7 +213,7 @@ final class OpenApiRequestValidator
                 sprintf(
                     "Malformed 'paths[\"%s\"].%s' for %s %s in '%s' spec: expected object, got %s.",
                     $matchedPath,
-                    $lowerMethod,
+                    $operationLocation,
                     $method,
                     $matchedPath,
                     $specName,

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -7,6 +7,7 @@ namespace Studio\OpenApiContractTesting;
 use InvalidArgumentException;
 use RuntimeException;
 use Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension;
+use Studio\OpenApiContractTesting\Spec\OpenApiOperationResolver;
 use Studio\OpenApiContractTesting\Spec\OpenApiPathMatcher;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\Validation\Response\ResponseBodyValidationResult;
@@ -30,7 +31,6 @@ use function array_merge;
 use function get_debug_type;
 use function is_array;
 use function sprintf;
-use function strtolower;
 use function strtoupper;
 
 final class OpenApiResponseValidator
@@ -144,7 +144,6 @@ final class OpenApiResponseValidator
             ]);
         }
 
-        $lowerMethod = strtolower($method);
         // `$matchedPath` is always a key of `$spec['paths']` (the matcher was
         // built from its `array_keys()`), so `?? null` here only fires for an
         // explicit `null` *value* — which the guard below then treats as
@@ -169,16 +168,15 @@ final class OpenApiResponseValidator
             ], $matchedPath);
         }
 
-        // `array_key_exists` (not `isset`) so an explicit `{method}: null`
-        // reaches the operation guard below as malformed rather than being
-        // misreported as an undefined method.
-        if (!array_key_exists($lowerMethod, $pathSpec)) {
+        $resolvedOperation = OpenApiOperationResolver::resolve($pathSpec, $method);
+        if (!$resolvedOperation['found']) {
             return OpenApiValidationResult::failure([
                 PathDiagnosticsFormatter::methodNotDefined($specName, $method, $matchedPath, $spec),
             ], $matchedPath);
         }
 
-        $operation = $pathSpec[$lowerMethod];
+        $operation = $resolvedOperation['operation'];
+        $operationLocation = $resolvedOperation['location'];
 
         // An operation must decode to a JSON object; a scalar, `null`, or a
         // JSON list is malformed ({@see MalformedSpecNode}). Unguarded, a
@@ -189,7 +187,7 @@ final class OpenApiResponseValidator
                 sprintf(
                     "Malformed 'paths[\"%s\"].%s' for %s %s in '%s' spec: expected object, got %s.",
                     $matchedPath,
-                    $lowerMethod,
+                    $operationLocation,
                     $method,
                     $matchedPath,
                     $specName,
@@ -220,7 +218,7 @@ final class OpenApiResponseValidator
                 sprintf(
                     "Malformed 'paths[\"%s\"].%s.responses' for %s %s in '%s' spec: expected object, got %s.",
                     $matchedPath,
-                    $lowerMethod,
+                    $operationLocation,
                     $method,
                     $matchedPath,
                     $specName,

--- a/src/OpenApiVersion.php
+++ b/src/OpenApiVersion.php
@@ -18,6 +18,7 @@ enum OpenApiVersion: string
 {
     case V3_0 = '3.0';
     case V3_1 = '3.1';
+    case V3_2 = '3.2';
 
     /**
      * Detect OAS version from a parsed spec array.
@@ -42,6 +43,10 @@ enum OpenApiVersion: string
             if ($family === self::V3_1->value) {
                 return self::V3_1;
             }
+
+            if ($family === self::V3_2->value) {
+                return self::V3_2;
+            }
         }
 
         $received = array_key_exists('openapi', $spec)
@@ -51,7 +56,7 @@ enum OpenApiVersion: string
         throw new InvalidOpenApiSpecException(
             InvalidOpenApiSpecReason::UnsupportedVersion,
             "Unsupported OpenAPI version: {$received}. The required `openapi` field must be a "
-            . 'major.minor.patch string in a supported version family: 3.0.x or 3.1.x.',
+            . 'major.minor.patch string in a supported version family: 3.0.x, 3.1.x, or 3.2.x.',
         );
     }
 }

--- a/src/Spec/OpenApiOperationResolver.php
+++ b/src/Spec/OpenApiOperationResolver.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Spec;
+
+use Studio\OpenApiContractTesting\Validation\Support\MalformedSpecNode;
+
+use function array_key_exists;
+use function in_array;
+use function is_array;
+use function is_string;
+use function strtolower;
+use function strtoupper;
+
+/**
+ * Resolves fixed Path Item operations and OpenAPI 3.2
+ * `additionalOperations` through one shared lookup path.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+final class OpenApiOperationResolver
+{
+    /** @var list<string> */
+    public const FIXED_OPERATION_FIELDS = [
+        'get',
+        'put',
+        'post',
+        'delete',
+        'options',
+        'head',
+        'patch',
+        'trace',
+        'query',
+    ];
+
+    /**
+     * @param array<string, mixed> $pathItem
+     *
+     * @return array{found: bool, operation: mixed, location: string}
+     */
+    public static function resolve(array $pathItem, string $method): array
+    {
+        $lowerMethod = strtolower($method);
+        if (in_array($lowerMethod, self::FIXED_OPERATION_FIELDS, true) && array_key_exists($lowerMethod, $pathItem)) {
+            return [
+                'found' => true,
+                'operation' => $pathItem[$lowerMethod],
+                'location' => $lowerMethod,
+            ];
+        }
+
+        if (!array_key_exists('additionalOperations', $pathItem)) {
+            return ['found' => false, 'operation' => null, 'location' => $lowerMethod];
+        }
+
+        $additional = $pathItem['additionalOperations'];
+        if (MalformedSpecNode::isMalformed($additional)) {
+            return [
+                'found' => true,
+                'operation' => $additional,
+                'location' => 'additionalOperations',
+            ];
+        }
+
+        $upperMethod = strtoupper($method);
+        foreach ($additional as $declaredMethod => $operation) {
+            if (!is_string($declaredMethod) || strtoupper($declaredMethod) !== $upperMethod) {
+                continue;
+            }
+
+            return [
+                'found' => true,
+                'operation' => $operation,
+                'location' => 'additionalOperations["' . $declaredMethod . '"]',
+            ];
+        }
+
+        return ['found' => false, 'operation' => null, 'location' => $lowerMethod];
+    }
+
+    /**
+     * Enumerate structurally valid fixed and additional operation entries.
+     * Malformed values are retained so callers can surface their own
+     * context-specific diagnostics instead of silently omitting them.
+     *
+     * @param array<string, mixed> $pathItem
+     *
+     * @return list<array{method: string, operation: mixed, location: string}>
+     */
+    public static function declaredOperations(array $pathItem): array
+    {
+        $operations = [];
+
+        foreach (self::FIXED_OPERATION_FIELDS as $field) {
+            if (!array_key_exists($field, $pathItem)) {
+                continue;
+            }
+
+            $operations[] = [
+                'method' => strtoupper($field),
+                'operation' => $pathItem[$field],
+                'location' => $field,
+            ];
+        }
+
+        $additional = $pathItem['additionalOperations'] ?? null;
+        if (!is_array($additional)) {
+            return $operations;
+        }
+
+        foreach ($additional as $method => $operation) {
+            if (!is_string($method) || $method === '') {
+                continue;
+            }
+
+            $operations[] = [
+                'method' => strtoupper($method),
+                'operation' => $operation,
+                'location' => 'additionalOperations["' . $method . '"]',
+            ];
+        }
+
+        return $operations;
+    }
+}

--- a/src/Spec/OpenApiOperationResolver.php
+++ b/src/Spec/OpenApiOperationResolver.php
@@ -63,9 +63,8 @@ final class OpenApiOperationResolver
             ];
         }
 
-        $upperMethod = strtoupper($method);
         foreach ($additional as $declaredMethod => $operation) {
-            if (!is_string($declaredMethod) || strtoupper($declaredMethod) !== $upperMethod) {
+            if (!is_string($declaredMethod) || $declaredMethod !== $method) {
                 continue;
             }
 
@@ -115,12 +114,26 @@ final class OpenApiOperationResolver
             }
 
             $operations[] = [
-                'method' => strtoupper($method),
+                'method' => $method,
                 'operation' => $operation,
                 'location' => 'additionalOperations["' . $method . '"]',
             ];
         }
 
         return $operations;
+    }
+
+    /**
+     * Fixed Path Item fields are case-insensitive at request lookup and use
+     * their canonical uppercase coverage key. Non-standard methods retain
+     * their exact spelling because `additionalOperations` is case-sensitive.
+     */
+    public static function normalizeMethodForKey(string $method): string
+    {
+        $lowerMethod = strtolower($method);
+
+        return in_array($lowerMethod, self::FIXED_OPERATION_FIELDS, true)
+            ? strtoupper($lowerMethod)
+            : $method;
     }
 }

--- a/src/Spec/OpenApiPathSuggester.php
+++ b/src/Spec/OpenApiPathSuggester.php
@@ -10,13 +10,10 @@ use function array_slice;
 use function count;
 use function explode;
 use function implode;
-use function in_array;
 use function is_array;
 use function levenshtein;
 use function min;
 use function sort;
-use function strtolower;
-use function strtoupper;
 use function trim;
 use function usort;
 
@@ -33,19 +30,6 @@ use function usort;
  */
 final class OpenApiPathSuggester
 {
-    /**
-     * The full set of operation keys that OpenAPI 3.x recognises at the
-     * path-item level. Kept local to the suggester rather than reusing the
-     * library's request-method enum — that enum models *request* methods the
-     * library validates (a smaller set), whereas the suggester needs the
-     * broader spec-vocabulary including HEAD / OPTIONS / TRACE. If the
-     * request-method enum ever expands to cover the same ground, this
-     * constant can be revisited.
-     */
-    private const OPENAPI_PATH_ITEM_METHODS = [
-        'get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace',
-    ];
-
     /**
      * @param array<string, mixed> $spec the decoded OpenAPI document
      * @param string $normalizedPath the request path *after* prefix stripping
@@ -95,17 +79,13 @@ final class OpenApiPathSuggester
             $commonPrefix = self::commonPrefixSegmentCount($requestSegments, $specSegments);
             $tailDistance = self::levenshteinTail($requestSegments, $specSegments, $commonPrefix);
 
-            foreach ($pathItem as $key => $value) {
-                $lower = strtolower((string) $key);
-                if (!in_array($lower, self::OPENAPI_PATH_ITEM_METHODS, true)) {
-                    continue;
-                }
-                if (!is_array($value)) {
+            foreach (OpenApiOperationResolver::declaredOperations($pathItem) as $declared) {
+                if (!is_array($declared['operation'])) {
                     continue;
                 }
 
                 $entries[] = [
-                    'method' => strtoupper($lower),
+                    'method' => $declared['method'],
                     'path' => (string) $specPath,
                     'segmentDiff' => $segmentDiff,
                     'commonPrefix' => $commonPrefix,
@@ -162,15 +142,11 @@ final class OpenApiPathSuggester
         }
 
         $methods = [];
-        foreach ($pathItem as $key => $value) {
-            $lower = strtolower((string) $key);
-            if (!in_array($lower, self::OPENAPI_PATH_ITEM_METHODS, true)) {
+        foreach (OpenApiOperationResolver::declaredOperations($pathItem) as $declared) {
+            if (!is_array($declared['operation'])) {
                 continue;
             }
-            if (!is_array($value)) {
-                continue;
-            }
-            $methods[] = strtoupper($lower);
+            $methods[] = $declared['method'];
         }
 
         sort($methods);

--- a/src/Spec/OpenApiPathSuggester.php
+++ b/src/Spec/OpenApiPathSuggester.php
@@ -120,10 +120,11 @@ final class OpenApiPathSuggester
 
     /**
      * Enumerate the operation methods declared under a given path item.
-     * Uppercase, alphabetically sorted, with non-method keys
-     * (`parameters`, `summary`, `$ref`, …) filtered out. Returns `[]` for an
-     * unknown path or a path-item that only declares shared parameters — the
-     * caller distinguishes the two via prior matching.
+     * Fixed fields are uppercased while additional operation methods retain
+     * the exact capitalization declared by the spec. Results are sorted, with
+     * non-method keys (`parameters`, `summary`, `$ref`, …) filtered out.
+     * Returns `[]` for an unknown path or a path-item that only declares shared
+     * parameters — the caller distinguishes the two via prior matching.
      *
      * @param array<string, mixed> $spec
      *

--- a/src/Spec/OpenApiRefResolver.php
+++ b/src/Spec/OpenApiRefResolver.php
@@ -23,8 +23,10 @@ use function is_string;
 use function parse_url;
 use function rawurldecode;
 use function sprintf;
+use function str_contains;
 use function str_replace;
 use function str_starts_with;
+use function strlen;
 use function strpos;
 use function strrpos;
 use function substr;
@@ -34,6 +36,13 @@ use function substr;
  */
 final class OpenApiRefResolver
 {
+    /**
+     * Internal provenance attached to direct component-schema references in
+     * `oneOf` / `anyOf`. Eager reference resolution otherwise erases the
+     * component name needed for OpenAPI discriminator implicit mappings.
+     */
+    public const IMPLICIT_SCHEMA_NAME_EXTENSION = 'x-studio-openapi-contract-testing-implicit-schema-name';
+
     /**
      * Keys whose value is opaque user data per OpenAPI 3.x and JSON Schema —
      * a `$ref` literal nested under one of these keys is a data field, not a
@@ -218,10 +227,22 @@ final class OpenApiRefResolver
         bool $insideUserNamedMap,
         RefResolutionContext $context,
         array &$documentCache,
+        bool $captureImplicitSchemaName = false,
     ): void {
+        // Reserve the provenance key for resolver-generated data. Removing a
+        // user-authored value before descent prevents an inline schema from
+        // spoofing an implicit discriminator mapping.
+        unset($node[self::IMPLICIT_SCHEMA_NAME_EXTENSION]);
+
         if (!$insideUserNamedMap && array_key_exists('$ref', $node)) {
             $ref = self::assertStringRef($node['$ref']);
+            $implicitSchemaName = $captureImplicitSchemaName
+                ? self::implicitSchemaNameFromRef($ref)
+                : null;
             self::resolveRef($node, $ref, $root, $chain, $context, $documentCache);
+            if ($implicitSchemaName !== null) {
+                $node[self::IMPLICIT_SCHEMA_NAME_EXTENSION] = $implicitSchemaName;
+            }
 
             return;
         }
@@ -273,6 +294,17 @@ final class OpenApiRefResolver
 
                     continue;
                 }
+
+                if (in_array($key, ['oneOf', 'anyOf'], true) && array_is_list($child)) {
+                    foreach ($child as &$alternative) {
+                        if (is_array($alternative)) {
+                            self::walk($alternative, $root, $chain, false, $context, $documentCache, true);
+                        }
+                    }
+                    unset($alternative);
+
+                    continue;
+                }
             }
 
             // additionalProperties is intentionally excluded: its value is a single
@@ -282,6 +314,21 @@ final class OpenApiRefResolver
             self::walk($child, $root, $chain, $childInsideUserNamedMap, $context, $documentCache);
         }
         unset($child);
+    }
+
+    private static function implicitSchemaNameFromRef(string $ref): ?string
+    {
+        $prefix = '#/components/schemas/';
+        if (!str_starts_with($ref, $prefix)) {
+            return null;
+        }
+
+        $segment = substr($ref, strlen($prefix));
+        if ($segment === '' || str_contains($segment, '/')) {
+            return null;
+        }
+
+        return self::unescapePointerSegment($segment);
     }
 
     /**

--- a/src/Spec/OpenApiSchemaConverter.php
+++ b/src/Spec/OpenApiSchemaConverter.php
@@ -14,6 +14,7 @@ use Studio\OpenApiContractTesting\Validation\Support\MalformedSpecNode;
 
 use function array_is_list;
 use function array_key_exists;
+use function array_keys;
 use function get_debug_type;
 use function implode;
 use function in_array;
@@ -48,6 +49,7 @@ final class OpenApiSchemaConverter
         'examples',
         'deprecated',
         '$schema',
+        OpenApiRefResolver::IMPLICIT_SCHEMA_NAME_EXTENSION,
     ];
 
     /** OAS 3.0 specific keys (not in JSON Schema Draft 07) */
@@ -185,6 +187,8 @@ final class OpenApiSchemaConverter
         SchemaContext $context,
         DiscriminatorContext $discriminator,
     ): void {
+        $implicitDiscriminatorValues = self::implicitDiscriminatorValues($schema);
+
         if ($version === OpenApiVersion::V3_0) {
             self::handleNullable($schema);
         } else {
@@ -319,7 +323,35 @@ final class OpenApiSchemaConverter
         // recursion above means the lowered `allOf` entries we append are
         // already converted by lowerDiscriminator itself and are not
         // re-visited here. See Issue #262.
-        self::lowerDiscriminator($schema, $version, $context, $discriminator);
+        self::lowerDiscriminator($schema, $version, $context, $discriminator, $implicitDiscriminatorValues);
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     *
+     * @return list<string>
+     */
+    private static function implicitDiscriminatorValues(array $schema): array
+    {
+        $values = [];
+        foreach (['oneOf', 'anyOf'] as $combiner) {
+            if (!is_array($schema[$combiner] ?? null)) {
+                continue;
+            }
+
+            foreach ($schema[$combiner] as $alternative) {
+                if (!is_array($alternative)) {
+                    continue;
+                }
+
+                $name = $alternative[OpenApiRefResolver::IMPLICIT_SCHEMA_NAME_EXTENSION] ?? null;
+                if (is_string($name) && $name !== '') {
+                    $values[$name] = true;
+                }
+            }
+        }
+
+        return array_keys($values);
     }
 
     /**
@@ -519,12 +551,14 @@ final class OpenApiSchemaConverter
      * behaviour, minus the removed warning).
      *
      * @param array<string, mixed> $schema
+     * @param list<string> $implicitValues component names referenced directly by adjacent oneOf/anyOf entries
      */
     private static function lowerDiscriminator(
         array &$schema,
         OpenApiVersion $version,
         SchemaContext $context,
         DiscriminatorContext $discriminator,
+        array $implicitValues,
     ): void {
         if (!array_key_exists('discriminator', $schema)) {
             return;
@@ -597,10 +631,13 @@ final class OpenApiSchemaConverter
 
         $childContext = $discriminator->withSignature($signature);
         $knownValues = [];
-        $branches = [];
+        $explicitValues = [];
+        /** @var list<array{value: string, pointer: string}> $routes */
+        $routes = [];
         foreach ($mapping as $value => $pointer) {
             $value = (string) $value;
             $knownValues[] = $value;
+            $explicitValues[$value] = true;
 
             if (!is_string($pointer)) {
                 throw new MalformedDiscriminatorException(sprintf(
@@ -609,6 +646,23 @@ final class OpenApiSchemaConverter
                     get_debug_type($pointer),
                 ));
             }
+
+            $routes[] = ['value' => $value, 'pointer' => $pointer];
+        }
+
+        foreach ($implicitValues as $value) {
+            if (isset($explicitValues[$value])) {
+                continue;
+            }
+
+            $knownValues[] = $value;
+            $routes[] = ['value' => $value, 'pointer' => $value];
+        }
+
+        $branches = [];
+        foreach ($routes as $route) {
+            $value = $route['value'];
+            $pointer = $route['pointer'];
 
             $subschema = self::resolveMappingTarget($value, $pointer, $discriminator->root);
             self::convertInPlace($subschema, $version, $context, $childContext);
@@ -646,10 +700,9 @@ final class OpenApiSchemaConverter
                 'then' => $defaultSubschema,
             ];
         } else {
-            // Without explicit mapping entries we cannot reconstruct the
-            // implicit oneOf/anyOf schema-name mapping after eager $ref
-            // resolution. We can still enforce the normative missing-value
-            // fallback and make the residual unknown-value gap observable.
+            // Without explicit or recoverable implicit mapping entries we can
+            // still enforce the missing-value fallback and make the residual
+            // unknown-value gap observable.
             $allOf[] = [
                 'if' => ['not' => ['required' => [$propertyName]]],
                 'then' => $defaultSubschema,
@@ -658,9 +711,9 @@ final class OpenApiSchemaConverter
             if (!isset(self::$warnedKeywords[$warningKey])) {
                 self::$warnedKeywords[$warningKey] = true;
                 trigger_error(
-                    '[OpenAPI 3.2 discriminator] defaultMapping without an explicit mapping can be enforced '
-                    . 'for a missing discriminator value, but implicit mapped names cannot be reconstructed '
-                    . 'after reference resolution; unknown present values rely on the underlying oneOf/anyOf.',
+                    '[OpenAPI 3.2 discriminator] defaultMapping without an explicit or recoverable implicit mapping '
+                    . 'can be enforced for a missing discriminator value, but unknown present values rely on the '
+                    . 'underlying oneOf/anyOf.',
                     E_USER_WARNING,
                 );
             }

--- a/src/Spec/OpenApiSchemaConverter.php
+++ b/src/Spec/OpenApiSchemaConverter.php
@@ -143,7 +143,8 @@ final class OpenApiSchemaConverter
      * motivating OpenAPI semantics.
      *
      * `$discriminator` carries the resolved root + enforce gate for
-     * `discriminator.mapping` lowering (Issue #262). `null` (the default for
+     * `discriminator.mapping` / 3.2 `defaultMapping` lowering (Issues #262
+     * and #273). `null` (the default for
      * callers that cannot enforce — parameter / header validators, the fuzz
      * explorer) is normalised to {@see DiscriminatorContext::disabled()}, under
      * which `discriminator` is stripped rather than enforced.
@@ -486,7 +487,8 @@ final class OpenApiSchemaConverter
 
     /**
      * Lower a schema's `discriminator` into enforceable Draft-07 conditionals,
-     * or strip it when enforcement is off (Issue #262).
+     * including OpenAPI 3.2 `defaultMapping`, or strip it when enforcement is
+     * off (Issues #262 and #273).
      *
      * `discriminator` is OAS-only — opis (Draft 07) cannot interpret it, so
      * historically the converter stripped it and the underlying `oneOf` /
@@ -552,21 +554,31 @@ final class OpenApiSchemaConverter
             ));
         }
 
-        // A bare discriminator (no mapping) is documentation-only — strip it.
-        if (!array_key_exists('mapping', $block)) {
+        $hasDefaultMapping = $version === OpenApiVersion::V3_2 && array_key_exists('defaultMapping', $block);
+        $defaultMapping = $hasDefaultMapping ? $block['defaultMapping'] : null;
+        if ($hasDefaultMapping && (!is_string($defaultMapping) || $defaultMapping === '')) {
+            throw new MalformedDiscriminatorException(sprintf(
+                "Malformed 'discriminator.defaultMapping': expected a non-empty string reference, got %s.",
+                get_debug_type($defaultMapping),
+            ));
+        }
+
+        // A bare discriminator (no mapping or 3.2 defaultMapping) is
+        // documentation-only — strip it.
+        if (!array_key_exists('mapping', $block) && !$hasDefaultMapping) {
             unset($schema['discriminator']);
 
             return;
         }
 
-        $mapping = $block['mapping'];
+        $mapping = $block['mapping'] ?? [];
         if (!is_array($mapping)) {
             throw new MalformedDiscriminatorException(sprintf(
                 "Malformed 'discriminator.mapping': expected object, got %s.",
                 get_debug_type($mapping),
             ));
         }
-        if ($mapping === []) {
+        if ($mapping === [] && !$hasDefaultMapping) {
             unset($schema['discriminator']);
 
             return;
@@ -576,7 +588,7 @@ final class OpenApiSchemaConverter
         // lowering already enforces this exact discriminator on the matched
         // branch, so strip without re-lowering. This both terminates the
         // recursion and avoids combinatorial blow-up for large mappings.
-        $signature = self::discriminatorSignature($propertyName, $mapping);
+        $signature = self::discriminatorSignature($propertyName, $mapping, $defaultMapping);
         if ($discriminator->hasSignature($signature)) {
             unset($schema['discriminator']);
 
@@ -610,14 +622,49 @@ final class OpenApiSchemaConverter
             ];
         }
 
+        $defaultSubschema = null;
+        if (is_string($defaultMapping)) {
+            $defaultSubschema = self::resolveMappingTarget('default', $defaultMapping, $discriminator->root, 'defaultMapping');
+            self::convertInPlace($defaultSubschema, $version, $context, $childContext);
+        }
+
         $allOf = (isset($schema['allOf']) && is_array($schema['allOf'])) ? $schema['allOf'] : [];
-        // Unknown-value guard first so its failure surfaces before the
-        // per-branch conditionals: the discriminator property must be present
-        // and one of the declared mapping keys.
-        $allOf[] = [
+        $knownValueCondition = [
             'properties' => [$propertyName => ['enum' => $knownValues]],
             'required' => [$propertyName],
         ];
+
+        if ($defaultSubschema === null) {
+            // OpenAPI 3.0/3.1 behavior: unknown or missing discriminator
+            // values fail loudly when explicit mappings are enforced.
+            $allOf[] = $knownValueCondition;
+        } elseif ($knownValues !== []) {
+            // OpenAPI 3.2: missing and unknown values route to
+            // defaultMapping, while explicit values keep their mapped branch.
+            $allOf[] = [
+                'if' => ['not' => $knownValueCondition],
+                'then' => $defaultSubschema,
+            ];
+        } else {
+            // Without explicit mapping entries we cannot reconstruct the
+            // implicit oneOf/anyOf schema-name mapping after eager $ref
+            // resolution. We can still enforce the normative missing-value
+            // fallback and make the residual unknown-value gap observable.
+            $allOf[] = [
+                'if' => ['not' => ['required' => [$propertyName]]],
+                'then' => $defaultSubschema,
+            ];
+            $warningKey = 'discriminator.defaultMapping-without-explicit-mapping';
+            if (!isset(self::$warnedKeywords[$warningKey])) {
+                self::$warnedKeywords[$warningKey] = true;
+                trigger_error(
+                    '[OpenAPI 3.2 discriminator] defaultMapping without an explicit mapping can be enforced '
+                    . 'for a missing discriminator value, but implicit mapped names cannot be reconstructed '
+                    . 'after reference resolution; unknown present values rely on the underlying oneOf/anyOf.',
+                    E_USER_WARNING,
+                );
+            }
+        }
         foreach ($branches as $branch) {
             $allOf[] = $branch;
         }
@@ -637,8 +684,12 @@ final class OpenApiSchemaConverter
      *
      * @return array<string, mixed>
      */
-    private static function resolveMappingTarget(string $value, string $pointer, array $root): array
-    {
+    private static function resolveMappingTarget(
+        string $value,
+        string $pointer,
+        array $root,
+        string $field = 'mapping',
+    ): array {
         $jsonPointer = str_starts_with($pointer, '#/')
             ? $pointer
             : '#/components/schemas/' . OpenApiRefResolver::escapePointerSegment($pointer);
@@ -646,14 +697,16 @@ final class OpenApiSchemaConverter
         [$found, $target] = OpenApiRefResolver::resolvePointer($jsonPointer, $root);
         if (!$found) {
             throw new MalformedDiscriminatorException(sprintf(
-                "Malformed 'discriminator.mapping[%s]': '%s' does not resolve to a schema in the spec.",
+                "Malformed 'discriminator.%s[%s]': '%s' does not resolve to a schema in the spec.",
+                $field,
                 $value,
                 $pointer,
             ));
         }
         if (!is_array($target)) {
             throw new MalformedDiscriminatorException(sprintf(
-                "Malformed 'discriminator.mapping[%s]': '%s' must reference a schema object, got %s.",
+                "Malformed 'discriminator.%s[%s]': '%s' must reference a schema object, got %s.",
+                $field,
                 $value,
                 $pointer,
                 get_debug_type($target),
@@ -681,7 +734,7 @@ final class OpenApiSchemaConverter
      *
      * @param array<array-key, mixed> $mapping
      */
-    private static function discriminatorSignature(string $propertyName, array $mapping): string
+    private static function discriminatorSignature(string $propertyName, array $mapping, mixed $defaultMapping = null): string
     {
         $pairs = [];
         foreach ($mapping as $key => $value) {
@@ -689,7 +742,8 @@ final class OpenApiSchemaConverter
         }
         sort($pairs);
 
-        return $propertyName . "\0" . implode("\0", $pairs);
+        return $propertyName . "\0" . implode("\0", $pairs) . "\0default\0"
+            . (is_string($defaultMapping) ? $defaultMapping : get_debug_type($defaultMapping));
     }
 
     /**

--- a/src/Spec/OpenApiSpecLoader.php
+++ b/src/Spec/OpenApiSpecLoader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Spec;
 
+use const E_USER_WARNING;
 use const JSON_THROW_ON_ERROR;
 
 use InvalidArgumentException;
@@ -18,6 +19,7 @@ use Studio\OpenApiContractTesting\OpenApiVersion;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
+use function array_key_exists;
 use function file_exists;
 use function file_get_contents;
 use function get_debug_type;
@@ -27,6 +29,7 @@ use function json_decode;
 use function realpath;
 use function rtrim;
 use function sprintf;
+use function trigger_error;
 use function trim;
 
 final class OpenApiSpecLoader
@@ -198,9 +201,21 @@ final class OpenApiSpecLoader
         // running any endpoint assertions. This also makes PHPUnit extension
         // bootstrap fail while eagerly loading its configured specs.
         try {
-            OpenApiVersion::fromSpec($decoded);
+            $version = OpenApiVersion::fromSpec($decoded);
         } catch (InvalidOpenApiSpecException $e) {
             throw $e->withSpecName($specName);
+        }
+
+        if ($version === OpenApiVersion::V3_2 && array_key_exists('$self', $decoded)) {
+            trigger_error(
+                sprintf(
+                    "[OpenAPI 3.2 \$self] spec '%s' declares a \$self base URI, but this loader still resolves "
+                    . 'relative references from the retrieved file path. Remove $self or pre-bundle the document '
+                    . 'until $self-aware resolution is implemented.',
+                    $specName,
+                ),
+                E_USER_WARNING,
+            );
         }
 
         // Canonicalize the source path so the resolver's cycle detection

--- a/src/Validation/Request/ParameterCollector.php
+++ b/src/Validation/Request/ParameterCollector.php
@@ -87,6 +87,23 @@ final class ParameterCollector
             }
         }
 
+        $queryParameters = 0;
+        $queryStringParameters = 0;
+        foreach ($merged as $param) {
+            if ($param['in'] === 'query') {
+                $queryParameters++;
+            } elseif ($param['in'] === 'querystring') {
+                $queryStringParameters++;
+            }
+        }
+
+        if ($queryStringParameters > 1) {
+            $errors[] = "OpenAPI 3.2 permits at most one 'in: querystring' parameter for {$method} {$matchedPath}.";
+        }
+        if ($queryStringParameters > 0 && $queryParameters > 0) {
+            $errors[] = "OpenAPI 3.2 forbids mixing 'in: querystring' with 'in: query' parameters for {$method} {$matchedPath}.";
+        }
+
         return new CollectionResult(array_values($merged), $errors);
     }
 }

--- a/src/Validation/Request/QueryParameterValidator.php
+++ b/src/Validation/Request/QueryParameterValidator.php
@@ -4,24 +4,43 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Validation\Request;
 
+use const E_USER_WARNING;
+
 use Studio\OpenApiContractTesting\OpenApiVersion;
 use Studio\OpenApiContractTesting\SchemaContext;
 use Studio\OpenApiContractTesting\Spec\OpenApiSchemaConverter;
+use Studio\OpenApiContractTesting\Validation\Support\MalformedSpecNode;
 use Studio\OpenApiContractTesting\Validation\Support\ObjectConverter;
 use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
 use Studio\OpenApiContractTesting\Validation\Support\TypeCoercer;
 
 use function array_key_exists;
+use function array_keys;
+use function count;
+use function implode;
 use function is_array;
+use function is_string;
+use function sprintf;
+use function strtolower;
+use function trigger_error;
 
 /**
  * @internal Not part of the package's public API. Do not use from user code.
  */
 final class QueryParameterValidator
 {
+    /** @var array<string, true> */
+    private static array $warnedUnsupportedQueryStringMediaTypes = [];
+
     public function __construct(
         private readonly SchemaValidatorRunner $runner,
     ) {}
+
+    /** @internal Test seam for the process-wide warning ledger. */
+    public static function resetWarningStateForTesting(): void
+    {
+        self::$warnedUnsupportedQueryStringMediaTypes = [];
+    }
 
     /**
      * Validate query parameters declared by the matched operation (or
@@ -47,6 +66,15 @@ final class QueryParameterValidator
         $errors = [];
 
         foreach ($parameters as $param) {
+            if (($param['in'] ?? null) === 'querystring') {
+                $errors = [
+                    ...$errors,
+                    ...$this->validateWholeQueryString($method, $matchedPath, $param, $queryParams, $version),
+                ];
+
+                continue;
+            }
+
             if (($param['in'] ?? null) !== 'query') {
                 continue;
             }
@@ -90,6 +118,104 @@ final class QueryParameterValidator
                 foreach ($messages as $message) {
                     $errors[] = "[query.{$name}{$suffix}] {$message}";
                 }
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param array<string, mixed> $parameter
+     * @param array<string, mixed> $queryParams
+     *
+     * @return string[]
+     */
+    private function validateWholeQueryString(
+        string $method,
+        string $matchedPath,
+        array $parameter,
+        array $queryParams,
+        OpenApiVersion $version,
+    ): array {
+        $content = $parameter['content'] ?? null;
+        if (MalformedSpecNode::isMalformed($content) || $content === []) {
+            return ["[querystring] parameter has no content map for {$method} {$matchedPath} — cannot validate."];
+        }
+        if (array_key_exists('schema', $parameter)) {
+            return ["[querystring] parameter must use content instead of schema for {$method} {$matchedPath}."];
+        }
+        if (count($content) !== 1) {
+            return ["[querystring] content must contain exactly one media type for {$method} {$matchedPath}."];
+        }
+
+        $mediaType = null;
+        $mediaTypeSpec = null;
+        foreach ($content as $candidate => $candidateSpec) {
+            if (!is_string($candidate) || strtolower($candidate) !== 'application/x-www-form-urlencoded') {
+                continue;
+            }
+
+            $mediaType = $candidate;
+            $mediaTypeSpec = $candidateSpec;
+            break;
+        }
+
+        if ($mediaType === null) {
+            $declared = implode(', ', array_keys($content));
+            if (!isset(self::$warnedUnsupportedQueryStringMediaTypes[$declared])) {
+                self::$warnedUnsupportedQueryStringMediaTypes[$declared] = true;
+                trigger_error(
+                    sprintf(
+                        '[OpenAPI 3.2 querystring] %s %s declares unsupported query-string media type(s): %s. '
+                        . 'Only application/x-www-form-urlencoded can be reconstructed from the parsed query map; validation was skipped.',
+                        $method,
+                        $matchedPath,
+                        $declared,
+                    ),
+                    E_USER_WARNING,
+                );
+            }
+
+            return [];
+        }
+
+        if (MalformedSpecNode::isMalformed($mediaTypeSpec)) {
+            return ["[querystring] content '{$mediaType}' must be an object for {$method} {$matchedPath}."];
+        }
+
+        $schema = $mediaTypeSpec['schema'] ?? null;
+        if (MalformedSpecNode::isMalformed($schema)) {
+            return ["[querystring] content '{$mediaType}' has no schema for {$method} {$matchedPath} — cannot validate."];
+        }
+
+        if ($queryParams === []) {
+            return ($parameter['required'] ?? false) === true
+                ? ["[querystring] required URL query string is missing for {$method} {$matchedPath}."]
+                : [];
+        }
+
+        $coerced = $queryParams;
+        $properties = $schema['properties'] ?? null;
+        if (is_array($properties)) {
+            foreach ($coerced as $name => $value) {
+                $propertySchema = $properties[$name] ?? null;
+                if (is_array($propertySchema)) {
+                    $coerced[$name] = TypeCoercer::coerceQuery($value, $propertySchema);
+                }
+            }
+        }
+
+        $jsonSchema = OpenApiSchemaConverter::convert($schema, $version, SchemaContext::Request);
+        $formatted = $this->runner->validate(
+            ObjectConverter::convert($jsonSchema),
+            ObjectConverter::convert($coerced),
+        );
+
+        $errors = [];
+        foreach ($formatted as $path => $messages) {
+            $suffix = $path === '/' ? '' : $path;
+            foreach ($messages as $message) {
+                $errors[] = "[querystring{$suffix}] {$message}";
             }
         }
 

--- a/src/Validation/Request/RequestBodyValidator.php
+++ b/src/Validation/Request/RequestBodyValidator.php
@@ -141,6 +141,19 @@ final class RequestBodyValidator
                     ),
                 ]);
             }
+
+            if (array_key_exists('itemSchema', $mediaTypeSpec) && MalformedSpecNode::isMalformed($mediaTypeSpec['itemSchema'])) {
+                return new RequestBodyValidationResult([
+                    sprintf(
+                        "Malformed 'requestBody.content[\"%s\"].itemSchema' for %s %s in '%s' spec: expected object, got %s.",
+                        $mediaType,
+                        $method,
+                        $matchedPath,
+                        $specName,
+                        MalformedSpecNode::describe($mediaTypeSpec['itemSchema']),
+                    ),
+                ]);
+            }
         }
 
         // When the actual request Content-Type is provided, handle content negotiation:
@@ -152,6 +165,10 @@ final class RequestBodyValidator
             if (!ContentTypeMatcher::isJsonContentType($normalizedType)) {
                 $matchedKey = ContentTypeMatcher::findContentTypeKey($normalizedType, $content);
                 if ($matchedKey !== null) {
+                    if (isset($content[$matchedKey]['itemSchema'])) {
+                        return self::unsupportedItemSchemaResult($normalizedType);
+                    }
+
                     // A matched non-JSON media type that declares a `schema`
                     // is an unvalidatable contract: OpenAPI permits a schema
                     // on any media type, but this engine only evaluates JSON
@@ -199,10 +216,20 @@ final class RequestBodyValidator
         // This validator only handles JSON schemas; non-JSON types (e.g. application/xml,
         // application/octet-stream) are outside its scope.
         if ($jsonContentType === null) {
+            foreach ($content as $mediaType => $mediaTypeSpec) {
+                if (isset($mediaTypeSpec['itemSchema'])) {
+                    return self::unsupportedItemSchemaResult((string) $mediaType);
+                }
+            }
+
             return new RequestBodyValidationResult([]);
         }
 
         if (!isset($content[$jsonContentType]['schema'])) {
+            if (isset($content[$jsonContentType]['itemSchema'])) {
+                return self::unsupportedItemSchemaResult($jsonContentType);
+            }
+
             return new RequestBodyValidationResult([]);
         }
 
@@ -254,9 +281,21 @@ final class RequestBodyValidator
         return new RequestBodyValidationResult($errors);
     }
 
+    private static function unsupportedItemSchemaResult(string $mediaType): RequestBodyValidationResult
+    {
+        return new RequestBodyValidationResult(
+            [],
+            sprintf(
+                "request Content-Type '%s' uses OpenAPI 3.2 itemSchema streaming semantics; "
+                . 'stream items cannot be validated from the buffered request body and were explicitly skipped',
+                $mediaType,
+            ),
+        );
+    }
+
     /**
      * Whether the schema's top-level type explicitly accepts a JSON object.
-     * Handles OAS 3.0 (`type: object`) and OAS 3.1 (`type: ["object", "null"]`).
+     * Handles OAS 3.0 (`type: object`) and OAS 3.1/3.2 (`type: ["object", "null"]`).
      * Composition keywords (`oneOf` / `anyOf` / `allOf`) are intentionally
      * NOT walked — coercion only fires for the unambiguous case so a real
      * type-mismatch error still surfaces for `type: array` schemas where the

--- a/src/Validation/Response/ResponseBodyValidator.php
+++ b/src/Validation/Response/ResponseBodyValidator.php
@@ -113,6 +113,20 @@ final class ResponseBodyValidator
                     ),
                 ], null);
             }
+
+            if (array_key_exists('itemSchema', $mediaTypeSpec) && MalformedSpecNode::isMalformed($mediaTypeSpec['itemSchema'])) {
+                return new ResponseBodyValidationResult([
+                    sprintf(
+                        "Malformed 'responses[%s].content[\"%s\"].itemSchema' for %s %s in '%s' spec: expected object, got %s.",
+                        $statusCode,
+                        $mediaType,
+                        $method,
+                        $matchedPath,
+                        $specName,
+                        MalformedSpecNode::describe($mediaTypeSpec['itemSchema']),
+                    ),
+                ], null);
+            }
         }
 
         // When the actual response Content-Type is provided, handle content negotiation:
@@ -130,6 +144,10 @@ final class ResponseBodyValidator
                 // Non-JSON response: check if the content type is defined in the spec.
                 $matchedKey = ContentTypeMatcher::findContentTypeKey($normalizedType, $content);
                 if ($matchedKey !== null) {
+                    if (isset($content[$matchedKey]['itemSchema'])) {
+                        return self::unsupportedItemSchemaResult($matchedKey, $normalizedType);
+                    }
+
                     // A matched non-JSON media type that declares a `schema`
                     // is an unvalidatable contract: OpenAPI permits a schema
                     // on any media type, but this engine only evaluates JSON
@@ -181,10 +199,20 @@ final class ResponseBodyValidator
         // This validator only handles JSON schemas; non-JSON types (e.g. text/html,
         // application/xml) are outside its scope.
         if ($jsonContentType === null) {
+            foreach ($content as $mediaType => $mediaTypeSpec) {
+                if (isset($mediaTypeSpec['itemSchema'])) {
+                    return self::unsupportedItemSchemaResult((string) $mediaType, (string) $mediaType);
+                }
+            }
+
             return new ResponseBodyValidationResult([], null);
         }
 
         if (!isset($content[$jsonContentType]['schema'])) {
+            if (isset($content[$jsonContentType]['itemSchema'])) {
+                return self::unsupportedItemSchemaResult($jsonContentType, $jsonContentType);
+            }
+
             return new ResponseBodyValidationResult([], $jsonContentType);
         }
 
@@ -236,9 +264,22 @@ final class ResponseBodyValidator
         return new ResponseBodyValidationResult($errors, $jsonContentType);
     }
 
+    private static function unsupportedItemSchemaResult(string $matchedKey, string $actualMediaType): ResponseBodyValidationResult
+    {
+        return new ResponseBodyValidationResult(
+            [],
+            $matchedKey,
+            sprintf(
+                "response Content-Type '%s' uses OpenAPI 3.2 itemSchema streaming semantics; "
+                . 'stream items cannot be validated from the buffered response body and were explicitly skipped',
+                $actualMediaType,
+            ),
+        );
+    }
+
     /**
      * Whether the schema's top-level type explicitly accepts a JSON object.
-     * Handles OAS 3.0 (`type: object`) and OAS 3.1 (`type: ["object", "null"]`).
+     * Handles OAS 3.0 (`type: object`) and OAS 3.1/3.2 (`type: ["object", "null"]`).
      * Composition keywords (`oneOf` / `anyOf` / `allOf`) are intentionally
      * NOT walked — coercion only fires for the unambiguous case so a real
      * type-mismatch error still surfaces for `type: array` schemas where the

--- a/tests/Integration/Laravel/AutoAssertIntegrationTest.php
+++ b/tests/Integration/Laravel/AutoAssertIntegrationTest.php
@@ -67,7 +67,7 @@ class AutoAssertIntegrationTest extends TestCase
         config()->set('openapi-contract-testing.auto_assert', true);
 
         $this->expectException(InvalidOpenApiSpecException::class);
-        $this->expectExceptionMessage("Unsupported OpenAPI version: '3.2.0' (string)");
+        $this->expectExceptionMessage("Unsupported OpenAPI version: '3.3.0' (string)");
 
         $this->get('/v1/pets');
     }
@@ -175,6 +175,20 @@ class AutoAssertIntegrationTest extends TestCase
         $covered = OpenApiCoverageTracker::getCovered();
         $this->assertArrayHasKey('petstore-3.1', $covered);
         $this->assertArrayNotHasKey('petstore-3.0', $covered);
+    }
+
+    #[Test]
+    #[OpenApiSpec('openapi-3.2')]
+    public function openapi_32_plain_operation_works_through_laravel_auto_assert(): void
+    {
+        config()->set('openapi-contract-testing.auto_assert', true);
+
+        $response = $this->get('/v1/pets');
+        $response->assertOk();
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayHasKey('openapi-3.2', $covered);
+        $this->assertArrayHasKey('GET /v1/pets', $covered['openapi-3.2']);
     }
 
     #[Test]

--- a/tests/Integration/OpenApiCoverageExtensionBootstrapTest.php
+++ b/tests/Integration/OpenApiCoverageExtensionBootstrapTest.php
@@ -65,8 +65,8 @@ class OpenApiCoverageExtensionBootstrapTest extends TestCase
 
         $this->assertNotSame(0, $exit, "Expected non-zero exit; stderr was:\n" . $stderr);
         $this->assertStringContainsString('FATAL', $stderr);
-        $this->assertStringContainsString("Unsupported OpenAPI version: '3.2.0' (string)", $stderr);
-        $this->assertStringContainsString('3.0.x or 3.1.x', $stderr);
+        $this->assertStringContainsString("Unsupported OpenAPI version: '3.3.0' (string)", $stderr);
+        $this->assertStringContainsString('3.0.x, 3.1.x, or 3.2.x', $stderr);
     }
 
     #[Test]

--- a/tests/Integration/Pest/ExpectationsTest.php
+++ b/tests/Integration/Pest/ExpectationsTest.php
@@ -54,6 +54,19 @@ it('honours the spec: argument as a per-call override', function (): void {
         ->and($covered)->not->toHaveKey('petstore-3.0');
 });
 
+it('validates a plain OpenAPI 3.2 response through the Pest adapter', function (): void {
+    $response = $this->get('/v1/pets');
+    $response->assertOk();
+
+    expect($response)->toMatchOpenApiResponseSchema(spec: 'openapi-3.2');
+
+    $covered = OpenApiCoverageTracker::getCovered();
+    expect($covered)
+        ->toHaveKey('openapi-3.2')
+        ->and($covered['openapi-3.2'])
+        ->toHaveKey('GET /v1/pets');
+});
+
 it('clears the per-call spec override after a single assertion', function (): void {
     // Pin the documented "self-clears after the next resolveOpenApiSpec()
     // call" invariant: one explicit `spec:` followed by an implicit call must

--- a/tests/Unit/Coverage/OpenApiCoverageTrackerTest.php
+++ b/tests/Unit/Coverage/OpenApiCoverageTrackerTest.php
@@ -6,11 +6,17 @@ namespace Studio\OpenApiContractTesting\Tests\Unit\Coverage;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Coverage\ConsoleCoverageRenderer;
 use Studio\OpenApiContractTesting\Coverage\EndpointCoverageState;
+use Studio\OpenApiContractTesting\Coverage\HtmlCoverageRenderer;
+use Studio\OpenApiContractTesting\Coverage\JsonCoverageRenderer;
+use Studio\OpenApiContractTesting\Coverage\JUnitCoverageRenderer;
+use Studio\OpenApiContractTesting\Coverage\MarkdownCoverageRenderer;
 use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
 use Studio\OpenApiContractTesting\Coverage\ResponseCoverageState;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 
+use function array_column;
 use function implode;
 use function restore_error_handler;
 use function set_error_handler;
@@ -728,6 +734,55 @@ class OpenApiCoverageTrackerTest extends TestCase
         $joined = implode(' | ', $captured);
         $this->assertStringContainsString("spec 'malformed-response'", $joined);
         $this->assertStringContainsString('not an object', $joined);
+    }
+
+    #[Test]
+    public function openapi_32_query_and_additional_operations_appear_in_coverage(): void
+    {
+        $this->tracker->recordResponseOn(
+            'openapi-3.2',
+            'QUERY',
+            '/v1/search',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        $this->tracker->recordResponseOn(
+            'openapi-3.2',
+            'COPY',
+            '/v1/pets/{petId}',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        $result = $this->tracker->computeCoverageOn('openapi-3.2');
+        $endpointKeys = array_column($result['endpoints'], 'endpoint');
+
+        $this->assertContains('QUERY /v1/search', $endpointKeys);
+        $this->assertContains('COPY /v1/pets/{petId}', $endpointKeys);
+        $this->assertSame(6, $result['endpointTotal']);
+        $this->assertSame(2, $result['endpointFullyCovered']);
+    }
+
+    #[Test]
+    public function openapi_32_operation_forms_render_in_every_report_format(): void
+    {
+        $result = $this->tracker->computeCoverageOn('openapi-3.2');
+        $results = ['openapi-3.2' => $result];
+
+        $outputs = [
+            ConsoleCoverageRenderer::render($results),
+            MarkdownCoverageRenderer::render($results),
+            JUnitCoverageRenderer::render($results),
+            JsonCoverageRenderer::render($results),
+            HtmlCoverageRenderer::render($results),
+        ];
+
+        foreach ($outputs as $output) {
+            $this->assertStringContainsString('QUERY /v1/search', $output);
+            $this->assertStringContainsString('COPY /v1/pets/{petId}', $output);
+        }
     }
 
     #[Test]

--- a/tests/Unit/Coverage/OpenApiCoverageTrackerTest.php
+++ b/tests/Unit/Coverage/OpenApiCoverageTrackerTest.php
@@ -766,6 +766,21 @@ class OpenApiCoverageTrackerTest extends TestCase
     }
 
     #[Test]
+    public function coverage_keeps_custom_method_capitalization_distinct(): void
+    {
+        $this->tracker->recordRequestOn('custom-methods', 'COPY', '/resources');
+        $this->tracker->recordRequestOn('custom-methods', 'copy', '/resources');
+        $this->tracker->recordRequestOn('custom-methods', 'get', '/resources');
+
+        $covered = $this->tracker->getCoveredOn();
+
+        $this->assertArrayHasKey('COPY /resources', $covered['custom-methods']);
+        $this->assertArrayHasKey('copy /resources', $covered['custom-methods']);
+        $this->assertArrayHasKey('GET /resources', $covered['custom-methods']);
+        $this->assertCount(3, $covered['custom-methods']);
+    }
+
+    #[Test]
     public function openapi_32_operation_forms_render_in_every_report_format(): void
     {
         $result = $this->tracker->computeCoverageOn('openapi-3.2');

--- a/tests/Unit/Fuzz/OpenApiEndpointExplorerTest.php
+++ b/tests/Unit/Fuzz/OpenApiEndpointExplorerTest.php
@@ -45,7 +45,7 @@ class OpenApiEndpointExplorerTest extends TestCase
     public function rejects_unsupported_openapi_version(): void
     {
         $this->expectException(InvalidOpenApiSpecException::class);
-        $this->expectExceptionMessage("Unsupported OpenAPI version: '3.2.0' (string)");
+        $this->expectExceptionMessage("Unsupported OpenAPI version: '3.3.0' (string)");
 
         OpenApiEndpointExplorer::explore('unsupported-version', 'GET', '/v1/pets', cases: 1);
     }
@@ -80,6 +80,19 @@ class OpenApiEndpointExplorerTest extends TestCase
             $this->assertInstanceOf(ExploredCase::class, $case);
             $this->assertSame(HttpMethod::POST, $case->method);
             $this->assertSame('/v1/pets', $case->matchedPath);
+        }
+    }
+
+    #[Test]
+    public function explores_openapi_32_query_operation(): void
+    {
+        $cases = OpenApiEndpointExplorer::explore('openapi-3.2', 'QUERY', '/v1/search', cases: 2, seed: 1);
+
+        foreach ($cases as $case) {
+            $this->assertSame(HttpMethod::QUERY, $case->method);
+            $this->assertSame('/v1/search', $case->matchedPath);
+            $this->assertIsArray($case->body);
+            $this->assertArrayHasKey('term', $case->body);
         }
     }
 

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -60,9 +60,75 @@ class OpenApiRequestValidatorTest extends TestCase
     public function rejects_unsupported_openapi_version(): void
     {
         $this->expectException(InvalidOpenApiSpecException::class);
-        $this->expectExceptionMessage("Unsupported OpenAPI version: '3.2.0' (string)");
+        $this->expectExceptionMessage("Unsupported OpenAPI version: '3.3.0' (string)");
 
         $this->validator->validate('unsupported-version', 'GET', '/v1/pets', [], [], null);
+    }
+
+    #[Test]
+    public function openapi_32_query_operation_and_request_body_are_validated(): void
+    {
+        $valid = $this->validator->validate(
+            'openapi-3.2',
+            'QUERY',
+            '/v1/search',
+            [],
+            [],
+            ['term' => 'cat'],
+            'application/json',
+        );
+        $invalid = $this->validator->validate(
+            'openapi-3.2',
+            'QUERY',
+            '/v1/search',
+            [],
+            [],
+            [],
+            'application/json',
+        );
+
+        $this->assertTrue($valid->isValid(), $valid->errorMessage());
+        $this->assertFalse($invalid->isValid());
+    }
+
+    #[Test]
+    public function openapi_32_custom_operation_is_resolved(): void
+    {
+        $result = $this->validator->validate('openapi-3.2', 'COPY', '/v1/pets/7', [], [], null);
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+        $this->assertSame('/v1/pets/{petId}', $result->matchedPath());
+    }
+
+    #[Test]
+    public function openapi_32_querystring_validates_the_whole_form_query(): void
+    {
+        $valid = $this->validator->validate('openapi-3.2', 'GET', '/v1/filter', ['limit' => '2'], [], null);
+        $invalid = $this->validator->validate('openapi-3.2', 'GET', '/v1/filter', ['limit' => '0'], [], null);
+        $missing = $this->validator->validate('openapi-3.2', 'GET', '/v1/filter', [], [], null);
+
+        $this->assertTrue($valid->isValid(), $valid->errorMessage());
+        $this->assertFalse($invalid->isValid());
+        $this->assertFalse($missing->isValid());
+        $this->assertStringContainsString('querystring', $missing->errorMessage());
+    }
+
+    #[Test]
+    public function openapi_32_item_schema_request_is_explicitly_skipped(): void
+    {
+        $result = $this->validator->validate(
+            'openapi-3.2',
+            'GET',
+            '/v1/events',
+            [],
+            [],
+            "event: updated\n\ndata: {}\n\n",
+            'text/event-stream',
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+        $this->assertTrue($result->isSkipped());
+        $this->assertStringContainsString('itemSchema', $result->skipReason() ?? '');
     }
 
     #[Test]

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -72,9 +72,86 @@ class OpenApiResponseValidatorTest extends TestCase
     public function rejects_unsupported_openapi_version(): void
     {
         $this->expectException(InvalidOpenApiSpecException::class);
-        $this->expectExceptionMessage("Unsupported OpenAPI version: '3.2.0' (string)");
+        $this->expectExceptionMessage("Unsupported OpenAPI version: '3.3.0' (string)");
 
         $this->validator->validate('unsupported-version', 'GET', '/v1/pets', 200, null);
+    }
+
+    #[Test]
+    public function openapi_32_plain_and_new_operation_forms_are_validated(): void
+    {
+        $plain = $this->validator->validate(
+            'openapi-3.2',
+            'GET',
+            '/v1/pets',
+            200,
+            ['data' => [['id' => 1, 'name' => 'Fido']]],
+            'application/json',
+        );
+        $query = $this->validator->validate('openapi-3.2', 'QUERY', '/v1/search', 200, [], 'application/json');
+        $custom = $this->validator->validate(
+            'openapi-3.2',
+            'COPY',
+            '/v1/pets/1',
+            200,
+            ['id' => 2, 'name' => 'Copy'],
+            'application/json',
+        );
+
+        $this->assertTrue($plain->isValid(), $plain->errorMessage());
+        $this->assertTrue($query->isValid(), $query->errorMessage());
+        $this->assertTrue($custom->isValid(), $custom->errorMessage());
+    }
+
+    #[Test]
+    public function openapi_32_discriminator_default_mapping_handles_missing_and_unknown_values(): void
+    {
+        $missing = $this->validator->validate(
+            'openapi-3.2',
+            'GET',
+            '/v1/pets/1',
+            200,
+            ['name' => 'Mystery'],
+            'application/json',
+        );
+        $unknown = $this->validator->validate(
+            'openapi-3.2',
+            'GET',
+            '/v1/pets/1',
+            200,
+            ['kind' => 'bird', 'name' => 'Tweety'],
+            'application/json',
+        );
+        $invalidFallback = $this->validator->validate(
+            'openapi-3.2',
+            'GET',
+            '/v1/pets/1',
+            200,
+            ['kind' => 'bird'],
+            'application/json',
+        );
+
+        $this->assertTrue($missing->isValid(), $missing->errorMessage());
+        $this->assertTrue($unknown->isValid(), $unknown->errorMessage());
+        $this->assertFalse($invalidFallback->isValid());
+    }
+
+    #[Test]
+    public function openapi_32_item_schema_response_is_explicitly_skipped(): void
+    {
+        $result = $this->validator->validate(
+            'openapi-3.2',
+            'GET',
+            '/v1/events',
+            200,
+            "event: updated\n\ndata: {}\n\n",
+            'text/event-stream',
+        );
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+        $this->assertTrue($result->isSkipped());
+        $this->assertStringContainsString('itemSchema', $result->skipReason() ?? '');
+        $this->assertSame('text/event-stream', $result->matchedContentType());
     }
 
     #[Test]

--- a/tests/Unit/OpenApiVersionTest.php
+++ b/tests/Unit/OpenApiVersionTest.php
@@ -23,6 +23,8 @@ class OpenApiVersionTest extends TestCase
             '3.1.0' => [['openapi' => '3.1.0'], OpenApiVersion::V3_1],
             '3.1.1' => [['openapi' => '3.1.1'], OpenApiVersion::V3_1],
             '3.1 future patch' => [['openapi' => '3.1.999'], OpenApiVersion::V3_1],
+            '3.2.0' => [['openapi' => '3.2.0'], OpenApiVersion::V3_2],
+            '3.2 future patch' => [['openapi' => '3.2.999'], OpenApiVersion::V3_2],
         ];
     }
 
@@ -34,7 +36,7 @@ class OpenApiVersionTest extends TestCase
             'empty string' => [['openapi' => ''], "'' (string)"],
             'non-string value' => [['openapi' => 3], '3 (int)'],
             'Swagger 2.0' => [['openapi' => '2.0.0'], "'2.0.0' (string)"],
-            'unsupported 3.2' => [['openapi' => '3.2.0'], "'3.2.0' (string)"],
+            'unsupported 3.3' => [['openapi' => '3.3.0'], "'3.3.0' (string)"],
             'unsupported 3.10' => [['openapi' => '3.10.0'], "'3.10.0' (string)"],
             'unknown future version' => [['openapi' => '4.0.0'], "'4.0.0' (string)"],
             'missing patch' => [['openapi' => '3.1'], "'3.1' (string)"],
@@ -61,7 +63,7 @@ class OpenApiVersionTest extends TestCase
         } catch (InvalidOpenApiSpecException $e) {
             $this->assertSame(InvalidOpenApiSpecReason::UnsupportedVersion, $e->reason);
             $this->assertStringContainsString($received, $e->getMessage());
-            $this->assertStringContainsString('3.0.x or 3.1.x', $e->getMessage());
+            $this->assertStringContainsString('3.0.x, 3.1.x, or 3.2.x', $e->getMessage());
         }
     }
 }

--- a/tests/Unit/Spec/OpenApiOperationResolverTest.php
+++ b/tests/Unit/Spec/OpenApiOperationResolverTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Spec;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Spec\OpenApiOperationResolver;
+
+use function array_column;
+
+final class OpenApiOperationResolverTest extends TestCase
+{
+    #[Test]
+    public function resolves_query_fixed_field(): void
+    {
+        $operation = ['operationId' => 'search'];
+
+        $result = OpenApiOperationResolver::resolve(['query' => $operation], 'QUERY');
+
+        $this->assertTrue($result['found']);
+        $this->assertSame($operation, $result['operation']);
+        $this->assertSame('query', $result['location']);
+    }
+
+    #[Test]
+    public function resolves_custom_method_from_additional_operations(): void
+    {
+        $operation = ['operationId' => 'copy'];
+
+        $result = OpenApiOperationResolver::resolve(
+            ['additionalOperations' => ['COPY' => $operation]],
+            'copy',
+        );
+
+        $this->assertTrue($result['found']);
+        $this->assertSame($operation, $result['operation']);
+        $this->assertSame('additionalOperations["COPY"]', $result['location']);
+    }
+
+    #[Test]
+    public function does_not_treat_path_item_metadata_as_an_operation(): void
+    {
+        $result = OpenApiOperationResolver::resolve(['servers' => []], 'SERVERS');
+
+        $this->assertFalse($result['found']);
+    }
+
+    #[Test]
+    public function malformed_additional_operations_container_is_returned_for_loud_validation(): void
+    {
+        $result = OpenApiOperationResolver::resolve(['additionalOperations' => ['not-an-object-map']], 'COPY');
+
+        $this->assertTrue($result['found']);
+        $this->assertSame('additionalOperations', $result['location']);
+        $this->assertSame(['not-an-object-map'], $result['operation']);
+    }
+
+    #[Test]
+    public function declared_operations_include_query_and_custom_methods(): void
+    {
+        $result = OpenApiOperationResolver::declaredOperations([
+            'get' => ['responses' => []],
+            'query' => ['responses' => []],
+            'additionalOperations' => ['COPY' => ['responses' => []]],
+        ]);
+
+        $this->assertSame(['GET', 'QUERY', 'COPY'], array_column($result, 'method'));
+    }
+}

--- a/tests/Unit/Spec/OpenApiOperationResolverTest.php
+++ b/tests/Unit/Spec/OpenApiOperationResolverTest.php
@@ -31,12 +31,29 @@ final class OpenApiOperationResolverTest extends TestCase
 
         $result = OpenApiOperationResolver::resolve(
             ['additionalOperations' => ['COPY' => $operation]],
-            'copy',
+            'COPY',
         );
 
         $this->assertTrue($result['found']);
         $this->assertSame($operation, $result['operation']);
         $this->assertSame('additionalOperations["COPY"]', $result['location']);
+    }
+
+    #[Test]
+    public function additional_operation_method_matching_is_case_sensitive(): void
+    {
+        $pathItem = ['additionalOperations' => [
+            'COPY' => ['operationId' => 'upperCopy'],
+            'copy' => ['operationId' => 'lowerCopy'],
+        ]];
+
+        $upper = OpenApiOperationResolver::resolve($pathItem, 'COPY');
+        $lower = OpenApiOperationResolver::resolve($pathItem, 'copy');
+        $mixed = OpenApiOperationResolver::resolve($pathItem, 'Copy');
+
+        $this->assertSame('upperCopy', $upper['operation']['operationId']);
+        $this->assertSame('lowerCopy', $lower['operation']['operationId']);
+        $this->assertFalse($mixed['found']);
     }
 
     #[Test]
@@ -63,9 +80,12 @@ final class OpenApiOperationResolverTest extends TestCase
         $result = OpenApiOperationResolver::declaredOperations([
             'get' => ['responses' => []],
             'query' => ['responses' => []],
-            'additionalOperations' => ['COPY' => ['responses' => []]],
+            'additionalOperations' => [
+                'COPY' => ['responses' => []],
+                'copy' => ['responses' => []],
+            ],
         ]);
 
-        $this->assertSame(['GET', 'QUERY', 'COPY'], array_column($result, 'method'));
+        $this->assertSame(['GET', 'QUERY', 'COPY', 'copy'], array_column($result, 'method'));
     }
 }

--- a/tests/Unit/Spec/OpenApiPathSuggesterTest.php
+++ b/tests/Unit/Spec/OpenApiPathSuggesterTest.php
@@ -72,12 +72,12 @@ class OpenApiPathSuggesterTest extends TestCase
     }
 
     #[Test]
-    public function suggest_recognises_all_eight_openapi_path_item_methods(): void
+    public function suggest_recognises_all_openapi_path_item_methods(): void
     {
-        // OpenAPI 3.x defines exactly these eight operation keys for a path item.
+        // OpenAPI 3.2 adds QUERY to the eight operation keys from 3.0/3.1.
         // Any future broadening of HttpMethod for request validation must not
         // silently drop one of these from suggestions.
-        $methods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
+        $methods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace', 'query'];
         $pathItem = [];
         foreach ($methods as $m) {
             $pathItem[$m] = ['responses' => []];
@@ -89,9 +89,29 @@ class OpenApiPathSuggesterTest extends TestCase
         sort($resultMethods);
 
         $this->assertSame(
-            ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE'],
+            ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'QUERY', 'TRACE'],
             $resultMethods,
         );
+    }
+
+    #[Test]
+    public function suggest_and_methods_include_additional_operations(): void
+    {
+        $spec = [
+            'paths' => [
+                '/v1/pets' => [
+                    'get' => ['responses' => []],
+                    'additionalOperations' => [
+                        'COPY' => ['responses' => []],
+                    ],
+                ],
+            ],
+        ];
+
+        $suggestions = OpenApiPathSuggester::suggest($spec, '/v1/pets', 10);
+
+        $this->assertContains(['method' => 'COPY', 'path' => '/v1/pets'], $suggestions);
+        $this->assertSame(['COPY', 'GET'], OpenApiPathSuggester::methodsForPath($spec, '/v1/pets'));
     }
 
     #[Test]

--- a/tests/Unit/Spec/OpenApiRefResolverTest.php
+++ b/tests/Unit/Spec/OpenApiRefResolverTest.php
@@ -45,6 +45,26 @@ class OpenApiRefResolverTest extends TestCase
     }
 
     #[Test]
+    public function records_implicit_schema_name_only_for_direct_composition_refs(): void
+    {
+        $marker = OpenApiRefResolver::IMPLICIT_SCHEMA_NAME_EXTENSION;
+        $resolved = OpenApiRefResolver::resolve([
+            'components' => ['schemas' => [
+                'Cat' => ['type' => 'object', 'required' => ['meow']],
+            ]],
+            'schema' => [
+                'oneOf' => [
+                    ['$ref' => '#/components/schemas/Cat'],
+                    ['type' => 'object', $marker => 'Spoofed'],
+                ],
+            ],
+        ]);
+
+        $this->assertSame('Cat', $resolved['schema']['oneOf'][0][$marker]);
+        $this->assertArrayNotHasKey($marker, $resolved['schema']['oneOf'][1]);
+    }
+
+    #[Test]
     public function resolves_nested_refs(): void
     {
         $spec = [

--- a/tests/Unit/Spec/OpenApiSchemaConverterTest.php
+++ b/tests/Unit/Spec/OpenApiSchemaConverterTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\Exception\MalformedDiscriminatorException;
 use Studio\OpenApiContractTesting\OpenApiVersion;
 use Studio\OpenApiContractTesting\SchemaContext;
+use Studio\OpenApiContractTesting\Spec\OpenApiRefResolver;
 use Studio\OpenApiContractTesting\Spec\OpenApiSchemaConverter;
 use Studio\OpenApiContractTesting\Validation\Support\DiscriminatorContext;
 use Studio\OpenApiContractTesting\Validation\Support\ObjectConverter;
@@ -1466,6 +1467,60 @@ class OpenApiSchemaConverterTest extends TestCase
         $this->assertSame(['kind' => ['enum' => ['cat']]], $result['allOf'][0]['if']['not']['properties']);
         $this->assertSame(['name'], $result['allOf'][0]['then']['required']);
         $this->assertSame(['meow'], $result['allOf'][1]['then']['required']);
+    }
+
+    #[Test]
+    public function openapi_32_default_mapping_runs_after_implicit_schema_name_mapping(): void
+    {
+        $root = OpenApiRefResolver::resolve([
+            'components' => ['schemas' => [
+                'Cat' => ['type' => 'object', 'required' => ['meow']],
+                'Dog' => ['type' => 'object', 'required' => ['bark']],
+                'Other' => ['type' => 'object', 'required' => ['other']],
+            ]],
+            'schema' => [
+                'oneOf' => [
+                    ['$ref' => '#/components/schemas/Cat'],
+                    ['$ref' => '#/components/schemas/Dog'],
+                    ['$ref' => '#/components/schemas/Other'],
+                ],
+                'discriminator' => [
+                    'propertyName' => 'kind',
+                    'mapping' => ['doggo' => 'Dog'],
+                    'defaultMapping' => 'Other',
+                ],
+            ],
+        ]);
+
+        $lowered = OpenApiSchemaConverter::convert(
+            $root['schema'],
+            OpenApiVersion::V3_2,
+            SchemaContext::Response,
+            $this->enforcing($root),
+        );
+        $runner = new SchemaValidatorRunner(20);
+        $schemaObject = ObjectConverter::convert($lowered);
+
+        $this->assertSame(
+            [],
+            $runner->validate($schemaObject, ObjectConverter::convert((object) ['kind' => 'Cat', 'meow' => true])),
+            'an implicit Cat mapping must be selected before defaultMapping',
+        );
+        $this->assertSame(
+            [],
+            $runner->validate($schemaObject, ObjectConverter::convert((object) ['kind' => 'doggo', 'bark' => true])),
+            'an explicit mapping must continue to override the implicit schema name',
+        );
+        $this->assertSame(
+            [],
+            $runner->validate($schemaObject, ObjectConverter::convert((object) ['kind' => 'unknown', 'other' => true])),
+            'an unmapped value must use defaultMapping',
+        );
+        $this->assertNotSame(
+            [],
+            $runner->validate($schemaObject, ObjectConverter::convert((object) ['kind' => 'Cat', 'other' => true])),
+            'a known implicit value must not be routed to defaultMapping',
+        );
     }
 
     #[Test]

--- a/tests/Unit/Spec/OpenApiSchemaConverterTest.php
+++ b/tests/Unit/Spec/OpenApiSchemaConverterTest.php
@@ -1441,6 +1441,72 @@ class OpenApiSchemaConverterTest extends TestCase
     }
 
     #[Test]
+    public function openapi_32_discriminator_default_mapping_lowers_missing_and_unknown_branch(): void
+    {
+        $root = ['components' => ['schemas' => [
+            'Cat' => ['type' => 'object', 'required' => ['meow']],
+            'Other' => ['type' => 'object', 'required' => ['name']],
+        ]]];
+        $schema = [
+            'type' => 'object',
+            'discriminator' => [
+                'propertyName' => 'kind',
+                'mapping' => ['cat' => 'Cat'],
+                'defaultMapping' => 'Other',
+            ],
+        ];
+
+        $result = OpenApiSchemaConverter::convert(
+            $schema,
+            OpenApiVersion::V3_2,
+            SchemaContext::Response,
+            $this->enforcing($root),
+        );
+
+        $this->assertSame(['kind' => ['enum' => ['cat']]], $result['allOf'][0]['if']['not']['properties']);
+        $this->assertSame(['name'], $result['allOf'][0]['then']['required']);
+        $this->assertSame(['meow'], $result['allOf'][1]['then']['required']);
+    }
+
+    #[Test]
+    public function openapi_32_default_mapping_without_explicit_mapping_warns(): void
+    {
+        $root = ['components' => ['schemas' => [
+            'Other' => ['type' => 'object', 'required' => ['name']],
+        ]]];
+
+        $warnings = $this->captureWarnings(fn() => OpenApiSchemaConverter::convert(
+            [
+                'type' => 'object',
+                'discriminator' => [
+                    'propertyName' => 'kind',
+                    'defaultMapping' => 'Other',
+                ],
+            ],
+            OpenApiVersion::V3_2,
+            SchemaContext::Response,
+            $this->enforcing($root),
+        ));
+
+        $this->assertCount(1, $warnings);
+        $this->assertStringContainsString('[OpenAPI 3.2 discriminator]', $warnings[0]);
+    }
+
+    #[Test]
+    public function openapi_32_malformed_default_mapping_throws_when_enforced(): void
+    {
+        $this->expectException(MalformedDiscriminatorException::class);
+        $this->expectExceptionMessage('discriminator.defaultMapping');
+
+        OpenApiSchemaConverter::convert(
+            ['discriminator' => ['propertyName' => 'kind', 'defaultMapping' => 42]],
+            OpenApiVersion::V3_2,
+            SchemaContext::Response,
+            $this->enforcing(['components' => ['schemas' => []]]),
+        );
+    }
+
+    #[Test]
     public function discriminator_then_subschema_is_recursively_converted(): void
     {
         // The resolved subtype is raw OAS and must itself be lowered — a 3.0

--- a/tests/Unit/Spec/OpenApiSpecLoaderTest.php
+++ b/tests/Unit/Spec/OpenApiSpecLoaderTest.php
@@ -20,7 +20,9 @@ use function class_exists;
 use function file_put_contents;
 use function json_encode;
 use function mkdir;
+use function restore_error_handler;
 use function rmdir;
+use function set_error_handler;
 use function sys_get_temp_dir;
 use function uniqid;
 use function unlink;
@@ -165,9 +167,31 @@ class OpenApiSpecLoaderTest extends TestCase
         } catch (InvalidOpenApiSpecException $e) {
             $this->assertSame(InvalidOpenApiSpecReason::UnsupportedVersion, $e->reason);
             $this->assertSame('unsupported-version', $e->specName);
-            $this->assertStringContainsString("'3.2.0' (string)", $e->getMessage());
-            $this->assertStringContainsString('3.0.x or 3.1.x', $e->getMessage());
+            $this->assertStringContainsString("'3.3.0' (string)", $e->getMessage());
+            $this->assertStringContainsString('3.0.x, 3.1.x, or 3.2.x', $e->getMessage());
         }
+    }
+
+    #[Test]
+    public function openapi_32_self_base_uri_is_never_silently_ignored(): void
+    {
+        OpenApiSpecLoader::configure(__DIR__ . '/../../fixtures/specs');
+        $warning = null;
+        set_error_handler(static function (int $errno, string $message) use (&$warning): bool {
+            $warning = $message;
+
+            return true;
+        });
+
+        try {
+            $spec = OpenApiSpecLoader::load('openapi-3.2-self');
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame('3.2.0', $spec['openapi']);
+        $this->assertStringContainsString('[OpenAPI 3.2 $self]', $warning ?? '');
+        $this->assertStringContainsString('pre-bundle', $warning ?? '');
     }
 
     #[Test]

--- a/tests/Unit/Symfony/OpenApiAssertionsTest.php
+++ b/tests/Unit/Symfony/OpenApiAssertionsTest.php
@@ -47,6 +47,19 @@ final class OpenApiAssertionsTest extends TestCase
     }
 
     #[Test]
+    #[OpenApiSpec('openapi-3.2')]
+    public function openapi_32_plain_operation_works_through_symfony_adapter(): void
+    {
+        $request = Request::create('/v1/pets', 'GET');
+        $response = new JsonResponse(['data' => [['id' => 1, 'name' => 'Fido']]]);
+
+        $this->assertResponseMatchesOpenApiSchema($request, $response);
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayHasKey('GET /v1/pets', $covered['openapi-3.2'] ?? []);
+    }
+
+    #[Test]
     #[OpenApiSpec('unsupported-version')]
     public function unsupported_openapi_version_fails_before_response_assertion(): void
     {
@@ -54,7 +67,7 @@ final class OpenApiAssertionsTest extends TestCase
         $response = new Response('', 200);
 
         $this->expectException(InvalidOpenApiSpecException::class);
-        $this->expectExceptionMessage("Unsupported OpenAPI version: '3.2.0' (string)");
+        $this->expectExceptionMessage("Unsupported OpenAPI version: '3.3.0' (string)");
 
         $this->assertResponseMatchesOpenApiSchema($request, $response);
     }

--- a/tests/Unit/Validation/Request/ParameterCollectorTest.php
+++ b/tests/Unit/Validation/Request/ParameterCollectorTest.php
@@ -96,4 +96,32 @@ class ParameterCollectorTest extends TestCase
         $this->assertSame([], $result->specErrors);
         $this->assertCount(1, $result->parameters);
     }
+
+    #[Test]
+    public function collect_rejects_query_and_querystring_mix(): void
+    {
+        $result = ParameterCollector::collect('GET', '/pets', [], [
+            'parameters' => [
+                ['name' => 'q', 'in' => 'query', 'schema' => ['type' => 'string']],
+                ['name' => 'all', 'in' => 'querystring', 'content' => []],
+            ],
+        ]);
+
+        $this->assertCount(1, $result->specErrors);
+        $this->assertStringContainsString('forbids mixing', $result->specErrors[0]);
+    }
+
+    #[Test]
+    public function collect_rejects_multiple_querystring_parameters(): void
+    {
+        $result = ParameterCollector::collect('GET', '/pets', [], [
+            'parameters' => [
+                ['name' => 'one', 'in' => 'querystring', 'content' => []],
+                ['name' => 'two', 'in' => 'querystring', 'content' => []],
+            ],
+        ]);
+
+        $this->assertCount(1, $result->specErrors);
+        $this->assertStringContainsString('at most one', $result->specErrors[0]);
+    }
 }

--- a/tests/Unit/Validation/Request/QueryParameterValidatorTest.php
+++ b/tests/Unit/Validation/Request/QueryParameterValidatorTest.php
@@ -10,6 +10,9 @@ use Studio\OpenApiContractTesting\OpenApiVersion;
 use Studio\OpenApiContractTesting\Validation\Request\QueryParameterValidator;
 use Studio\OpenApiContractTesting\Validation\Support\SchemaValidatorRunner;
 
+use function restore_error_handler;
+use function set_error_handler;
+
 class QueryParameterValidatorTest extends TestCase
 {
     private QueryParameterValidator $validator;
@@ -17,7 +20,14 @@ class QueryParameterValidatorTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+        QueryParameterValidator::resetWarningStateForTesting();
         $this->validator = new QueryParameterValidator(new SchemaValidatorRunner(20));
+    }
+
+    protected function tearDown(): void
+    {
+        QueryParameterValidator::resetWarningStateForTesting();
+        parent::tearDown();
     }
 
     #[Test]
@@ -59,5 +69,57 @@ class QueryParameterValidatorTest extends TestCase
         $errors = $this->validator->validate('GET', '/pets', $parameters, [], OpenApiVersion::V3_0);
 
         $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function validate_checks_form_encoded_querystring_schema(): void
+    {
+        $parameters = [[
+            'name' => 'filter',
+            'in' => 'querystring',
+            'required' => true,
+            'content' => [
+                'application/x-www-form-urlencoded' => [
+                    'schema' => [
+                        'type' => 'object',
+                        'required' => ['limit'],
+                        'properties' => ['limit' => ['type' => 'integer', 'minimum' => 1]],
+                        'additionalProperties' => false,
+                    ],
+                ],
+            ],
+        ]];
+
+        $valid = $this->validator->validate('GET', '/pets', $parameters, ['limit' => '2'], OpenApiVersion::V3_2);
+        $invalid = $this->validator->validate('GET', '/pets', $parameters, ['limit' => '0'], OpenApiVersion::V3_2);
+
+        $this->assertSame([], $valid);
+        $this->assertNotSame([], $invalid);
+        $this->assertStringContainsString('[querystring', $invalid[0]);
+    }
+
+    #[Test]
+    public function validate_warns_when_querystring_media_type_cannot_be_reconstructed(): void
+    {
+        $warning = null;
+        set_error_handler(static function (int $errno, string $message) use (&$warning): bool {
+            $warning = $message;
+
+            return true;
+        });
+
+        try {
+            $errors = $this->validator->validate('GET', '/pets', [[
+                'name' => 'raw',
+                'in' => 'querystring',
+                'content' => ['application/json' => ['schema' => ['type' => 'object']]],
+            ]], ['raw' => 'value'], OpenApiVersion::V3_2);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $errors);
+        $this->assertStringContainsString('[OpenAPI 3.2 querystring]', $warning ?? '');
+        $this->assertStringContainsString('validation was skipped', $warning ?? '');
     }
 }

--- a/tests/fixtures/specs/openapi-3.2-self.json
+++ b/tests/fixtures/specs/openapi-3.2-self.json
@@ -1,0 +1,6 @@
+{
+  "openapi": "3.2.0",
+  "$self": "https://example.test/openapi/root.json",
+  "info": {"title": "$self warning fixture", "version": "1.0.0"},
+  "paths": {}
+}

--- a/tests/fixtures/specs/openapi-3.2.json
+++ b/tests/fixtures/specs/openapi-3.2.json
@@ -1,0 +1,218 @@
+{
+  "openapi": "3.2.0",
+  "info": {
+    "title": "OpenAPI 3.2 contract fixture",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/v1/pets": {
+      "get": {
+        "operationId": "listPets32",
+        "responses": {
+          "200": {
+            "description": "Pet list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["data"],
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Pet"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/search": {
+      "query": {
+        "operationId": "searchPets32",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["term"],
+                "properties": {
+                  "term": {"type": "string"}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Search result",
+            "content": {
+              "application/json": {
+                "schema": {"type": "array", "items": {"$ref": "#/components/schemas/Pet"}}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/pets/{petId}": {
+      "parameters": [
+        {
+          "name": "petId",
+          "in": "path",
+          "required": true,
+          "schema": {"type": "integer"}
+        }
+      ],
+      "get": {
+        "operationId": "getPet32",
+        "responses": {
+          "200": {
+            "description": "A polymorphic pet",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {"$ref": "#/components/schemas/Cat"},
+                    {"$ref": "#/components/schemas/Dog"},
+                    {"$ref": "#/components/schemas/OtherPet"}
+                  ],
+                  "discriminator": {
+                    "propertyName": "kind",
+                    "mapping": {
+                      "cat": "#/components/schemas/Cat",
+                      "dog": "#/components/schemas/Dog"
+                    },
+                    "defaultMapping": "#/components/schemas/OtherPet"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "additionalOperations": {
+        "COPY": {
+          "operationId": "copyPet32",
+          "responses": {
+            "200": {
+              "description": "Copied pet",
+              "content": {
+                "application/json": {
+                  "schema": {"$ref": "#/components/schemas/Pet"}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/filter": {
+      "get": {
+        "operationId": "filterPets32",
+        "parameters": [
+          {
+            "name": "filter",
+            "in": "querystring",
+            "required": true,
+            "content": {
+              "application/x-www-form-urlencoded": {
+                "schema": {
+                  "type": "object",
+                  "required": ["limit"],
+                  "properties": {
+                    "limit": {"type": "integer", "minimum": 1},
+                    "tag": {"type": "string"}
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {"description": "Filtered pets"}
+        }
+      }
+    },
+    "/v1/events": {
+      "get": {
+        "operationId": "streamEvents32",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "text/event-stream": {
+              "itemSchema": {
+                "type": "object",
+                "required": ["event"],
+                "properties": {
+                  "event": {"type": "string"}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Pet events",
+            "content": {
+              "text/event-stream": {
+                "itemSchema": {
+                  "type": "object",
+                  "required": ["event"],
+                  "properties": {
+                    "event": {"type": "string"}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+          "id": {"type": "integer"},
+          "name": {"type": "string"}
+        }
+      },
+      "Cat": {
+        "type": "object",
+        "required": ["kind", "lives"],
+        "properties": {
+          "kind": {"const": "cat"},
+          "lives": {"type": "integer"}
+        },
+        "additionalProperties": false
+      },
+      "Dog": {
+        "type": "object",
+        "required": ["kind", "barks"],
+        "properties": {
+          "kind": {"const": "dog"},
+          "barks": {"type": "boolean"}
+        },
+        "additionalProperties": false
+      },
+      "OtherPet": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "kind": {"not": {"enum": ["cat", "dog"]}},
+          "name": {"type": "string"}
+        },
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/tests/fixtures/specs/unsupported-version.json
+++ b/tests/fixtures/specs/unsupported-version.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.2.0",
+  "openapi": "3.3.0",
   "info": {
     "title": "Unsupported OpenAPI version",
     "version": "1.0.0"


### PR DESCRIPTION
## Summary

- Accept OpenAPI 3.2.x documents and keep ordinary 3.2 operations on the tested 3.1-compatible schema pipeline.
- Add shared operation resolution for QUERY and custom additionalOperations, including coverage in console, Markdown, JUnit, JSON, and HTML reports.
- Validate form-encoded querystring parameters, enforce discriminator.defaultMapping, and make itemSchema streaming, implicit-only default mappings, and $self base-URI limitations observable through explicit skip reasons or categorized warnings.
- Add a 3.2 fixture plus direct-validator, Laravel, Symfony, Pest, fuzzing, loader, converter, and coverage regression tests; update README, Composer metadata, and supported-feature documentation.

## Why

OpenAPI 3.2 is the current OpenAPI release, but the package previously rejected it. Explicit, tested support provides a first-mover differentiator while preserving loud behavior for 3.2 features the current buffered-body and Draft 07 pipeline cannot enforce safely.

The implementation follows the official OpenAPI 3.2 specification and upgrade guide:

- https://spec.openapis.org/oas/v3.2.0.html
- https://learn.openapis.org/upgrading/v3.1-to-v3.2.html

Fixes #273

## Verification

- [x] `composer test` equivalent: `vendor/bin/phpunit` — 1,925 tests, 4,596 assertions
- [x] `composer stan` equivalent: `vendor/bin/phpstan analyse` — no errors
- [x] `composer cs-check` equivalent: both standard and Pest PHP-CS-Fixer configs pass in sequential dry-run mode
- [x] `composer validate --strict`
- [x] `composer audit` — no advisories
- [x] `git diff --check`

The local dependency set intentionally does not install Pest 3 because it conflicts with the PHPUnit 12/13 matrix. The Pest integration regression was added and will run in the dedicated Pest CI jobs.

## Notes for reviewers

- `itemSchema` bodies are intentionally returned as Skipped with their matched media type. The current public API receives a buffered body, so pretending to validate individual SSE/JSONL/JSON-seq/multipart stream items would be a silent false positive.
- Arbitrary custom method tokens under `additionalOperations` work in direct validators and coverage. Enum-based Laravel/Symfony/Pest/fuzz APIs add QUERY but do not claim arbitrary custom-token support.
- OpenAPI 3.2 schemas still use the existing 3.1-to-Draft-07 conversion pipeline. Native JSON Schema 2020-12 support remains scoped to #274.
- A root `$self` emits a categorized warning until reference resolution can apply that base URI; pre-bundling is the documented workaround.
- No production dependency was added.
