### PR TITLE
feat(cli): add pre-test OpenAPI doctor command

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Three steps to your first contract-tested endpoint with the Laravel adapter. For
 
 Point the loader at your spec's entry file. Internal and local-filesystem `$ref` are resolved automatically — no pre-bundling required:
 
-```
+```text
 openapi/
 ├── root.yaml          # paths reference ./schemas/*.yaml
 └── schemas/
@@ -119,6 +119,19 @@ openapi/
 ```
 
 ### 2. Register the PHPUnit extension
+
+Before running your first test, verify that the package can load and enforce the contract:
+
+```bash
+vendor/bin/openapi-contract doctor \
+  --spec=openapi/root.yaml \
+  --strip-prefix=/api \
+  --phpunit-snippet
+```
+
+The command resolves local references, checks the OpenAPI/JSON Schema dialect, reports unsupported enforcement features, counts discovered operations and responses, and exits non-zero for incompatible specs. Use `--format=json` in CI. See the [doctor command reference](docs/doctor.md) for multiple specs, HTTP references, output categories, and exit codes.
+
+Then register the emitted configuration:
 
 ```xml
 <extensions>
@@ -161,6 +174,7 @@ To validate every response automatically, set `'auto_assert' => true` and drop t
 | Topic | Reference |
 |---|---|
 | Full setup, Laravel / Symfony / framework-agnostic adapters, auto-assert, opt-out attributes, request validation, HTTP `$ref` | [`docs/setup.md`](docs/setup.md) |
+| Pre-test compatibility diagnostics (`openapi-contract doctor`) | [`docs/doctor.md`](docs/doctor.md) |
 | Pest plugin: `expect()->toMatchOpenApiResponseSchema()` and friends | [`docs/pest-plugin.md`](docs/pest-plugin.md) |
 | Schema-driven request fuzzing | [`docs/fuzzing.md`](docs/fuzzing.md) |
 | Enum drift detection | [`docs/enum-drift.md`](docs/enum-drift.md) |

--- a/bin/openapi-contract
+++ b/bin/openapi-contract
@@ -1,0 +1,33 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Studio\OpenApiContractTesting\Cli\DoctorCommand;
+
+$autoloadCandidates = [
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../autoload.php',
+];
+
+$autoload = null;
+foreach ($autoloadCandidates as $candidate) {
+    if (file_exists($candidate)) {
+        $autoload = $candidate;
+
+        break;
+    }
+}
+
+if ($autoload === null) {
+    fwrite(STDERR, "[OpenAPI Doctor] FATAL: could not locate Composer autoload.\n");
+    exit(1);
+}
+
+require $autoload;
+
+$argv = $_SERVER['argv'] ?? [];
+array_shift($argv);
+
+$command = new DoctorCommand();
+exit($command->run(DoctorCommand::parseArgv($argv)));

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         ]
     },
     "bin": [
+        "bin/openapi-contract",
         "bin/openapi-coverage-merge"
     ],
     "autoload-dev": {

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -1,0 +1,82 @@
+# Doctor command
+
+`openapi-contract doctor` answers one focused question before the test suite starts: can this package load and enforce the selected OpenAPI contract as configured?
+
+It is not a replacement for a semantic or style linter such as Spectral or Redocly.
+
+## Basic usage
+
+```bash
+vendor/bin/openapi-contract doctor \
+  --spec=openapi/front.yaml \
+  --strip-prefix=/api
+```
+
+The command checks file readability and parser availability, the declared OpenAPI version and JSON Schema dialect, internal and external references, schema keywords that the validator warns about, and structurally valid operations and response definitions. It also reports recognized features that are intentionally not enforced.
+
+JSON and YAML are supported. YAML requires the optional `symfony/yaml` package, just like runtime validation.
+
+## Multiple specs
+
+Repeat `--spec`, or provide comma-separated paths:
+
+```bash
+vendor/bin/openapi-contract doctor \
+  --spec=openapi/front.yaml \
+  --spec=openapi/admin.json \
+  --strip-prefix=/api
+```
+
+`--phpunit-snippet` prints the equivalent extension configuration when all entry documents share one directory. The snippet uses each entry document's filename without its extension as the configured spec name.
+
+## HTTP references
+
+Remote references remain opt-in because diagnostics must not access the network unexpectedly:
+
+```bash
+vendor/bin/openapi-contract doctor \
+  --spec=openapi/root.yaml \
+  --allow-remote-refs
+```
+
+The command automatically uses an installed Guzzle (`guzzlehttp/guzzle` plus `guzzlehttp/psr7`) or Symfony HttpClient PSR-18 implementation. Without `--allow-remote-refs`, an HTTP(S) `$ref` is reported as a reference error with an actionable hint. Network failures, malformed remote documents, content-type mismatches, and reference cycles also exit non-zero.
+
+## Machine-readable output
+
+Use `--format=json` for CI and tooling. The top-level `schemaVersion` is currently `1` and will change if the machine-readable contract requires an incompatible revision.
+
+```json
+{
+    "schemaVersion": 1,
+    "status": "ok",
+    "summary": {
+        "specs": 1,
+        "operations": 4,
+        "responses": 7,
+        "errors": 0,
+        "warnings": 0,
+        "skipped": 0
+    },
+    "specs": [],
+    "issues": [],
+    "phpunit": null
+}
+```
+
+Every issue has a stable `severity`, `category`, `spec`, `message`, and nullable `suggestion` field. Severities are:
+
+- `error`: the contract cannot be loaded or enforced as configured;
+- `warning`: validation can proceed, but the package detected a compatibility limitation;
+- `skipped`: a recognized contract feature is not currently enforced and needs a separate test.
+
+Categories currently emitted by schema version 1 are `io`, `parser`, `version`, `dialect`, `references`, `structure`, `keyword`, `feature`, `dependency`, `configuration`, `spec`, `compatibility`, and `internal`. Consumers should branch on `severity` and `category`, not the human-readable message.
+
+## Exit codes
+
+| Code | Meaning |
+|---:|---|
+| `0` | All selected specs are compatible. Warnings and skipped features may still be present. |
+| `1` | At least one diagnostic error prevents reliable contract enforcement. |
+| `2` | The command-line invocation is invalid, such as a missing `--spec` or unknown format. |
+
+Treat both `1` and `2` as CI failures. Always inspect warnings and skipped features even when the exit code is `0`.

--- a/src/Cli/DoctorCommand.php
+++ b/src/Cli/DoctorCommand.php
@@ -21,12 +21,14 @@ use InvalidArgumentException;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecException;
+use Studio\OpenApiContractTesting\Exception\MalformedDiscriminatorException;
 use Studio\OpenApiContractTesting\Exception\SpecFileNotFoundException;
 use Studio\OpenApiContractTesting\OpenApiVersion;
 use Studio\OpenApiContractTesting\Spec\OpenApiOperationResolver;
 use Studio\OpenApiContractTesting\Spec\OpenApiSchemaConverter;
 use Studio\OpenApiContractTesting\Spec\OpenApiSchemaDialect;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\Validation\Support\DiscriminatorContext;
 use Studio\OpenApiContractTesting\Validation\Support\MalformedSpecNode;
 use Symfony\Component\HttpClient\Psr18Client;
 use Throwable;
@@ -302,7 +304,7 @@ final class DoctorCommand
             $version = OpenApiVersion::fromSpec($spec);
             $dialect = OpenApiSchemaDialect::fromSpec($spec, $version);
             [$operations, $responses] = $this->inspectStructure($spec, $label, $issues);
-            $this->inspectSchemas($spec, $version, $dialect);
+            $this->inspectSchemas($spec, $version, $dialect, new DiscriminatorContext($spec, true));
             $this->inspectSkippedFeatures($spec, $label, $issues);
 
             $specResults[] = [
@@ -315,6 +317,8 @@ final class DoctorCommand
             ];
         } catch (InvalidOpenApiSpecException $e) {
             $issues[] = $this->issue('error', $this->categoryForException($e), $label, $e->getMessage(), $this->suggestionForException($e));
+        } catch (MalformedDiscriminatorException $e) {
+            $issues[] = $this->issue('error', 'structure', $label, $e->getMessage(), 'Fix the discriminator definition or explicitly disable enforcement in PHPUnit.');
         } catch (InvalidArgumentException|SpecFileNotFoundException $e) {
             $issues[] = $this->issue('error', 'configuration', $label, $e->getMessage(), null);
         } catch (Throwable $e) {
@@ -463,17 +467,26 @@ final class DoctorCommand
     }
 
     /** @param array<string, mixed> $spec */
-    private function inspectSchemas(array $spec, OpenApiVersion $version, string $dialect): void
-    {
-        $this->walkForSchemas($spec, $version, $dialect, null);
+    private function inspectSchemas(
+        array $spec,
+        OpenApiVersion $version,
+        string $dialect,
+        DiscriminatorContext $discriminator,
+    ): void {
+        $this->walkForSchemas($spec, $version, $dialect, $discriminator, null);
     }
 
     /** @param array<mixed> $node */
-    private function walkForSchemas(array $node, OpenApiVersion $version, string $dialect, ?string $parentKey): void
-    {
+    private function walkForSchemas(
+        array $node,
+        OpenApiVersion $version,
+        string $dialect,
+        DiscriminatorContext $discriminator,
+        ?string $parentKey,
+    ): void {
         if ($parentKey === 'schema') {
             /** @var array<string, mixed> $node */
-            OpenApiSchemaConverter::convert($node, $version, jsonSchemaDialect: $dialect);
+            OpenApiSchemaConverter::convert($node, $version, discriminator: $discriminator, jsonSchemaDialect: $dialect);
 
             return;
         }
@@ -486,13 +499,13 @@ final class DoctorCommand
                 foreach ($value as $schema) {
                     if (is_array($schema)) {
                         /** @var array<string, mixed> $schema */
-                        OpenApiSchemaConverter::convert($schema, $version, jsonSchemaDialect: $dialect);
+                        OpenApiSchemaConverter::convert($schema, $version, discriminator: $discriminator, jsonSchemaDialect: $dialect);
                     }
                 }
 
                 continue;
             }
-            $this->walkForSchemas($value, $version, $dialect, is_string($key) ? $key : null);
+            $this->walkForSchemas($value, $version, $dialect, $discriminator, is_string($key) ? $key : null);
         }
     }
 

--- a/src/Cli/DoctorCommand.php
+++ b/src/Cli/DoctorCommand.php
@@ -27,10 +27,12 @@ use Studio\OpenApiContractTesting\Spec\OpenApiOperationResolver;
 use Studio\OpenApiContractTesting\Spec\OpenApiSchemaConverter;
 use Studio\OpenApiContractTesting\Spec\OpenApiSchemaDialect;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+use Studio\OpenApiContractTesting\Validation\Support\MalformedSpecNode;
 use Symfony\Component\HttpClient\Psr18Client;
 use Throwable;
 
 use function array_filter;
+use function array_key_exists;
 use function array_map;
 use function array_values;
 use function class_exists;
@@ -39,7 +41,6 @@ use function count;
 use function dirname;
 use function explode;
 use function fwrite;
-use function get_debug_type;
 use function getcwd;
 use function htmlspecialchars;
 use function implode;
@@ -338,8 +339,8 @@ final class DoctorCommand
     private function inspectStructure(array $spec, string $label, array &$issues): array
     {
         $paths = $spec['paths'] ?? null;
-        if (!is_array($paths)) {
-            $issues[] = $this->issue('error', 'structure', $label, sprintf('`paths` must be an object, got %s.', get_debug_type($paths)), null);
+        if (MalformedSpecNode::isMalformed($paths)) {
+            $issues[] = $this->issue('error', 'structure', $label, sprintf('`paths` must be an object, got %s.', MalformedSpecNode::describe($paths)), null);
 
             return [0, 0];
         }
@@ -347,29 +348,118 @@ final class DoctorCommand
         $operationCount = 0;
         $responseCount = 0;
         foreach ($paths as $path => $pathItem) {
-            if (!is_array($pathItem)) {
-                $issues[] = $this->issue('error', 'structure', $label, sprintf('Path `%s` must be an object, got %s.', (string) $path, get_debug_type($pathItem)), null);
+            if (MalformedSpecNode::isMalformed($pathItem)) {
+                $issues[] = $this->issue('error', 'structure', $label, sprintf('Path `%s` must be an object, got %s.', (string) $path, MalformedSpecNode::describe($pathItem)), null);
 
                 continue;
             }
             foreach (OpenApiOperationResolver::declaredOperations($pathItem) as $declared) {
                 $operation = $declared['operation'];
-                if (!is_array($operation)) {
-                    $issues[] = $this->issue('error', 'structure', $label, sprintf('Operation `%s %s` must be an object, got %s.', $declared['method'], (string) $path, get_debug_type($operation)), null);
+                if (MalformedSpecNode::isMalformed($operation)) {
+                    $issues[] = $this->issue('error', 'structure', $label, sprintf('Operation `%s %s` must be an object, got %s.', $declared['method'], (string) $path, MalformedSpecNode::describe($operation)), null);
 
                     continue;
                 }
                 $operationCount++;
-                if (!is_array($operation['responses'] ?? null)) {
-                    $issues[] = $this->issue('error', 'structure', $label, sprintf('Operation `%s %s` has no valid `responses` object.', $declared['method'], (string) $path), null);
+                $responses = $operation['responses'] ?? null;
+                if (MalformedSpecNode::isMalformed($responses)) {
+                    $issues[] = $this->issue(
+                        'error',
+                        'structure',
+                        $label,
+                        sprintf('Operation `%s %s` has an invalid `responses` object: got %s.', $declared['method'], (string) $path, MalformedSpecNode::describe($responses)),
+                        null,
+                    );
 
                     continue;
                 }
-                $responseCount += count($operation['responses']);
+
+                foreach ($responses as $status => $response) {
+                    if ($this->inspectResponseDefinition($response, $declared['method'], (string) $path, (string) $status, $label, $issues)) {
+                        $responseCount++;
+                    }
+                }
             }
         }
 
         return [$operationCount, $responseCount];
+    }
+
+    /**
+     * Mirror the response-side runtime guards so doctor never reports a
+     * response as enforceable when validation would reject its structure.
+     *
+     * @param list<DoctorIssue> $issues
+     */
+    private function inspectResponseDefinition(
+        mixed $response,
+        string $method,
+        string $path,
+        string $status,
+        string $label,
+        array &$issues,
+    ): bool {
+        $location = sprintf('responses[%s]', $status);
+        if (MalformedSpecNode::isMalformed($response)) {
+            $issues[] = $this->malformedStructureIssue($label, $method, $path, $location, $response);
+
+            return false;
+        }
+
+        if (!array_key_exists('content', $response)) {
+            return true;
+        }
+
+        $content = $response['content'];
+        if (MalformedSpecNode::isMalformed($content)) {
+            $issues[] = $this->malformedStructureIssue($label, $method, $path, $location . '.content', $content);
+
+            return false;
+        }
+
+        $valid = true;
+        foreach ($content as $mediaType => $mediaTypeSpec) {
+            $mediaLocation = sprintf('%s.content["%s"]', $location, (string) $mediaType);
+            if (MalformedSpecNode::isMalformed($mediaTypeSpec)) {
+                $issues[] = $this->malformedStructureIssue($label, $method, $path, $mediaLocation, $mediaTypeSpec);
+                $valid = false;
+
+                continue;
+            }
+
+            foreach (['schema', 'itemSchema'] as $schemaKey) {
+                if (!array_key_exists($schemaKey, $mediaTypeSpec) || !MalformedSpecNode::isMalformed($mediaTypeSpec[$schemaKey])) {
+                    continue;
+                }
+                $issues[] = $this->malformedStructureIssue(
+                    $label,
+                    $method,
+                    $path,
+                    $mediaLocation . '.' . $schemaKey,
+                    $mediaTypeSpec[$schemaKey],
+                );
+                $valid = false;
+            }
+        }
+
+        return $valid;
+    }
+
+    /** @return DoctorIssue */
+    private function malformedStructureIssue(
+        string $label,
+        string $method,
+        string $path,
+        string $location,
+        mixed $node,
+    ): array {
+        return $this->issue(
+            'error',
+            'structure',
+            $label,
+            sprintf('Malformed `%s` for %s %s: expected object, got %s.', $location, $method, $path, MalformedSpecNode::describe($node)),
+            null,
+        );
     }
 
     /** @param array<string, mixed> $spec */

--- a/src/Cli/DoctorCommand.php
+++ b/src/Cli/DoctorCommand.php
@@ -1,0 +1,646 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Cli;
+
+use const E_USER_WARNING;
+use const ENT_QUOTES;
+use const ENT_XML1;
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+use const PATHINFO_DIRNAME;
+use const PATHINFO_EXTENSION;
+use const PATHINFO_FILENAME;
+use const STDERR;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\HttpFactory;
+use InvalidArgumentException;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecException;
+use Studio\OpenApiContractTesting\Exception\SpecFileNotFoundException;
+use Studio\OpenApiContractTesting\OpenApiVersion;
+use Studio\OpenApiContractTesting\Spec\OpenApiOperationResolver;
+use Studio\OpenApiContractTesting\Spec\OpenApiSchemaConverter;
+use Studio\OpenApiContractTesting\Spec\OpenApiSchemaDialect;
+use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+use Symfony\Component\HttpClient\Psr18Client;
+use Throwable;
+
+use function array_filter;
+use function array_map;
+use function array_values;
+use function class_exists;
+use function compact;
+use function count;
+use function dirname;
+use function explode;
+use function fwrite;
+use function get_debug_type;
+use function getcwd;
+use function htmlspecialchars;
+use function implode;
+use function in_array;
+use function is_array;
+use function is_callable;
+use function is_file;
+use function is_readable;
+use function is_string;
+use function json_encode;
+use function pathinfo;
+use function realpath;
+use function restore_error_handler;
+use function rtrim;
+use function set_error_handler;
+use function sprintf;
+use function str_contains;
+use function str_replace;
+use function str_starts_with;
+use function strlen;
+use function strtoupper;
+use function substr;
+
+/**
+ * Pre-test compatibility diagnostics for one or more OpenAPI documents.
+ *
+ * @phpstan-type DoctorOptions array{specs?: list<string>, strip_prefixes?: list<string>, format?: string, allow_remote_refs?: bool, phpunit_snippet?: bool, help?: bool, invalid_options?: list<string>}
+ * @phpstan-type DoctorIssue array{severity: 'error'|'warning'|'skipped', category: string, spec: ?string, message: string, suggestion: ?string}
+ * @phpstan-type SpecResult array{path: string, name: string, openapi: string, dialect: string, operations: int, responses: int}
+ *
+ * @internal The `openapi-contract doctor` CLI is the supported API.
+ */
+final class DoctorCommand
+{
+    public const JSON_SCHEMA_VERSION = 1;
+    public const EXIT_OK = 0;
+    public const EXIT_DIAGNOSTIC_FAILURE = 1;
+    public const EXIT_USAGE = 2;
+
+    /** @param null|callable(string): void $stdoutWriter */
+    public function __construct(
+        private mixed $stdoutWriter = null,
+        private mixed $stderrWriter = null,
+        private mixed $remoteTransportFactory = null,
+    ) {}
+
+    /**
+     * @param list<string> $argv
+     *
+     * @return DoctorOptions
+     */
+    public static function parseArgv(array $argv): array
+    {
+        $options = ['specs' => [], 'strip_prefixes' => [], 'invalid_options' => []];
+
+        foreach ($argv as $arg) {
+            if ($arg === 'doctor') {
+                continue;
+            }
+            if ($arg === '--help' || $arg === '-h') {
+                $options['help'] = true;
+
+                continue;
+            }
+            if (!str_starts_with($arg, '--')) {
+                $options['invalid_options'][] = $arg;
+
+                continue;
+            }
+
+            $option = substr($arg, 2);
+            [$name, $value] = str_contains($option, '=') ? explode('=', $option, 2) : [$option, 'true'];
+            $name = str_replace('-', '_', $name);
+
+            switch ($name) {
+                case 'spec':
+                    $options['specs'] = [
+                        ...$options['specs'],
+                        ...array_values(array_filter(array_map('trim', explode(',', $value)), static fn(string $item): bool => $item !== '')),
+                    ];
+
+                    break;
+                case 'strip_prefix':
+                    $options['strip_prefixes'] = [
+                        ...$options['strip_prefixes'],
+                        ...array_values(array_filter(array_map('trim', explode(',', $value)), static fn(string $item): bool => $item !== '')),
+                    ];
+
+                    break;
+                case 'format':
+                    $options['format'] = $value;
+
+                    break;
+                case 'allow_remote_refs':
+                    $options['allow_remote_refs'] = !in_array($value, ['0', 'false', 'no'], true);
+
+                    break;
+                case 'phpunit_snippet':
+                    $options['phpunit_snippet'] = !in_array($value, ['0', 'false', 'no'], true);
+
+                    break;
+                default:
+                    $options['invalid_options'][] = '--' . str_replace('_', '-', $name);
+            }
+        }
+
+        return $options;
+    }
+
+    public static function usage(): string
+    {
+        return <<<'USAGE'
+            openapi-contract doctor — check whether this package can load and enforce your contract.
+
+            Usage:
+              openapi-contract doctor --spec=<path> [--spec=<path> ...] [options]
+
+            Options:
+              --spec=<path[,path]>       JSON/YAML entry document. Repeat for multiple specs.
+              --strip-prefix=<prefix>    Request-path prefix used by PHPUnit. Repeat as needed.
+              --format=text|json         Output format (default: text).
+              --allow-remote-refs        Resolve HTTP(S) refs with an installed Guzzle or
+                                         Symfony PSR-18 implementation.
+              --phpunit-snippet          Include the equivalent PHPUnit extension XML.
+              --help                     Show this message.
+
+            Exit codes:
+              0  All specs are compatible (warnings/skipped features may be present).
+              1  A spec cannot be loaded or enforced.
+              2  Command-line usage is invalid.
+
+            USAGE;
+    }
+
+    /** @param DoctorOptions $options */
+    public function run(array $options): int
+    {
+        if (($options['help'] ?? false) === true) {
+            $this->writeStdout(self::usage());
+
+            return self::EXIT_OK;
+        }
+
+        $format = $options['format'] ?? 'text';
+        $invalid = $options['invalid_options'] ?? [];
+        if (!in_array($format, ['text', 'json'], true) || $invalid !== [] || ($options['specs'] ?? []) === []) {
+            $message = $invalid !== []
+                ? 'Unknown argument(s): ' . implode(', ', $invalid)
+                : (($options['specs'] ?? []) === [] ? 'At least one --spec is required.' : "Unsupported --format={$format}.");
+            $this->writeStderr("[OpenAPI Doctor] {$message}\n\n" . self::usage());
+
+            return self::EXIT_USAGE;
+        }
+
+        $allowRemoteRefs = $options['allow_remote_refs'] ?? false;
+        $transport = $allowRemoteRefs ? $this->remoteTransport() : null;
+        if ($allowRemoteRefs && $transport === null) {
+            $report = $this->report([], [[
+                'severity' => 'error',
+                'category' => 'dependency',
+                'spec' => null,
+                'message' => '--allow-remote-refs requires an installed PSR-18/PSR-17 implementation.',
+                'suggestion' => 'Install guzzlehttp/guzzle + guzzlehttp/psr7, or symfony/http-client.',
+            ]], $options);
+            $this->render($report, $format);
+
+            return self::EXIT_DIAGNOSTIC_FAILURE;
+        }
+
+        $specResults = [];
+        $issues = [];
+        foreach ($options['specs'] as $path) {
+            $this->diagnoseSpec($path, $options['strip_prefixes'] ?? [], $allowRemoteRefs, $transport, $specResults, $issues);
+        }
+
+        $report = $this->report($specResults, $issues, $options);
+        $this->render($report, $format);
+
+        foreach ($issues as $issue) {
+            if ($issue['severity'] === 'error') {
+                return self::EXIT_DIAGNOSTIC_FAILURE;
+            }
+        }
+
+        return self::EXIT_OK;
+    }
+
+    /**
+     * @param list<string> $stripPrefixes
+     * @param null|array{0: ClientInterface, 1: RequestFactoryInterface} $transport
+     * @param list<SpecResult> $specResults
+     * @param list<DoctorIssue> $issues
+     */
+    private function diagnoseSpec(
+        string $inputPath,
+        array $stripPrefixes,
+        bool $allowRemoteRefs,
+        ?array $transport,
+        array &$specResults,
+        array &$issues,
+    ): void {
+        $path = $this->absolutise($inputPath);
+        $label = $inputPath;
+        if (!is_file($path) || !is_readable($path)) {
+            $issues[] = $this->issue('error', 'io', $label, "Spec is not a readable file: {$path}", 'Check the path and file permissions.');
+
+            return;
+        }
+
+        $extension = pathinfo($path, PATHINFO_EXTENSION);
+        if (!in_array($extension, ['json', 'yaml', 'yml'], true)) {
+            $issues[] = $this->issue('error', 'parser', $label, "Unsupported spec extension: .{$extension}", 'Use .json, .yaml, or .yml.');
+
+            return;
+        }
+
+        $name = pathinfo($path, PATHINFO_FILENAME);
+        $basePath = pathinfo($path, PATHINFO_DIRNAME);
+        foreach (['json', 'yaml', 'yml'] as $candidateExtension) {
+            $candidate = $basePath . '/' . $name . '.' . $candidateExtension;
+            if (!is_file($candidate)) {
+                continue;
+            }
+            if (realpath($candidate) !== realpath($path)) {
+                $issues[] = $this->issue(
+                    'error',
+                    'configuration',
+                    $label,
+                    sprintf('The runtime loader selects `%s` before the requested `%s`.', $candidate, $path),
+                    'Remove or rename the shadowing entry document so the doctor and PHPUnit select the same spec.',
+                );
+
+                return;
+            }
+
+            break;
+        }
+        $warnings = [];
+        set_error_handler(static function (int $severity, string $message) use (&$warnings): bool {
+            if ($severity !== E_USER_WARNING) {
+                return false;
+            }
+            $warnings[] = $message;
+
+            return true;
+        }, E_USER_WARNING);
+
+        try {
+            OpenApiSpecLoader::reset();
+            OpenApiSchemaConverter::resetWarningStateForTesting();
+            OpenApiSpecLoader::configure(
+                $basePath,
+                $stripPrefixes,
+                $transport[0] ?? null,
+                $transport[1] ?? null,
+                $allowRemoteRefs,
+            );
+            $spec = OpenApiSpecLoader::load($name);
+            $version = OpenApiVersion::fromSpec($spec);
+            $dialect = OpenApiSchemaDialect::fromSpec($spec, $version);
+            [$operations, $responses] = $this->inspectStructure($spec, $label, $issues);
+            $this->inspectSchemas($spec, $version, $dialect);
+            $this->inspectSkippedFeatures($spec, $label, $issues);
+
+            $specResults[] = [
+                'path' => $path,
+                'name' => $name,
+                'openapi' => is_string($spec['openapi'] ?? null) ? $spec['openapi'] : $version->value,
+                'dialect' => $dialect,
+                'operations' => $operations,
+                'responses' => $responses,
+            ];
+        } catch (InvalidOpenApiSpecException $e) {
+            $issues[] = $this->issue('error', $this->categoryForException($e), $label, $e->getMessage(), $this->suggestionForException($e));
+        } catch (InvalidArgumentException|SpecFileNotFoundException $e) {
+            $issues[] = $this->issue('error', 'configuration', $label, $e->getMessage(), null);
+        } catch (Throwable $e) {
+            $issues[] = $this->issue('error', 'internal', $label, $e->getMessage(), 'Report this diagnostic failure with the spec and stack trace.');
+        } finally {
+            restore_error_handler();
+            OpenApiSpecLoader::reset();
+            OpenApiSchemaConverter::resetWarningStateForTesting();
+        }
+
+        foreach ($warnings as $warning) {
+            $issues[] = $this->issue('warning', $this->warningCategory($warning), $label, $warning, null);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $spec
+     * @param list<DoctorIssue> $issues
+     *
+     * @return array{0: int, 1: int}
+     */
+    private function inspectStructure(array $spec, string $label, array &$issues): array
+    {
+        $paths = $spec['paths'] ?? null;
+        if (!is_array($paths)) {
+            $issues[] = $this->issue('error', 'structure', $label, sprintf('`paths` must be an object, got %s.', get_debug_type($paths)), null);
+
+            return [0, 0];
+        }
+
+        $operationCount = 0;
+        $responseCount = 0;
+        foreach ($paths as $path => $pathItem) {
+            if (!is_array($pathItem)) {
+                $issues[] = $this->issue('error', 'structure', $label, sprintf('Path `%s` must be an object, got %s.', (string) $path, get_debug_type($pathItem)), null);
+
+                continue;
+            }
+            foreach (OpenApiOperationResolver::declaredOperations($pathItem) as $declared) {
+                $operation = $declared['operation'];
+                if (!is_array($operation)) {
+                    $issues[] = $this->issue('error', 'structure', $label, sprintf('Operation `%s %s` must be an object, got %s.', $declared['method'], (string) $path, get_debug_type($operation)), null);
+
+                    continue;
+                }
+                $operationCount++;
+                if (!is_array($operation['responses'] ?? null)) {
+                    $issues[] = $this->issue('error', 'structure', $label, sprintf('Operation `%s %s` has no valid `responses` object.', $declared['method'], (string) $path), null);
+
+                    continue;
+                }
+                $responseCount += count($operation['responses']);
+            }
+        }
+
+        return [$operationCount, $responseCount];
+    }
+
+    /** @param array<string, mixed> $spec */
+    private function inspectSchemas(array $spec, OpenApiVersion $version, string $dialect): void
+    {
+        $this->walkForSchemas($spec, $version, $dialect, null);
+    }
+
+    /** @param array<mixed> $node */
+    private function walkForSchemas(array $node, OpenApiVersion $version, string $dialect, ?string $parentKey): void
+    {
+        if ($parentKey === 'schema') {
+            /** @var array<string, mixed> $node */
+            OpenApiSchemaConverter::convert($node, $version, jsonSchemaDialect: $dialect);
+
+            return;
+        }
+
+        foreach ($node as $key => $value) {
+            if (!is_array($value)) {
+                continue;
+            }
+            if ($key === 'schemas') {
+                foreach ($value as $schema) {
+                    if (is_array($schema)) {
+                        /** @var array<string, mixed> $schema */
+                        OpenApiSchemaConverter::convert($schema, $version, jsonSchemaDialect: $dialect);
+                    }
+                }
+
+                continue;
+            }
+            $this->walkForSchemas($value, $version, $dialect, is_string($key) ? $key : null);
+        }
+    }
+
+    /** @return null|array{0: ClientInterface, 1: RequestFactoryInterface} */
+    private function remoteTransport(): ?array
+    {
+        if (is_callable($this->remoteTransportFactory)) {
+            $transport = ($this->remoteTransportFactory)();
+            if (is_array($transport) &&
+                ($transport[0] ?? null) instanceof ClientInterface &&
+                ($transport[1] ?? null) instanceof RequestFactoryInterface
+            ) {
+                return [$transport[0], $transport[1]];
+            }
+
+            return null;
+        }
+        if (class_exists(Client::class) && class_exists(HttpFactory::class)) {
+            return [new Client(), new HttpFactory()];
+        }
+        if (class_exists(Psr18Client::class)) {
+            $client = new Psr18Client();
+            if ($client instanceof ClientInterface && $client instanceof RequestFactoryInterface) {
+                return [$client, $client];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $spec
+     * @param list<DoctorIssue> $issues
+     */
+    private function inspectSkippedFeatures(array $spec, string $label, array &$issues): void
+    {
+        $schemes = $spec['components']['securitySchemes'] ?? null;
+        if (!is_array($schemes)) {
+            return;
+        }
+
+        foreach ($schemes as $name => $scheme) {
+            if (!is_array($scheme)) {
+                continue;
+            }
+            $type = $scheme['type'] ?? null;
+            $isUnsupportedHttp = $type === 'http' && ($scheme['scheme'] ?? null) !== 'bearer';
+            if (!in_array($type, ['oauth2', 'openIdConnect', 'mutualTLS'], true) && !$isUnsupportedHttp) {
+                continue;
+            }
+            $issues[] = $this->issue(
+                'skipped',
+                'feature',
+                $label,
+                sprintf('Security scheme `%s` (%s) is recognized but not enforced.', (string) $name, $type),
+                'Keep a separate authentication test until this scheme is supported.',
+            );
+        }
+    }
+
+    /**
+     * @param list<SpecResult> $specs
+     * @param list<DoctorIssue> $issues
+     * @param DoctorOptions $options
+     *
+     * @return array<string, mixed>
+     */
+    private function report(array $specs, array $issues, array $options): array
+    {
+        $counts = ['errors' => 0, 'warnings' => 0, 'skipped' => 0];
+        foreach ($issues as $issue) {
+            $countKey = $issue['severity'] === 'skipped' ? 'skipped' : $issue['severity'] . 's';
+            $counts[$countKey]++;
+        }
+        $operations = 0;
+        $responses = 0;
+        foreach ($specs as $spec) {
+            $operations += $spec['operations'];
+            $responses += $spec['responses'];
+        }
+
+        return [
+            'schemaVersion' => self::JSON_SCHEMA_VERSION,
+            'status' => $counts['errors'] > 0 ? 'error' : ($counts['warnings'] > 0 || $counts['skipped'] > 0 ? 'warning' : 'ok'),
+            'summary' => [
+                'specs' => count($specs),
+                'operations' => $operations,
+                'responses' => $responses,
+                ...$counts,
+            ],
+            'specs' => $specs,
+            'issues' => $issues,
+            'phpunit' => ($options['phpunit_snippet'] ?? false) ? $this->phpunitSnippet($specs, $options['strip_prefixes'] ?? []) : null,
+        ];
+    }
+
+    /** @param array<string, mixed> $report */
+    private function render(array $report, string $format): void
+    {
+        if ($format === 'json') {
+            $this->writeStdout(json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n");
+
+            return;
+        }
+
+        /** @var array{specs: int, operations: int, responses: int, errors: int, warnings: int, skipped: int} $summary */
+        $summary = $report['summary'];
+        $lines = [
+            sprintf('OpenAPI Doctor: %s', $report['status'] === 'error' ? 'FAILED' : 'COMPATIBLE'),
+            sprintf('Specs: %d | Operations: %d | Responses: %d', $summary['specs'], $summary['operations'], $summary['responses']),
+        ];
+        foreach ($report['specs'] as $spec) {
+            $lines[] = sprintf('  OK %s (OpenAPI %s, %d operations, %d responses)', $spec['path'], $spec['openapi'], $spec['operations'], $spec['responses']);
+        }
+        foreach ($report['issues'] as $issue) {
+            $lines[] = sprintf('  %s [%s]%s %s', strtoupper($issue['severity']), $issue['category'], $issue['spec'] !== null ? ' ' . $issue['spec'] . ':' : '', $issue['message']);
+            if ($issue['suggestion'] !== null) {
+                $lines[] = '    Fix: ' . $issue['suggestion'];
+            }
+        }
+        $lines[] = sprintf('Errors: %d | Warnings: %d | Skipped: %d', $summary['errors'], $summary['warnings'], $summary['skipped']);
+        if (is_string($report['phpunit'])) {
+            $lines[] = "\nEquivalent PHPUnit configuration:\n" . $report['phpunit'];
+        }
+        $this->writeStdout(implode("\n", $lines) . "\n");
+    }
+
+    /**
+     * @param list<SpecResult> $specs
+     * @param list<string> $stripPrefixes
+     */
+    private function phpunitSnippet(array $specs, array $stripPrefixes): ?string
+    {
+        if ($specs === []) {
+            return null;
+        }
+        $basePath = dirname($specs[0]['path']);
+        foreach ($specs as $spec) {
+            if (dirname($spec['path']) !== $basePath) {
+                return '<!-- Specs use different directories; one PHPUnit extension instance requires a shared spec_base_path. -->';
+            }
+        }
+        $names = implode(',', array_map(static fn(array $spec): string => $spec['name'], $specs));
+        $prefixes = implode(',', $stripPrefixes);
+        $cwd = getcwd();
+        if ($cwd !== false && str_starts_with($basePath, rtrim($cwd, '/') . '/')) {
+            $basePath = substr($basePath, strlen(rtrim($cwd, '/')) + 1);
+        }
+        $basePath = htmlspecialchars($basePath, ENT_XML1 | ENT_QUOTES, 'UTF-8');
+        $names = htmlspecialchars($names, ENT_XML1 | ENT_QUOTES, 'UTF-8');
+        $prefixLine = $prefixes === '' ? '' : "\n        <parameter name=\"strip_prefixes\" value=\"" . htmlspecialchars($prefixes, ENT_XML1 | ENT_QUOTES, 'UTF-8') . '"/>';
+
+        return <<<XML
+            <extensions>
+                <bootstrap class="Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension">
+                    <parameter name="spec_base_path" value="{$basePath}"/>
+                    <parameter name="specs" value="{$names}"/>{$prefixLine}
+                </bootstrap>
+            </extensions>
+            XML;
+    }
+
+    private function categoryForException(InvalidOpenApiSpecException $e): string
+    {
+        $reason = $e->reason->name;
+        if (str_contains($reason, 'Ref') || $reason === 'CircularRef') {
+            return 'references';
+        }
+        if (str_contains($reason, 'Dialect')) {
+            return 'dialect';
+        }
+        if (str_contains($reason, 'Version')) {
+            return 'version';
+        }
+        if (str_contains($reason, 'Yaml') || str_contains($reason, 'Json') || $reason === 'NonMappingRoot') {
+            return 'parser';
+        }
+
+        return 'spec';
+    }
+
+    private function suggestionForException(InvalidOpenApiSpecException $e): ?string
+    {
+        return match ($e->reason->name) {
+            'YamlLibraryMissing' => 'Run: composer require --dev symfony/yaml',
+            'RemoteRefDisallowed' => 'Re-run with --allow-remote-refs and install a supported PSR-18 implementation, or bundle the spec.',
+            'HttpClientNotConfigured' => 'Install Guzzle or Symfony HttpClient and re-run with --allow-remote-refs.',
+            default => null,
+        };
+    }
+
+    private function warningCategory(string $warning): string
+    {
+        if (str_contains($warning, '$self')) {
+            return 'references';
+        }
+        if (str_contains($warning, 'keyword') || str_contains($warning, 'format')) {
+            return 'keyword';
+        }
+
+        return 'compatibility';
+    }
+
+    /** @return DoctorIssue */
+    private function issue(string $severity, string $category, ?string $spec, string $message, ?string $suggestion): array
+    {
+        /** @var 'error'|'skipped'|'warning' $severity */
+        return compact('severity', 'category', 'spec', 'message', 'suggestion');
+    }
+
+    private function absolutise(string $path): string
+    {
+        if (str_starts_with($path, '/')) {
+            return $path;
+        }
+        $cwd = getcwd();
+        $absolute = rtrim($cwd !== false ? $cwd : '.', '/') . '/' . $path;
+
+        return realpath($absolute) ?: $absolute;
+    }
+
+    private function writeStdout(string $message): void
+    {
+        if (is_callable($this->stdoutWriter)) {
+            ($this->stdoutWriter)($message);
+
+            return;
+        }
+        echo $message;
+    }
+
+    private function writeStderr(string $message): void
+    {
+        if (is_callable($this->stderrWriter)) {
+            ($this->stderrWriter)($message);
+
+            return;
+        }
+        fwrite(STDERR, $message);
+    }
+}

--- a/tests/Integration/DoctorCliIntegrationTest.php
+++ b/tests/Integration/DoctorCliIntegrationTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Integration;
+
+use const JSON_THROW_ON_ERROR;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function dirname;
+use function escapeshellarg;
+use function fclose;
+use function is_resource;
+use function json_decode;
+use function proc_close;
+use function proc_open;
+use function realpath;
+use function sprintf;
+use function stream_get_contents;
+
+class DoctorCliIntegrationTest extends TestCase
+{
+    private string $repoRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repoRoot = realpath(__DIR__ . '/../..') ?: dirname(__DIR__, 2);
+    }
+
+    #[Test]
+    public function composer_bin_diagnoses_json_yaml_local_refs_and_multiple_specs(): void
+    {
+        [$exit, $stdout, $stderr] = $this->runCli([
+            'doctor',
+            '--spec=tests/fixtures/specs/petstore-3.0.json',
+            '--spec=tests/fixtures/specs/external-refs/multi-file.yaml',
+            '--format=json',
+        ]);
+
+        $this->assertSame(0, $exit, "stderr: {$stderr}\nstdout: {$stdout}");
+        $report = json_decode($stdout, true, flags: JSON_THROW_ON_ERROR);
+        $this->assertSame(1, $report['schemaVersion']);
+        $this->assertSame(2, $report['summary']['specs']);
+        $this->assertGreaterThan(0, $report['summary']['operations']);
+    }
+
+    #[Test]
+    public function composer_bin_reports_malformed_and_http_ref_configuration_failures(): void
+    {
+        [$malformedExit, $malformedOutput] = $this->runCli([
+            'doctor',
+            '--spec=tests/fixtures/specs/malformed-json.json',
+            '--format=json',
+        ]);
+        $this->assertSame(1, $malformedExit);
+        $this->assertSame('parser', json_decode($malformedOutput, true, flags: JSON_THROW_ON_ERROR)['issues'][0]['category']);
+
+        [$httpExit, $httpOutput] = $this->runCli([
+            'doctor',
+            '--spec=tests/fixtures/specs/http-ref.json',
+            '--format=json',
+        ]);
+        $httpReport = json_decode($httpOutput, true, flags: JSON_THROW_ON_ERROR);
+        $this->assertSame(1, $httpExit);
+        $this->assertSame('references', $httpReport['issues'][0]['category']);
+        $this->assertStringContainsString('--allow-remote-refs', $httpReport['issues'][0]['suggestion']);
+    }
+
+    #[Test]
+    public function composer_bin_help_documents_exit_codes(): void
+    {
+        [$exit, $stdout] = $this->runCli(['doctor', '--help']);
+
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('Exit codes:', $stdout);
+        $this->assertStringContainsString('--spec', $stdout);
+    }
+
+    /**
+     * @param list<string> $args
+     *
+     * @return array{0: int, 1: string, 2: string}
+     */
+    private function runCli(array $args): array
+    {
+        $command = sprintf('php %s', escapeshellarg($this->repoRoot . '/bin/openapi-contract'));
+        foreach ($args as $arg) {
+            $command .= ' ' . escapeshellarg($arg);
+        }
+        $process = proc_open($command, [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes, $this->repoRoot);
+        if (!is_resource($process)) {
+            $this->fail('failed to spawn doctor CLI');
+        }
+        $stdout = (string) stream_get_contents($pipes[1]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        foreach ($pipes as $pipe) {
+            fclose($pipe);
+        }
+
+        return [proc_close($process), $stdout, $stderr];
+    }
+}

--- a/tests/Integration/DoctorCliIntegrationTest.php
+++ b/tests/Integration/DoctorCliIntegrationTest.php
@@ -70,6 +70,22 @@ class DoctorCliIntegrationTest extends TestCase
     }
 
     #[Test]
+    public function composer_bin_rejects_malformed_response_object(): void
+    {
+        [$exit, $stdout] = $this->runCli([
+            'doctor',
+            '--spec=tests/fixtures/specs/malformed-response.json',
+            '--format=json',
+        ]);
+        $report = json_decode($stdout, true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $exit);
+        $this->assertSame('error', $report['status']);
+        $this->assertSame(0, $report['summary']['responses']);
+        $this->assertStringContainsString('responses[200]', $report['issues'][0]['message']);
+    }
+
+    #[Test]
     public function composer_bin_help_documents_exit_codes(): void
     {
         [$exit, $stdout] = $this->runCli(['doctor', '--help']);

--- a/tests/Unit/Cli/DoctorCommandTest.php
+++ b/tests/Unit/Cli/DoctorCommandTest.php
@@ -232,6 +232,48 @@ class DoctorCommandTest extends TestCase
         }
     }
 
+    #[Test]
+    public function rejects_malformed_discriminator_in_response_schema_with_default_enforcement(): void
+    {
+        $spec = $this->writeSpec('response-discriminator.json', (string) json_encode([
+            'openapi' => '3.1.0',
+            'info' => ['title' => 'Test', 'version' => '1'],
+            'paths' => ['/pets' => ['get' => ['responses' => ['200' => [
+                'description' => 'ok',
+                'content' => ['application/json' => ['schema' => [
+                    'type' => 'object',
+                    'discriminator' => ['propertyName' => 'type', 'mapping' => 'not-an-object'],
+                ]]],
+            ]]]]],
+        ], JSON_THROW_ON_ERROR));
+        $report = $this->runJsonDoctor($spec, $exit);
+
+        $this->assertSame(DoctorCommand::EXIT_DIAGNOSTIC_FAILURE, $exit);
+        $this->assertSame('error', $report['status']);
+        $this->assertSame('structure', $report['issues'][0]['category']);
+        $this->assertStringContainsString('discriminator.mapping', $report['issues'][0]['message']);
+    }
+
+    #[Test]
+    public function rejects_malformed_discriminator_in_component_schema_with_default_enforcement(): void
+    {
+        $spec = $this->writeSpec('component-discriminator.json', (string) json_encode([
+            'openapi' => '3.1.0',
+            'info' => ['title' => 'Test', 'version' => '1'],
+            'paths' => [],
+            'components' => ['schemas' => ['Pet' => [
+                'type' => 'object',
+                'discriminator' => ['propertyName' => 'type', 'mapping' => 'not-an-object'],
+            ]]],
+        ], JSON_THROW_ON_ERROR));
+        $report = $this->runJsonDoctor($spec, $exit);
+
+        $this->assertSame(DoctorCommand::EXIT_DIAGNOSTIC_FAILURE, $exit);
+        $this->assertSame('error', $report['status']);
+        $this->assertSame('structure', $report['issues'][0]['category']);
+        $this->assertStringContainsString('discriminator.mapping', $report['issues'][0]['message']);
+    }
+
     private function writeSpec(string $name, string $contents): string
     {
         $path = $this->workDir . '/' . $name;

--- a/tests/Unit/Cli/DoctorCommandTest.php
+++ b/tests/Unit/Cli/DoctorCommandTest.php
@@ -197,6 +197,41 @@ class DoctorCommandTest extends TestCase
         $this->assertSame(['skipped', 'warning'], array_column($report['issues'], 'severity'));
     }
 
+    #[Test]
+    public function rejects_malformed_response_objects_instead_of_counting_them(): void
+    {
+        $spec = $this->writeSpec('response-null.json', $this->specWithResponse(null));
+        $report = $this->runJsonDoctor($spec, $exit);
+
+        $this->assertSame(DoctorCommand::EXIT_DIAGNOSTIC_FAILURE, $exit);
+        $this->assertSame('error', $report['status']);
+        $this->assertSame(0, $report['summary']['responses']);
+        $this->assertSame('structure', $report['issues'][0]['category']);
+        $this->assertStringContainsString('responses[200]', $report['issues'][0]['message']);
+        $this->assertStringContainsString('got null', $report['issues'][0]['message']);
+    }
+
+    #[Test]
+    public function rejects_nested_response_nodes_using_runtime_malformed_node_rules(): void
+    {
+        $cases = [
+            ['content' => null],
+            ['content' => ['application/json' => null]],
+            ['content' => ['application/json' => ['schema' => null]]],
+            ['content' => ['application/json' => ['schema' => [['type' => 'string']]]]],
+            ['content' => ['application/json' => ['itemSchema' => 'string']]],
+        ];
+
+        foreach ($cases as $index => $response) {
+            $spec = $this->writeSpec("response-malformed-{$index}.json", $this->specWithResponse($response));
+            $report = $this->runJsonDoctor($spec, $exit);
+
+            $this->assertSame(DoctorCommand::EXIT_DIAGNOSTIC_FAILURE, $exit, "case {$index}");
+            $this->assertSame(0, $report['summary']['responses'], "case {$index}");
+            $this->assertSame('structure', $report['issues'][0]['category'], "case {$index}");
+        }
+    }
+
     private function writeSpec(string $name, string $contents): string
     {
         $path = $this->workDir . '/' . $name;
@@ -212,5 +247,30 @@ class DoctorCommandTest extends TestCase
             'info' => ['title' => 'Test', 'version' => '1'],
             'paths' => [$path => ['get' => ['responses' => ['200' => ['description' => 'ok']]]]],
         ], JSON_THROW_ON_ERROR);
+    }
+
+    private function specWithResponse(mixed $response): string
+    {
+        return (string) json_encode([
+            'openapi' => '3.1.0',
+            'info' => ['title' => 'Test', 'version' => '1'],
+            'paths' => ['/pets' => ['get' => ['responses' => ['200' => $response]]]],
+        ], JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param-out int $exit
+     *
+     * @return array<string, mixed>
+     */
+    private function runJsonDoctor(string $spec, ?int &$exit): array
+    {
+        $output = '';
+        $command = new DoctorCommand(stdoutWriter: static function (string $message) use (&$output): void {
+            $output .= $message;
+        });
+        $exit = $command->run(['specs' => [$spec], 'format' => 'json']);
+
+        return json_decode($output, true, flags: JSON_THROW_ON_ERROR);
     }
 }

--- a/tests/Unit/Cli/DoctorCommandTest.php
+++ b/tests/Unit/Cli/DoctorCommandTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Cli;
+
+use const JSON_THROW_ON_ERROR;
+
+use GuzzleHttp\Psr7\HttpFactory;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Cli\DoctorCommand;
+use Studio\OpenApiContractTesting\Tests\Helpers\FakeHttpClient;
+
+use function array_column;
+use function file_put_contents;
+use function glob;
+use function json_decode;
+use function json_encode;
+use function mkdir;
+use function rmdir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+class DoctorCommandTest extends TestCase
+{
+    private string $workDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->workDir = sys_get_temp_dir() . '/openapi-doctor-' . uniqid('', true);
+        mkdir($this->workDir);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->workDir . '/*') ?: [] as $path) {
+            @unlink($path);
+        }
+        @rmdir($this->workDir);
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function parses_repeatable_specs_and_prefixes(): void
+    {
+        $this->assertSame(
+            [
+                'specs' => ['front.json', 'admin.yaml'],
+                'strip_prefixes' => ['/api', '/internal'],
+                'invalid_options' => [],
+                'format' => 'json',
+                'allow_remote_refs' => true,
+                'phpunit_snippet' => true,
+            ],
+            DoctorCommand::parseArgv([
+                'doctor',
+                '--spec=front.json,admin.yaml',
+                '--strip-prefix=/api',
+                '--strip-prefix=/internal',
+                '--format=json',
+                '--allow-remote-refs',
+                '--phpunit-snippet',
+            ]),
+        );
+    }
+
+    #[Test]
+    public function reports_versioned_json_counts_for_multiple_specs(): void
+    {
+        $first = $this->writeSpec('front.json', $this->validSpec('/pets'));
+        $second = $this->writeSpec('admin.json', $this->validSpec('/users'));
+        $output = '';
+        $command = new DoctorCommand(stdoutWriter: static function (string $message) use (&$output): void {
+            $output .= $message;
+        });
+
+        $exit = $command->run([
+            'specs' => [$first, $second],
+            'strip_prefixes' => ['/api'],
+            'format' => 'json',
+            'phpunit_snippet' => true,
+        ]);
+
+        $this->assertSame(DoctorCommand::EXIT_OK, $exit);
+        $report = json_decode($output, true, flags: JSON_THROW_ON_ERROR);
+        $this->assertSame(DoctorCommand::JSON_SCHEMA_VERSION, $report['schemaVersion']);
+        $this->assertSame('ok', $report['status']);
+        $this->assertSame(2, $report['summary']['specs']);
+        $this->assertSame(2, $report['summary']['operations']);
+        $this->assertSame(2, $report['summary']['responses']);
+        $this->assertStringContainsString('spec_base_path', $report['phpunit']);
+        $this->assertStringContainsString('front,admin', $report['phpunit']);
+    }
+
+    #[Test]
+    public function malformed_and_unresolved_specs_exit_non_zero_with_stable_categories(): void
+    {
+        $malformed = $this->writeSpec('malformed.json', '{nope');
+        $unresolved = $this->writeSpec('unresolved.json', (string) json_encode([
+            'openapi' => '3.1.0',
+            'info' => ['title' => 'Test', 'version' => '1'],
+            'paths' => [],
+            'components' => ['schemas' => ['Missing' => ['$ref' => './missing.json']]],
+        ], JSON_THROW_ON_ERROR));
+
+        foreach ([[$malformed, 'parser'], [$unresolved, 'references']] as [$path, $category]) {
+            $output = '';
+            $command = new DoctorCommand(stdoutWriter: static function (string $message) use (&$output): void {
+                $output .= $message;
+            });
+            $exit = $command->run(['specs' => [$path], 'format' => 'json']);
+            $report = json_decode($output, true, flags: JSON_THROW_ON_ERROR);
+
+            $this->assertSame(DoctorCommand::EXIT_DIAGNOSTIC_FAILURE, $exit);
+            $this->assertSame('error', $report['status']);
+            $this->assertSame($category, $report['issues'][0]['category']);
+        }
+    }
+
+    #[Test]
+    public function resolves_http_refs_with_injected_psr_transport(): void
+    {
+        $url = 'https://example.com/pet.json';
+        $root = $this->writeSpec('remote.json', (string) json_encode([
+            'openapi' => '3.1.0',
+            'info' => ['title' => 'Test', 'version' => '1'],
+            'paths' => ['/pets' => ['get' => ['responses' => ['200' => [
+                'description' => 'ok',
+                'content' => ['application/json' => ['schema' => ['$ref' => $url]]],
+            ]]]]],
+        ], JSON_THROW_ON_ERROR));
+        $client = new FakeHttpClient([$url => FakeHttpClient::jsonResponse('{"type":"object"}')]);
+        $output = '';
+        $command = new DoctorCommand(
+            stdoutWriter: static function (string $message) use (&$output): void {
+                $output .= $message;
+            },
+            remoteTransportFactory: static fn(): array => [$client, new HttpFactory()],
+        );
+
+        $exit = $command->run(['specs' => [$root], 'format' => 'json', 'allow_remote_refs' => true]);
+        $report = json_decode($output, true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(DoctorCommand::EXIT_OK, $exit);
+        $this->assertSame('ok', $report['status']);
+        $this->assertSame([$url], $client->sentUrls());
+    }
+
+    #[Test]
+    public function fails_when_runtime_extension_priority_would_shadow_requested_spec(): void
+    {
+        $this->writeSpec('root.json', $this->validSpec('/json'));
+        $yaml = $this->writeSpec('root.yaml', "openapi: 3.1.0\ninfo: {title: Test, version: '1'}\npaths: {}\n");
+        $output = '';
+        $command = new DoctorCommand(stdoutWriter: static function (string $message) use (&$output): void {
+            $output .= $message;
+        });
+
+        $exit = $command->run(['specs' => [$yaml], 'format' => 'json']);
+        $report = json_decode($output, true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(DoctorCommand::EXIT_DIAGNOSTIC_FAILURE, $exit);
+        $this->assertSame('configuration', $report['issues'][0]['category']);
+        $this->assertStringContainsString('selects', $report['issues'][0]['message']);
+    }
+
+    #[Test]
+    public function separates_warning_and_skipped_feature_diagnostics(): void
+    {
+        $spec = $this->writeSpec('features.json', (string) json_encode([
+            'openapi' => '3.0.3',
+            'info' => ['title' => 'Test', 'version' => '1'],
+            'paths' => ['/pets' => ['get' => ['responses' => ['200' => [
+                'description' => 'ok',
+                'content' => ['application/json' => ['schema' => [
+                    'type' => 'object',
+                    'unevaluatedProperties' => false,
+                ]]],
+            ]]]]],
+            'components' => ['securitySchemes' => ['oauth' => ['type' => 'oauth2']]],
+        ], JSON_THROW_ON_ERROR));
+        $output = '';
+        $command = new DoctorCommand(stdoutWriter: static function (string $message) use (&$output): void {
+            $output .= $message;
+        });
+
+        $exit = $command->run(['specs' => [$spec], 'format' => 'json']);
+        $report = json_decode($output, true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(DoctorCommand::EXIT_OK, $exit);
+        $this->assertSame('warning', $report['status']);
+        $this->assertSame(1, $report['summary']['warnings']);
+        $this->assertSame(1, $report['summary']['skipped']);
+        $this->assertSame(['skipped', 'warning'], array_column($report['issues'], 'severity'));
+    }
+
+    private function writeSpec(string $name, string $contents): string
+    {
+        $path = $this->workDir . '/' . $name;
+        file_put_contents($path, $contents);
+
+        return $path;
+    }
+
+    private function validSpec(string $path): string
+    {
+        return (string) json_encode([
+            'openapi' => '3.1.0',
+            'info' => ['title' => 'Test', 'version' => '1'],
+            'paths' => [$path => ['get' => ['responses' => ['200' => ['description' => 'ok']]]]],
+        ], JSON_THROW_ON_ERROR);
+    }
+}

--- a/tests/fixtures/specs/http-ref.json
+++ b/tests/fixtures/specs/http-ref.json
@@ -1,0 +1,25 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "HTTP ref fixture",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/pets": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "ok",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "https://example.invalid/pet.json"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add the framework-agnostic `openapi-contract doctor` Composer binary
- diagnose JSON/YAML parsing, OpenAPI versions and dialects, local/HTTP references, schema compatibility warnings, skipped enforcement features, and operation/response counts
- provide versioned JSON output, actionable text output, documented exit codes, multi-spec support, and optional PHPUnit XML generation
- update the README quick start and add a complete doctor command reference

## Why

New users currently discover loader, optional dependency, reference, and schema compatibility problems only after wiring PHPUnit and running a real test. This command validates the package-specific enforcement path before that setup is complete without becoming a general-purpose OpenAPI style linter.

## Validation

- `vendor/bin/phpunit tests/Unit/Cli/DoctorCommandTest.php tests/Integration/DoctorCliIntegrationTest.php` (9 tests, 38 assertions)
- `vendor/bin/phpstan analyse --no-progress --debug --memory-limit=1G`
- `vendor/bin/php-cs-fixer fix --dry-run --diff --sequential --config=.php-cs-fixer.dist.php`
- `composer validate --strict --no-check-publish`
- `markdownlint-cli2 docs/doctor.md`

Closes #276
