### PR TITLE
feat(laravel): add OpenAPI route parity command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Validate your API responses against your OpenAPI specification during testing, a
 - **OpenAPI 3.0, 3.1 & 3.2 support** — Explicit version detection, including 3.2 `QUERY`, custom `additionalOperations`, form `querystring`, `discriminator.defaultMapping`, and observable streaming limitations
 - **Response & request validation** — dialect-aware JSON Schema via opis/json-schema: Draft 07 compatibility for OpenAPI 3.0 and native 2020-12 semantics for OpenAPI 3.1/3.2; `application/json` and any `+json` content type
 - **Endpoint coverage tracking** — Unique PHPUnit extension that reports which spec endpoints are covered by tests, at `(method, path, status, content-type)` granularity
+- **Laravel route/spec parity** — `openapi:routes` finds documented operations without routes and registered routes without OpenAPI operations, with filters, stable JSON, and independent CI gates
 - **Schema-driven request fuzzing** — `ExploresOpenApiEndpoint` trait generates N happy-path inputs straight from the spec (Schemathesis-style)
 - **Enum drift detection** — Static comparison between PHP backed enums and their `enum:` spec arrays, with PHPUnit-extension auto-discovery
 - **Schema under-description detection** — Optional strict mode that flags response fields the implementation always returns but the spec marks as optional, catching the spec gaps that conformance checks alone can't. See [`docs/strict-required.md`](docs/strict-required.md) for current scope and limitations.
@@ -36,7 +37,7 @@ Validate your API responses against your OpenAPI specification during testing, a
 Choose based on the workflow you need rather than on a single yes/no feature count:
 
 - Choose **this library** when you need response-level coverage at `(method, path, status, content-type)` granularity, several CI report formats, OpenAPI 3.1/3.2 JSON Schema semantics, schema-driven exploration, or drift detection across a framework-agnostic core and Laravel, Symfony, and Pest adapters.
-- Choose **[Spectator][spectator]** for a Laravel 12 application when route/spec parity, Artisan diagnostics, generated test stubs, JSON assertion failures, or remote/private-GitHub spec sources matter more than response-level coverage granularity.
+- Choose **[Spectator][spectator]** for a Laravel 12 application when generated test stubs, JSON assertion failures, or remote/private-GitHub spec sources matter more than response-level coverage granularity and broader framework support.
 - Choose **[league/openapi-psr7-validator][league]** when you want a low-level PSR-7 validator or PSR-15 middleware and will build the test/reporting integration yourself.
 - Choose **[osteel/openapi-httpfoundation-testing][osteel]** when you want a small HttpFoundation-to-PSR-7 validation bridge, or **[laravel-openapi-validator][kirschbaum]** when automatic validation around Laravel HTTP tests is the main requirement.
 
@@ -49,8 +50,8 @@ Choose based on the workflow you need rather than on a single yes/no feature cou
 | Coverage granularity | [`method, path, status, content-type`](docs/coverage.md) | [`method, path` operation][spectator-coverage-source] | — | — | — |
 | Coverage outputs | [Markdown, JUnit XML, JSON, HTML, GitHub Step Summary](docs/coverage.md) | [Text, JSON][spectator-coverage] | — | — | — |
 | Parallel coverage merge | [Sidecar + merge CLI](docs/parallel.md) | Not documented | — | — | — |
-| Route/spec parity | Not yet ([#277](https://github.com/studio-design/openapi-contract-testing/issues/277)) | [`spectator:routes`][spectator-cli] | — | — | — |
-| CLI diagnostics / scaffolding | Coverage merge only | [`validate`, `coverage`, `routes`, `stubs`][spectator-cli] | — | — | — |
+| Route/spec parity | [`openapi:routes`](docs/laravel-route-parity.md) with text/JSON and CI gates | [`spectator:routes`][spectator-cli] | — | — | — |
+| CLI diagnostics / scaffolding | [`doctor`](docs/doctor.md), [`openapi:routes`](docs/laravel-route-parity.md), coverage merge; no scaffolding | [`validate`, `coverage`, `routes`, `stubs`][spectator-cli] | — | — | — |
 | Structured validation failures | Text messages; JSON planned ([#282](https://github.com/studio-design/openapi-contract-testing/issues/282)) | [JSON `{errors: [...]}`][spectator-errors] | [PHP exception hierarchy][league-errors] | [Wrapper exception][osteel-readme] | [PHPUnit failure text][kirschbaum-failure-source] |
 | Schema-driven exploration | [Deterministic happy-path generation](docs/fuzzing.md) | — | — | — | — |
 | Drift / under-description checks | [Enum drift](docs/enum-drift.md), [strict required](docs/strict-required.md) | — | — | — | — |
@@ -167,6 +168,12 @@ class GetPetsTest extends TestCase
 }
 ```
 
+Before running tests, compare Laravel's registered routes with the spec:
+
+```bash
+php artisan openapi:routes --fail-on-undocumented --fail-on-unimplemented
+```
+
 To validate every response automatically, set `'auto_assert' => true` and drop the explicit assert call. To also catch request-side drift, set `'auto_validate_request' => true`. See [`docs/setup.md`](docs/setup.md) for the full configuration and opt-out reference.
 
 ## Documentation
@@ -175,6 +182,7 @@ To validate every response automatically, set `'auto_assert' => true` and drop t
 |---|---|
 | Full setup, Laravel / Symfony / framework-agnostic adapters, auto-assert, opt-out attributes, request validation, HTTP `$ref` | [`docs/setup.md`](docs/setup.md) |
 | Pre-test compatibility diagnostics (`openapi-contract doctor`) | [`docs/doctor.md`](docs/doctor.md) |
+| Laravel route/spec parity (`openapi:routes`) | [`docs/laravel-route-parity.md`](docs/laravel-route-parity.md) |
 | Pest plugin: `expect()->toMatchOpenApiResponseSchema()` and friends | [`docs/pest-plugin.md`](docs/pest-plugin.md) |
 | Schema-driven request fuzzing | [`docs/fuzzing.md`](docs/fuzzing.md) |
 | Enum drift detection | [`docs/enum-drift.md`](docs/enum-drift.md) |

--- a/docs/laravel-route-parity.md
+++ b/docs/laravel-route-parity.md
@@ -64,8 +64,9 @@ Filters are combined with AND semantics:
 Laravel parameter names do not need to equal OpenAPI parameter names:
 `/pets/{pet}` matches `/pets/{petId}`. A trailing optional Laravel parameter
 is compared in both forms, so `/users/{user?}` can implement both `/users` and
-`/users/{userId}`. Laravel's implicit `HEAD` on a `GET` route is not reported as
-an undocumented route.
+`/users/{userId}`. Laravel's implicit `HEAD` on a `GET` route is ignored when
+the spec omits `head`, but it implements and matches an explicitly documented
+OpenAPI `head` operation on the same path.
 
 Fallback routes are reported as ambiguous because they cannot prove that one
 specific OpenAPI path is implemented. A custom HTTP method is supported when

--- a/docs/laravel-route-parity.md
+++ b/docs/laravel-route-parity.md
@@ -1,0 +1,109 @@
+# Laravel route parity
+
+`openapi:routes` compares Laravel's registered routes with the operations in
+one or more OpenAPI specs. It catches drift before runtime coverage can: a
+documented operation may have no application route, or an application route
+may never have been documented.
+
+Route parity complements contract coverage. Parity checks that a route and an
+operation exist; runtime coverage still proves that tests exercised the
+operation and validated its responses.
+
+## Configuration
+
+Publish the Laravel config if you have not already:
+
+```bash
+php artisan vendor:publish --tag=openapi-contract-testing
+```
+
+Configure the spec directory, default spec, and the same prefixes used by the
+PHPUnit extension:
+
+```php
+return [
+    'default_spec' => 'front',
+    'spec_base_path' => base_path('openapi/bundled'),
+    'strip_prefixes' => ['/api'],
+];
+```
+
+`spec_base_path` is the directory searched for `front.json`, `front.yaml`, or
+`front.yml`. Keep `strip_prefixes` aligned with the PHPUnit extension. The
+command applies the runtime matcher's first-match prefix and trailing-slash
+rules, so the static result matches request/response validation.
+
+## Usage
+
+Use the configured `default_spec`:
+
+```bash
+php artisan openapi:routes
+```
+
+Select multiple specs and narrow the Laravel route collection:
+
+```bash
+php artisan openapi:routes \
+  --spec=front \
+  --spec=admin \
+  --prefix=api/v2 \
+  --middleware=api \
+  --domain=api.example.com \
+  --exclude-route='internal.*'
+```
+
+Filters are combined with AND semantics:
+
+- `--prefix` matches a complete Laravel URI prefix segment.
+- Repeat `--middleware` to require every listed middleware name.
+- Repeat `--domain` to allow any listed exact route domain.
+- Repeat `--exclude-route` to exclude named routes; `*` wildcards are
+  supported. Unnamed routes are not excluded by this option.
+
+Laravel parameter names do not need to equal OpenAPI parameter names:
+`/pets/{pet}` matches `/pets/{petId}`. A trailing optional Laravel parameter
+is compared in both forms, so `/users/{user?}` can implement both `/users` and
+`/users/{userId}`. Laravel's implicit `HEAD` on a `GET` route is not reported as
+an undocumented route.
+
+Fallback routes are reported as ambiguous because they cannot prove that one
+specific OpenAPI path is implemented. A custom HTTP method is supported when
+the selected OpenAPI 3.2 spec declares the same, case-sensitive key under
+`additionalOperations`; otherwise it is reported as unsupported.
+
+## CI exit codes
+
+By default, discovered differences are reported but the command exits `0`.
+Enable either gate independently:
+
+```bash
+php artisan openapi:routes --fail-on-undocumented
+php artisan openapi:routes --fail-on-unimplemented
+```
+
+- `--fail-on-undocumented` exits `1` for registered-but-undocumented routes or
+  unsupported route methods.
+- `--fail-on-unimplemented` exits `1` for documented-but-not-registered
+  operations.
+- Invalid command options exit `2`; load/configuration failures exit `1`.
+
+## JSON output
+
+Use stable machine-readable output in CI:
+
+```bash
+php artisan openapi:routes --format=json
+```
+
+The top-level `schema_version` is currently `1`. The payload contains the
+selected `specs`, a `summary`, and these result arrays:
+
+- `matched`
+- `documented_but_not_registered`
+- `registered_but_undocumented`
+- `ambiguous`
+- `unsupported`
+
+Paths and route names are emitted, but absolute filesystem paths and spec
+contents are not.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -78,6 +78,12 @@ This creates `config/openapi-contract-testing.php`:
 return [
     'default_spec' => '', // e.g., 'front'
 
+    // Used by Laravel Artisan commands such as openapi:routes.
+    'spec_base_path' => base_path('openapi'),
+
+    // Keep aligned with the PHPUnit extension's strip_prefixes parameter.
+    'strip_prefixes' => [],
+
     // Maximum number of validation errors to report per response.
     // 0 = unlimited (reports all errors).
     'max_errors' => 20,
@@ -101,6 +107,11 @@ return [
 ```
 
 Set `default_spec` to your spec name, then use the trait — no per-class override needed:
+
+The Laravel config and PHPUnit extension are separate entry points. Configure
+the same spec directory and prefixes in both so `openapi:routes` and runtime
+validation compare the same paths. See [Laravel route parity](laravel-route-parity.md)
+for filters, JSON output, and CI exit codes.
 
 ```php
 use Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema;

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -15,6 +15,7 @@ This library follows [Semantic Versioning 2.0](https://semver.org/). v1.0.0 is t
 - Enum cases (additions are minor; removals or renames are major)
 - The `OpenApiValidationResult` shape (`outcome()`, `errors()`, `matchedPath()`, `skipReason()`, `isValid()`, `isSkipped()`)
 - The CLI surface of `bin/openapi-coverage-merge` (flags, exit codes, sidecar JSON wire format via `STATE_FORMAT_VERSION`)
+- The Laravel `openapi:routes` command surface (flags, exit codes, and versioned JSON output)
 - The `OpenApiCoverageExtension` PHPUnit configuration parameters (`spec_base_path`, `strip_prefixes`, `specs`, `output_file`, `console_output`, …)
 - The Laravel `ValidatesOpenApiSchema` trait's public methods
 - The category prefixes used in `E_USER_WARNING` messages (`[security]`, `[OpenAPI Schema]`, and the `[OpenAPI 3.2 ...]` categories)

--- a/src/Laravel/Commands/OpenApiRoutesCommand.php
+++ b/src/Laravel/Commands/OpenApiRoutesCommand.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Laravel\Commands;
+
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Routing\Router;
+use InvalidArgumentException;
+use JsonException;
+use Studio\OpenApiContractTesting\Laravel\RouteParity\LaravelRouteParityAnalyzer;
+use Studio\OpenApiContractTesting\Laravel\RouteParity\RouteParityResult;
+use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+use Throwable;
+
+use function array_filter;
+use function array_map;
+use function array_values;
+use function count;
+use function implode;
+use function in_array;
+use function is_array;
+use function is_string;
+use function json_encode;
+use function preg_match;
+use function str_starts_with;
+use function trim;
+
+final class OpenApiRoutesCommand extends Command
+{
+    protected $signature = 'openapi:routes
+        {--spec=* : Spec name to compare; repeat for multiple specs}
+        {--prefix= : Only include Laravel routes under this URI prefix}
+        {--middleware=* : Only include routes using all of these middleware names}
+        {--domain=* : Only include routes registered for these exact domains}
+        {--exclude-route=* : Exclude route names; * wildcards are supported}
+        {--format=text : Output format: text or json}
+        {--fail-on-undocumented : Fail when a Laravel route is absent from OpenAPI}
+        {--fail-on-unimplemented : Fail when an OpenAPI operation has no Laravel route}';
+    protected $description = 'Compare registered Laravel routes with OpenAPI operations';
+
+    public function handle(
+        Application $application,
+        Router $router,
+        LaravelRouteParityAnalyzer $analyzer,
+    ): int {
+        $format = trim((string) $this->option('format'));
+        if (!in_array($format, ['text', 'json'], true)) {
+            $this->components->error("Unsupported format '{$format}'. Use text or json.");
+
+            return self::INVALID;
+        }
+
+        try {
+            $specNames = $this->specNames();
+            [$basePath, $stripPrefixes] = $this->loaderConfiguration($application);
+            OpenApiSpecLoader::configure($basePath, $stripPrefixes);
+
+            $specs = [];
+            foreach ($specNames as $specName) {
+                $specs[$specName] = OpenApiSpecLoader::load($specName);
+            }
+
+            $result = $analyzer->analyze(
+                $specs,
+                $router->getRoutes(),
+                $stripPrefixes,
+                [
+                    'prefix' => $this->nullableStringOption('prefix'),
+                    'middleware' => $this->stringListOption('middleware'),
+                    'domains' => $this->stringListOption('domain'),
+                    'excluded_route_names' => $this->stringListOption('exclude-route'),
+                ],
+            );
+        } catch (Throwable $e) {
+            $this->components->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        if ($format === 'json') {
+            try {
+                $this->line((string) json_encode($result, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES));
+            } catch (JsonException $e) {
+                $this->components->error($e->getMessage());
+
+                return self::FAILURE;
+            }
+        } else {
+            $this->renderText($result);
+        }
+
+        if ($this->option('fail-on-undocumented') &&
+            ($result->registeredButUndocumented !== [] || $result->unsupported !== [])) {
+            return self::FAILURE;
+        }
+
+        if ($this->option('fail-on-unimplemented') && $result->documentedButNotRegistered !== []) {
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+
+    /** @return list<string> */
+    private function specNames(): array
+    {
+        $specs = $this->stringListOption('spec');
+        if ($specs !== []) {
+            return $specs;
+        }
+
+        $defaultSpec = config('openapi-contract-testing.default_spec');
+        if (!is_string($defaultSpec) || trim($defaultSpec) === '') {
+            throw new InvalidArgumentException(
+                'No OpenAPI spec selected. Pass --spec or configure openapi-contract-testing.default_spec.',
+            );
+        }
+
+        return [trim($defaultSpec)];
+    }
+
+    /** @return array{string, list<string>} */
+    private function loaderConfiguration(Application $application): array
+    {
+        $basePath = config('openapi-contract-testing.spec_base_path');
+        if (!is_string($basePath) || trim($basePath) === '') {
+            throw new InvalidArgumentException(
+                'openapi-contract-testing.spec_base_path must be a non-empty directory path.',
+            );
+        }
+
+        $stripPrefixes = config('openapi-contract-testing.strip_prefixes', []);
+        if (!is_array($stripPrefixes)) {
+            throw new InvalidArgumentException('openapi-contract-testing.strip_prefixes must be an array of strings.');
+        }
+
+        $normalizedPrefixes = [];
+        foreach ($stripPrefixes as $prefix) {
+            if (!is_string($prefix) || trim($prefix) === '') {
+                throw new InvalidArgumentException(
+                    'openapi-contract-testing.strip_prefixes must contain only non-empty strings.',
+                );
+            }
+            $normalizedPrefixes[] = $prefix;
+        }
+
+        $basePath = trim($basePath);
+        if (!$this->isAbsolutePath($basePath)) {
+            $basePath = $application->basePath($basePath);
+        }
+
+        return [$basePath, $normalizedPrefixes];
+    }
+
+    private function isAbsolutePath(string $path): bool
+    {
+        return str_starts_with($path, '/') ||
+            str_starts_with($path, '\\\\') ||
+            preg_match('/^[A-Za-z]:[\\\\\/]/', $path) === 1;
+    }
+
+    private function nullableStringOption(string $name): ?string
+    {
+        $value = $this->option($name);
+        if (!is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        return trim($value);
+    }
+
+    /** @return list<string> */
+    private function stringListOption(string $name): array
+    {
+        $value = $this->option($name);
+        if (!is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(
+            static fn(mixed $entry): string => is_string($entry) ? trim($entry) : '',
+            $value,
+        ), static fn(string $entry): bool => $entry !== ''));
+    }
+
+    private function renderText(RouteParityResult $result): void
+    {
+        $this->components->info('OpenAPI route parity');
+        $this->line('Specs: ' . implode(', ', $result->specs));
+        $this->newLine();
+        $this->table(
+            ['Matched', 'OpenAPI only', 'Laravel only', 'Ambiguous', 'Unsupported'],
+            [[
+                count($result->matched),
+                count($result->documentedButNotRegistered),
+                count($result->registeredButUndocumented),
+                count($result->ambiguous),
+                count($result->unsupported),
+            ]],
+        );
+
+        if ($result->documentedButNotRegistered !== []) {
+            $this->components->warn('Documented but not registered');
+            $this->table(['Spec', 'Method', 'OpenAPI path', 'operationId'], array_map(
+                static fn(array $entry): array => [
+                    $entry['spec'],
+                    $entry['method'],
+                    $entry['openapi_path'],
+                    $entry['operation_id'] ?? '',
+                ],
+                $result->documentedButNotRegistered,
+            ));
+        }
+
+        if ($result->registeredButUndocumented !== []) {
+            $this->components->warn('Registered but undocumented');
+            $this->table(['Method', 'Laravel URI', 'Name', 'Domain'], array_map(
+                static fn(array $entry): array => [
+                    $entry['method'],
+                    $entry['route_uri'],
+                    $entry['route_name'] ?? '',
+                    $entry['domain'] ?? '',
+                ],
+                $result->registeredButUndocumented,
+            ));
+        }
+
+        if ($result->ambiguous !== []) {
+            $this->components->warn('Ambiguous routes');
+            $this->table(['Kind', 'Method', 'Laravel URI', 'Name', 'Domain'], array_map(
+                static fn(array $entry): array => [
+                    $entry['kind'],
+                    $entry['method'] ?? '',
+                    $entry['route_uri'],
+                    $entry['route_name'] ?? '',
+                    $entry['domain'] ?? '',
+                ],
+                $result->ambiguous,
+            ));
+        }
+
+        if ($result->unsupported !== []) {
+            $this->components->warn('Unsupported route methods');
+            $this->table(['Method', 'Laravel URI', 'Name', 'Reason'], array_map(
+                static fn(array $entry): array => [
+                    $entry['method'],
+                    $entry['route_uri'],
+                    $entry['route_name'] ?? '',
+                    $entry['reason'],
+                ],
+                $result->unsupported,
+            ));
+        }
+    }
+}

--- a/src/Laravel/OpenApiContractTestingServiceProvider.php
+++ b/src/Laravel/OpenApiContractTestingServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Studio\OpenApiContractTesting\Laravel;
 
 use Illuminate\Support\ServiceProvider;
+use Studio\OpenApiContractTesting\Laravel\Commands\OpenApiRoutesCommand;
 
 class OpenApiContractTestingServiceProvider extends ServiceProvider
 {
@@ -18,5 +19,9 @@ class OpenApiContractTestingServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__ . '/config.php' => config_path('openapi-contract-testing.php'),
         ], 'openapi-contract-testing');
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([OpenApiRoutesCommand::class]);
+        }
     }
 }

--- a/src/Laravel/RouteParity/LaravelRouteParityAnalyzer.php
+++ b/src/Laravel/RouteParity/LaravelRouteParityAnalyzer.php
@@ -1,0 +1,341 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Laravel\RouteParity;
+
+use Illuminate\Routing\Route;
+use Illuminate\Support\Str;
+use Studio\OpenApiContractTesting\Spec\OpenApiOperationResolver;
+use Studio\OpenApiContractTesting\Spec\OpenApiPathMatcher;
+use Studio\OpenApiContractTesting\Validation\Support\MalformedSpecNode;
+
+use function array_filter;
+use function array_keys;
+use function array_map;
+use function array_slice;
+use function array_unique;
+use function array_values;
+use function count;
+use function explode;
+use function implode;
+use function in_array;
+use function is_array;
+use function is_string;
+use function ltrim;
+use function preg_match;
+use function preg_replace;
+use function rtrim;
+use function str_starts_with;
+use function strtolower;
+use function strtoupper;
+use function trim;
+
+/**
+ * Compares Laravel's registered routes with resolved OpenAPI operations.
+ *
+ * @internal Not part of the package's public API.
+ *
+ * @phpstan-type Filters array{prefix?: ?string, middleware?: list<string>, domains?: list<string>, excluded_route_names?: list<string>}
+ * @phpstan-type Operation array{spec: string, method: string, openapi_path: string, normalized_path: string, operation_id: ?string}
+ * @phpstan-type RegisteredRoute array{method: string, route_uri: string, normalized_path: string, route_name: ?string, domain: ?string}
+ */
+final class LaravelRouteParityAnalyzer
+{
+    /**
+     * @param array<string, array<string, mixed>> $specs
+     * @param iterable<Route> $routes
+     * @param list<string> $stripPrefixes
+     * @param Filters $filters
+     */
+    public function analyze(array $specs, iterable $routes, array $stripPrefixes = [], array $filters = []): RouteParityResult
+    {
+        $operations = $this->collectOperations($specs);
+        $registered = [];
+        $ambiguous = [];
+        $unsupported = [];
+        $documentedMethods = array_unique(array_map(
+            static fn(array $operation): string => $operation['method'],
+            $operations,
+        ));
+
+        foreach ($routes as $route) {
+            if (!$this->passesFilters($route, $filters)) {
+                continue;
+            }
+
+            if ($route->isFallback) {
+                $ambiguous[] = [
+                    'kind' => 'fallback_route',
+                    'method' => null,
+                    'route_uri' => $this->displayUri($route->uri()),
+                    'route_name' => $route->getName(),
+                    'domain' => $route->getDomain(),
+                    'candidates' => [],
+                ];
+
+                continue;
+            }
+
+            $methods = array_values(array_unique(array_map(
+                static fn(string $method): string => strtoupper($method),
+                $route->methods(),
+            )));
+            if (in_array('GET', $methods, true)) {
+                $methods = array_values(array_filter(
+                    $methods,
+                    static fn(string $method): bool => $method !== 'HEAD',
+                ));
+            }
+
+            foreach ($methods as $method) {
+                if (!in_array(strtolower($method), OpenApiOperationResolver::FIXED_OPERATION_FIELDS, true) &&
+                    !in_array($method, $documentedMethods, true)) {
+                    $unsupported[] = [
+                        'method' => $method,
+                        'route_uri' => $this->displayUri($route->uri()),
+                        'route_name' => $route->getName(),
+                        'domain' => $route->getDomain(),
+                        'reason' => 'The method is not a fixed OpenAPI operation and is not declared by the selected specs.',
+                    ];
+
+                    continue;
+                }
+
+                foreach ($this->expandOptionalUri($route->uri()) as $uri) {
+                    $registered[] = [
+                        'method' => $method,
+                        'route_uri' => $this->displayUri($uri),
+                        'normalized_path' => $this->normalizeRoutePath($uri, $stripPrefixes),
+                        'route_name' => $route->getName(),
+                        'domain' => $route->getDomain(),
+                    ];
+                }
+            }
+        }
+
+        $matched = [];
+        $routeOnly = [];
+        $matchedOperationIndexes = [];
+
+        foreach ($registered as $route) {
+            $candidateIndexes = [];
+            foreach ($operations as $index => $operation) {
+                if ($route['method'] === $operation['method'] &&
+                    $route['normalized_path'] === $operation['normalized_path']) {
+                    $candidateIndexes[] = $index;
+                }
+            }
+
+            if ($candidateIndexes === []) {
+                $routeOnly[] = $this->routeOnlyEntry($route);
+
+                continue;
+            }
+
+            $candidateIndexesBySpec = [];
+            foreach ($candidateIndexes as $index) {
+                $candidateIndexesBySpec[$operations[$index]['spec']][] = $index;
+            }
+
+            foreach ($candidateIndexesBySpec as $indexesForSpec) {
+                if (count($indexesForSpec) > 1) {
+                    $candidates = [];
+                    foreach ($indexesForSpec as $index) {
+                        $operation = $operations[$index];
+                        $matchedOperationIndexes[$index] = true;
+                        $candidates[] = [
+                            'spec' => $operation['spec'],
+                            'method' => $operation['method'],
+                            'openapi_path' => $operation['openapi_path'],
+                        ];
+                    }
+                    $ambiguous[] = [
+                        'kind' => 'multiple_openapi_operations',
+                        'method' => $route['method'],
+                        'route_uri' => $route['route_uri'],
+                        'route_name' => $route['route_name'],
+                        'domain' => $route['domain'],
+                        'candidates' => $candidates,
+                    ];
+
+                    continue;
+                }
+
+                $index = $indexesForSpec[0];
+                $operation = $operations[$index];
+                $matchedOperationIndexes[$index] = true;
+                $matched[] = [
+                    'spec' => $operation['spec'],
+                    'method' => $operation['method'],
+                    'openapi_path' => $operation['openapi_path'],
+                    'operation_id' => $operation['operation_id'],
+                    'route_uri' => $route['route_uri'],
+                    'route_name' => $route['route_name'],
+                    'domain' => $route['domain'],
+                ];
+            }
+        }
+
+        $openApiOnly = [];
+        foreach ($operations as $index => $operation) {
+            if (isset($matchedOperationIndexes[$index])) {
+                continue;
+            }
+
+            $openApiOnly[] = [
+                'spec' => $operation['spec'],
+                'method' => $operation['method'],
+                'openapi_path' => $operation['openapi_path'],
+                'operation_id' => $operation['operation_id'],
+            ];
+        }
+
+        return new RouteParityResult(
+            specs: array_keys($specs),
+            matched: $matched,
+            documentedButNotRegistered: $openApiOnly,
+            registeredButUndocumented: $routeOnly,
+            ambiguous: $ambiguous,
+            unsupported: $unsupported,
+        );
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $specs
+     *
+     * @return list<Operation>
+     */
+    private function collectOperations(array $specs): array
+    {
+        $operations = [];
+
+        foreach ($specs as $specName => $spec) {
+            $paths = is_array($spec['paths'] ?? null) ? $spec['paths'] : [];
+            foreach ($paths as $path => $pathItem) {
+                if (!is_string($path) || MalformedSpecNode::isMalformed($pathItem)) {
+                    continue;
+                }
+
+                foreach (OpenApiOperationResolver::declaredOperations($pathItem) as $declared) {
+                    if (MalformedSpecNode::isMalformed($declared['operation'])) {
+                        continue;
+                    }
+
+                    $method = OpenApiOperationResolver::normalizeMethodForKey($declared['method']);
+                    $operations[] = [
+                        'spec' => $specName,
+                        'method' => $method,
+                        'openapi_path' => $path,
+                        'normalized_path' => $this->normalizeTemplate($path),
+                        'operation_id' => is_string($declared['operation']['operationId'] ?? null)
+                            ? $declared['operation']['operationId']
+                            : null,
+                    ];
+                }
+            }
+        }
+
+        return $operations;
+    }
+
+    /** @param Filters $filters */
+    private function passesFilters(Route $route, array $filters): bool
+    {
+        $prefix = trim((string) ($filters['prefix'] ?? ''), '/');
+        $uri = trim($route->uri(), '/');
+        if ($prefix !== '' && $uri !== $prefix && !str_starts_with($uri, $prefix . '/')) {
+            return false;
+        }
+
+        $requiredMiddleware = $filters['middleware'] ?? [];
+        $routeMiddleware = $route->gatherMiddleware();
+        foreach ($requiredMiddleware as $middleware) {
+            if (!in_array($middleware, $routeMiddleware, true)) {
+                return false;
+            }
+        }
+
+        $domains = $filters['domains'] ?? [];
+        if ($domains !== [] && !in_array($route->getDomain() ?? '', $domains, true)) {
+            return false;
+        }
+
+        $routeName = $route->getName();
+        foreach ($filters['excluded_route_names'] ?? [] as $pattern) {
+            if ($routeName !== null && Str::is($pattern, $routeName)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /** @return list<string> */
+    private function expandOptionalUri(string $uri): array
+    {
+        $segments = $uri === '/' ? [] : explode('/', trim($uri, '/'));
+        $required = [];
+        $optional = [];
+
+        foreach ($segments as $segment) {
+            if (preg_match('/^\{[^{}]+\?\}$/', $segment) === 1) {
+                $optional[] = $segment;
+
+                continue;
+            }
+
+            $required[] = $segment;
+        }
+
+        if ($optional === []) {
+            return [$uri];
+        }
+
+        $expanded = [];
+        for ($included = 0; $included <= count($optional); $included++) {
+            $expanded[] = implode('/', [...$required, ...array_slice($optional, 0, $included)]);
+        }
+
+        return $expanded;
+    }
+
+    /** @param list<string> $stripPrefixes */
+    private function normalizeRoutePath(string $uri, array $stripPrefixes): string
+    {
+        $requestPath = $this->displayUri($uri);
+        $matcher = new OpenApiPathMatcher([], $stripPrefixes);
+        $normalized = $matcher->normalizeRequestPath($requestPath)['path'];
+
+        return $this->normalizeTemplate($normalized);
+    }
+
+    private function normalizeTemplate(string $path): string
+    {
+        $normalized = preg_replace('/\{[^{}]+\??\}/', '{}', $path);
+
+        return $normalized === null ? $path : (rtrim($normalized, '/') ?: '/');
+    }
+
+    private function displayUri(string $uri): string
+    {
+        $trimmed = ltrim($uri, '/');
+
+        return $trimmed === '' ? '/' : '/' . $trimmed;
+    }
+
+    /**
+     * @param RegisteredRoute $route
+     *
+     * @return array{method: string, route_uri: string, route_name: ?string, domain: ?string}
+     */
+    private function routeOnlyEntry(array $route): array
+    {
+        return [
+            'method' => $route['method'],
+            'route_uri' => $route['route_uri'],
+            'route_name' => $route['route_name'],
+            'domain' => $route['domain'],
+        ];
+    }
+}

--- a/src/Laravel/RouteParity/LaravelRouteParityAnalyzer.php
+++ b/src/Laravel/RouteParity/LaravelRouteParityAnalyzer.php
@@ -10,7 +10,6 @@ use Studio\OpenApiContractTesting\Spec\OpenApiOperationResolver;
 use Studio\OpenApiContractTesting\Spec\OpenApiPathMatcher;
 use Studio\OpenApiContractTesting\Validation\Support\MalformedSpecNode;
 
-use function array_filter;
 use function array_keys;
 use function array_map;
 use function array_slice;
@@ -81,12 +80,7 @@ final class LaravelRouteParityAnalyzer
                 static fn(string $method): string => strtoupper($method),
                 $route->methods(),
             )));
-            if (in_array('GET', $methods, true)) {
-                $methods = array_values(array_filter(
-                    $methods,
-                    static fn(string $method): bool => $method !== 'HEAD',
-                ));
-            }
+            $hasGet = in_array('GET', $methods, true);
 
             foreach ($methods as $method) {
                 if (!in_array(strtolower($method), OpenApiOperationResolver::FIXED_OPERATION_FIELDS, true) &&
@@ -103,10 +97,15 @@ final class LaravelRouteParityAnalyzer
                 }
 
                 foreach ($this->expandOptionalUri($route->uri()) as $uri) {
+                    $normalizedPath = $this->normalizeRoutePath($uri, $stripPrefixes);
+                    if ($method === 'HEAD' && $hasGet && !$this->hasOperation($operations, 'HEAD', $normalizedPath)) {
+                        continue;
+                    }
+
                     $registered[] = [
                         'method' => $method,
                         'route_uri' => $this->displayUri($uri),
-                        'normalized_path' => $this->normalizeRoutePath($uri, $stripPrefixes),
+                        'normalized_path' => $normalizedPath,
                         'route_name' => $route->getName(),
                         'domain' => $route->getDomain(),
                     ];
@@ -315,6 +314,18 @@ final class LaravelRouteParityAnalyzer
         $normalized = preg_replace('/\{[^{}]+\??\}/', '{}', $path);
 
         return $normalized === null ? $path : (rtrim($normalized, '/') ?: '/');
+    }
+
+    /** @param list<Operation> $operations */
+    private function hasOperation(array $operations, string $method, string $normalizedPath): bool
+    {
+        foreach ($operations as $operation) {
+            if ($operation['method'] === $method && $operation['normalized_path'] === $normalizedPath) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function displayUri(string $uri): string

--- a/src/Laravel/RouteParity/RouteParityResult.php
+++ b/src/Laravel/RouteParity/RouteParityResult.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Laravel\RouteParity;
+
+use JsonSerializable;
+
+use function count;
+
+/**
+ * Stable result returned by the Laravel route-parity analyzer.
+ *
+ * @internal Not part of the package's public API. The versioned JSON emitted
+ *           by `openapi:routes` is the supported machine-readable contract.
+ *
+ * @phpstan-type MatchedEntry array{spec: string, method: string, openapi_path: string, operation_id: ?string, route_uri: string, route_name: ?string, domain: ?string}
+ * @phpstan-type OpenApiOnlyEntry array{spec: string, method: string, openapi_path: string, operation_id: ?string}
+ * @phpstan-type RouteOnlyEntry array{method: string, route_uri: string, route_name: ?string, domain: ?string}
+ * @phpstan-type AmbiguousEntry array{kind: string, method: ?string, route_uri: string, route_name: ?string, domain: ?string, candidates: list<array{spec: string, method: string, openapi_path: string}>}
+ * @phpstan-type UnsupportedEntry array{method: string, route_uri: string, route_name: ?string, domain: ?string, reason: string}
+ */
+final readonly class RouteParityResult implements JsonSerializable
+{
+    /**
+     * @param list<string> $specs
+     * @param list<MatchedEntry> $matched
+     * @param list<OpenApiOnlyEntry> $documentedButNotRegistered
+     * @param list<RouteOnlyEntry> $registeredButUndocumented
+     * @param list<AmbiguousEntry> $ambiguous
+     * @param list<UnsupportedEntry> $unsupported
+     */
+    public function __construct(
+        public array $specs,
+        public array $matched,
+        public array $documentedButNotRegistered,
+        public array $registeredButUndocumented,
+        public array $ambiguous,
+        public array $unsupported,
+    ) {}
+
+    /** @return array<string, mixed> */
+    public function jsonSerialize(): array
+    {
+        return [
+            'schema_version' => 1,
+            'specs' => $this->specs,
+            'summary' => [
+                'matched' => count($this->matched),
+                'documented_but_not_registered' => count($this->documentedButNotRegistered),
+                'registered_but_undocumented' => count($this->registeredButUndocumented),
+                'ambiguous' => count($this->ambiguous),
+                'unsupported' => count($this->unsupported),
+            ],
+            'matched' => $this->matched,
+            'documented_but_not_registered' => $this->documentedButNotRegistered,
+            'registered_but_undocumented' => $this->registeredButUndocumented,
+            'ambiguous' => $this->ambiguous,
+            'unsupported' => $this->unsupported,
+        ];
+    }
+}

--- a/src/Laravel/config.php
+++ b/src/Laravel/config.php
@@ -8,6 +8,15 @@ use Studio\OpenApiContractTesting\OpenApiResponseValidator;
 return [
     'default_spec' => '',
 
+    // Directory containing named OpenAPI spec files used by Laravel Artisan
+    // commands. `--spec=front` resolves front.json/front.yaml/front.yml here.
+    'spec_base_path' => 'openapi',
+
+    // Prefixes removed from registered Laravel route URIs before comparing
+    // them with OpenAPI paths. Keep this aligned with the PHPUnit extension's
+    // `strip_prefixes` parameter so static parity and runtime validation agree.
+    'strip_prefixes' => [],
+
     // Maximum number of validation errors to report per response.
     // 0 = unlimited (reports all errors).
     'max_errors' => 20,

--- a/tests/Integration/Laravel/OpenApiRoutesCommandIntegrationTest.php
+++ b/tests/Integration/Laravel/OpenApiRoutesCommandIntegrationTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Integration\Laravel;
+
+use const JSON_THROW_ON_ERROR;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Route;
+use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Studio\OpenApiContractTesting\Laravel\OpenApiContractTestingServiceProvider;
+use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+
+use function dirname;
+use function json_decode;
+use function trim;
+
+final class OpenApiRoutesCommandIntegrationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiSpecLoader::reset();
+        config()->set('openapi-contract-testing.default_spec', 'route-parity');
+        config()->set('openapi-contract-testing.spec_base_path', dirname(__DIR__, 2) . '/fixtures/specs');
+        config()->set('openapi-contract-testing.strip_prefixes', ['/api']);
+    }
+
+    protected function tearDown(): void
+    {
+        OpenApiSpecLoader::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function command_is_registered_and_renders_route_parity(): void
+    {
+        $exitCode = Artisan::call('openapi:routes', [
+            '--prefix' => 'api',
+            '--middleware' => ['api'],
+            '--domain' => ['api.example.test'],
+            '--exclude-route' => ['internal.*'],
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $output = Artisan::output();
+        $this->assertStringContainsString('OpenAPI route parity', $output);
+        $this->assertStringContainsString('Documented but not registered', $output);
+        $this->assertStringContainsString('/v1/missing', $output);
+        $this->assertStringContainsString('Registered but undocumented', $output);
+        $this->assertStringContainsString('/api/v1/undocumented', $output);
+    }
+
+    #[Test]
+    public function json_output_is_versioned_and_supports_multiple_specs(): void
+    {
+        $exitCode = Artisan::call('openapi:routes', [
+            '--spec' => ['route-parity', 'route-parity-admin'],
+            '--prefix' => 'api',
+            '--middleware' => ['api'],
+            '--domain' => ['api.example.test'],
+            '--exclude-route' => ['internal.*'],
+            '--format' => 'json',
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $decoded = json_decode(trim(Artisan::output()), true, flags: JSON_THROW_ON_ERROR);
+        $this->assertSame(1, $decoded['schema_version']);
+        $this->assertSame(['route-parity', 'route-parity-admin'], $decoded['specs']);
+        $this->assertSame(6, $decoded['summary']['matched']);
+        $this->assertSame(1, $decoded['summary']['documented_but_not_registered']);
+        $this->assertSame(1, $decoded['summary']['registered_but_undocumented']);
+        $this->assertSame(0, $decoded['summary']['ambiguous']);
+    }
+
+    #[Test]
+    public function strict_exit_flags_fail_independently(): void
+    {
+        $options = [
+            '--prefix' => 'api',
+            '--middleware' => ['api'],
+            '--domain' => ['api.example.test'],
+            '--exclude-route' => ['internal.*'],
+            '--format' => 'json',
+        ];
+
+        $this->assertSame(1, Artisan::call('openapi:routes', [
+            ...$options,
+            '--fail-on-undocumented' => true,
+        ]));
+        $this->assertSame(1, Artisan::call('openapi:routes', [
+            ...$options,
+            '--fail-on-unimplemented' => true,
+        ]));
+    }
+
+    #[Test]
+    public function invalid_format_returns_invalid_exit_code(): void
+    {
+        $this->assertSame(2, Artisan::call('openapi:routes', ['--format' => 'xml']));
+        $this->assertStringContainsString('Unsupported format', Artisan::output());
+    }
+
+    /** @return array<int, class-string> */
+    protected function getPackageProviders($app): array
+    {
+        return [OpenApiContractTestingServiceProvider::class];
+    }
+
+    protected function defineRoutes($router): void
+    {
+        Route::domain('api.example.test')->middleware('api')->group(static function (): void {
+            Route::match(['GET', 'POST'], '/api/v1/pets', static fn() => null)->name('pets.index');
+            Route::get('/api/v1/pets/{pet}', static fn() => null)->name('pets.show');
+            Route::get('/api/v1/optional/{optional?}', static fn() => null)->name('optional.show');
+            Route::get('/api/v1/undocumented', static fn() => null)->name('undocumented');
+            Route::get('/api/v1/internal', static fn() => null)->name('internal.status');
+        });
+
+        Route::domain('other.example.test')->middleware('api')->get(
+            '/api/v1/other-domain',
+            static fn() => null,
+        )->name('other-domain');
+
+        Route::fallback(static fn() => null)->name('fallback');
+    }
+}

--- a/tests/Unit/Laravel/LaravelRouteParityAnalyzerTest.php
+++ b/tests/Unit/Laravel/LaravelRouteParityAnalyzerTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Laravel;
+
+use Illuminate\Routing\Route;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Laravel\RouteParity\LaravelRouteParityAnalyzer;
+
+use function array_column;
+
+final class LaravelRouteParityAnalyzerTest extends TestCase
+{
+    #[Test]
+    public function matches_parameterized_route_after_runtime_prefix_normalization(): void
+    {
+        $route = new Route(['GET'], 'api/v2/pets/{pet}', static fn() => null);
+        $route->name('pets.show');
+
+        $result = (new LaravelRouteParityAnalyzer())->analyze(
+            ['front' => $this->spec(['/v2/pets/{petId}' => ['get' => ['operationId' => 'showPet']]])],
+            [$route],
+            ['/api'],
+        );
+
+        $this->assertCount(1, $result->matched);
+        $this->assertSame('GET', $result->matched[0]['method']);
+        $this->assertSame('/v2/pets/{petId}', $result->matched[0]['openapi_path']);
+        $this->assertSame('/api/v2/pets/{pet}', $result->matched[0]['route_uri']);
+        $this->assertSame([], $result->documentedButNotRegistered);
+        $this->assertSame([], $result->registeredButUndocumented);
+    }
+
+    #[Test]
+    public function expands_optional_parameters_and_multi_method_routes(): void
+    {
+        $optional = new Route(['GET'], 'users/{user?}', static fn() => null);
+        $multiMethod = new Route(['GET', 'POST'], 'pets', static fn() => null);
+
+        $result = (new LaravelRouteParityAnalyzer())->analyze(
+            ['front' => $this->spec([
+                '/users' => ['get' => []],
+                '/users/{id}' => ['get' => []],
+                '/pets' => ['get' => [], 'post' => []],
+            ])],
+            [$optional, $multiMethod],
+        );
+
+        $this->assertCount(4, $result->matched);
+        $this->assertSame([], $result->documentedButNotRegistered);
+        $this->assertSame([], $result->registeredButUndocumented);
+    }
+
+    #[Test]
+    public function selected_specs_are_compared_independently(): void
+    {
+        $route = new Route(['GET'], 'pets', static fn() => null);
+
+        $result = (new LaravelRouteParityAnalyzer())->analyze(
+            [
+                'front' => $this->spec(['/pets' => ['get' => []]]),
+                'admin' => $this->spec(['/pets' => ['get' => []]]),
+            ],
+            [$route],
+        );
+
+        $this->assertCount(2, $result->matched);
+        $this->assertSame(['front', 'admin'], array_column($result->matched, 'spec'));
+        $this->assertSame([], $result->ambiguous);
+    }
+
+    #[Test]
+    public function filters_by_prefix_middleware_domain_and_route_name(): void
+    {
+        $included = new Route(['GET'], 'api/pets', static fn() => null);
+        $included->middleware('api')->domain('api.example.com')->name('pets.index');
+
+        $wrongMiddleware = new Route(['GET'], 'api/internal', static fn() => null);
+        $wrongMiddleware->middleware('web')->domain('api.example.com')->name('internal.index');
+
+        $excludedByName = new Route(['GET'], 'api/health', static fn() => null);
+        $excludedByName->middleware('api')->domain('api.example.com')->name('health.check');
+
+        $result = (new LaravelRouteParityAnalyzer())->analyze(
+            ['front' => $this->spec(['/api/pets' => ['get' => []]])],
+            [$included, $wrongMiddleware, $excludedByName],
+            filters: [
+                'prefix' => 'api',
+                'middleware' => ['api'],
+                'domains' => ['api.example.com'],
+                'excluded_route_names' => ['health.*'],
+            ],
+        );
+
+        $this->assertCount(1, $result->matched);
+        $this->assertSame('pets.index', $result->matched[0]['route_name']);
+        $this->assertSame([], $result->registeredButUndocumented);
+    }
+
+    #[Test]
+    public function reports_fallback_and_custom_method_without_openapi_declaration(): void
+    {
+        $fallback = new Route(['GET'], '{fallbackPlaceholder}', static fn() => null);
+        $fallback->fallback()->name('fallback');
+        $custom = new Route(['CONNECT'], 'tunnel', static fn() => null);
+
+        $result = (new LaravelRouteParityAnalyzer())->analyze(
+            ['front' => $this->spec([])],
+            [$fallback, $custom],
+        );
+
+        $this->assertSame('fallback_route', $result->ambiguous[0]['kind']);
+        $this->assertSame('CONNECT', $result->unsupported[0]['method']);
+    }
+
+    #[Test]
+    public function preserves_additional_operation_capitalization(): void
+    {
+        $upper = new Route(['COPY'], 'documents', static fn() => null);
+
+        $result = (new LaravelRouteParityAnalyzer())->analyze(
+            ['front' => $this->spec([
+                '/documents' => [
+                    'additionalOperations' => [
+                        'COPY' => [],
+                        'copy' => [],
+                    ],
+                ],
+            ])],
+            [$upper],
+        );
+
+        $this->assertCount(1, $result->matched);
+        $this->assertSame('COPY', $result->matched[0]['method']);
+        $this->assertSame('copy', $result->documentedButNotRegistered[0]['method']);
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $paths
+     *
+     * @return array<string, mixed>
+     */
+    private function spec(array $paths): array
+    {
+        return ['openapi' => '3.2.0', 'paths' => $paths];
+    }
+}

--- a/tests/Unit/Laravel/LaravelRouteParityAnalyzerTest.php
+++ b/tests/Unit/Laravel/LaravelRouteParityAnalyzerTest.php
@@ -34,6 +34,26 @@ final class LaravelRouteParityAnalyzerTest extends TestCase
     }
 
     #[Test]
+    public function implicit_head_matches_an_explicit_openapi_head_operation(): void
+    {
+        $route = new Route(['GET'], 'pets', static fn() => null);
+
+        $result = (new LaravelRouteParityAnalyzer())->analyze(
+            ['front' => $this->spec([
+                '/pets' => [
+                    'get' => ['operationId' => 'listPets'],
+                    'head' => ['operationId' => 'inspectPets'],
+                ],
+            ])],
+            [$route],
+        );
+
+        $this->assertSame(['GET', 'HEAD'], array_column($result->matched, 'method'));
+        $this->assertSame([], $result->documentedButNotRegistered);
+        $this->assertSame([], $result->registeredButUndocumented);
+    }
+
+    #[Test]
     public function expands_optional_parameters_and_multi_method_routes(): void
     {
         $optional = new Route(['GET'], 'users/{user?}', static fn() => null);

--- a/tests/fixtures/specs/route-parity-admin.json
+++ b/tests/fixtures/specs/route-parity-admin.json
@@ -1,0 +1,19 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Route parity admin fixture",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/v1/pets": {
+      "get": {
+        "operationId": "adminListPets",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/specs/route-parity.json
+++ b/tests/fixtures/specs/route-parity.json
@@ -1,0 +1,67 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Route parity fixture",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/v1/pets": {
+      "get": {
+        "operationId": "listPets",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "post": {
+        "operationId": "createPet",
+        "responses": {
+          "201": {
+            "description": "Created"
+          }
+        }
+      }
+    },
+    "/v1/pets/{petId}": {
+      "get": {
+        "operationId": "showPet",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/v1/optional": {
+      "get": {
+        "operationId": "listOptional",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/v1/optional/{optionalId}": {
+      "get": {
+        "operationId": "showOptional",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/v1/missing": {
+      "delete": {
+        "operationId": "deleteMissing",
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add an auto-registered `openapi:routes` Artisan command for comparing Laravel routes with one or more resolved OpenAPI specs
- normalize parameter names, optional parameters, configured `strip_prefixes`, implicit `HEAD`, and OpenAPI 3.2 custom method capitalization
- add prefix, middleware, domain, and route-name filters plus text and versioned JSON output
- add independent CI gates for undocumented Laravel routes and unimplemented OpenAPI operations
- document configuration, usage, output, exit codes, and how route parity complements runtime coverage

## Why

Runtime coverage can show which documented operations tests exercised, but it cannot identify undocumented Laravel routes or OpenAPI operations that have no registered route. This closes that adoption gap while reusing the package's existing loader, operation resolver, and runtime path normalization rules.

Closes #277.

## Validation

- `vendor/bin/phpunit tests/Unit/Laravel/LaravelRouteParityAnalyzerTest.php tests/Integration/Laravel/OpenApiRoutesCommandIntegrationTest.php`
- `vendor/bin/phpunit tests/Integration/Laravel`
- `vendor/bin/phpstan analyse --debug --memory-limit=1G`
- `vendor/bin/php-cs-fixer fix --dry-run --diff --sequential`
- `NPM_CONFIG_CACHE=/private/tmp/openapi-contract-testing-npm-cache vendor/bin/phpunit --filter MarkdownCoverageRendererLintTest`

The full local suite passes all feature and integration coverage; four existing stack-trace assertions remain path-sensitive to the temporary clone directory name. GitHub Actions runs in the canonical checkout path and is the authoritative full-matrix check.
