### PR TITLE
feat(psr7): add request and response validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,26 @@ jobs:
         working-directory: examples/pest
         run: vendor/bin/pest --colors=always
 
+  psr7-example:
+    name: PSR-7 example
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+        with:
+          php-version: '8.2'
+          coverage: none
+
+      - name: Install example dependencies
+        working-directory: examples/psr7
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Run PSR-7 example
+        working-directory: examples/psr7
+        run: composer test
+
   static-analysis:
     name: PHPStan
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,8 @@ maintenance cost.
   shared validation boundaries.
 - `src/Coverage/`, `src/PHPUnit/`: coverage state/renderers/merge protocol and the
   PHPUnit extension.
-- `src/Laravel/`, `src/Symfony/`, `src/Pest/`: integration layers. Keep policy in
-  the core when it is not framework-specific.
+- `src/Psr7/`, `src/Laravel/`, `src/Symfony/`, `src/Pest/`: integration layers.
+  Keep policy in the core when it is not framework-specific.
 - `src/Fuzz/`, `src/Schema/`: generated exploration cases and enum-drift checks.
 - `src/Internal/`: implementation details; do not expose these as public API.
 - `bin/openapi-contract`, `bin/openapi-coverage-merge`: Composer-installed CLIs.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Validate your API responses against your OpenAPI specification during testing, a
 - **Enum drift detection** — Static comparison between PHP backed enums and their `enum:` spec arrays, with PHPUnit-extension auto-discovery
 - **Schema under-description detection** — Optional strict mode that flags response fields the implementation always returns but the spec marks as optional, catching the spec gaps that conformance checks alone can't. See [`docs/strict-required.md`](docs/strict-required.md) for current scope and limitations.
 - **Skip-by-status-code** — Configurable regex list of status codes whose bodies are not validated (default: every `5xx`); per-request via `skipResponseCode()`
-- **Laravel, Symfony & Pest adapters** — Auto-assert / auto-validate-request integration for Laravel, an `OpenApiAssertions` trait for Symfony HttpFoundation, and explicit `expect(...)->toMatchOpenApiResponseSchema()` for Pest
+- **PSR-7, Laravel, Symfony & Pest adapters** — First-class PSR-7 request/response/exchange validation, auto-assert / auto-validate-request integration for Laravel, HttpFoundation assertions for Symfony, and Pest expectations
 - **Parallel-runner safe** — Coordinated sidecar+merge workflow for paratest / `pest --parallel`
 - **Multi-format reports** — Markdown / JUnit XML / JSON / HTML output with one-click GitHub Step Summary
 - **Zero runtime overhead** — Only used in test suites
@@ -55,7 +55,7 @@ Choose based on the workflow you need rather than on a single yes/no feature cou
 | Structured validation failures | Text messages; JSON planned ([#282](https://github.com/studio-design/openapi-contract-testing/issues/282)) | [JSON `{errors: [...]}`][spectator-errors] | [PHP exception hierarchy][league-errors] | [Wrapper exception][osteel-readme] | [PHPUnit failure text][kirschbaum-failure-source] |
 | Schema-driven exploration | [Deterministic happy-path generation](docs/fuzzing.md) | — | — | — | — |
 | Drift / under-description checks | [Enum drift](docs/enum-drift.md), [strict required](docs/strict-required.md) | — | — | — | — |
-| First-class integration | [Framework-agnostic, Laravel, Symfony, Pest](docs/setup.md) | [Laravel][spectator] | [PSR-7, PSR-15 middleware][league-middleware] | [HttpFoundation, PSR-7][osteel-readme] | [Laravel auto-validation][kirschbaum-readme] |
+| First-class integration | [PSR-7](docs/psr7.md), [Laravel, Symfony, Pest](docs/setup.md) | [Laravel][spectator] | [PSR-7, PSR-15 middleware][league-middleware] | [HttpFoundation, PSR-7][osteel-readme] | [Laravel auto-validation][kirschbaum-readme] |
 | Declared runtime floor | PHP 8.2 core; [Testbench 9–11](composer.json) ([Laravel 11–12][testbench-compat]; [Laravel 13 / PHP 8.3][testbench-11-composer]) | [PHP 8.3, Laravel 12][spectator-composer] | [PHP 7.2][league-composer] | [PHP 8.0, HttpFoundation 5–8][osteel-composer] | [PHP 8.0, Illuminate 10–13][kirschbaum-composer] |
 
 **Legend**: ✅ supported · — no equivalent feature documented. “Not documented” is intentionally different from “unsupported”.
@@ -105,7 +105,9 @@ composer require --dev studio-design/openapi-contract-testing
 
 ## Quick start
 
-Three steps to your first contract-tested endpoint with the Laravel adapter. For the Symfony adapter, framework-agnostic usage, configuration knobs, opt-out attributes, and request-side validation, see [`docs/setup.md`](docs/setup.md).
+Three steps to your first contract-tested endpoint. The example below uses a
+PSR-7 request and response; Laravel and Symfony integrations are documented in
+[`docs/setup.md`](docs/setup.md).
 
 ### 1. Provide your OpenAPI spec
 
@@ -144,7 +146,26 @@ Then register the emitted configuration:
 </extensions>
 ```
 
-### 3. Assert in tests (Laravel)
+### 3. Validate a PSR-7 exchange
+
+When your application or HTTP client already returns PSR-7 messages, validate
+both sides and record coverage with one framework-independent call:
+
+```php
+use Studio\OpenApiContractTesting\Psr7\OpenApiPsr7Validator;
+
+$validator = new OpenApiPsr7Validator('front');
+$result = $validator->validateExchange($request, $response);
+
+$this->assertTrue($result->isValid(), $result->errorMessage());
+```
+
+The adapter accepts any `psr/http-message` implementation; no concrete PSR-7
+package is added to production dependencies. A PHPUnit assertion trait,
+response-only operation addressing, PSR-15 test recipe, and stream guarantees
+are covered in the [PSR-7 guide](docs/psr7.md).
+
+### Laravel adapter
 
 ```bash
 php artisan vendor:publish --tag=openapi-contract-testing
@@ -180,6 +201,7 @@ To validate every response automatically, set `'auto_assert' => true` and drop t
 
 | Topic | Reference |
 |---|---|
+| PSR-7 request / response / exchange validation and PSR-15 test recipe | [`docs/psr7.md`](docs/psr7.md) |
 | Full setup, Laravel / Symfony / framework-agnostic adapters, auto-assert, opt-out attributes, request validation, HTTP `$ref` | [`docs/setup.md`](docs/setup.md) |
 | Pre-test compatibility diagnostics (`openapi-contract doctor`) | [`docs/doctor.md`](docs/doctor.md) |
 | Laravel route/spec parity (`openapi:routes`) | [`docs/laravel-route-parity.md`](docs/laravel-route-parity.md) |

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "friendsofphp/php-cs-fixer": "^3.94",
         "guzzlehttp/guzzle": "^7.12.1",
         "guzzlehttp/psr7": "^2.12.1",
+        "nyholm/psr7": "^1.8",
         "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
         "phpstan/phpstan": "^2.1.13",
         "symfony/browser-kit": "^6.4 || ^7.0 || ^8.0",

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,7 @@
 # API Reference
 
 - [`OpenApiResponseValidator`](#openapiresponsevalidator)
+- [`OpenApiPsr7Validator`](#openapipsr7validator)
 - [`OpenApiSpecLoader`](#openapispecloader)
 - [`OpenApiCoverageTracker`](#openapicoveragetracker)
 
@@ -44,6 +45,26 @@ match ($result->outcome()) {
     OpenApiValidationOutcome::Skipped => logger()->info('skipped', ['reason' => $result->skipReason()]),
 };
 ```
+
+## `OpenApiPsr7Validator`
+
+Adapts PSR-7 messages to the request and response validators and records the
+same coverage as framework integrations:
+
+```php
+use Studio\OpenApiContractTesting\Psr7\OpenApiPsr7Validator;
+
+$validator = new OpenApiPsr7Validator('front');
+
+$exchange = $validator->validateExchange($request, $response);
+$requestResult = $exchange->requestResult();
+$responseResult = $exchange->responseResult();
+```
+
+Use `validateRequest()`, `validateResponse()`, or
+`validateResponseForOperation()` when only one side is available. See the
+[PSR-7 guide](psr7.md) for PHPUnit assertions, stream handling, and a PSR-15
+test integration recipe.
 
 ## `OpenApiSpecLoader`
 

--- a/docs/psr7.md
+++ b/docs/psr7.md
@@ -1,0 +1,131 @@
+# PSR-7 request and response validation
+
+Use the PSR-7 adapter when your application or HTTP client already exposes
+`RequestInterface`, `ServerRequestInterface`, and `ResponseInterface` messages.
+It validates both sides of an exchange through the same core validators and
+records the same response-level coverage as the Laravel and Symfony adapters.
+
+No concrete PSR-7 implementation is required by this package. The examples use
+Guzzle PSR-7, but Nyholm PSR-7, Laminas Diactoros, Slim messages, and other
+implementations of `psr/http-message` use the same API.
+
+## Result API
+
+Configure the spec loader once, then construct an adapter for a spec:
+
+```php
+use Studio\OpenApiContractTesting\Psr7\OpenApiPsr7Validator;
+use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+
+OpenApiSpecLoader::configure(__DIR__ . '/openapi', ['/api']);
+
+$validator = new OpenApiPsr7Validator('front');
+$result = $validator->validateExchange($request, $response);
+
+if (!$result->isValid()) {
+    throw new RuntimeException($result->errorMessage());
+}
+```
+
+`validateExchange()` validates the request first and forwards the response
+status to the request validator, preserving the documented-4xx downgrade used
+by the framework adapters. The returned `OpenApiPsr7ValidationResult` exposes
+`requestResult()` and `responseResult()` when the two outcomes need to be
+handled separately.
+
+The individual entry points are:
+
+```php
+$requestResult = $validator->validateRequest($request, $response->getStatusCode());
+
+// Resolve method and path from a RequestInterface.
+$responseResult = $validator->validateResponse($request, $response);
+
+// Or provide the operation address when only a response is available.
+$responseResult = $validator->validateResponseForOperation(
+    method: 'POST',
+    requestPath: '/v1/pets',
+    response: $response,
+);
+```
+
+A `ServerRequestInterface` contributes its parsed query and cookie parameters.
+For a client-side `RequestInterface`, the adapter parses the URI query and
+`Cookie` header. Method spelling is preserved so OpenAPI 3.2 custom
+`additionalOperations` remain case-sensitive.
+
+## PHPUnit assertions
+
+Mix the PSR-7 assertion trait into a PHPUnit test and select the spec with an
+attribute or the `openApiSpec()` hook:
+
+```php
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Attribute\OpenApiSpec;
+use Studio\OpenApiContractTesting\Psr7\OpenApiAssertions;
+
+#[OpenApiSpec('front')]
+final class CreatePetTest extends TestCase
+{
+    use OpenApiAssertions;
+
+    public function test_create_pet(): void
+    {
+        [$request, $response] = $this->callApplication();
+
+        $this->assertPsr7ExchangeMatchesOpenApiSchema($request, $response);
+    }
+}
+```
+
+Request-only, response-only, and explicit-operation assertions are also
+available:
+
+```php
+$this->assertPsr7RequestMatchesOpenApiSchema($request, $response->getStatusCode());
+$this->assertPsr7ResponseMatchesOpenApiSchema($request, $response);
+$this->assertPsr7ResponseForOperationMatchesOpenApiSchema('POST', '/v1/pets', $response);
+```
+
+## PSR-15 test integration
+
+Keep contract validation in tests rather than placing validation middleware on
+the production request path. A PSR-15 handler test can validate the exchange
+immediately after invoking the handler:
+
+```php
+final class ContractTest extends TestCase
+{
+    public function test_handler_contract(): void
+    {
+        $request = $this->serverRequestFactory->createServerRequest('GET', '/v1/pets');
+        $response = $this->handler->handle($request);
+
+        $result = $this->openApi->validateExchange($request, $response);
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+}
+```
+
+This works at the outer handler boundary or in a test-only middleware harness;
+the adapter does not require `psr/http-server-middleware` and adds no runtime
+middleware to the application.
+
+## Body streams
+
+The adapter preserves a seekable stream's current cursor: it remembers the
+position, reads from the beginning, and restores the original position before
+returning. Empty, scalar, object/array, and literal JSON `null` bodies remain
+distinct.
+
+A non-seekable JSON stream cannot be read and then restored through the
+[PSR-7 `StreamInterface`](https://www.php-fig.org/psr/psr-7/#34-psrhttpmessagestreaminterface).
+The adapter therefore returns a failure without reading it. Buffer or decorate
+the body with a seekable/caching stream before validation when the application
+uses a one-pass stream. Non-JSON bodies are not consumed; the core validator
+still checks their declared content type and reports schema enforcement as
+skipped where appropriate.
+
+See the [runnable Guzzle example](../examples/psr7/README.md) for a complete
+project.

--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -33,11 +33,11 @@ For OpenAPI 3.1/3.2, the root `jsonSchemaDialect` supplies the default dialect a
 
 OpenAPI 3.2 is backward compatible with 3.1, so ordinary 3.2 operations use the tested 3.1 conversion pipeline. The behavior below follows the official [OpenAPI 3.2 specification](https://spec.openapis.org/oas/v3.2.0.html) and [3.1-to-3.2 upgrade guide](https://learn.openapis.org/upgrading/v3.1-to-v3.2.html). The contract-relevant 3.2 additions have explicit behavior:
 
-- `QUERY` works in direct validators, Laravel, Symfony, Pest, fuzz exploration, and coverage reports.
-- Custom methods under `additionalOperations` resolve in direct request/response validators and appear in coverage. The enum-based framework and fuzz adapters accept `QUERY` but not arbitrary custom method tokens.
+- `QUERY` works in direct validators, PSR-7, Laravel, Symfony, Pest, fuzz exploration, and coverage reports.
+- Custom methods under `additionalOperations` resolve in direct request/response validators and the PSR-7 adapter, preserving their case-sensitive method spelling, and appear in coverage. The enum-based framework and fuzz adapters accept `QUERY` but not arbitrary custom method tokens.
 - One `in: querystring` parameter with `application/x-www-form-urlencoded` content validates the entire framework-parsed query map against its schema. Mixing it with `in: query`, declaring it more than once, or omitting its schema fails loudly. Other query-string media types emit `[OpenAPI 3.2 querystring]` because the public validator receives a parsed map rather than the original serialized query string.
 - `discriminator.defaultMapping` is enforced for missing and unknown values when an explicit `mapping` is also present. With implicit mappings only, missing values use the fallback while unknown present values rely on the underlying `oneOf` / `anyOf`; `[OpenAPI 3.2 discriminator]` makes that residual limitation observable.
-- `itemSchema` streaming bodies are returned as `Skipped` with a reason and matched content type. The current adapters buffer a complete body and cannot safely apply a schema independently to each SSE, JSON Lines, JSON Text Sequence, or multipart stream item.
+- `itemSchema` streaming bodies are returned as `Skipped` with a reason and matched content type. Framework adapters buffer a complete body, while the PSR-7 adapter refuses to consume a non-seekable JSON stream; neither path can safely apply a schema independently to each SSE, JSON Lines, JSON Text Sequence, or multipart stream item.
 - A root `$self` emits `[OpenAPI 3.2 $self]`: relative references still resolve from the retrieved file path, so specs depending on a different `$self` base URI must be pre-bundled.
 
 ### `readOnly` / `writeOnly` enforcement
@@ -93,7 +93,7 @@ Detection looks at each property schema's own top-level `readOnly` / `writeOnly`
 - **`readOnly` / `writeOnly`**: enforced at the property's own top level only (see [readOnly / writeOnly enforcement](#readonly--writeonly-enforcement)).
 
 ## HTTP methods
-The PHPUnit coverage report counts `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, OpenAPI 3.2 `QUERY`, and every custom method declared under `additionalOperations`. Laravel, Symfony, Pest, and the fuzz explorer accept the six named enum methods including `QUERY`; arbitrary custom tokens are supported by the direct validators and coverage tracker. Operations under `HEAD`, `OPTIONS`, and `TRACE` are still outside the coverage allowlist and enum-based adapters, although direct validator calls resolve them.
+The PHPUnit coverage report counts `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, OpenAPI 3.2 `QUERY`, and every custom method declared under `additionalOperations`. Laravel, Symfony, Pest, and the fuzz explorer accept the six named enum methods including `QUERY`; arbitrary custom tokens are supported by the direct validators, PSR-7 adapter, and coverage tracker. Operations under `HEAD`, `OPTIONS`, and `TRACE` are still outside the coverage allowlist and enum-based adapters, although direct validator and PSR-7 adapter calls resolve them.
 
 ## Spec features not consulted
 Webhooks (3.1+), Callbacks, Response `Links`, Server URL templating (`servers` with `variables`), Examples (`example` / `examples`, including 3.2 `dataValue` / `serializedValue` — not used for fuzzing or validation), 3.2 tag hierarchy (`summary` / `parent` / `kind`), `externalDocs`, and vendor extensions (`x-*` keys, ignored harmlessly). OAuth2 device authorization and other OAuth/OpenID schemes remain on the existing `[security]` warning path.

--- a/examples/psr7/README.md
+++ b/examples/psr7/README.md
@@ -1,0 +1,13 @@
+# PSR-7 example
+
+This runnable example validates a Guzzle PSR-7 request and response as one
+exchange and records OpenAPI coverage.
+
+```bash
+composer install
+composer test
+```
+
+The package is loaded from the repository root through a Composer path
+repository, so CI exercises the current working tree rather than a released
+version.

--- a/examples/psr7/composer.json
+++ b/examples/psr7/composer.json
@@ -1,0 +1,30 @@
+{
+    "name": "studio-design/openapi-contract-testing-psr7-example",
+    "description": "Runnable PSR-7 example for studio-design/openapi-contract-testing.",
+    "license": "MIT",
+    "type": "project",
+    "require": {
+        "php": "^8.2",
+        "guzzlehttp/psr7": "^2.7",
+        "studio-design/openapi-contract-testing": "@dev"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Examples\\Psr7\\Tests\\": "tests/"
+        }
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../..",
+            "options": {
+                "symlink": true
+            }
+        }
+    ],
+    "scripts": {
+        "test": "phpunit"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/examples/psr7/openapi/petstore.json
+++ b/examples/psr7/openapi/petstore.json
@@ -1,0 +1,44 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "PSR-7 example",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/pets": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                  "name": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["id", "name"],
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "name": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/psr7/phpunit.xml.dist
+++ b/examples/psr7/phpunit.xml.dist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="PSR-7 example">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <extensions>
+        <bootstrap class="Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension">
+            <parameter name="spec_base_path" value="openapi"/>
+            <parameter name="specs" value="petstore"/>
+        </bootstrap>
+    </extensions>
+</phpunit>

--- a/examples/psr7/tests/PetContractTest.php
+++ b/examples/psr7/tests/PetContractTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Examples\Psr7\Tests;
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Attribute\OpenApiSpec;
+use Studio\OpenApiContractTesting\Psr7\OpenApiAssertions;
+
+#[OpenApiSpec('petstore')]
+final class PetContractTest extends TestCase
+{
+    use OpenApiAssertions;
+
+    #[Test]
+    public function validates_a_psr7_exchange(): void
+    {
+        $request = new Request(
+            'POST',
+            'https://example.test/pets',
+            ['Content-Type' => 'application/json'],
+            '{"name":"Fido"}',
+        );
+        $response = new Response(
+            201,
+            ['Content-Type' => 'application/json'],
+            '{"id":1,"name":"Fido"}',
+        );
+
+        $this->assertPsr7ExchangeMatchesOpenApiSchema($request, $response);
+    }
+}

--- a/src/Internal/StackTraceFilter.php
+++ b/src/Internal/StackTraceFilter.php
@@ -48,6 +48,7 @@ final class StackTraceFilter
     private const DROP_PATTERNS = [
         '/studio-design/openapi-contract-testing/src/',
         '/openapi-contract-testing/src/Laravel/',
+        '/openapi-contract-testing/src/Psr7/',
         '/openapi-contract-testing/src/Symfony/',
         '/openapi-contract-testing/src/Internal/',
         '/openapi-contract-testing/src/PHPUnit/',

--- a/src/Psr7/OpenApiAssertions.php
+++ b/src/Psr7/OpenApiAssertions.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Psr7;
+
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\AssertionFailedError;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Studio\OpenApiContractTesting\Internal\StackTraceFilter;
+use Studio\OpenApiContractTesting\OpenApiRequestValidator;
+use Studio\OpenApiContractTesting\OpenApiResponseValidator;
+use Studio\OpenApiContractTesting\OpenApiValidationResult;
+use Studio\OpenApiContractTesting\Spec\OpenApiSpecResolver;
+
+use function sprintf;
+
+/**
+ * PHPUnit assertions for PSR-7 request and response messages.
+ *
+ * Resolve the spec with #[OpenApiSpec] or by overriding openApiSpec(). For a
+ * non-PHPUnit result API, instantiate {@see OpenApiPsr7Validator} directly.
+ */
+trait OpenApiAssertions
+{
+    use OpenApiSpecResolver;
+    private ?OpenApiPsr7Validator $cachedPsr7Validator = null;
+    private ?string $cachedPsr7SpecName = null;
+
+    public function assertPsr7RequestMatchesOpenApiSchema(
+        RequestInterface $request,
+        ?int $responseStatusCode = null,
+    ): void {
+        $result = $this->psr7Validator()->validateRequest($request, $responseStatusCode);
+
+        $this->assertPsr7Result(
+            $result,
+            sprintf(
+                'OpenAPI PSR-7 request validation failed for %s %s',
+                $request->getMethod(),
+                $request->getUri()->getPath() ?: '/',
+            ),
+        );
+    }
+
+    public function assertPsr7ResponseMatchesOpenApiSchema(
+        RequestInterface $request,
+        ResponseInterface $response,
+    ): void {
+        $result = $this->psr7Validator()->validateResponse($request, $response);
+
+        $this->assertPsr7Result(
+            $result,
+            sprintf(
+                'OpenAPI PSR-7 response validation failed for %s %s',
+                $request->getMethod(),
+                $request->getUri()->getPath() ?: '/',
+            ),
+        );
+    }
+
+    public function assertPsr7ResponseForOperationMatchesOpenApiSchema(
+        string $method,
+        string $requestPath,
+        ResponseInterface $response,
+    ): void {
+        $result = $this->psr7Validator()->validateResponseForOperation($method, $requestPath, $response);
+
+        $this->assertPsr7Result(
+            $result,
+            sprintf('OpenAPI PSR-7 response validation failed for %s %s', $method, $requestPath),
+        );
+    }
+
+    public function assertPsr7ExchangeMatchesOpenApiSchema(
+        RequestInterface $request,
+        ResponseInterface $response,
+    ): void {
+        $result = $this->psr7Validator()->validateExchange($request, $response);
+
+        $this->assertPsr7(
+            $result->isValid(),
+            sprintf(
+                "OpenAPI PSR-7 exchange validation failed for %s %s (spec: %s):\n%s",
+                $request->getMethod(),
+                $request->getUri()->getPath() ?: '/',
+                $this->cachedPsr7SpecName,
+                $result->errorMessage(),
+            ),
+        );
+    }
+
+    /** User-overridable fallback when no #[OpenApiSpec] attribute is present. */
+    protected function openApiSpec(): string
+    {
+        return '';
+    }
+
+    protected function openApiMaxErrors(): int
+    {
+        return 20;
+    }
+
+    /** @return string[] */
+    protected function openApiSkipResponseCodes(): array
+    {
+        return OpenApiResponseValidator::DEFAULT_SKIP_RESPONSE_CODES;
+    }
+
+    /** @return string[] */
+    protected function openApiSkipRequestValidationResponseCodes(): array
+    {
+        return OpenApiRequestValidator::DEFAULT_SKIP_REQUEST_VALIDATION_RESPONSE_CODES;
+    }
+
+    protected function openApiSpecFallback(): string
+    {
+        return $this->openApiSpec();
+    }
+
+    private function psr7Validator(): OpenApiPsr7Validator
+    {
+        $specName = $this->resolveOpenApiSpec();
+        if ($specName === '') {
+            $this->failPsr7(
+                'No OpenAPI spec is configured for this PSR-7 assertion. Add '
+                . "#[OpenApiSpec('your-spec')] or override openApiSpec().",
+            );
+        }
+
+        if ($this->cachedPsr7Validator === null || $this->cachedPsr7SpecName !== $specName) {
+            $this->cachedPsr7Validator = new OpenApiPsr7Validator(
+                $specName,
+                maxErrors: $this->openApiMaxErrors(),
+                skipResponseCodes: $this->openApiSkipResponseCodes(),
+                skipRequestValidationResponseCodes: $this->openApiSkipRequestValidationResponseCodes(),
+            );
+            $this->cachedPsr7SpecName = $specName;
+        }
+
+        return $this->cachedPsr7Validator;
+    }
+
+    private function assertPsr7Result(OpenApiValidationResult $result, string $prefix): void
+    {
+        $this->assertPsr7(
+            $result->isValid(),
+            sprintf("%s (spec: %s):\n%s", $prefix, $this->cachedPsr7SpecName, $result->errorMessage()),
+        );
+    }
+
+    private function failPsr7(string $message): never
+    {
+        try {
+            Assert::fail($message);
+        } catch (AssertionFailedError $e) {
+            StackTraceFilter::rethrowWithCleanTrace($e);
+        }
+    }
+
+    private function assertPsr7(bool $condition, string $message): void
+    {
+        try {
+            Assert::assertTrue($condition, $message);
+        } catch (AssertionFailedError $e) {
+            StackTraceFilter::rethrowWithCleanTrace($e);
+        }
+    }
+}

--- a/src/Psr7/OpenApiPsr7ValidationResult.php
+++ b/src/Psr7/OpenApiPsr7ValidationResult.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Psr7;
+
+use Studio\OpenApiContractTesting\OpenApiValidationResult;
+
+use function array_map;
+use function array_merge;
+use function implode;
+
+/**
+ * Result of validating a PSR-7 request and response as one exchange.
+ */
+final readonly class OpenApiPsr7ValidationResult
+{
+    public function __construct(
+        private OpenApiValidationResult $requestResult,
+        private OpenApiValidationResult $responseResult,
+    ) {}
+
+    public function requestResult(): OpenApiValidationResult
+    {
+        return $this->requestResult;
+    }
+
+    public function responseResult(): OpenApiValidationResult
+    {
+        return $this->responseResult;
+    }
+
+    public function isValid(): bool
+    {
+        return $this->requestResult->isValid() && $this->responseResult->isValid();
+    }
+
+    /** @return string[] */
+    public function errors(): array
+    {
+        return array_merge(
+            array_map(static fn(string $error): string => '[request] ' . $error, $this->requestResult->errors()),
+            array_map(static fn(string $error): string => '[response] ' . $error, $this->responseResult->errors()),
+        );
+    }
+
+    public function errorMessage(): string
+    {
+        return implode("\n", $this->errors());
+    }
+}

--- a/src/Psr7/OpenApiPsr7Validator.php
+++ b/src/Psr7/OpenApiPsr7Validator.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Psr7;
+
+use const JSON_THROW_ON_ERROR;
+
+use JsonException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use RuntimeException;
+use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\DecodedBody;
+use Studio\OpenApiContractTesting\OpenApiRequestValidator;
+use Studio\OpenApiContractTesting\OpenApiResponseValidator;
+use Studio\OpenApiContractTesting\OpenApiValidationResult;
+use Studio\OpenApiContractTesting\Validation\Support\ContentTypeMatcher;
+
+use function array_merge;
+use function explode;
+use function json_decode;
+use function ltrim;
+use function parse_str;
+use function rawurldecode;
+use function sprintf;
+use function str_contains;
+use function trim;
+
+/**
+ * Framework-independent adapter for validating PSR-7 HTTP messages.
+ *
+ * Body streams are read only when they are seekable. The original cursor is
+ * restored after decoding; a non-seekable stream produces a validation error
+ * without being consumed.
+ */
+final class OpenApiPsr7Validator
+{
+    private readonly OpenApiRequestValidator $requestValidator;
+    private readonly OpenApiResponseValidator $responseValidator;
+
+    /**
+     * @param string[] $skipResponseCodes
+     * @param string[] $skipRequestValidationResponseCodes
+     */
+    public function __construct(
+        private readonly string $specName,
+        int $maxErrors = 20,
+        array $skipResponseCodes = OpenApiResponseValidator::DEFAULT_SKIP_RESPONSE_CODES,
+        array $skipRequestValidationResponseCodes = OpenApiRequestValidator::DEFAULT_SKIP_REQUEST_VALIDATION_RESPONSE_CODES,
+    ) {
+        $this->requestValidator = new OpenApiRequestValidator(
+            maxErrors: $maxErrors,
+            skipRequestValidationResponseCodes: $skipRequestValidationResponseCodes,
+        );
+        $this->responseValidator = new OpenApiResponseValidator(
+            maxErrors: $maxErrors,
+            skipResponseCodes: $skipResponseCodes,
+        );
+    }
+
+    /**
+     * Validate a PSR-7 request. ServerRequestInterface supplies its parsed
+     * query/cookie parameters; a client RequestInterface is parsed from the
+     * URI query and Cookie header.
+     */
+    public function validateRequest(
+        RequestInterface $request,
+        ?int $responseStatusCode = null,
+    ): OpenApiValidationResult {
+        $method = $request->getMethod();
+        $path = self::requestPath($request);
+        $contentType = self::contentType($request);
+        $decoded = $this->decodeBody($request->getBody(), $contentType, 'Request');
+
+        if ($request instanceof ServerRequestInterface) {
+            /** @var array<string, mixed> $queryParams */
+            $queryParams = $request->getQueryParams();
+            /** @var array<string, mixed> $cookies */
+            $cookies = $request->getCookieParams();
+        } else {
+            $queryParams = self::parseQuery($request);
+            $cookies = self::parseCookieHeader($request);
+        }
+
+        $result = $this->requestValidator->validate(
+            $this->specName,
+            $method,
+            $path,
+            $queryParams,
+            $request->getHeaders(),
+            $decoded['body'],
+            $contentType,
+            $cookies,
+            $responseStatusCode,
+        );
+        $result = self::withAdapterErrors($result, $decoded['errors']);
+
+        if ($result->matchedPath() !== null) {
+            OpenApiCoverageTracker::recordRequest(
+                $this->specName,
+                $method,
+                $result->matchedPath(),
+                $result->isSkipped() ? $result->skipReason() : null,
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * Resolve the operation from a PSR-7 request and validate the response.
+     */
+    public function validateResponse(
+        RequestInterface $request,
+        ResponseInterface $response,
+    ): OpenApiValidationResult {
+        return $this->validateResponseForOperation(
+            $request->getMethod(),
+            self::requestPath($request),
+            $response,
+        );
+    }
+
+    /**
+     * Validate a response for an explicit OpenAPI operation address.
+     */
+    public function validateResponseForOperation(
+        string $method,
+        string $requestPath,
+        ResponseInterface $response,
+    ): OpenApiValidationResult {
+        $contentType = self::contentType($response);
+        $decoded = $this->decodeBody($response->getBody(), $contentType, 'Response');
+        $result = $this->responseValidator->validate(
+            $this->specName,
+            $method,
+            $requestPath,
+            $response->getStatusCode(),
+            $decoded['body'],
+            $contentType,
+            $response->getHeaders(),
+        );
+        $result = self::withAdapterErrors($result, $decoded['errors']);
+
+        if ($result->matchedPath() !== null) {
+            OpenApiCoverageTracker::recordResponse(
+                $this->specName,
+                $method,
+                $result->matchedPath(),
+                $result->matchedStatusCode() ?? (string) $response->getStatusCode(),
+                $result->matchedContentType(),
+                schemaValidated: !$result->isSkipped(),
+                skipReason: $result->skipReason(),
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * Validate both sides of one PSR-7 exchange against the request operation.
+     */
+    public function validateExchange(
+        RequestInterface $request,
+        ResponseInterface $response,
+    ): OpenApiPsr7ValidationResult {
+        return new OpenApiPsr7ValidationResult(
+            $this->validateRequest($request, $response->getStatusCode()),
+            $this->validateResponse($request, $response),
+        );
+    }
+
+    /** @return array{body: DecodedBody, errors: non-empty-list<string>} */
+    private static function bodyReadFailure(string $subject, string $reason): array
+    {
+        return [
+            'body' => DecodedBody::absent(),
+            'errors' => [sprintf('%s %s.', $subject, $reason)],
+        ];
+    }
+
+    /** @param list<string> $adapterErrors */
+    private static function withAdapterErrors(
+        OpenApiValidationResult $result,
+        array $adapterErrors,
+    ): OpenApiValidationResult {
+        if ($adapterErrors === []) {
+            return $result;
+        }
+
+        return OpenApiValidationResult::failure(
+            array_merge($adapterErrors, $result->errors()),
+            $result->matchedPath(),
+            $result->matchedStatusCode(),
+            $result->matchedContentType(),
+        );
+    }
+
+    private static function requestPath(RequestInterface $request): string
+    {
+        $path = $request->getUri()->getPath();
+
+        return $path === '' ? '/' : $path;
+    }
+
+    private static function contentType(RequestInterface|ResponseInterface $message): ?string
+    {
+        $contentType = trim($message->getHeaderLine('Content-Type'));
+
+        return $contentType === '' ? null : $contentType;
+    }
+
+    /** @return array<string, mixed> */
+    private static function parseQuery(RequestInterface $request): array
+    {
+        $query = [];
+        parse_str($request->getUri()->getQuery(), $query);
+
+        return $query;
+    }
+
+    /** @return array<string, string> */
+    private static function parseCookieHeader(RequestInterface $request): array
+    {
+        $cookies = [];
+        foreach ($request->getHeader('Cookie') as $header) {
+            foreach (explode(';', $header) as $pair) {
+                $pair = trim($pair);
+                if ($pair === '' || !str_contains($pair, '=')) {
+                    continue;
+                }
+
+                [$name, $value] = explode('=', $pair, 2);
+                $name = trim($name);
+                if ($name === '') {
+                    continue;
+                }
+
+                $cookies[$name] = rawurldecode(ltrim($value));
+            }
+        }
+
+        return $cookies;
+    }
+
+    /**
+     * @return array{body: DecodedBody, errors: list<string>}
+     */
+    private function decodeBody(
+        StreamInterface $stream,
+        ?string $contentType,
+        string $subject,
+    ): array {
+        if ($contentType !== null && !ContentTypeMatcher::isJsonContentType(
+            ContentTypeMatcher::normalizeMediaType($contentType),
+        )) {
+            return ['body' => DecodedBody::absent(), 'errors' => []];
+        }
+
+        if ($stream->getSize() === 0) {
+            return ['body' => DecodedBody::absent(), 'errors' => []];
+        }
+
+        if (!$stream->isReadable()) {
+            return self::bodyReadFailure($subject, 'body stream is not readable');
+        }
+
+        if (!$stream->isSeekable()) {
+            return self::bodyReadFailure(
+                $subject,
+                'body stream is not seekable; validation was refused to avoid consuming caller state',
+            );
+        }
+
+        try {
+            $position = $stream->tell();
+            $stream->rewind();
+            $content = $stream->getContents();
+        } catch (RuntimeException $e) {
+            return self::bodyReadFailure($subject, 'body stream could not be read: ' . $e->getMessage());
+        } finally {
+            if (isset($position)) {
+                try {
+                    $stream->seek($position);
+                } catch (RuntimeException $e) {
+                    return self::bodyReadFailure($subject, 'body stream cursor could not be restored: ' . $e->getMessage());
+                }
+            }
+        }
+
+        if ($content === '') {
+            return ['body' => DecodedBody::absent(), 'errors' => []];
+        }
+
+        try {
+            /** @var mixed $value */
+            $value = json_decode($content, true, flags: JSON_THROW_ON_ERROR);
+
+            return ['body' => DecodedBody::present($value), 'errors' => []];
+        } catch (JsonException $e) {
+            return [
+                'body' => DecodedBody::present($content),
+                'errors' => [sprintf('%s body could not be parsed as JSON: %s', $subject, $e->getMessage())],
+            ];
+        }
+    }
+}

--- a/src/Psr7/OpenApiPsr7Validator.php
+++ b/src/Psr7/OpenApiPsr7Validator.php
@@ -19,15 +19,18 @@ use Studio\OpenApiContractTesting\OpenApiResponseValidator;
 use Studio\OpenApiContractTesting\OpenApiValidationResult;
 use Studio\OpenApiContractTesting\Validation\Support\ContentTypeMatcher;
 
+use function array_key_exists;
 use function array_merge;
+use function array_pad;
 use function explode;
+use function is_array;
 use function json_decode;
 use function ltrim;
-use function parse_str;
 use function rawurldecode;
 use function sprintf;
 use function str_contains;
 use function trim;
+use function urldecode;
 
 /**
  * Framework-independent adapter for validating PSR-7 HTTP messages.
@@ -216,8 +219,36 @@ final class OpenApiPsr7Validator
     /** @return array<string, mixed> */
     private static function parseQuery(RequestInterface $request): array
     {
+        /** @var array<string, mixed> $query */
         $query = [];
-        parse_str($request->getUri()->getQuery(), $query);
+        $queryString = $request->getUri()->getQuery();
+        if ($queryString === '') {
+            return $query;
+        }
+
+        // OpenAPI `style: form, explode: true` serializes arrays by repeating
+        // the parameter name (`tags=a&tags=b`). PHP's parse_str() overwrites
+        // earlier unbracketed values, so parse the wire pairs directly and
+        // promote a repeated key to an ordered list instead.
+        foreach (explode('&', $queryString) as $pair) {
+            [$encodedName, $encodedValue] = array_pad(explode('=', $pair, 2), 2, '');
+            $name = urldecode($encodedName);
+            if ($name === '') {
+                continue;
+            }
+
+            $value = urldecode($encodedValue);
+            if (!array_key_exists($name, $query)) {
+                $query[$name] = $value;
+
+                continue;
+            }
+
+            if (!is_array($query[$name])) {
+                $query[$name] = [$query[$name]];
+            }
+            $query[$name][] = $value;
+        }
 
         return $query;
     }

--- a/tests/Unit/Psr7/OpenApiAssertionsTest.php
+++ b/tests/Unit/Psr7/OpenApiAssertionsTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Psr7;
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\Psr7\OpenApiAssertions;
+use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+
+final class OpenApiAssertionsTest extends TestCase
+{
+    use OpenApiAssertions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiSpecLoader::reset();
+        OpenApiCoverageTracker::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../../fixtures/specs');
+    }
+
+    protected function tearDown(): void
+    {
+        OpenApiSpecLoader::reset();
+        OpenApiCoverageTracker::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function asserts_a_psr7_response_for_an_explicit_operation(): void
+    {
+        $response = new Response(
+            201,
+            ['Content-Type' => 'application/json', 'X-Trace' => 'trace-1'],
+            '{"id":42}',
+        );
+
+        $this->assertPsr7ResponseForOperationMatchesOpenApiSchema('POST', '/widgets/42', $response);
+    }
+
+    #[Test]
+    public function assertion_failure_includes_the_operation_and_spec(): void
+    {
+        $request = new Request('GET', 'https://example.test/body/scalar');
+        $response = new Response(200, ['Content-Type' => 'application/json'], '"wrong"');
+
+        try {
+            $this->assertPsr7ResponseMatchesOpenApiSchema($request, $response);
+            $this->fail('Expected the PSR-7 assertion to fail.');
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString('GET /body/scalar', $e->getMessage());
+            $this->assertStringContainsString('spec: psr7', $e->getMessage());
+        }
+    }
+
+    protected function openApiSpec(): string
+    {
+        return 'psr7';
+    }
+}

--- a/tests/Unit/Psr7/OpenApiPsr7ValidatorTest.php
+++ b/tests/Unit/Psr7/OpenApiPsr7ValidatorTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Psr7;
+
+use GuzzleHttp\Psr7\NoSeekStream;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\ServerRequest;
+use GuzzleHttp\Psr7\Utils;
+use Nyholm\Psr7\Request as NyholmRequest;
+use Nyholm\Psr7\Response as NyholmResponse;
+use Nyholm\Psr7\ServerRequest as NyholmServerRequest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\Psr7\OpenApiPsr7Validator;
+use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
+
+final class OpenApiPsr7ValidatorTest extends TestCase
+{
+    private OpenApiPsr7Validator $validator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiSpecLoader::reset();
+        OpenApiCoverageTracker::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../../fixtures/specs');
+        $this->validator = new OpenApiPsr7Validator('psr7');
+    }
+
+    protected function tearDown(): void
+    {
+        OpenApiSpecLoader::reset();
+        OpenApiCoverageTracker::reset();
+        parent::tearDown();
+    }
+
+    /**
+     * @return iterable<string, array{string, int, string}>
+     */
+    public static function providePreserves_json_null_scalar_and_empty_body_distinctionsCases(): iterable
+    {
+        yield 'literal null' => ['/body/null', 200, 'null'];
+        yield 'scalar' => ['/body/scalar', 200, '42'];
+        yield 'empty' => ['/body/empty', 204, ''];
+    }
+
+    #[Test]
+    public function validates_a_server_request_and_response_as_one_exchange(): void
+    {
+        $request = (new ServerRequest(
+            'POST',
+            'https://example.test/widgets/42?q=blue',
+            ['Content-Type' => 'application/json', 'X-Token' => 'secret'],
+            '{"message":"hello"}',
+        ))
+            ->withQueryParams(['q' => 'blue'])
+            ->withCookieParams(['session' => 'abc']);
+        $response = new Response(
+            201,
+            ['Content-Type' => 'application/json; charset=utf-8', 'X-Trace' => 'trace-1'],
+            '{"id":42}',
+        );
+
+        $result = $this->validator->validateExchange($request, $response);
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+        $this->assertSame('/widgets/{id}', $result->requestResult()->matchedPath());
+        $this->assertSame('/widgets/{id}', $result->responseResult()->matchedPath());
+
+        $coverage = OpenApiCoverageTracker::computeCoverage('psr7');
+        $this->assertSame(1, $coverage['responseCovered']);
+        $this->assertArrayHasKey('POST /widgets/{id}', OpenApiCoverageTracker::getCovered()['psr7']);
+    }
+
+    #[Test]
+    public function validates_nyholm_psr7_messages_through_the_same_api(): void
+    {
+        $request = (new NyholmServerRequest(
+            'POST',
+            'https://example.test/widgets/42?q=blue',
+            ['Content-Type' => 'application/json', 'X-Token' => 'secret'],
+            '{"message":"hello"}',
+        ))->withCookieParams(['session' => 'abc']);
+        $response = new NyholmResponse(
+            201,
+            ['Content-Type' => 'application/json', 'X-Trace' => 'trace-1'],
+            '{"id":42}',
+        );
+
+        $result = $this->validator->validateExchange($request, $response);
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function parses_query_and_cookie_values_from_a_client_request(): void
+    {
+        $request = new Request(
+            'POST',
+            'https://example.test/widgets/42?q=blue',
+            [
+                'Content-Type' => 'application/json',
+                'Cookie' => 'session=abc',
+                'X-Token' => 'secret',
+            ],
+            '{"message":"hello"}',
+        );
+
+        $result = $this->validator->validateRequest($request);
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function reports_a_missing_cookie_from_a_client_request(): void
+    {
+        $request = new Request(
+            'POST',
+            'https://example.test/widgets/42?q=blue',
+            ['Content-Type' => 'application/json', 'X-Token' => 'secret'],
+            '{"message":"hello"}',
+        );
+
+        $result = $this->validator->validateRequest($request);
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString("api key 'session' is missing from the cookie", $result->errorMessage());
+    }
+
+    #[Test]
+    public function validates_a_response_with_an_explicit_operation_address(): void
+    {
+        $response = new Response(
+            201,
+            ['Content-Type' => 'application/json', 'X-Trace' => 'trace-1'],
+            '{"id":42}',
+        );
+
+        $result = $this->validator->validateResponseForOperation('POST', '/widgets/42', $response);
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+        $this->assertSame('/widgets/{id}', $result->matchedPath());
+    }
+
+    #[Test]
+    public function preserves_custom_openapi_32_method_casing(): void
+    {
+        $validator = new OpenApiPsr7Validator('openapi-3.2');
+        $response = new Response(
+            200,
+            ['Content-Type' => 'application/json'],
+            '{"id":2,"name":"Copy"}',
+        );
+
+        $matching = $validator->validateResponse(
+            new NyholmRequest('COPY', 'https://example.test/v1/pets/1'),
+            $response,
+        );
+        $wrongCase = $validator->validateResponse(
+            new NyholmRequest('copy', 'https://example.test/v1/pets/1'),
+            $response,
+        );
+
+        $this->assertTrue($matching->isValid(), $matching->errorMessage());
+        $this->assertFalse($wrongCase->isValid());
+    }
+
+    #[Test]
+    public function restores_the_original_position_of_a_seekable_stream(): void
+    {
+        $stream = Utils::streamFor('{"id":42}');
+        $stream->read(4);
+        $response = new Response(
+            201,
+            ['Content-Type' => 'application/json', 'X-Trace' => 'trace-1'],
+            $stream,
+        );
+
+        $result = $this->validator->validateResponseForOperation('POST', '/widgets/42', $response);
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+        $this->assertSame(4, $stream->tell());
+    }
+
+    #[Test]
+    public function refuses_a_non_seekable_stream_without_consuming_it(): void
+    {
+        $stream = new NoSeekStream(Utils::streamFor('{"id":42}'));
+        $response = new Response(
+            201,
+            ['Content-Type' => 'application/json', 'X-Trace' => 'trace-1'],
+            $stream,
+        );
+
+        $result = $this->validator->validateResponseForOperation('POST', '/widgets/42', $response);
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('not seekable', $result->errorMessage());
+        $this->assertSame(0, $stream->tell());
+        $this->assertSame('{"id":42}', $stream->getContents());
+    }
+
+    #[DataProvider('providePreserves_json_null_scalar_and_empty_body_distinctionsCases')]
+    #[Test]
+    public function preserves_json_null_scalar_and_empty_body_distinctions(
+        string $path,
+        int $status,
+        string $body,
+    ): void {
+        $request = new Request('GET', 'https://example.test' . $path);
+        $response = new Response($status, ['Content-Type' => 'application/json'], $body);
+
+        $result = $this->validator->validateResponse($request, $response);
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function reports_invalid_json_as_an_adapter_error(): void
+    {
+        $response = new Response(
+            201,
+            ['Content-Type' => 'application/json', 'X-Trace' => 'trace-1'],
+            '{invalid',
+        );
+
+        $result = $this->validator->validateResponseForOperation('POST', '/widgets/42', $response);
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('could not be parsed as JSON', $result->errorMessage());
+        $this->assertSame('/widgets/{id}', $result->matchedPath());
+    }
+}

--- a/tests/Unit/Psr7/OpenApiPsr7ValidatorTest.php
+++ b/tests/Unit/Psr7/OpenApiPsr7ValidatorTest.php
@@ -117,6 +117,27 @@ final class OpenApiPsr7ValidatorTest extends TestCase
     }
 
     #[Test]
+    public function preserves_repeated_form_explode_query_values_as_an_array(): void
+    {
+        $request = new Request('GET', 'https://example.test/search?tags=a&tags=b');
+
+        $result = $this->validator->validateRequest($request);
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+
+    #[Test]
+    public function retains_an_invalid_value_before_a_repeated_query_key(): void
+    {
+        $request = new Request('GET', 'https://example.test/search?tags=invalid&tags=b');
+
+        $result = $this->validator->validateRequest($request);
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString('query.tags/0', $result->errorMessage());
+    }
+
+    #[Test]
     public function reports_a_missing_cookie_from_a_client_request(): void
     {
         $request = new Request(

--- a/tests/fixtures/specs/psr7.json
+++ b/tests/fixtures/specs/psr7.json
@@ -1,0 +1,124 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "PSR-7 adapter fixture",
+    "version": "1.0.0"
+  },
+  "components": {
+    "securitySchemes": {
+      "sessionCookie": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "session"
+      }
+    }
+  },
+  "paths": {
+    "/widgets/{id}": {
+      "post": {
+        "security": [
+          { "sessionCookie": [] }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "X-Token",
+            "in": "header",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "session",
+            "in": "cookie",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["message"],
+                "properties": {
+                  "message": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "headers": {
+              "X-Trace": {
+                "required": true,
+                "schema": { "type": "string" }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["id"],
+                  "properties": {
+                    "id": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/body/null": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "JSON null",
+            "content": {
+              "application/json": {
+                "schema": { "type": "null" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/body/scalar": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "JSON scalar",
+            "content": {
+              "application/json": {
+                "schema": { "type": "integer" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/body/empty": {
+      "get": {
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/specs/psr7.json
+++ b/tests/fixtures/specs/psr7.json
@@ -119,6 +119,32 @@
           }
         }
       }
+    },
+    "/search": {
+      "get": {
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "minItems": 2,
+              "items": {
+                "type": "string",
+                "enum": ["a", "b"]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #278.

## Summary

- add a first-class PSR-7 result API for request, response,
  explicit-operation, and combined exchange validation
- add PHPUnit assertions with the existing spec-resolution and clean-stack
  behavior
- preserve seekable stream positions and refuse non-seekable JSON streams
  without consuming caller state
- record request and response coverage through the existing tracker
- verify interoperability with Guzzle PSR-7 and Nyholm PSR-7
- add a runnable, CI-tested PSR-7 example and PSR-15 test integration
  documentation

## Why

The package already requires `psr/http-message`, but PSR-7 applications had to
manually unpack method, URI, parameters, headers, cookies, status, and bodies
into low-level validator calls. This adapter makes the framework-agnostic path
a first-class integration without adding a concrete PSR-7 production dependency
or production middleware.

## User impact

Users of Slim, Mezzio, PSR-15 stacks, HTTP clients, and custom PSR-7
applications can validate one request/response exchange with
`OpenApiPsr7Validator::validateExchange()` or use the PHPUnit
`OpenApiAssertions` trait. Coverage has the same method/path/status/content-type
granularity as the Laravel and Symfony adapters.

## Verification

- `vendor/bin/phpunit tests/Unit/Psr7` — 14 tests, 29 assertions
- full PHPUnit suite excluding only local clone-path-sensitive stack-trace
  tests and npm-home-cache-sensitive lint tests — 1,963 tests passed
- Markdown lint tests rerun with a writable tmp npm cache — passed
- `vendor/bin/phpstan analyse --no-progress --debug --memory-limit=1G` — no
  errors
- PHP-CS-Fixer checks — no changes required
- `composer validate --strict` — passed
- `composer audit --abandoned=fail` — no advisories
- `examples/psr7: composer test` — passed with 1/1 response coverage
