### PR TITLE
feat(fuzz): add advanced generation strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Validate your API responses against your OpenAPI specification during testing, a
 - **Response & request validation** — dialect-aware JSON Schema via opis/json-schema: Draft 07 compatibility for OpenAPI 3.0 and native 2020-12 semantics for OpenAPI 3.1/3.2; `application/json` and any `+json` content type
 - **Endpoint coverage tracking** — Unique PHPUnit extension that reports which spec endpoints are covered by tests, at `(method, path, status, content-type)` granularity
 - **Laravel route/spec parity** — `openapi:routes` finds documented operations without routes and registered routes without OpenAPI operations, with filters, stable JSON, and independent CI gates
-- **Schema-driven request fuzzing** — Explore one endpoint or every supported operation with deterministic replay, filters, lifecycle/auth hooks, and explicit skip reasons
+- **Schema-driven request fuzzing** — Valid boundaries, composition branches, targeted negative cases with explicit expected status classes, deterministic replay/reduction, whole-spec filters, lifecycle/auth hooks, and explicit skip reasons
 - **Enum drift detection** — Static comparison between PHP backed enums and their `enum:` spec arrays, with PHPUnit-extension auto-discovery
 - **Schema under-description detection** — Optional strict mode that flags response fields the implementation always returns but the spec marks as optional, catching the spec gaps that conformance checks alone can't. See [`docs/strict-required.md`](docs/strict-required.md) for current scope and limitations.
 - **Skip-by-status-code** — Configurable regex list of status codes whose bodies are not validated (default: every `5xx`); per-request via `skipResponseCode()`

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -90,6 +90,13 @@ operations. `authenticateUsing()`, `setUpUsing()`, `tearDownUsing()`, and
 `ExploredOperation` rows (including their coverage keys), and a list of
 `ExplorationSkip` entries. See [schema-driven request fuzzing](fuzzing.md).
 
+Call `negativeCases([4])` to switch a whole-spec plan to targeted invalid
+inputs and carry explicit expected response classes on each `ExploredCase`.
+For one operation, use
+`OpenApiEndpointExplorer::exploreInvalid(..., expectedStatusClasses: [4])` or
+Laravel's `exploreInvalidEndpoint()`. `FailureReducer::reduce()` minimizes a
+failing body while preserving a caller-defined failure classification.
+
 ## `OpenApiSpecLoader`
 
 Manages spec loading and configuration.

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -1,6 +1,9 @@
 # Schema-driven request fuzzing
 
-The `ExploresOpenApiEndpoint` trait generates N happy-path request inputs for one (method, path) operation directly from the OpenAPI spec — the PHP equivalent of [Schemathesis][schemathesis]. Pair it with the existing `ValidatesOpenApiSchema` trait and every fuzzed call automatically asserts response contract conformance and records coverage.
+The `ExploresOpenApiEndpoint` trait generates deterministic request inputs for
+one operation or a filtered whole spec. Its workflow is inspired by
+[Schemathesis][schemathesis], but the supported strategy matrix below is the
+contract; this package does not claim feature parity.
 
 ```php
 use PHPUnit\Framework\TestCase;
@@ -32,6 +35,9 @@ What you get per case (`Studio\OpenApiContractTesting\Fuzz\ExploredCase`):
 | `headers` | name → value for every `in: header` parameter (excludes the OpenAPI-reserved `Accept`/`Content-Type`/`Authorization`) |
 | `pathParams` | name → value for every `{placeholder}` segment |
 | `method`, `matchedPath` | The resolved spec template (`/v1/pets/{petId}`) and its method |
+| `kind`, `targetKeyword`, `targetPointer` | Valid/invalid classification and the single constraint targeted by a negative case |
+| `expectedStatusClasses` | Explicit response classes supplied for a negative case (for example `[4]`) |
+| `seed`, `caseIndex` | Stable replay identity |
 
 The collection is `Countable` and `IteratorAggregate`, so `foreach ($cases as $case)` works too if you prefer it over the fluent `each()` helper.
 
@@ -111,6 +117,9 @@ seed based on `(spec, method, path, global seed)`, so adding or reordering a
 different operation does not change existing cases. A dispatch, mutation, or
 assertion failure prints the spec, operation ID, method/path, both seeds, case
 index, and a minimal `OpenApiEndpointExplorer::explore(...)` replay expression.
+Each case also exposes `replayToken()`, `replaySnippet($specName)`, and
+`curlSnippet($baseUrl)`. The token identifies generation inputs; the PHP and
+curl output include the concrete generated request.
 
 Summaries are local immutable values; the explorer adds no process-global
 aggregation. Run one plan per parallel worker partition and use the existing
@@ -127,27 +136,78 @@ external effects that a database rollback cannot undo.
 
 ## Generation behaviour
 
-- Supported keywords: `type` (`string`/`integer`/`number`/`boolean`/`object`/`array`/`null`), `enum`, `format` (`email`/`idn-email`/`uuid`/`date`/`date-time`/`time`/`uri`/`url`/`iri`/`hostname`/`ipv4`/`ipv6`), `minLength`/`maxLength`, `minimum`/`maximum`, `required`, `properties`, `items`.
+Every purportedly valid value is checked against the converted JSON Schema
+before dispatch. A generator bug therefore fails locally with an `Internal
+fuzz generator defect` diagnostic instead of sending invalid data to the API.
+
+| Strategy | Valid generation | Targeted invalid mutation |
+|---|---|---|
+| Scalars | `type`, `const`, `enum`, nullable branches | wrong type, const/enum miss |
+| Strings | min/max length, common regex patterns, Unicode code points, Faker-backed email/UUID/date/time/URI/host/IP formats | below/above length, pattern miss, invalid recognized format |
+| Numbers | inclusive/exclusive bounds and `multipleOf`, including OAS 3.0 boolean-exclusive lowering | outside/equal-exclusive bound, non-multiple |
+| Arrays | `items`, `prefixItems`, min/max items, `uniqueItems` | too few/many or duplicate items |
+| Objects | properties, required, min/max properties, schema-valued/default additional properties | missing required, extra forbidden, too few/many properties, nested property constraint |
+| Composition | branch rotation for `oneOf`/`anyOf`, merged object/range assertions for `allOf`, `not`, and `if`/`then`/`else`; lowered discriminator branches use the same path | deterministic composition miss where one can be isolated |
+
+Arbitrary regex synthesis, recursive schemas, `contains`,
+`patternProperties`, `dependentSchemas`, and `unevaluated*` generation are not
+currently strategies. Those keywords remain validator features; an operation
+whose valid value cannot be synthesized fails locally or is an explicit
+whole-spec skip.
+
 - Optional object properties alternate between included and omitted across cases, so each batch exercises both required-only and required+optional shapes.
 - Required keys are always emitted.
 - Path resolution accepts both the spec template form (`/v1/pets/{petId}`) and concrete URIs that match it (`/api/v1/pets/123` with `strip_prefixes=/api`). Captured URI values are intentionally discarded — `pathParams` is always regenerated from the operation spec for consistency.
 
 ## `seed` and determinism
 
-When [`fakerphp/faker`][faker] is installed (already a transitive dev dependency via `orchestra/testbench` for most projects), generation uses Faker's locale-aware primitives and is fully deterministic for a given `seed:`. Without Faker, the trait falls back to deterministic counter-based primitives that still pass schema validation — your CI never depends on a runtime-installed package.
+When [`fakerphp/faker`][faker] is installed, generation uses Faker's
+locale-aware primitives and is deterministic for a given `seed:`. Without it,
+ordinary strings and scalar boundaries use deterministic counter-based values.
+Recognized formats such as email and UUID cannot be synthesized reliably by
+that fallback: the existing one-shot warning is followed by the valid-case
+self-check, so the operation fails locally rather than dispatching a value that
+does not satisfy its format.
 
 ```bash
-# Optional but recommended for realistic generation
+# Required when explored schemas use Faker-backed formats
 composer require --dev fakerphp/faker
 ```
 
-## Out of scope (today)
+## Negative cases and reduction
 
-The MVP intentionally targets happy-path generation. Tracked separately:
+Negative exploration requires the expected response class. There is no
+implicit "anything except 5xx" fallback:
 
-- Boundary value injection (min/max-length extremes, Unicode edge cases)
-- Negative-case generation (deliberately invalid inputs to assert 4xx responses)
-- `oneOf` / `anyOf` / `allOf` composition; regex `pattern`; `multipleOf`; `minItems` / `maxItems`
+```php
+$this->exploreInvalidEndpoint(
+    'POST',
+    '/v1/pets',
+    expectedStatusClasses: [4],
+    cases: 20,
+    seed: 7,
+)->each(function (ExploredCase $case): void {
+    $response = $this->postJson('/api/v1/pets', $case->body);
+    self::assertContains(intdiv($response->getStatusCode(), 100), $case->expectedStatusClasses);
+});
+```
+
+For a whole spec, add `->negativeCases([4])` before `dispatchUsing()` and
+inspect the same metadata in `assertResponseUsing()`. Each generated invalid
+case is self-checked to ensure it actually fails the complete schema.
+
+`FailureReducer::reduce($case, $classify)` deterministically removes body
+members only while the callback returns the original non-empty classification.
+Use a stable value such as `status:500` or an exception class. Reduction is
+deliberately classification-preserving; it never equates every failure.
+
+## Remaining gaps
+
+- Arbitrary ECMA-262 regex synthesis and recursive/reference-cycle generation.
+- Cookie and `parameters[].content` fuzz generation.
+- Structural shrinking inside nested arrays/objects; current reduction removes
+  top-level body members.
+- Measurement-based feature parity with Schemathesis.
 
 [schemathesis]: https://github.com/schemathesis/schemathesis
 [faker]: https://github.com/FakerPHP/Faker

--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -23,6 +23,7 @@ For supported versions, the package detects the OAS feature family from the `ope
 | Feature | 3.0 handling | 3.1 / 3.2 handling |
 |---|---|---|
 | `nullable: true` | Converted to type array `["string", "null"]`; `null` appended to `enum` if present | Not applicable (uses type arrays natively) |
+| Boolean `exclusiveMinimum` / `exclusiveMaximum` | Lowered with its numeric `minimum` / `maximum` to the Draft 07 numeric form | Native numeric JSON Schema keyword |
 | `prefixItems` | N/A | Preserved and enforced natively by JSON Schema 2020-12 |
 | `$dynamicRef` / `$dynamicAnchor` | N/A | Preserved and enforced natively |
 | `examples` (array) | Removed (Draft 2020-12 keyword, not Draft 07) | Removed (Draft 2020-12 keyword, not Draft 07) |

--- a/src/Fuzz/DecimalMultiple.php
+++ b/src/Fuzz/DecimalMultiple.php
@@ -27,6 +27,42 @@ final class DecimalMultiple
      */
     public static function integerStep(float|int $multipleOf): ?int
     {
+        $fraction = self::fraction($multipleOf);
+
+        return $fraction['numerator'] ?? null;
+    }
+
+    /**
+     * Return the smallest positive value that is an integer multiple of both
+     * finite JSON numbers.
+     */
+    public static function leastCommonMultiple(float|int $left, float|int $right): null|float|int
+    {
+        $leftFraction = self::fraction($left);
+        $rightFraction = self::fraction($right);
+        if ($leftFraction === null || $rightFraction === null) {
+            return null;
+        }
+
+        $numeratorFactor = intdiv(
+            $leftFraction['numerator'],
+            self::greatestCommonDivisor($leftFraction['numerator'], $rightFraction['numerator']),
+        );
+        if ($numeratorFactor > intdiv(PHP_INT_MAX, $rightFraction['numerator'])) {
+            return null;
+        }
+        $numerator = $numeratorFactor * $rightFraction['numerator'];
+        $denominator = self::greatestCommonDivisor(
+            $leftFraction['denominator'],
+            $rightFraction['denominator'],
+        );
+
+        return $denominator === 1 ? $numerator : $numerator / $denominator;
+    }
+
+    /** @return null|array{numerator: int, denominator: int} */
+    private static function fraction(float|int $multipleOf): ?array
+    {
         if ($multipleOf <= 0) {
             return null;
         }
@@ -55,8 +91,12 @@ final class DecimalMultiple
 
         $numerator = (int) $digits;
         $denominator = 10 ** $decimalPlaces;
+        $divisor = self::greatestCommonDivisor($numerator, $denominator);
 
-        return intdiv($numerator, self::greatestCommonDivisor($numerator, $denominator));
+        return [
+            'numerator' => intdiv($numerator, $divisor),
+            'denominator' => intdiv($denominator, $divisor),
+        ];
     }
 
     private static function fitsPlatformInteger(string $digits): bool

--- a/src/Fuzz/DecimalMultiple.php
+++ b/src/Fuzz/DecimalMultiple.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Fuzz;
+
+use const JSON_PRESERVE_ZERO_FRACTION;
+use const PHP_INT_MAX;
+
+use function abs;
+use function intdiv;
+use function is_string;
+use function json_encode;
+use function ltrim;
+use function preg_match;
+use function str_repeat;
+use function strcmp;
+use function strlen;
+
+/** @internal */
+final class DecimalMultiple
+{
+    /**
+     * Return the smallest positive integer that is a multiple of the supplied
+     * finite JSON number. For example 1.5 (3/2) yields 3, while 0.5 (1/2)
+     * yields 1. Values outside the platform integer range return null.
+     */
+    public static function integerStep(float|int $multipleOf): ?int
+    {
+        if ($multipleOf <= 0) {
+            return null;
+        }
+
+        $encoded = json_encode($multipleOf, JSON_PRESERVE_ZERO_FRACTION);
+        if (!is_string($encoded) ||
+            preg_match('/^(\d+)(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/', $encoded, $matches) !== 1) {
+            return null;
+        }
+
+        $fraction = $matches[2] ?? '';
+        $exponent = (int) ($matches[3] ?? 0);
+        $digits = ltrim($matches[1] . $fraction, '0');
+        if ($digits === '') {
+            return null;
+        }
+
+        $decimalPlaces = strlen($fraction) - $exponent;
+        if ($decimalPlaces < 0) {
+            $digits .= str_repeat('0', -$decimalPlaces);
+            $decimalPlaces = 0;
+        }
+        if ($decimalPlaces > 18 || !self::fitsPlatformInteger($digits)) {
+            return null;
+        }
+
+        $numerator = (int) $digits;
+        $denominator = 10 ** $decimalPlaces;
+
+        return intdiv($numerator, self::greatestCommonDivisor($numerator, $denominator));
+    }
+
+    private static function fitsPlatformInteger(string $digits): bool
+    {
+        $maximum = (string) PHP_INT_MAX;
+
+        return strlen($digits) < strlen($maximum) ||
+            (strlen($digits) === strlen($maximum) && strcmp($digits, $maximum) <= 0);
+    }
+
+    private static function greatestCommonDivisor(int $left, int $right): int
+    {
+        $left = abs($left);
+        $right = abs($right);
+        while ($right !== 0) {
+            [$left, $right] = [$right, $left % $right];
+        }
+
+        return $left;
+    }
+}

--- a/src/Fuzz/ExplorationCaseKind.php
+++ b/src/Fuzz/ExplorationCaseKind.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Fuzz;
+
+enum ExplorationCaseKind: string
+{
+    case Valid = 'valid';
+    case Invalid = 'invalid';
+}

--- a/src/Fuzz/ExploredCase.php
+++ b/src/Fuzz/ExploredCase.php
@@ -7,6 +7,15 @@ namespace Studio\OpenApiContractTesting\Fuzz;
 use InvalidArgumentException;
 use Studio\OpenApiContractTesting\HttpMethod;
 
+use function base64_encode;
+use function escapeshellarg;
+use function http_build_query;
+use function implode;
+use function json_encode;
+use function rawurlencode;
+use function sprintf;
+use function str_replace;
+
 /**
  * One generated request case produced by {@see OpenApiEndpointExplorer}.
  *
@@ -37,6 +46,13 @@ final readonly class ExploredCase
         public array $pathParams,
         public HttpMethod $method,
         public string $matchedPath,
+        public ExplorationCaseKind $kind = ExplorationCaseKind::Valid,
+        public ?string $targetKeyword = null,
+        public ?string $targetPointer = null,
+        /** @var list<int> */
+        public array $expectedStatusClasses = [],
+        public ?int $seed = null,
+        public ?int $caseIndex = null,
     ) {
         if ($matchedPath === '') {
             throw new InvalidArgumentException(
@@ -48,24 +64,106 @@ final readonly class ExploredCase
 
     public function withBody(mixed $body): self
     {
-        return new self($body, $this->query, $this->headers, $this->pathParams, $this->method, $this->matchedPath);
+        return $this->copy($body, $this->query, $this->headers, $this->pathParams);
     }
 
     /** @param array<string, mixed> $query */
     public function withQuery(array $query): self
     {
-        return new self($this->body, $query, $this->headers, $this->pathParams, $this->method, $this->matchedPath);
+        return $this->copy($this->body, $query, $this->headers, $this->pathParams);
     }
 
     /** @param array<string, mixed> $headers */
     public function withHeaders(array $headers): self
     {
-        return new self($this->body, $this->query, $headers, $this->pathParams, $this->method, $this->matchedPath);
+        return $this->copy($this->body, $this->query, $headers, $this->pathParams);
     }
 
     /** @param array<string, mixed> $pathParams */
     public function withPathParams(array $pathParams): self
     {
-        return new self($this->body, $this->query, $this->headers, $pathParams, $this->method, $this->matchedPath);
+        return $this->copy($this->body, $this->query, $this->headers, $pathParams);
+    }
+
+    public function replayToken(): string
+    {
+        return base64_encode((string) json_encode([
+            'method' => $this->method->value,
+            'path' => $this->matchedPath,
+            'seed' => $this->seed,
+            'case' => $this->caseIndex,
+            'kind' => $this->kind->value,
+            'keyword' => $this->targetKeyword,
+            'pointer' => $this->targetPointer,
+        ]));
+    }
+
+    public function replaySnippet(string $specName): string
+    {
+        if ($this->kind === ExplorationCaseKind::Invalid) {
+            return sprintf(
+                "OpenApiEndpointExplorer::exploreInvalid('%s', '%s', '%s', expectedStatusClasses: [%s], cases: %d, seed: %d)",
+                $specName,
+                $this->method->value,
+                $this->matchedPath,
+                implode(', ', $this->expectedStatusClasses),
+                ($this->caseIndex ?? 0) + 1,
+                $this->seed ?? 0,
+            );
+        }
+
+        return sprintf(
+            "OpenApiEndpointExplorer::explore('%s', '%s', '%s', cases: %d, seed: %d)",
+            $specName,
+            $this->method->value,
+            $this->matchedPath,
+            ($this->caseIndex ?? 0) + 1,
+            $this->seed ?? 0,
+        );
+    }
+
+    public function curlSnippet(string $baseUrl = ''): string
+    {
+        $path = $this->matchedPath;
+        foreach ($this->pathParams as $name => $value) {
+            $path = str_replace('{' . $name . '}', rawurlencode((string) $value), $path);
+        }
+        $query = $this->query !== [] ? '?' . http_build_query($this->query) : '';
+        $command = sprintf('curl -X %s %s', $this->method->value, escapeshellarg($baseUrl . $path . $query));
+        foreach ($this->headers as $name => $value) {
+            $command .= ' -H ' . escapeshellarg($name . ': ' . (string) $value);
+        }
+        if ($this->body !== null) {
+            $command .= " -H 'Content-Type: application/json' --data " . escapeshellarg((string) json_encode($this->body));
+        }
+
+        return $command;
+    }
+
+    /**
+     * @param array<string, mixed> $query
+     * @param array<string, mixed> $headers
+     * @param array<string, mixed> $pathParams
+     */
+    private function copy(
+        mixed $body,
+        array $query,
+        array $headers,
+        array $pathParams,
+    ): self {
+        return new self(
+            $body,
+            $query,
+            $headers,
+            $pathParams,
+            $this->method,
+            $this->matchedPath,
+            $this->kind,
+            $this->targetKeyword,
+            $this->targetPointer,
+            $this->expectedStatusClasses,
+            $this->seed,
+            $this->caseIndex,
+        );
     }
 }

--- a/src/Fuzz/FailureReducer.php
+++ b/src/Fuzz/FailureReducer.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Fuzz;
+
+use InvalidArgumentException;
+
+use function array_keys;
+use function is_array;
+
+/**
+ * Deterministically removes payload members while preserving a caller-defined
+ * failure classification (for example `status:500` or an exception class).
+ */
+final class FailureReducer
+{
+    /** @param callable(ExploredCase): ?string $classify */
+    public static function reduce(ExploredCase $case, callable $classify): ExploredCase
+    {
+        $classification = $classify($case);
+        if ($classification === null || $classification === '') {
+            throw new InvalidArgumentException('FailureReducer requires the original case to have a failure classification.');
+        }
+
+        if (!is_array($case->body)) {
+            return $case;
+        }
+
+        $body = $case->body;
+        foreach (array_keys($body) as $key) {
+            $candidate = $body;
+            unset($candidate[$key]);
+            $candidateCase = $case->withBody($candidate);
+            if ($classify($candidateCase) === $classification) {
+                $body = $candidate;
+            }
+        }
+
+        return $case->withBody($body);
+    }
+}

--- a/src/Fuzz/OpenApiEndpointExplorer.php
+++ b/src/Fuzz/OpenApiEndpointExplorer.php
@@ -15,11 +15,13 @@ use Studio\OpenApiContractTesting\Spec\OpenApiSchemaConverter;
 use Studio\OpenApiContractTesting\Spec\OpenApiSchemaDialect;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 use Studio\OpenApiContractTesting\Validation\Request\ParameterCollector;
+use Studio\OpenApiContractTesting\Validation\Support\DiscriminatorContext;
 use ValueError;
 
 use function array_filter;
 use function array_keys;
 use function array_map;
+use function count;
 use function implode;
 use function is_array;
 use function is_string;
@@ -42,8 +44,8 @@ use function trim;
  * `in:path` parameters are always (re)generated from the operation's spec
  * so callers never depend on whichever URI form they passed.
  *
- * Out-of-scope today: `oneOf`/`anyOf`/`allOf` body composition, non-JSON
- * media types (only `application/json` is generated for `requestBody`).
+ * Only JSON-compatible request bodies and schema-form parameters are
+ * generated; unsupported media/parameter forms fail loudly.
  */
 final class OpenApiEndpointExplorer
 {
@@ -57,6 +59,129 @@ final class OpenApiEndpointExplorer
         string $path,
         int $cases = 30,
         ?int $seed = null,
+    ): ExplorationCases {
+        return self::buildValidCases($specName, $method, $path, $cases, $seed);
+    }
+
+    /**
+     * Generate request cases that each violate one identified schema keyword.
+     * Expected response classes are explicit by design: negative contract
+     * tests must assert the documented client-error behavior, not merely
+     * accept every response that is not a 5xx.
+     *
+     * @param list<int> $expectedStatusClasses
+     */
+    public static function exploreInvalid(
+        string $specName,
+        string $method,
+        string $path,
+        array $expectedStatusClasses,
+        int $cases = 30,
+        ?int $seed = null,
+    ): ExplorationCases {
+        if ($expectedStatusClasses === []) {
+            throw new InvalidArgumentException('exploreInvalid() requires at least one expected HTTP status class.');
+        }
+        foreach ($expectedStatusClasses as $statusClass) {
+            if ($statusClass < 1 || $statusClass > 5) {
+                throw new InvalidArgumentException(sprintf('Expected HTTP status class must be between 1 and 5, got %d.', $statusClass));
+            }
+        }
+
+        $validCases = self::buildValidCases($specName, $method, $path, $cases, $seed);
+        [$bodySchema, $parameterSchemas, $bodyRequired] = self::schemasForOperation($specName, $method, $path);
+        $faker = SchemaDataGenerator::createFaker($seed);
+        $built = [];
+
+        foreach ($validCases as $index => $validCase) {
+            $targets = [];
+            if ($bodyRequired) {
+                $targets[] = [
+                    'location' => 'body',
+                    'name' => null,
+                    'mutation' => new SchemaMutation(null, 'required', ''),
+                    'remove' => true,
+                ];
+            }
+            if ($bodySchema !== null) {
+                try {
+                    foreach (SchemaMutationGenerator::generate($bodySchema, 100, $faker, $index) as $mutation) {
+                        $targets[] = ['location' => 'body', 'name' => null, 'mutation' => $mutation, 'remove' => false];
+                    }
+                } catch (InvalidArgumentException) {
+                    // Try parameter constraints before declaring the operation unsupported.
+                }
+            }
+            foreach ($parameterSchemas as $parameter) {
+                if ($parameter['required']) {
+                    $targets[] = [
+                        'location' => $parameter['in'],
+                        'name' => $parameter['name'],
+                        'mutation' => new SchemaMutation(null, 'required', ''),
+                        'remove' => true,
+                    ];
+                }
+
+                try {
+                    foreach (SchemaMutationGenerator::generate($parameter['schema'], 100, $faker, $index) as $mutation) {
+                        $targets[] = [
+                            'location' => $parameter['in'],
+                            'name' => $parameter['name'],
+                            'mutation' => $mutation,
+                            'remove' => false,
+                        ];
+                    }
+                } catch (InvalidArgumentException) {
+                    // This parameter has no supported deterministic mutation.
+                }
+            }
+
+            if ($targets === []) {
+                throw new InvalidArgumentException(sprintf(
+                    "Operation %s '%s' in spec '%s' has no supported invalid mutation target.",
+                    strtoupper($method),
+                    $validCase->matchedPath,
+                    $specName,
+                ));
+            }
+
+            $target = $targets[$index % count($targets)];
+            /** @var SchemaMutation $mutation */
+            $mutation = $target['mutation'];
+            $mutated = $target['remove'] === true
+                ? self::removeInput($validCase, $target['location'], $target['name'])
+                : match ($target['location']) {
+                    'body' => $validCase->withBody($mutation->value),
+                    'query' => $validCase->withQuery(self::replaceValue($validCase->query, $target['name'], $mutation->value)),
+                    'header' => $validCase->withHeaders(self::replaceValue($validCase->headers, $target['name'], $mutation->value)),
+                    'path' => $validCase->withPathParams(self::replaceValue($validCase->pathParams, $target['name'], $mutation->value)),
+                    default => $validCase,
+                };
+            $built[] = new ExploredCase(
+                $mutated->body,
+                $mutated->query,
+                $mutated->headers,
+                $mutated->pathParams,
+                $mutated->method,
+                $mutated->matchedPath,
+                ExplorationCaseKind::Invalid,
+                $mutation->keyword,
+                $target['location'] . $mutation->pointer,
+                $expectedStatusClasses,
+                $seed,
+                $index,
+            );
+        }
+
+        return new ExplorationCases($built);
+    }
+
+    private static function buildValidCases(
+        string $specName,
+        string $method,
+        string $path,
+        int $cases,
+        ?int $seed,
     ): ExplorationCases {
         if ($cases < 1) {
             throw new InvalidArgumentException(sprintf(
@@ -105,7 +230,7 @@ final class OpenApiEndpointExplorer
 
         $version = OpenApiVersion::fromSpec($spec);
         $jsonSchemaDialect = OpenApiSchemaDialect::fromSpec($spec, $version);
-        $bodySchema = self::extractRequestBodySchema($operation, $version, $methodUpper, $matchedPath, $specName, $jsonSchemaDialect);
+        $bodySchema = self::extractRequestBodySchema($operation, $version, $methodUpper, $matchedPath, $specName, $jsonSchemaDialect, $spec);
         /** @var list<array<string, mixed>> $parameters */
         $parameters = ParameterCollector::collect($methodUpper, $matchedPath, $pathSpec, $operation)->parameters;
         self::assertParametersGeneratable($parameters, $methodUpper, $matchedPath, $specName);
@@ -113,17 +238,107 @@ final class OpenApiEndpointExplorer
         $faker = SchemaDataGenerator::createFaker($seed);
         $built = [];
         for ($i = 0; $i < $cases; $i++) {
+            $body = $bodySchema !== null ? SchemaDataGenerator::generateOne($bodySchema, $faker, $i) : null;
+            if ($bodySchema !== null) {
+                SchemaValueValidator::assertValid($body, $bodySchema, $i);
+            }
+            $query = self::generateParameterValues($parameters, 'query', $version, $jsonSchemaDialect, $faker, $i);
+            $headers = self::generateParameterValues($parameters, 'header', $version, $jsonSchemaDialect, $faker, $i);
+            $pathParams = self::generateParameterValues($parameters, 'path', $version, $jsonSchemaDialect, $faker, $i);
             $built[] = new ExploredCase(
-                body: $bodySchema !== null ? SchemaDataGenerator::generateOne($bodySchema, $faker, $i) : null,
-                query: self::generateParameterValues($parameters, 'query', $version, $jsonSchemaDialect, $faker, $i),
-                headers: self::generateParameterValues($parameters, 'header', $version, $jsonSchemaDialect, $faker, $i),
-                pathParams: self::generateParameterValues($parameters, 'path', $version, $jsonSchemaDialect, $faker, $i),
+                body: $body,
+                query: $query,
+                headers: $headers,
+                pathParams: $pathParams,
                 method: $methodEnum,
                 matchedPath: $matchedPath,
+                seed: $seed,
+                caseIndex: $i,
             );
         }
 
         return new ExplorationCases($built);
+    }
+
+    /**
+     * @return array{0: null|array<string, mixed>, 1: list<array{in: string, name: string, required: bool, schema: array<string, mixed>}>, 2: bool}
+     */
+    private static function schemasForOperation(string $specName, string $method, string $path): array
+    {
+        $spec = OpenApiSpecLoader::load($specName);
+        /** @var array<string, mixed> $paths */
+        $paths = is_array($spec['paths'] ?? null) ? $spec['paths'] : [];
+        $matchedPath = self::resolveMatchedPath($paths, $path);
+        if ($matchedPath === null || !is_array($paths[$matchedPath] ?? null)) {
+            throw new InvalidArgumentException(sprintf("Path '%s' is not declared in OpenAPI spec '%s'.", $path, $specName));
+        }
+        $methodUpper = strtoupper($method);
+        $pathSpec = $paths[$matchedPath];
+        $resolved = OpenApiOperationResolver::resolve($pathSpec, $methodUpper);
+        if (!$resolved['found'] || !is_array($resolved['operation'])) {
+            throw new InvalidArgumentException(sprintf("Operation %s '%s' is not declared in OpenAPI spec '%s'.", $methodUpper, $matchedPath, $specName));
+        }
+        $operation = $resolved['operation'];
+        $version = OpenApiVersion::fromSpec($spec);
+        $dialect = OpenApiSchemaDialect::fromSpec($spec, $version);
+        $body = self::extractRequestBodySchema($operation, $version, $methodUpper, $matchedPath, $specName, $dialect, $spec);
+        $parameterSchemas = [];
+        foreach (ParameterCollector::collect($methodUpper, $matchedPath, $pathSpec, $operation)->parameters as $parameter) {
+            if (!is_string($parameter['in'] ?? null) || !is_string($parameter['name'] ?? null) || !is_array($parameter['schema'] ?? null)) {
+                continue;
+            }
+            $parameterSchemas[] = [
+                'in' => $parameter['in'],
+                'name' => $parameter['name'],
+                'required' => ($parameter['required'] ?? false) === true || $parameter['in'] === 'path',
+                'schema' => OpenApiSchemaConverter::convert($parameter['schema'], $version, SchemaContext::Request, null, $dialect),
+            ];
+        }
+
+        return [$body, $parameterSchemas, ($operation['requestBody']['required'] ?? false) === true];
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     *
+     * @return array<string, mixed>
+     */
+    private static function replaceValue(array $values, mixed $name, mixed $value): array
+    {
+        if (is_string($name)) {
+            $values[$name] = $value;
+        }
+
+        return $values;
+    }
+
+    private static function removeInput(ExploredCase $case, mixed $location, mixed $name): ExploredCase
+    {
+        if ($location === 'body') {
+            return $case->withBody(null);
+        }
+        if (!is_string($name)) {
+            return $case;
+        }
+
+        return match ($location) {
+            'query' => $case->withQuery(self::withoutKey($case->query, $name)),
+            'header' => $case->withHeaders(self::withoutKey($case->headers, $name)),
+            'path' => $case->withPathParams(self::withoutKey($case->pathParams, $name)),
+            default => $case,
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     *
+     * @return array<string, mixed>
+     */
+    private static function withoutKey(array $values, string $name): array
+    {
+        unset($values[$name]);
+
+        return $values;
     }
 
     /**
@@ -167,6 +382,7 @@ final class OpenApiEndpointExplorer
      * mode the rest of the library tries to avoid.
      *
      * @param array<string, mixed> $operation
+     * @param array<string, mixed> $spec
      *
      * @return null|array<string, mixed>
      *
@@ -179,6 +395,7 @@ final class OpenApiEndpointExplorer
         string $matchedPath,
         string $specName,
         string $jsonSchemaDialect,
+        array $spec,
     ): ?array {
         $requestBody = $operation['requestBody'] ?? null;
         if (!is_array($requestBody)) {
@@ -219,7 +436,13 @@ final class OpenApiEndpointExplorer
             return null;
         }
 
-        return OpenApiSchemaConverter::convert($schema, $version, SchemaContext::Request, null, $jsonSchemaDialect);
+        return OpenApiSchemaConverter::convert(
+            $schema,
+            $version,
+            SchemaContext::Request,
+            new DiscriminatorContext($spec, true),
+            $jsonSchemaDialect,
+        );
     }
 
     /**
@@ -293,7 +516,9 @@ final class OpenApiEndpointExplorer
                 continue;
             }
             $converted = OpenApiSchemaConverter::convert($schema, $version, SchemaContext::Request, null, $jsonSchemaDialect);
-            $values[$name] = SchemaDataGenerator::generateOne($converted, $faker, $iteration);
+            $value = SchemaDataGenerator::generateOne($converted, $faker, $iteration);
+            SchemaValueValidator::assertValid($value, $converted, $iteration);
+            $values[$name] = $value;
         }
 
         return $values;

--- a/src/Fuzz/OpenApiSpecExploration.php
+++ b/src/Fuzz/OpenApiSpecExploration.php
@@ -58,6 +58,9 @@ final class OpenApiSpecExploration
     private array $excludedOperationIds = [];
     private bool $includeDeprecated = false;
 
+    /** @var null|list<int> */
+    private ?array $negativeExpectedStatusClasses = null;
+
     /** @var null|callable(ExploredOperation): void */
     private $authenticate;
 
@@ -153,6 +156,30 @@ final class OpenApiSpecExploration
         return $this;
     }
 
+    /**
+     * Switch the plan to single-constraint invalid cases. The expected status
+     * classes are carried by every ExploredCase for the response assertion.
+     *
+     * @param list<int> $expectedStatusClasses
+     */
+    public function negativeCases(array $expectedStatusClasses): self
+    {
+        if ($expectedStatusClasses === []) {
+            throw new InvalidArgumentException('negativeCases() requires at least one expected HTTP status class.');
+        }
+        foreach ($expectedStatusClasses as $statusClass) {
+            if ($statusClass < 1 || $statusClass > 5) {
+                throw new InvalidArgumentException(sprintf(
+                    'Expected HTTP status class must be between 1 and 5, got %d.',
+                    $statusClass,
+                ));
+            }
+        }
+        $this->negativeExpectedStatusClasses = $expectedStatusClasses;
+
+        return $this;
+    }
+
     /** @param callable(ExploredOperation): void $callback */
     public function authenticateUsing(callable $callback): self
     {
@@ -233,13 +260,22 @@ final class OpenApiSpecExploration
                 }
 
                 try {
-                    $cases = OpenApiEndpointExplorer::explore(
-                        $this->specName,
-                        $operation->method,
-                        $operation->path,
-                        $this->casesPerOperation,
-                        $operation->seed,
-                    );
+                    $cases = $this->negativeExpectedStatusClasses === null
+                        ? OpenApiEndpointExplorer::explore(
+                            $this->specName,
+                            $operation->method,
+                            $operation->path,
+                            $this->casesPerOperation,
+                            $operation->seed,
+                        )
+                        : OpenApiEndpointExplorer::exploreInvalid(
+                            $this->specName,
+                            $operation->method,
+                            $operation->path,
+                            $this->negativeExpectedStatusClasses,
+                            $this->casesPerOperation,
+                            $operation->seed,
+                        );
                 } catch (InvalidArgumentException $e) {
                     $skips[] = new ExplorationSkip($operation, $e->getMessage());
 
@@ -417,7 +453,7 @@ final class OpenApiSpecExploration
                     }
                     $executedCases++;
                 } catch (Throwable $e) {
-                    throw new RuntimeException($this->caseFailureMessage($operation, $caseIndex), 0, $e);
+                    throw new RuntimeException($this->caseFailureMessage($operation, $case, $caseIndex), 0, $e);
                 }
             }
         } finally {
@@ -427,7 +463,7 @@ final class OpenApiSpecExploration
         }
     }
 
-    private function caseFailureMessage(ExploredOperation $operation, int $caseIndex): string
+    private function caseFailureMessage(ExploredOperation $operation, ExploredCase $case, int $caseIndex): string
     {
         return sprintf(
             "Whole-spec exploration failed.\nSpec: %s\nOperation: %s\nMethod/path: %s %s\nGlobal seed: %d\nOperation seed: %d\nCase: %d\nReplay: %s",
@@ -438,7 +474,7 @@ final class OpenApiSpecExploration
             $this->seed,
             $operation->seed,
             $caseIndex,
-            $operation->replaySnippet($caseIndex),
+            $case->replaySnippet($operation->specName),
         );
     }
 }

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -754,7 +754,7 @@ final class SchemaDataGenerator
     {
         $merged = array_merge($left, $right);
         if (is_array($left['properties'] ?? null) || is_array($right['properties'] ?? null)) {
-            $merged['properties'] = array_merge(
+            $merged['properties'] = self::mergePropertySchemas(
                 is_array($left['properties'] ?? null) ? $left['properties'] : [],
                 is_array($right['properties'] ?? null) ? $right['properties'] : [],
             );
@@ -776,6 +776,25 @@ final class SchemaDataGenerator
         }
         if (isset($left['maxLength'], $right['maxLength'])) {
             $merged['maxLength'] = min($left['maxLength'], $right['maxLength']);
+        }
+
+        return $merged;
+    }
+
+    /**
+     * @param array<string, mixed> $left
+     * @param array<string, mixed> $right
+     *
+     * @return array<string, mixed>
+     */
+    private static function mergePropertySchemas(array $left, array $right): array
+    {
+        $merged = $left;
+        foreach ($right as $name => $rightSchema) {
+            $leftSchema = $merged[$name] ?? null;
+            $merged[$name] = is_array($leftSchema) && is_array($rightSchema)
+                ? self::mergeSchemas($leftSchema, $rightSchema)
+                : $rightSchema;
         }
 
         return $merged;

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -26,6 +26,7 @@ use function count;
 use function floor;
 use function implode;
 use function in_array;
+use function intdiv;
 use function is_array;
 use function is_float;
 use function is_int;
@@ -549,9 +550,9 @@ final class SchemaDataGenerator
         $max = $exclusiveMax !== null ? min($max, $exclusiveMax) : $max;
 
         $multipleOf = isset($schema['multipleOf']) && (is_int($schema['multipleOf']) || is_float($schema['multipleOf']))
-            ? (int) $schema['multipleOf']
+            ? DecimalMultiple::integerStep($schema['multipleOf'])
             : 0;
-        if ($multipleOf > 0) {
+        if ($multipleOf !== null && $multipleOf > 0) {
             $min = (int) (ceil($min / $multipleOf) * $multipleOf);
             $max = (int) (floor($max / $multipleOf) * $multipleOf);
         }
@@ -571,7 +572,17 @@ final class SchemaDataGenerator
             return $max;
         }
         if ($faker !== null) {
+            if ($multipleOf !== null && $multipleOf > 0) {
+                return $faker->numberBetween(intdiv($min, $multipleOf), intdiv($max, $multipleOf)) * $multipleOf;
+            }
+
             return $faker->numberBetween($min, $max);
+        }
+
+        if ($multipleOf !== null && $multipleOf > 0) {
+            $span = intdiv($max - $min, $multipleOf) + 1;
+
+            return $min + ($iteration % max(1, $span)) * $multipleOf;
         }
 
         $span = $max - $min + 1;

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -532,13 +532,13 @@ final class SchemaDataGenerator
             : null;
 
         if ($minSet && $maxSet) {
-            $min = (int) $schema['minimum'];
-            $max = (int) $schema['maximum'];
+            $min = (int) ceil($schema['minimum']);
+            $max = (int) floor($schema['maximum']);
         } elseif ($minSet) {
-            $min = (int) $schema['minimum'];
+            $min = (int) ceil($schema['minimum']);
             $max = $min + 1000;
         } elseif ($maxSet) {
-            $max = (int) $schema['maximum'];
+            $max = (int) floor($schema['maximum']);
             $min = $max - 1000;
         } else {
             $min = 1;

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -316,13 +316,16 @@ final class SchemaDataGenerator
         $prefixItems = $schema['prefixItems'] ?? null;
         if (is_array($prefixItems)) {
             $prefixCount = count($prefixItems);
-            $minimum = isset($schema['minItems']) && is_int($schema['minItems']) ? max(0, $schema['minItems']) : $prefixCount;
-            $maximum = isset($schema['maxItems']) && is_int($schema['maxItems']) ? max(0, $schema['maxItems']) : $prefixCount;
+            $minimum = isset($schema['minItems']) && is_int($schema['minItems']) ? max(0, $schema['minItems']) : 0;
+            $maximum = isset($schema['maxItems']) && is_int($schema['maxItems']) ? max(0, $schema['maxItems']) : null;
             $size = match ($iteration % 3) {
                 0 => $minimum,
-                1 => $maximum,
+                1 => $maximum ?? $prefixCount,
                 default => $prefixCount,
             };
+            if ($maximum !== null) {
+                $size = min($size, $maximum);
+            }
             if (($schema['items'] ?? true) === false) {
                 $size = min($size, $prefixCount);
             }
@@ -644,10 +647,25 @@ final class SchemaDataGenerator
             return $max;
         }
         if ($faker !== null) {
+            if ($multipleOf > 0.0) {
+                $minimumMultiplier = (int) ceil($min / $multipleOf);
+                $maximumMultiplier = (int) floor($max / $multipleOf);
+
+                return round($faker->numberBetween($minimumMultiplier, $maximumMultiplier) * $multipleOf, 12);
+            }
+
             // randomFloat(null, …) lets faker pick precision dynamically so
             // tight ranges (e.g. minimum=0.001 maximum=0.002) don't collapse
             // to 0.00 from a fixed two-decimal rounding.
             return $faker->randomFloat(null, $min, $max);
+        }
+
+        if ($multipleOf > 0.0) {
+            $minimumMultiplier = (int) ceil($min / $multipleOf);
+            $maximumMultiplier = (int) floor($max / $multipleOf);
+            $span = $maximumMultiplier - $minimumMultiplier + 1;
+
+            return round(($minimumMultiplier + $iteration % max(1, $span)) * $multipleOf, 12);
         }
 
         // Scale the iteration-driven offset to the actual span so the value

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -404,9 +404,9 @@ final class SchemaDataGenerator
             : 16;
 
         if (isset($schema['pattern']) && is_string($schema['pattern'])) {
-            $patternValue = self::generateCommonPattern($schema['pattern'], $iteration);
+            $patternValue = self::generateCommonPattern($schema['pattern'], $schema, $iteration);
             if ($patternValue !== null) {
-                return self::clampLength($patternValue, $schema);
+                return $patternValue;
             }
         }
 
@@ -777,6 +777,16 @@ final class SchemaDataGenerator
         if (isset($left['maxLength'], $right['maxLength'])) {
             $merged['maxLength'] = min($left['maxLength'], $right['maxLength']);
         }
+        if ((is_int($left['multipleOf'] ?? null) || is_float($left['multipleOf'] ?? null)) &&
+            (is_int($right['multipleOf'] ?? null) || is_float($right['multipleOf'] ?? null))) {
+            $multipleOf = DecimalMultiple::leastCommonMultiple($left['multipleOf'], $right['multipleOf']);
+            if ($multipleOf === null) {
+                throw new InvalidArgumentException(
+                    'Cannot compose allOf multipleOf constraints within the platform numeric range.',
+                );
+            }
+            $merged['multipleOf'] = $multipleOf;
+        }
 
         return $merged;
     }
@@ -800,18 +810,44 @@ final class SchemaDataGenerator
         return $merged;
     }
 
-    private static function generateCommonPattern(string $pattern, int $iteration): ?string
+    /** @param array<string, mixed> $schema */
+    private static function generateCommonPattern(string $pattern, array $schema, int $iteration): ?string
     {
         $candidates = ['a', 'A', '0', 'abc', 'ABC', '123', 'test-' . $iteration, 'é', '日本語'];
+        $minimum = isset($schema['minLength']) && is_int($schema['minLength']) ? max(0, $schema['minLength']) : null;
+        $maximum = isset($schema['maxLength']) && is_int($schema['maxLength']) ? max(0, $schema['maxLength']) : null;
+        $delimiter = '~';
+        $escaped = str_replace($delimiter, '\\' . $delimiter, $pattern);
         foreach ($candidates as $candidate) {
-            $delimiter = '~';
-            $escaped = str_replace($delimiter, '\\' . $delimiter, $pattern);
-            if (@preg_match($delimiter . $escaped . $delimiter . 'u', $candidate) === 1) {
-                return $candidate;
+            $candidateLength = self::unicodeLength($candidate);
+            $targets = array_values(array_unique(array_filter(
+                [$minimum, $maximum, $candidateLength],
+                static fn(?int $length): bool => $length !== null,
+            )));
+            foreach ($targets as $target) {
+                if ($maximum !== null && $target > $maximum) {
+                    continue;
+                }
+                $value = self::repeatToLength($candidate, $target);
+                if (($minimum === null || self::unicodeLength($value) >= $minimum) &&
+                    @preg_match($delimiter . $escaped . $delimiter . 'u', $value) === 1) {
+                    return $value;
+                }
             }
         }
 
         return null;
+    }
+
+    private static function repeatToLength(string $value, int $length): string
+    {
+        if ($length === 0 || $value === '') {
+            return '';
+        }
+
+        $repetitions = (int) ceil($length / self::unicodeLength($value));
+
+        return implode('', array_slice(self::unicodeCharacters(str_repeat($value, $repetitions)), 0, $length));
     }
 
     private static function unicodeLength(string $value): int

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -5,16 +5,26 @@ declare(strict_types=1);
 namespace Studio\OpenApiContractTesting\Fuzz;
 
 use const E_USER_WARNING;
+use const PHP_FLOAT_EPSILON;
 
 use Faker\Factory;
 use Faker\Generator;
 use InvalidArgumentException;
+use stdClass;
 use Studio\OpenApiContractTesting\Spec\OpenApiSchemaConverter;
 
+use function array_filter;
 use function array_key_exists;
+use function array_keys;
+use function array_merge;
+use function array_slice;
+use function array_unique;
 use function array_values;
+use function ceil;
 use function class_exists;
 use function count;
+use function floor;
+use function implode;
 use function in_array;
 use function is_array;
 use function is_float;
@@ -22,27 +32,27 @@ use function is_int;
 use function is_string;
 use function max;
 use function min;
+use function preg_match;
+use function preg_match_all;
+use function round;
 use function sprintf;
-use function str_pad;
 use function str_repeat;
-use function strlen;
-use function substr;
+use function str_replace;
 use function trigger_error;
 
 /**
  * Generate happy-path values that conform to a converted JSON Schema.
  *
  * Inputs are expected to be already-converted via {@see OpenApiSchemaConverter}
- * — i.e. OAS-only keys (`nullable`, `discriminator`, etc.) have been stripped
- * and OAS 3.1 type-arrays normalised. The generator is deliberately minimal:
+ * — i.e. OAS-only keys have been stripped or lowered (including
+ * `discriminator`), and OAS 3.1 type-arrays normalised.
  *
  * Supported keywords: `type` (string|integer|number|boolean|object|array|null),
  * `const`, `enum`, `format` (email|uuid|date|date-time|uri|url),
- * `minLength`/`maxLength`, `minimum`/`maximum`, `required`, `properties`,
- * `items`, and `prefixItems`.
- *
- * Out of scope (MVP): `oneOf`/`anyOf`/`allOf` composition, regex `pattern`,
- * `additionalProperties: <schema>`, `minItems`/`maxItems`, `multipleOf`.
+ * length/numeric/collection boundaries, object properties, `items` /
+ * `prefixItems`, common patterns, and composition (`oneOf`, `anyOf`, `allOf`,
+ * `not`, and conditionals). The public strategy matrix in docs/fuzzing.md is
+ * authoritative for exact support and limitations.
  *
  * Determinism: when a `$seed` is supplied AND `fakerphp/faker` is installed,
  * faker is seeded so the same `(schema, count, seed)` triple produces the same
@@ -79,7 +89,9 @@ final class SchemaDataGenerator
         $faker = self::createFaker($seed);
         $results = [];
         for ($i = 0; $i < $count; $i++) {
-            $results[] = self::generateOne($schema, $faker, $i);
+            $value = self::generateOne($schema, $faker, $i);
+            SchemaValueValidator::assertValid($value, $schema, $i);
+            $results[] = $value;
         }
 
         return $results;
@@ -94,6 +106,8 @@ final class SchemaDataGenerator
      */
     public static function generateOne(array $schema, ?Generator $faker, int $iteration): mixed
     {
+        $schema = self::resolveComposition($schema, $faker, $iteration);
+
         if (array_key_exists('const', $schema)) {
             return $schema['const'];
         }
@@ -102,6 +116,25 @@ final class SchemaDataGenerator
             $values = array_values($schema['enum']);
 
             return $values[$iteration % count($values)];
+        }
+
+        if (is_array($schema['type'] ?? null) && in_array('null', $schema['type'], true) && ($iteration % 3) === 2) {
+            return null;
+        }
+
+        if (isset($schema['not']) && is_array($schema['not'])) {
+            $withoutNot = $schema;
+            unset($withoutNot['not']);
+            $candidate = self::generateOne($withoutNot, $faker, $iteration);
+            if (!SchemaValueValidator::isValid($candidate, $schema)) {
+                foreach ([null, false, 0, 1, '', 'value', [], ['value' => true]] as $alternative) {
+                    if (SchemaValueValidator::isValid($alternative, $schema)) {
+                        return $alternative;
+                    }
+                }
+            }
+
+            return $candidate;
         }
 
         $type = self::resolveType($schema);
@@ -192,9 +225,9 @@ final class SchemaDataGenerator
     /**
      * @param array<string, mixed> $schema
      *
-     * @return array<string, mixed>
+     * @return array<string, mixed>|stdClass
      */
-    private static function generateObject(array $schema, ?Generator $faker, int $iteration): array
+    private static function generateObject(array $schema, ?Generator $faker, int $iteration): array|stdClass
     {
         $properties = $schema['properties'] ?? [];
         if (!is_array($properties)) {
@@ -228,6 +261,47 @@ final class SchemaDataGenerator
             $result[$name] = self::generateOne($propSchema, $faker, $iteration);
         }
 
+        $minProperties = isset($schema['minProperties']) && is_int($schema['minProperties'])
+            ? $schema['minProperties']
+            : 0;
+        if (count($result) < $minProperties && ($schema['additionalProperties'] ?? true) !== false) {
+            while (count($result) < $minProperties) {
+                $name = 'property' . count($result);
+                $additionalSchema = is_array($schema['additionalProperties'] ?? null)
+                    ? $schema['additionalProperties']
+                    : ['type' => 'string'];
+                $result[$name] = self::generateOne($additionalSchema, $faker, $iteration + count($result));
+            }
+        }
+        $maxProperties = isset($schema['maxProperties']) && is_int($schema['maxProperties'])
+            ? $schema['maxProperties']
+            : null;
+        if ($maxProperties !== null && ($iteration % 3) === 1 && ($schema['additionalProperties'] ?? true) !== false) {
+            while (count($result) < $maxProperties) {
+                $name = 'property' . count($result);
+                $additionalSchema = is_array($schema['additionalProperties'] ?? null)
+                    ? $schema['additionalProperties']
+                    : ['type' => 'string'];
+                $result[$name] = self::generateOne($additionalSchema, $faker, $iteration + count($result));
+            }
+        }
+        if ($maxProperties !== null && count($result) > $maxProperties) {
+            foreach (array_keys($result) as $name) {
+                if (count($result) <= $maxProperties) {
+                    break;
+                }
+                if (!in_array($name, $required, true)) {
+                    unset($result[$name]);
+                }
+            }
+        }
+        if ($result === []) {
+            if ($maxProperties === 0 || ($schema['additionalProperties'] ?? true) === false) {
+                return new stdClass();
+            }
+            $result['property0'] = 'value';
+        }
+
         return $result;
     }
 
@@ -240,10 +314,24 @@ final class SchemaDataGenerator
     {
         $prefixItems = $schema['prefixItems'] ?? null;
         if (is_array($prefixItems)) {
+            $prefixCount = count($prefixItems);
+            $minimum = isset($schema['minItems']) && is_int($schema['minItems']) ? max(0, $schema['minItems']) : $prefixCount;
+            $maximum = isset($schema['maxItems']) && is_int($schema['maxItems']) ? max(0, $schema['maxItems']) : $prefixCount;
+            $size = match ($iteration % 3) {
+                0 => $minimum,
+                1 => $maximum,
+                default => $prefixCount,
+            };
+            if (($schema['items'] ?? true) === false) {
+                $size = min($size, $prefixCount);
+            }
             $result = [];
-            foreach ($prefixItems as $index => $item) {
+            for ($index = 0; $index < $size; $index++) {
+                $item = $prefixItems[$index] ?? ($schema['items'] ?? []);
                 if (is_array($item)) {
                     $result[] = self::generateOne($item, $faker, $iteration + $index);
+                } else {
+                    $result[] = 'item-' . $index;
                 }
             }
 
@@ -255,10 +343,27 @@ final class SchemaDataGenerator
             return [];
         }
 
-        $size = ($iteration % 2) + 1;
+        $minimum = isset($schema['minItems']) && is_int($schema['minItems']) ? max(0, $schema['minItems']) : 1;
+        $maximum = isset($schema['maxItems']) && is_int($schema['maxItems']) ? max(0, $schema['maxItems']) : null;
+        $size = match ($iteration % 3) {
+            0 => $minimum,
+            1 => $maximum ?? max(1, $minimum),
+            default => max(1, $minimum),
+        };
+        if ($maximum !== null) {
+            $size = min($size, $maximum);
+        }
         $result = [];
         for ($i = 0; $i < $size; $i++) {
-            $result[] = self::generateOne($items, $faker, $iteration + $i);
+            $item = self::generateOne($items, $faker, $iteration + $i);
+            if (($schema['uniqueItems'] ?? false) === true) {
+                $attempt = 0;
+                while (in_array($item, $result, true) && $attempt < 100) {
+                    $attempt++;
+                    $item = self::generateOne($items, $faker, $iteration + $i + $attempt);
+                }
+            }
+            $result[] = $item;
         }
 
         return $result;
@@ -289,10 +394,17 @@ final class SchemaDataGenerator
 
         $minLength = isset($schema['minLength']) && is_int($schema['minLength']) && $schema['minLength'] >= 0
             ? $schema['minLength']
-            : 0;
-        $maxLength = isset($schema['maxLength']) && is_int($schema['maxLength']) && $schema['maxLength'] > 0
+            : 1;
+        $maxLength = isset($schema['maxLength']) && is_int($schema['maxLength']) && $schema['maxLength'] >= 0
             ? $schema['maxLength']
             : 16;
+
+        if (isset($schema['pattern']) && is_string($schema['pattern'])) {
+            $patternValue = self::generateCommonPattern($schema['pattern'], $iteration);
+            if ($patternValue !== null) {
+                return self::clampLength($patternValue, $schema);
+            }
+        }
 
         if ($faker !== null) {
             // bothify('?') yields random alpha sized to the chosen target.
@@ -300,13 +412,21 @@ final class SchemaDataGenerator
             // above and min($maxLength, 8) >= 1. clampLength still runs to
             // honor `minLength > 8` (where the target was capped at 8) and
             // to defensively pad when bothify ever returns a short result.
-            $target = max($minLength, min($maxLength, 8));
+            $target = match ($iteration % 3) {
+                0 => $minLength,
+                1 => $maxLength,
+                default => max($minLength, min($maxLength, 8)),
+            };
             $generated = $faker->bothify(str_repeat('?', $target));
 
             return self::clampLength($generated, $schema);
         }
 
-        $base = 'string-' . $iteration;
+        $base = match ($iteration % 3) {
+            0 => str_repeat('x', $minLength),
+            1 => str_repeat('x', $maxLength),
+            default => 'string-' . $iteration,
+        };
 
         return self::clampLength($base, $schema);
     }
@@ -376,15 +496,16 @@ final class SchemaDataGenerator
         $minLength = isset($schema['minLength']) && is_int($schema['minLength']) && $schema['minLength'] >= 0
             ? $schema['minLength']
             : 0;
-        $maxLength = isset($schema['maxLength']) && is_int($schema['maxLength']) && $schema['maxLength'] > 0
+        $maxLength = isset($schema['maxLength']) && is_int($schema['maxLength']) && $schema['maxLength'] >= 0
             ? $schema['maxLength']
             : null;
 
-        if ($maxLength !== null && strlen($value) > $maxLength) {
-            $value = substr($value, 0, $maxLength);
+        if ($maxLength !== null && self::unicodeLength($value) > $maxLength) {
+            $characters = self::unicodeCharacters($value);
+            $value = implode('', array_slice($characters, 0, $maxLength));
         }
-        if (strlen($value) < $minLength) {
-            $value = str_pad($value, $minLength, 'x');
+        if (self::unicodeLength($value) < $minLength) {
+            $value .= str_repeat('x', $minLength - self::unicodeLength($value));
         }
 
         return $value;
@@ -403,6 +524,13 @@ final class SchemaDataGenerator
         $minSet = isset($schema['minimum']) && (is_int($schema['minimum']) || is_float($schema['minimum']));
         $maxSet = isset($schema['maximum']) && (is_int($schema['maximum']) || is_float($schema['maximum']));
 
+        $exclusiveMin = isset($schema['exclusiveMinimum']) && (is_int($schema['exclusiveMinimum']) || is_float($schema['exclusiveMinimum']))
+            ? (int) floor($schema['exclusiveMinimum']) + 1
+            : null;
+        $exclusiveMax = isset($schema['exclusiveMaximum']) && (is_int($schema['exclusiveMaximum']) || is_float($schema['exclusiveMaximum']))
+            ? (int) ceil($schema['exclusiveMaximum']) - 1
+            : null;
+
         if ($minSet && $maxSet) {
             $min = (int) $schema['minimum'];
             $max = (int) $schema['maximum'];
@@ -417,6 +545,17 @@ final class SchemaDataGenerator
             $max = 1000;
         }
 
+        $min = $exclusiveMin !== null ? max($min, $exclusiveMin) : $min;
+        $max = $exclusiveMax !== null ? min($max, $exclusiveMax) : $max;
+
+        $multipleOf = isset($schema['multipleOf']) && (is_int($schema['multipleOf']) || is_float($schema['multipleOf']))
+            ? (int) $schema['multipleOf']
+            : 0;
+        if ($multipleOf > 0) {
+            $min = (int) (ceil($min / $multipleOf) * $multipleOf);
+            $max = (int) (floor($max / $multipleOf) * $multipleOf);
+        }
+
         if ($max < $min) {
             // Spec inversion (e.g. min=10, max=5). Honor `min` since it is the
             // tighter constraint for "this value must exist at all"; the tests
@@ -425,6 +564,12 @@ final class SchemaDataGenerator
             $max = $min;
         }
 
+        if (($iteration % 3) === 0) {
+            return $min;
+        }
+        if (($iteration % 3) === 1) {
+            return $max;
+        }
         if ($faker !== null) {
             return $faker->numberBetween($min, $max);
         }
@@ -442,6 +587,13 @@ final class SchemaDataGenerator
         $minSet = isset($schema['minimum']) && (is_int($schema['minimum']) || is_float($schema['minimum']));
         $maxSet = isset($schema['maximum']) && (is_int($schema['maximum']) || is_float($schema['maximum']));
 
+        $exclusiveMin = isset($schema['exclusiveMinimum']) && (is_int($schema['exclusiveMinimum']) || is_float($schema['exclusiveMinimum']))
+            ? (float) $schema['exclusiveMinimum']
+            : null;
+        $exclusiveMax = isset($schema['exclusiveMaximum']) && (is_int($schema['exclusiveMaximum']) || is_float($schema['exclusiveMaximum']))
+            ? (float) $schema['exclusiveMaximum']
+            : null;
+
         if ($minSet && $maxSet) {
             $min = (float) $schema['minimum'];
             $max = (float) $schema['maximum'];
@@ -456,10 +608,30 @@ final class SchemaDataGenerator
             $max = 1000.0;
         }
 
+        $epsilon = isset($schema['multipleOf']) && (is_int($schema['multipleOf']) || is_float($schema['multipleOf']))
+            ? (float) $schema['multipleOf']
+            : max(PHP_FLOAT_EPSILON, ($max - $min) / 1000000.0);
+        $min = $exclusiveMin !== null ? max($min, $exclusiveMin + $epsilon) : $min;
+        $max = $exclusiveMax !== null ? min($max, $exclusiveMax - $epsilon) : $max;
+
+        $multipleOf = isset($schema['multipleOf']) && (is_int($schema['multipleOf']) || is_float($schema['multipleOf']))
+            ? (float) $schema['multipleOf']
+            : 0.0;
+        if ($multipleOf > 0.0) {
+            $min = round(ceil($min / $multipleOf) * $multipleOf, 12);
+            $max = round(floor($max / $multipleOf) * $multipleOf, 12);
+        }
+
         if ($max < $min) {
             $max = $min;
         }
 
+        if (($iteration % 3) === 0) {
+            return $min;
+        }
+        if (($iteration % 3) === 1) {
+            return $max;
+        }
         if ($faker !== null) {
             // randomFloat(null, …) lets faker pick precision dynamically so
             // tight ranges (e.g. minimum=0.001 maximum=0.002) don't collapse
@@ -481,5 +653,129 @@ final class SchemaDataGenerator
     private static function generateBoolean(int $iteration): bool
     {
         return ($iteration % 2) === 1;
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     *
+     * @return array<string, mixed>
+     */
+    private static function resolveComposition(array $schema, ?Generator $faker, int $iteration): array
+    {
+        foreach (['oneOf', 'anyOf'] as $keyword) {
+            if (!isset($schema[$keyword]) || !is_array($schema[$keyword]) || $schema[$keyword] === []) {
+                continue;
+            }
+            $branches = array_values(array_filter($schema[$keyword], is_array(...)));
+            if ($branches === []) {
+                continue;
+            }
+            unset($schema[$keyword]);
+            $schema = self::mergeSchemas($schema, $branches[$iteration % count($branches)]);
+            break;
+        }
+
+        if (isset($schema['allOf']) && is_array($schema['allOf'])) {
+            $branches = $schema['allOf'];
+            unset($schema['allOf']);
+            $conditionals = [];
+            foreach ($branches as $branch) {
+                if (!is_array($branch)) {
+                    continue;
+                }
+                if (isset($branch['if']) && is_array($branch['if'])) {
+                    $conditionals[] = $branch;
+                } else {
+                    $schema = self::mergeSchemas($schema, $branch);
+                }
+            }
+            if ($conditionals !== []) {
+                $selected = $conditionals[$iteration % count($conditionals)];
+                $schema = self::mergeSchemas($schema, $selected['if']);
+                if (isset($selected['then']) && is_array($selected['then'])) {
+                    $schema = self::mergeSchemas($schema, $selected['then']);
+                }
+            }
+        }
+
+        if (isset($schema['if']) && is_array($schema['if'])) {
+            $useThen = ($iteration % 2) === 0;
+            $conditional = $useThen
+                ? self::mergeSchemas($schema['if'], is_array($schema['then'] ?? null) ? $schema['then'] : [])
+                : self::mergeSchemas(
+                    ['not' => $schema['if']],
+                    is_array($schema['else'] ?? null) ? $schema['else'] : [],
+                );
+            unset($schema['if'], $schema['then'], $schema['else']);
+            $schema = self::mergeSchemas($schema, $conditional);
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Merge the assertion keywords needed for deterministic allOf generation.
+     *
+     * @param array<string, mixed> $left
+     * @param array<string, mixed> $right
+     *
+     * @return array<string, mixed>
+     */
+    private static function mergeSchemas(array $left, array $right): array
+    {
+        $merged = array_merge($left, $right);
+        if (is_array($left['properties'] ?? null) || is_array($right['properties'] ?? null)) {
+            $merged['properties'] = array_merge(
+                is_array($left['properties'] ?? null) ? $left['properties'] : [],
+                is_array($right['properties'] ?? null) ? $right['properties'] : [],
+            );
+        }
+        if (is_array($left['required'] ?? null) || is_array($right['required'] ?? null)) {
+            $merged['required'] = array_values(array_unique(array_merge(
+                is_array($left['required'] ?? null) ? $left['required'] : [],
+                is_array($right['required'] ?? null) ? $right['required'] : [],
+            )));
+        }
+        if (isset($left['minimum'], $right['minimum'])) {
+            $merged['minimum'] = max($left['minimum'], $right['minimum']);
+        }
+        if (isset($left['maximum'], $right['maximum'])) {
+            $merged['maximum'] = min($left['maximum'], $right['maximum']);
+        }
+        if (isset($left['minLength'], $right['minLength'])) {
+            $merged['minLength'] = max($left['minLength'], $right['minLength']);
+        }
+        if (isset($left['maxLength'], $right['maxLength'])) {
+            $merged['maxLength'] = min($left['maxLength'], $right['maxLength']);
+        }
+
+        return $merged;
+    }
+
+    private static function generateCommonPattern(string $pattern, int $iteration): ?string
+    {
+        $candidates = ['a', 'A', '0', 'abc', 'ABC', '123', 'test-' . $iteration, 'é', '日本語'];
+        foreach ($candidates as $candidate) {
+            $delimiter = '~';
+            $escaped = str_replace($delimiter, '\\' . $delimiter, $pattern);
+            if (@preg_match($delimiter . $escaped . $delimiter . 'u', $candidate) === 1) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private static function unicodeLength(string $value): int
+    {
+        return count(self::unicodeCharacters($value));
+    }
+
+    /** @return list<string> */
+    private static function unicodeCharacters(string $value): array
+    {
+        preg_match_all('/./us', $value, $matches);
+
+        return $matches[0];
     }
 }

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -777,6 +777,16 @@ final class SchemaDataGenerator
         if (isset($left['maxLength'], $right['maxLength'])) {
             $merged['maxLength'] = min($left['maxLength'], $right['maxLength']);
         }
+        foreach (['minItems', 'minProperties'] as $minimumKeyword) {
+            if (isset($left[$minimumKeyword], $right[$minimumKeyword])) {
+                $merged[$minimumKeyword] = max($left[$minimumKeyword], $right[$minimumKeyword]);
+            }
+        }
+        foreach (['maxItems', 'maxProperties'] as $maximumKeyword) {
+            if (isset($left[$maximumKeyword], $right[$maximumKeyword])) {
+                $merged[$maximumKeyword] = min($left[$maximumKeyword], $right[$maximumKeyword]);
+            }
+        }
         if ((is_int($left['multipleOf'] ?? null) || is_float($left['multipleOf'] ?? null)) &&
             (is_int($right['multipleOf'] ?? null) || is_float($right['multipleOf'] ?? null))) {
             $multipleOf = DecimalMultiple::leastCommonMultiple($left['multipleOf'], $right['multipleOf']);

--- a/src/Fuzz/SchemaMutation.php
+++ b/src/Fuzz/SchemaMutation.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Fuzz;
+
+/** @internal */
+final readonly class SchemaMutation
+{
+    public function __construct(
+        public mixed $value,
+        public string $keyword,
+        public string $pointer,
+    ) {}
+}

--- a/src/Fuzz/SchemaMutationGenerator.php
+++ b/src/Fuzz/SchemaMutationGenerator.php
@@ -6,17 +6,25 @@ namespace Studio\OpenApiContractTesting\Fuzz;
 
 use Faker\Generator;
 use InvalidArgumentException;
+use stdClass;
 
+use function array_filter;
 use function array_is_list;
 use function array_key_exists;
+use function array_map;
 use function array_slice;
+use function array_values;
 use function count;
+use function explode;
+use function in_array;
 use function is_array;
 use function is_float;
 use function is_int;
 use function is_string;
+use function ltrim;
 use function sprintf;
 use function str_repeat;
+use function str_replace;
 
 /**
  * Produces deterministic, single-constraint mutations from a known-valid value.
@@ -43,6 +51,10 @@ final class SchemaMutationGenerator
         $invalid = [];
         foreach ($candidates as $candidate) {
             if (SchemaValueValidator::isValid($candidate->value, $schema)) {
+                continue;
+            }
+            $relaxedSchema = self::schemaWithoutTargetConstraint($schema, $candidate);
+            if ($relaxedSchema === null || !SchemaValueValidator::isValid($candidate->value, $relaxedSchema)) {
                 continue;
             }
             $invalid[] = $candidate;
@@ -100,10 +112,16 @@ final class SchemaMutationGenerator
         }
 
         if (isset($schema['enum']) && is_array($schema['enum'])) {
-            $result[] = new SchemaMutation('__invalid_enum_value__', 'enum', $pointer);
+            $candidate = self::valueOutsideExactConstraint($schema, 'enum', $schema['enum']);
+            if ($candidate !== null) {
+                $result[] = new SchemaMutation($candidate['value'], 'enum', $pointer);
+            }
         }
         if (array_key_exists('const', $schema)) {
-            $result[] = new SchemaMutation('__invalid_const_value__', 'const', $pointer);
+            $candidate = self::valueOutsideExactConstraint($schema, 'const', [$schema['const']]);
+            if ($candidate !== null) {
+                $result[] = new SchemaMutation($candidate['value'], 'const', $pointer);
+            }
         }
 
         if (is_string($valid) && !$hasExactValueConstraint) {
@@ -168,7 +186,11 @@ final class SchemaMutationGenerator
                 }
                 $mutated = $valid;
                 unset($mutated[$name]);
-                $result[] = new SchemaMutation($mutated, 'required', $pointer . '/' . $name);
+                $result[] = new SchemaMutation(
+                    $mutated === [] ? new stdClass() : $mutated,
+                    'required',
+                    $pointer . '/' . $name,
+                );
             }
             if (($schema['additionalProperties'] ?? null) === false) {
                 $mutated = $valid;
@@ -176,7 +198,7 @@ final class SchemaMutationGenerator
                 $result[] = new SchemaMutation($mutated, 'additionalProperties', $pointer . '/__unexpected__');
             }
             if (isset($schema['minProperties']) && is_int($schema['minProperties']) && $schema['minProperties'] > 0) {
-                $result[] = new SchemaMutation([], 'minProperties', $pointer);
+                $result[] = new SchemaMutation(new stdClass(), 'minProperties', $pointer);
             }
             if (isset($schema['maxProperties']) && is_int($schema['maxProperties'])) {
                 $mutated = $valid;
@@ -200,6 +222,83 @@ final class SchemaMutationGenerator
         }
 
         return $result;
+    }
+
+    /**
+     * Remove only the mutation's target assertion at its instance pointer.
+     * A candidate is accepted only when it validates against this relaxed
+     * schema, proving that no sibling constraint is also required to explain
+     * the failure.
+     *
+     * @param array<string, mixed> $schema
+     *
+     * @return null|array<string, mixed>
+     */
+    private static function schemaWithoutTargetConstraint(array $schema, SchemaMutation $mutation): ?array
+    {
+        $segments = $mutation->pointer === ''
+            ? []
+            : array_map(
+                static fn(string $segment): string => str_replace(['~1', '~0'], ['/', '~'], $segment),
+                explode('/', ltrim($mutation->pointer, '/')),
+            );
+        $propertySegments = in_array($mutation->keyword, ['required', 'additionalProperties'], true)
+            ? array_slice($segments, 0, -1)
+            : $segments;
+
+        $relaxed = $schema;
+        $cursor = &$relaxed;
+        foreach ($propertySegments as $segment) {
+            if (!isset($cursor['properties'][$segment]) || !is_array($cursor['properties'][$segment])) {
+                return null;
+            }
+            $cursor = &$cursor['properties'][$segment];
+        }
+
+        if ($mutation->keyword === 'required') {
+            $propertyName = $segments[count($segments) - 1] ?? null;
+            if (!is_string($propertyName) || !is_array($cursor['required'] ?? null)) {
+                return null;
+            }
+            $cursor['required'] = array_values(array_filter(
+                $cursor['required'],
+                static fn(mixed $name): bool => $name !== $propertyName,
+            ));
+
+            return $relaxed;
+        }
+
+        if (!array_key_exists($mutation->keyword, $cursor)) {
+            return null;
+        }
+        unset($cursor[$mutation->keyword]);
+        if ($cursor === []) {
+            $cursor['title'] = 'relaxed mutation target';
+        }
+
+        return $relaxed;
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     * @param list<mixed> $excluded
+     *
+     * @return null|array{value: mixed}
+     */
+    private static function valueOutsideExactConstraint(array $schema, string $keyword, array $excluded): ?array
+    {
+        unset($schema[$keyword]);
+        if ($schema === []) {
+            $schema['title'] = 'relaxed exact-value target';
+        }
+        for ($iteration = 0; $iteration < 20; $iteration++) {
+            $candidate = SchemaDataGenerator::generateOne($schema, null, $iteration);
+            if (!in_array($candidate, $excluded, true) && SchemaValueValidator::isValid($candidate, $schema)) {
+                return ['value' => $candidate];
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Fuzz/SchemaMutationGenerator.php
+++ b/src/Fuzz/SchemaMutationGenerator.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Fuzz;
+
+use Faker\Generator;
+use InvalidArgumentException;
+
+use function array_is_list;
+use function array_key_exists;
+use function array_slice;
+use function count;
+use function is_array;
+use function is_float;
+use function is_int;
+use function is_string;
+use function sprintf;
+use function str_repeat;
+
+/**
+ * Produces deterministic, single-constraint mutations from a known-valid value.
+ * Unsupported constraints are omitted instead of emitting an ambiguously invalid case.
+ *
+ * @internal
+ */
+final class SchemaMutationGenerator
+{
+    /**
+     * @param array<string, mixed> $schema
+     *
+     * @return list<SchemaMutation>
+     */
+    public static function generate(array $schema, int $count, ?Generator $faker, int $iteration = 0): array
+    {
+        if ($count < 1) {
+            throw new InvalidArgumentException(sprintf('Invalid mutation count must be >= 1, got %d.', $count));
+        }
+
+        $valid = SchemaDataGenerator::generateOne($schema, $faker, $iteration);
+        SchemaValueValidator::assertValid($valid, $schema, $iteration);
+        $candidates = self::candidates($schema, $valid, '');
+        $invalid = [];
+        foreach ($candidates as $candidate) {
+            if (SchemaValueValidator::isValid($candidate->value, $schema)) {
+                continue;
+            }
+            $invalid[] = $candidate;
+            if (count($invalid) === $count) {
+                break;
+            }
+        }
+
+        if ($invalid === []) {
+            throw new InvalidArgumentException('No deterministic invalid mutation is supported for this schema.');
+        }
+
+        return $invalid;
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     *
+     * @return list<SchemaMutation>
+     */
+    private static function candidates(array $schema, mixed $valid, string $pointer): array
+    {
+        $result = [];
+        $type = $schema['type'] ?? null;
+        $hasExactValueConstraint = array_key_exists('const', $schema) ||
+            (isset($schema['enum']) && is_array($schema['enum']));
+
+        foreach (['oneOf', 'anyOf', 'allOf'] as $composition) {
+            if (!isset($schema[$composition]) || !is_array($schema[$composition])) {
+                continue;
+            }
+            foreach ([null, false, '__composition_miss__', [], ['__composition_miss__' => true]] as $candidate) {
+                $result[] = new SchemaMutation($candidate, $composition, $pointer);
+            }
+        }
+        if (isset($schema['not']) && is_array($schema['not'])) {
+            $result[] = new SchemaMutation(
+                SchemaDataGenerator::generateOne($schema['not'], null, 0),
+                'not',
+                $pointer,
+            );
+        }
+
+        if (is_string($type) && !$hasExactValueConstraint) {
+            $wrong = match ($type) {
+                'object' => 'not-an-object',
+                'array' => 'not-an-array',
+                'string' => 42,
+                'integer', 'number' => 'not-a-number',
+                'boolean' => 'not-a-boolean',
+                'null' => false,
+                default => null,
+            };
+            $result[] = new SchemaMutation($wrong, 'type', $pointer);
+        }
+
+        if (isset($schema['enum']) && is_array($schema['enum'])) {
+            $result[] = new SchemaMutation('__invalid_enum_value__', 'enum', $pointer);
+        }
+        if (array_key_exists('const', $schema)) {
+            $result[] = new SchemaMutation('__invalid_const_value__', 'const', $pointer);
+        }
+
+        if (is_string($valid) && !$hasExactValueConstraint) {
+            if (isset($schema['minLength']) && is_int($schema['minLength']) && $schema['minLength'] > 0) {
+                $result[] = new SchemaMutation(str_repeat('x', $schema['minLength'] - 1), 'minLength', $pointer);
+            }
+            if (isset($schema['maxLength']) && is_int($schema['maxLength'])) {
+                $result[] = new SchemaMutation(str_repeat('x', $schema['maxLength'] + 1), 'maxLength', $pointer);
+            }
+            if (isset($schema['pattern']) && is_string($schema['pattern'])) {
+                foreach (["\n", '__pattern_miss__', '123', 'abc'] as $candidate) {
+                    $result[] = new SchemaMutation($candidate, 'pattern', $pointer);
+                }
+            }
+            if (isset($schema['format']) && is_string($schema['format'])) {
+                $result[] = new SchemaMutation('not-a-' . $schema['format'], 'format', $pointer);
+            }
+        }
+
+        if (is_int($valid) || is_float($valid)) {
+            if (isset($schema['minimum']) && (is_int($schema['minimum']) || is_float($schema['minimum']))) {
+                $result[] = new SchemaMutation($schema['minimum'] - 1, 'minimum', $pointer);
+            }
+            if (isset($schema['maximum']) && (is_int($schema['maximum']) || is_float($schema['maximum']))) {
+                $result[] = new SchemaMutation($schema['maximum'] + 1, 'maximum', $pointer);
+            }
+            if (isset($schema['exclusiveMinimum']) && (is_int($schema['exclusiveMinimum']) || is_float($schema['exclusiveMinimum']))) {
+                $result[] = new SchemaMutation($schema['exclusiveMinimum'], 'exclusiveMinimum', $pointer);
+            }
+            if (isset($schema['exclusiveMaximum']) && (is_int($schema['exclusiveMaximum']) || is_float($schema['exclusiveMaximum']))) {
+                $result[] = new SchemaMutation($schema['exclusiveMaximum'], 'exclusiveMaximum', $pointer);
+            }
+            if (isset($schema['multipleOf']) && (is_int($schema['multipleOf']) || is_float($schema['multipleOf']))) {
+                $result[] = new SchemaMutation($valid + $schema['multipleOf'] / 2, 'multipleOf', $pointer);
+            }
+        }
+
+        if (is_array($valid) && array_is_list($valid)) {
+            if (isset($schema['minItems']) && is_int($schema['minItems']) && $schema['minItems'] > 0) {
+                $result[] = new SchemaMutation(array_slice($valid, 0, $schema['minItems'] - 1), 'minItems', $pointer);
+            }
+            if (isset($schema['maxItems']) && is_int($schema['maxItems'])) {
+                $expanded = $valid;
+                while (count($expanded) <= $schema['maxItems']) {
+                    $expanded[] = $valid[0] ?? null;
+                }
+                $result[] = new SchemaMutation($expanded, 'maxItems', $pointer);
+            }
+            if (($schema['uniqueItems'] ?? false) === true && $valid !== []) {
+                $result[] = new SchemaMutation([$valid[0], $valid[0]], 'uniqueItems', $pointer);
+            }
+        }
+
+        if (is_array($valid) && !array_is_list($valid)) {
+            $required = isset($schema['required']) && is_array($schema['required']) ? $schema['required'] : [];
+            foreach ($required as $name) {
+                if (!is_string($name) || !array_key_exists($name, $valid)) {
+                    continue;
+                }
+                $mutated = $valid;
+                unset($mutated[$name]);
+                $result[] = new SchemaMutation($mutated, 'required', $pointer . '/' . $name);
+            }
+            if (($schema['additionalProperties'] ?? null) === false) {
+                $mutated = $valid;
+                $mutated['__unexpected__'] = true;
+                $result[] = new SchemaMutation($mutated, 'additionalProperties', $pointer . '/__unexpected__');
+            }
+            if (isset($schema['minProperties']) && is_int($schema['minProperties']) && $schema['minProperties'] > 0) {
+                $result[] = new SchemaMutation([], 'minProperties', $pointer);
+            }
+            if (isset($schema['maxProperties']) && is_int($schema['maxProperties'])) {
+                $mutated = $valid;
+                while (count($mutated) <= $schema['maxProperties']) {
+                    $mutated['extra' . count($mutated)] = true;
+                }
+                $result[] = new SchemaMutation($mutated, 'maxProperties', $pointer);
+            }
+
+            $properties = isset($schema['properties']) && is_array($schema['properties']) ? $schema['properties'] : [];
+            foreach ($properties as $name => $propertySchema) {
+                if (!is_string($name) || !is_array($propertySchema) || !array_key_exists($name, $valid)) {
+                    continue;
+                }
+                foreach (self::candidates($propertySchema, $valid[$name], $pointer . '/' . $name) as $nested) {
+                    $mutated = $valid;
+                    $mutated[$name] = $nested->value;
+                    $result[] = new SchemaMutation($mutated, $nested->keyword, $nested->pointer);
+                }
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Fuzz/SchemaMutationGenerator.php
+++ b/src/Fuzz/SchemaMutationGenerator.php
@@ -7,6 +7,7 @@ namespace Studio\OpenApiContractTesting\Fuzz;
 use Faker\Generator;
 use InvalidArgumentException;
 
+use function abs;
 use function array_is_list;
 use function array_key_exists;
 use function array_slice;
@@ -15,6 +16,7 @@ use function is_array;
 use function is_float;
 use function is_int;
 use function is_string;
+use function round;
 use function sprintf;
 use function str_repeat;
 
@@ -137,7 +139,10 @@ final class SchemaMutationGenerator
                 $result[] = new SchemaMutation($schema['exclusiveMaximum'], 'exclusiveMaximum', $pointer);
             }
             if (isset($schema['multipleOf']) && (is_int($schema['multipleOf']) || is_float($schema['multipleOf']))) {
-                $result[] = new SchemaMutation($valid + $schema['multipleOf'] / 2, 'multipleOf', $pointer);
+                $multipleOfCandidate = self::multipleOfCandidate($schema, $valid);
+                if ($multipleOfCandidate !== null) {
+                    $result[] = new SchemaMutation($multipleOfCandidate, 'multipleOf', $pointer);
+                }
             }
         }
 
@@ -197,5 +202,49 @@ final class SchemaMutationGenerator
         }
 
         return $result;
+    }
+
+    /**
+     * Find a same-type value that remains valid when only `multipleOf` is
+     * removed. Some combinations are tautological (`integer` +
+     * `multipleOf: 1`), so no honest single-constraint mutation exists.
+     *
+     * @param array<string, mixed> $schema
+     */
+    private static function multipleOfCandidate(array $schema, float|int $valid): null|float|int
+    {
+        $withoutMultipleOf = $schema;
+        unset($withoutMultipleOf['multipleOf']);
+
+        if (is_int($valid)) {
+            $multipleOf = (float) $schema['multipleOf'];
+            if ($multipleOf <= 0.0) {
+                return null;
+            }
+            $reciprocal = 1.0 / $multipleOf;
+            if (abs($reciprocal - round($reciprocal)) < 1.0E-12) {
+                return null;
+            }
+            for ($offset = 1; $offset <= 1000; $offset++) {
+                foreach ([$valid + $offset, $valid - $offset] as $candidate) {
+                    if (SchemaValueValidator::isValid($candidate, $withoutMultipleOf) &&
+                        !SchemaValueValidator::isValid($candidate, $schema)) {
+                        return $candidate;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        $multipleOf = (float) $schema['multipleOf'];
+        foreach ([$valid + $multipleOf / 2, $valid - $multipleOf / 2] as $candidate) {
+            if (SchemaValueValidator::isValid($candidate, $withoutMultipleOf) &&
+                !SchemaValueValidator::isValid($candidate, $schema)) {
+                return $candidate;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Fuzz/SchemaMutationGenerator.php
+++ b/src/Fuzz/SchemaMutationGenerator.php
@@ -7,7 +7,6 @@ namespace Studio\OpenApiContractTesting\Fuzz;
 use Faker\Generator;
 use InvalidArgumentException;
 
-use function abs;
 use function array_is_list;
 use function array_key_exists;
 use function array_slice;
@@ -16,7 +15,6 @@ use function is_array;
 use function is_float;
 use function is_int;
 use function is_string;
-use function round;
 use function sprintf;
 use function str_repeat;
 
@@ -217,12 +215,8 @@ final class SchemaMutationGenerator
         unset($withoutMultipleOf['multipleOf']);
 
         if (is_int($valid)) {
-            $multipleOf = (float) $schema['multipleOf'];
-            if ($multipleOf <= 0.0) {
-                return null;
-            }
-            $reciprocal = 1.0 / $multipleOf;
-            if (abs($reciprocal - round($reciprocal)) < 1.0E-12) {
+            $integerStep = DecimalMultiple::integerStep($schema['multipleOf']);
+            if ($integerStep === null || $integerStep === 1) {
                 return null;
             }
             for ($offset = 1; $offset <= 1000; $offset++) {

--- a/src/Fuzz/SchemaValueValidator.php
+++ b/src/Fuzz/SchemaValueValidator.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Fuzz;
+
+use Opis\JsonSchema\Validator;
+use RuntimeException;
+
+use function json_decode;
+use function json_encode;
+use function sprintf;
+
+/** @internal */
+final class SchemaValueValidator
+{
+    /** @param array<string, mixed> $schema */
+    public static function isValid(mixed $value, array $schema): bool
+    {
+        $validator = new Validator();
+        $instance = json_decode((string) json_encode($value));
+        $jsonSchema = json_decode((string) json_encode($schema));
+
+        return $validator->validate($instance, $jsonSchema)->isValid();
+    }
+
+    /** @param array<string, mixed> $schema */
+    public static function assertValid(mixed $value, array $schema, int $iteration): void
+    {
+        if (self::isValid($value, $schema)) {
+            return;
+        }
+
+        throw new RuntimeException(sprintf(
+            'Internal fuzz generator defect: valid case %d does not satisfy its converted JSON Schema.',
+            $iteration,
+        ));
+    }
+}

--- a/src/Laravel/ExploresOpenApiEndpoint.php
+++ b/src/Laravel/ExploresOpenApiEndpoint.php
@@ -19,9 +19,9 @@ use function is_string;
 /**
  * Schema-driven request fuzzing trait — issue #136.
  *
- * Generates N happy-path request inputs for a single (method, path) operation
- * directly from the OpenAPI spec, returning an iterable {@see ExplorationCases}
- * collection that the test author drives through any HTTP client of choice.
+ * Generates valid-boundary or targeted-invalid request inputs directly from
+ * the OpenAPI spec, returning an iterable {@see ExplorationCases} collection
+ * that the test author drives through any HTTP client of choice.
  * Each HTTP call still goes through the existing {@see ValidatesOpenApiSchema}
  * auto-assert hook, so the response side and coverage tracking happen
  * automatically.
@@ -73,6 +73,33 @@ trait ExploresOpenApiEndpoint
             // (InvalidOpenApiSpecException, SpecFileNotFoundException, etc.)
             // — without this, a missing or malformed spec leaks the loader's
             // raw stack trace into PHPUnit instead of a clean assertion.
+            $this->failExplore($e->getMessage());
+        }
+    }
+
+    /** @param list<int> $expectedStatusClasses */
+    public function exploreInvalidEndpoint(
+        string $method,
+        string $path,
+        array $expectedStatusClasses,
+        int $cases = 30,
+        ?int $seed = null,
+    ): ExplorationCases {
+        $specName = $this->resolveOpenApiSpec();
+        if (!is_string($specName) || $specName === '') {
+            $this->failExplore('openApiSpec() must return a non-empty spec name.');
+        }
+
+        try {
+            return OpenApiEndpointExplorer::exploreInvalid(
+                $specName,
+                $method,
+                $path,
+                $expectedStatusClasses,
+                $cases,
+                $seed,
+            );
+        } catch (InvalidArgumentException|RuntimeException $e) {
             $this->failExplore($e->getMessage());
         }
     }

--- a/src/Spec/OpenApiSchemaConverter.php
+++ b/src/Spec/OpenApiSchemaConverter.php
@@ -21,6 +21,9 @@ use function get_debug_type;
 use function implode;
 use function in_array;
 use function is_array;
+use function is_bool;
+use function is_float;
+use function is_int;
 use function is_string;
 use function sort;
 use function sprintf;
@@ -142,8 +145,8 @@ final class OpenApiSchemaConverter
      * `$discriminator` carries the resolved root + enforce gate for
      * `discriminator.mapping` / 3.2 `defaultMapping` lowering (Issues #262
      * and #273). `null` (the default for
-     * callers that cannot enforce — parameter / header validators, the fuzz
-     * explorer) is normalised to {@see DiscriminatorContext::disabled()}, under
+     * callers that cannot enforce — parameter / header validators) is
+     * normalised to {@see DiscriminatorContext::disabled()}, under
      * which `discriminator` is stripped rather than enforced.
      *
      * @param array<string, mixed> $schema
@@ -212,6 +215,7 @@ final class OpenApiSchemaConverter
 
         if ($version === OpenApiVersion::V3_0) {
             self::handleNullable($schema);
+            self::normalizeOpenApi30ExclusiveBounds($schema);
             unset($schema['$schema']);
             self::removeKeys($schema, self::DRAFT_2020_12_KEYS);
             self::warnIfUsesUnsupportedKeywords($schema);
@@ -362,6 +366,29 @@ final class OpenApiSchemaConverter
         // already converted by lowerDiscriminator itself and are not
         // re-visited here. See Issue #262.
         self::lowerDiscriminator($schema, $version, $context, $discriminator, $implicitDiscriminatorValues);
+    }
+
+    /**
+     * OAS 3.0 inherits the boolean Draft Wright-00 form while opis consumes
+     * Draft 07's numeric form. Preserve the bound before attaching the
+     * Draft-07 dialect marker, otherwise `true` is interpreted as the number
+     * one and changes the contract.
+     *
+     * @param array<string, mixed> $schema
+     */
+    private static function normalizeOpenApi30ExclusiveBounds(array &$schema): void
+    {
+        foreach ([['minimum', 'exclusiveMinimum'], ['maximum', 'exclusiveMaximum']] as [$inclusive, $exclusive]) {
+            if (!is_bool($schema[$exclusive] ?? null)) {
+                continue;
+            }
+            if ($schema[$exclusive] === true && (is_int($schema[$inclusive] ?? null) || is_float($schema[$inclusive] ?? null))) {
+                $schema[$exclusive] = $schema[$inclusive];
+                unset($schema[$inclusive]);
+            } else {
+                unset($schema[$exclusive]);
+            }
+        }
     }
 
     /**

--- a/src/Validation/Support/DiscriminatorContext.php
+++ b/src/Validation/Support/DiscriminatorContext.php
@@ -26,7 +26,7 @@ use Studio\OpenApiContractTesting\Spec\OpenApiSchemaConverter;
  *    it both terminates the recursion and avoids combinatorial blow-up for
  *    mappings with many values.
  *
- * Non-body call sites (parameter / header validators, the fuzz explorer) pass
+ * Non-body call sites (parameter / header validators) pass
  * {@see self::disabled()} — those positions never carry a `discriminator` and
  * have no root to resolve against, so lowering is a no-op there.
  *

--- a/tests/Unit/Fuzz/ExploredCaseTest.php
+++ b/tests/Unit/Fuzz/ExploredCaseTest.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\Fuzz\ExploredCase;
+use Studio\OpenApiContractTesting\Fuzz\FailureReducer;
 use Studio\OpenApiContractTesting\HttpMethod;
 
 class ExploredCaseTest extends TestCase
@@ -46,5 +47,44 @@ class ExploredCaseTest extends TestCase
         $this->assertSame(['petId' => 7], $case->pathParams);
         $this->assertSame(HttpMethod::POST, $case->method);
         $this->assertSame('/v1/pets', $case->matchedPath);
+    }
+
+    #[Test]
+    public function renders_php_and_curl_reproduction_output(): void
+    {
+        $case = new ExploredCase(
+            body: ['name' => 'Snowy'],
+            query: ['dryRun' => true],
+            headers: ['X-Trace' => 'abc'],
+            pathParams: ['petId' => 7],
+            method: HttpMethod::POST,
+            matchedPath: '/v1/pets/{petId}',
+            seed: 42,
+            caseIndex: 2,
+        );
+
+        $this->assertStringContainsString('cases: 3, seed: 42', $case->replaySnippet('petstore'));
+        $this->assertStringContainsString("curl -X POST 'https://api.example.test/v1/pets/7?", $case->curlSnippet('https://api.example.test'));
+        $this->assertStringContainsString("--data '{\"name\":\"Snowy\"}'", $case->curlSnippet());
+    }
+
+    #[Test]
+    public function reducer_preserves_the_original_failure_classification(): void
+    {
+        $case = new ExploredCase(
+            body: ['trigger' => true, 'noiseA' => 1, 'noiseB' => 2],
+            query: [],
+            headers: [],
+            pathParams: [],
+            method: HttpMethod::POST,
+            matchedPath: '/v1/pets',
+        );
+
+        $reduced = FailureReducer::reduce(
+            $case,
+            static fn(ExploredCase $candidate): ?string => ($candidate->body['trigger'] ?? false) === true ? 'status:500' : null,
+        );
+
+        $this->assertSame(['trigger' => true], $reduced->body);
     }
 }

--- a/tests/Unit/Fuzz/OpenApiEndpointExplorerTest.php
+++ b/tests/Unit/Fuzz/OpenApiEndpointExplorerTest.php
@@ -9,6 +9,7 @@ use Opis\JsonSchema\Validator;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecException;
+use Studio\OpenApiContractTesting\Fuzz\ExplorationCaseKind;
 use Studio\OpenApiContractTesting\Fuzz\ExplorationCases;
 use Studio\OpenApiContractTesting\Fuzz\ExploredCase;
 use Studio\OpenApiContractTesting\Fuzz\OpenApiEndpointExplorer;
@@ -214,6 +215,37 @@ class OpenApiEndpointExplorerTest extends TestCase
         $this->assertCount(1, $cases);
         foreach ($cases as $case) {
             $this->assertSame(HttpMethod::POST, $case->method);
+        }
+    }
+
+    #[Test]
+    public function negative_exploration_requires_expected_status_classes(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('expected HTTP status class');
+
+        OpenApiEndpointExplorer::exploreInvalid('petstore-3.0', 'POST', '/v1/pets', [], cases: 1);
+    }
+
+    #[Test]
+    public function negative_exploration_exposes_target_and_replay_metadata(): void
+    {
+        $cases = OpenApiEndpointExplorer::exploreInvalid(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            expectedStatusClasses: [4],
+            cases: 3,
+            seed: 17,
+        );
+
+        foreach ($cases as $index => $case) {
+            $this->assertSame(ExplorationCaseKind::Invalid, $case->kind);
+            $this->assertNotNull($case->targetKeyword);
+            $this->assertSame([4], $case->expectedStatusClasses);
+            $this->assertSame(17, $case->seed);
+            $this->assertSame($index, $case->caseIndex);
+            $this->assertNotSame('', $case->replayToken());
         }
     }
 }

--- a/tests/Unit/Fuzz/OpenApiSpecExplorerTest.php
+++ b/tests/Unit/Fuzz/OpenApiSpecExplorerTest.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use Studio\OpenApiContractTesting\Fuzz\ExplorationCaseKind;
 use Studio\OpenApiContractTesting\Fuzz\ExplorationSkip;
 use Studio\OpenApiContractTesting\Fuzz\ExploredCase;
 use Studio\OpenApiContractTesting\Fuzz\ExploredOperation;
@@ -16,6 +17,7 @@ use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 
 use function array_filter;
 use function array_map;
+use function intdiv;
 use function sort;
 use function str_contains;
 
@@ -185,6 +187,32 @@ class OpenApiSpecExplorerTest extends TestCase
         }
 
         $this->assertSame($runs[0], $runs[1]);
+    }
+
+    #[Test]
+    public function whole_spec_plan_can_generate_explicitly_classified_negative_cases(): void
+    {
+        $seen = [];
+
+        OpenApiSpecExplorer::explore('whole-spec-exploration', casesPerOperation: 2, seed: 9)
+            ->includeOperations(['createPet'])
+            ->negativeCases([4])
+            ->dispatchUsing(static function (ExploredCase $case) use (&$seen): int {
+                $seen[] = [$case->kind, $case->targetKeyword, $case->expectedStatusClasses];
+
+                return 422;
+            })
+            ->assertResponseUsing(static function (int $status, ExploredCase $case): void {
+                self::assertContains(intdiv($status, 100), $case->expectedStatusClasses);
+            })
+            ->assertResponses();
+
+        $this->assertCount(2, $seen);
+        foreach ($seen as [$kind, $keyword, $classes]) {
+            $this->assertSame(ExplorationCaseKind::Invalid, $kind);
+            $this->assertNotNull($keyword);
+            $this->assertSame([4], $classes);
+        }
     }
 
     #[Test]

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -577,6 +577,50 @@ class SchemaDataGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function allof_recursively_merges_constraints_on_the_same_property(): void
+    {
+        $schema = [
+            'allOf' => [
+                [
+                    'type' => 'object',
+                    'required' => ['name', 'profile'],
+                    'properties' => [
+                        'name' => ['type' => 'string', 'minLength' => 2],
+                        'profile' => [
+                            'type' => 'object',
+                            'required' => ['nickname'],
+                            'properties' => [
+                                'nickname' => ['type' => 'string', 'minLength' => 3],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'type' => 'object',
+                    'properties' => [
+                        'name' => ['type' => 'string', 'maxLength' => 5],
+                        'profile' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'nickname' => ['type' => 'string', 'maxLength' => 6],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $values = SchemaDataGenerator::generate($schema, 3, seed: 1);
+
+        foreach ($values as $value) {
+            $this->assertGreaterThanOrEqual(2, strlen($value['name']));
+            $this->assertLessThanOrEqual(5, strlen($value['name']));
+            $this->assertGreaterThanOrEqual(3, strlen($value['profile']['nickname']));
+            $this->assertLessThanOrEqual(6, strlen($value['profile']['nickname']));
+        }
+    }
+
+    #[Test]
     public function invalid_mutations_each_name_and_violate_the_target_constraint(): void
     {
         $schema = [

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -11,6 +11,7 @@ use Opis\JsonSchema\Validator;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use stdClass;
 use Studio\OpenApiContractTesting\Fuzz\SchemaDataGenerator;
 use Studio\OpenApiContractTesting\Fuzz\SchemaMutationGenerator;
 use Studio\OpenApiContractTesting\Fuzz\SchemaValueValidator;
@@ -691,6 +692,50 @@ class SchemaDataGeneratorTest extends TestCase
         $this->assertContains('required', $keywords);
         $this->assertContains('additionalProperties', $keywords);
         $this->assertContains('enum', $keywords);
+    }
+
+    #[Test]
+    public function mutations_are_omitted_when_they_also_violate_a_sibling_constraint(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => ['a' => ['type' => 'string']],
+            'required' => ['a'],
+            'minProperties' => 1,
+            'additionalProperties' => false,
+        ];
+
+        $mutations = SchemaMutationGenerator::generate($schema, 100, SchemaDataGenerator::createFaker(1));
+        $keywords = array_map(static fn($mutation): string => $mutation->keyword, $mutations);
+
+        $this->assertNotContains('required', $keywords);
+        $this->assertNotContains('minProperties', $keywords);
+        $this->assertContains('additionalProperties', $keywords);
+        $this->assertContains('type', $keywords);
+    }
+
+    #[Test]
+    public function required_only_mutation_uses_a_json_object_and_is_single_constraint(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => ['a' => ['type' => 'string']],
+            'required' => ['a'],
+            'additionalProperties' => false,
+        ];
+        $relaxed = $schema;
+        unset($relaxed['required']);
+
+        $mutations = SchemaMutationGenerator::generate($schema, 100, SchemaDataGenerator::createFaker(1));
+        $required = array_values(array_filter(
+            $mutations,
+            static fn($mutation): bool => $mutation->keyword === 'required',
+        ));
+
+        $this->assertCount(1, $required);
+        $this->assertInstanceOf(stdClass::class, $required[0]->value);
+        $this->assertFalse(SchemaValueValidator::isValid($required[0]->value, $schema));
+        $this->assertTrue(SchemaValueValidator::isValid($required[0]->value, $relaxed));
     }
 
     #[Test]

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -10,8 +10,16 @@ use InvalidArgumentException;
 use Opis\JsonSchema\Validator;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use Studio\OpenApiContractTesting\Fuzz\SchemaDataGenerator;
+use Studio\OpenApiContractTesting\Fuzz\SchemaMutationGenerator;
+use Studio\OpenApiContractTesting\Fuzz\SchemaValueValidator;
+use Studio\OpenApiContractTesting\OpenApiVersion;
+use Studio\OpenApiContractTesting\SchemaContext;
+use Studio\OpenApiContractTesting\Spec\OpenApiSchemaConverter;
+use Studio\OpenApiContractTesting\Validation\Support\DiscriminatorContext;
 
+use function array_map;
 use function count;
 use function json_decode;
 use function json_encode;
@@ -252,16 +260,16 @@ class SchemaDataGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function nullable_type_array_picks_non_null(): void
+    public function nullable_type_array_explores_both_branches(): void
     {
         // Draft-2020 / OAS 3.1 normalised form after OpenApiSchemaConverter.
         $schema = ['type' => ['string', 'null']];
 
         $values = SchemaDataGenerator::generate($schema, 3, seed: 1);
 
-        foreach ($values as $value) {
-            $this->assertIsString($value);
-        }
+        $this->assertIsString($values[0]);
+        $this->assertIsString($values[1]);
+        $this->assertNull($values[2]);
     }
 
     #[Test]
@@ -404,12 +412,8 @@ class SchemaDataGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function oneof_schema_falls_through_to_string_default(): void
+    public function generates_from_each_oneof_branch(): void
     {
-        // Pin current MVP behaviour: composite schemas resolve to `string`
-        // because resolveType() bottoms out there. If a future change adds
-        // proper composition handling, this test should be updated — and the
-        // failure makes that explicit instead of silently changing semantics.
         $schema = [
             'oneOf' => [
                 ['type' => 'object'],
@@ -417,9 +421,193 @@ class SchemaDataGeneratorTest extends TestCase
             ],
         ];
 
-        $value = SchemaDataGenerator::generateOne($schema, faker: null, iteration: 0);
+        $this->assertIsArray(SchemaDataGenerator::generateOne($schema, faker: null, iteration: 0));
+        $this->assertIsInt(SchemaDataGenerator::generateOne($schema, faker: null, iteration: 1));
+    }
 
-        $this->assertIsString($value);
+    #[Test]
+    public function emits_valid_string_length_boundaries_using_unicode_code_points(): void
+    {
+        $values = SchemaDataGenerator::generate(['type' => 'string', 'minLength' => 1, 'maxLength' => 3], 3, seed: 7);
+
+        foreach ($values as $value) {
+            $this->assertTrue(SchemaValueValidator::isValid($value, ['type' => 'string', 'minLength' => 1, 'maxLength' => 3]));
+        }
+        $this->assertSame(1, strlen($values[0]));
+        $this->assertSame(3, strlen($values[1]));
+        $this->assertSame('é', SchemaDataGenerator::generateOne(['type' => 'string', 'pattern' => '^é$'], null, 0));
+    }
+
+    #[Test]
+    public function emits_numeric_boundaries_that_honor_exclusive_and_multiple_of(): void
+    {
+        $schema = [
+            'type' => 'integer',
+            'exclusiveMinimum' => 0,
+            'exclusiveMaximum' => 10,
+            'multipleOf' => 2,
+        ];
+
+        $values = SchemaDataGenerator::generate($schema, 3, seed: 1);
+        $this->assertSame(2, $values[0]);
+        $this->assertSame(8, $values[1]);
+        $this->assertSame(0, $values[2] % 2);
+    }
+
+    #[Test]
+    public function integer_exclusive_bounds_round_in_the_contract_safe_direction(): void
+    {
+        $values = SchemaDataGenerator::generate([
+            'type' => 'integer',
+            'exclusiveMinimum' => 0.5,
+            'exclusiveMaximum' => 10.5,
+        ], 2, seed: 1);
+
+        $this->assertSame([1, 10], $values);
+    }
+
+    #[Test]
+    public function emits_array_and_object_size_boundaries(): void
+    {
+        $arrays = SchemaDataGenerator::generate([
+            'type' => 'array',
+            'minItems' => 2,
+            'maxItems' => 4,
+            'items' => ['type' => 'integer'],
+        ], 3, seed: 1);
+        $this->assertCount(2, $arrays[0]);
+        $this->assertCount(4, $arrays[1]);
+
+        $objects = SchemaDataGenerator::generate([
+            'type' => 'object',
+            'minProperties' => 2,
+            'maxProperties' => 2,
+        ], 1, seed: 1);
+        $this->assertCount(2, $objects[0]);
+    }
+
+    #[Test]
+    public function generates_allof_not_and_conditional_schemas(): void
+    {
+        $allOf = [
+            'allOf' => [
+                ['type' => 'object', 'required' => ['id'], 'properties' => ['id' => ['type' => 'integer']]],
+                ['type' => 'object', 'required' => ['name'], 'properties' => ['name' => ['type' => 'string']]],
+            ],
+        ];
+        $value = SchemaDataGenerator::generate($allOf, 1, seed: 1)[0];
+        $this->assertIsArray($value);
+        $this->assertArrayHasKey('id', $value);
+        $this->assertArrayHasKey('name', $value);
+
+        $this->assertIsNotString(SchemaDataGenerator::generate(['not' => ['type' => 'string']], 1, seed: 1)[0]);
+
+        $conditional = [
+            'type' => 'object',
+            'if' => ['required' => ['kind'], 'properties' => ['kind' => ['const' => 'a']]],
+            'then' => ['required' => ['a'], 'properties' => ['a' => ['type' => 'string']]],
+            'else' => ['required' => ['b'], 'properties' => ['b' => ['type' => 'integer']]],
+        ];
+        foreach (SchemaDataGenerator::generate($conditional, 2, seed: 1) as $conditionalValue) {
+            $this->assertTrue(SchemaValueValidator::isValid($conditionalValue, $conditional));
+        }
+    }
+
+    #[Test]
+    public function invalid_mutations_each_name_and_violate_the_target_constraint(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'required' => ['name'],
+            'additionalProperties' => false,
+            'properties' => [
+                'name' => ['type' => 'string', 'minLength' => 2, 'maxLength' => 4, 'enum' => ['ab', 'cd']],
+            ],
+        ];
+
+        $mutations = SchemaMutationGenerator::generate($schema, 20, SchemaDataGenerator::createFaker(1));
+        $keywords = [];
+        foreach ($mutations as $mutation) {
+            $this->assertFalse(SchemaValueValidator::isValid($mutation->value, $schema));
+            $keywords[] = $mutation->keyword;
+        }
+
+        $this->assertContains('required', $keywords);
+        $this->assertContains('additionalProperties', $keywords);
+        $this->assertContains('enum', $keywords);
+    }
+
+    #[Test]
+    public function supported_constraint_families_have_targeted_invalid_mutations(): void
+    {
+        $schemas = [
+            'type' => ['type' => 'string'],
+            'const' => ['const' => 'fixed'],
+            'enum' => ['type' => 'string', 'enum' => ['a', 'b']],
+            'minLength' => ['type' => 'string', 'minLength' => 2],
+            'maxLength' => ['type' => 'string', 'maxLength' => 3],
+            'pattern' => ['type' => 'string', 'pattern' => '^a+$'],
+            'format' => ['type' => 'string', 'format' => 'email'],
+            'minimum' => ['type' => 'integer', 'minimum' => 2],
+            'maximum' => ['type' => 'integer', 'maximum' => 5],
+            'exclusiveMinimum' => ['type' => 'integer', 'exclusiveMinimum' => 0],
+            'exclusiveMaximum' => ['type' => 'integer', 'exclusiveMaximum' => 10],
+            'multipleOf' => ['type' => 'integer', 'multipleOf' => 2],
+            'minItems' => ['type' => 'array', 'minItems' => 2, 'items' => ['type' => 'integer']],
+            'maxItems' => ['type' => 'array', 'maxItems' => 2, 'items' => ['type' => 'integer']],
+            'uniqueItems' => ['type' => 'array', 'minItems' => 2, 'uniqueItems' => true, 'items' => ['type' => 'integer']],
+            'minProperties' => ['type' => 'object', 'minProperties' => 2],
+            'maxProperties' => ['type' => 'object', 'maxProperties' => 1],
+            'oneOf' => ['oneOf' => [['type' => 'integer'], ['type' => 'object']]],
+            'anyOf' => ['anyOf' => [['type' => 'integer'], ['type' => 'object']]],
+            'allOf' => ['allOf' => [['type' => 'string'], ['minLength' => 2]]],
+            'not' => ['not' => ['type' => 'string']],
+        ];
+
+        foreach ($schemas as $keyword => $schema) {
+            $mutations = SchemaMutationGenerator::generate($schema, 100, SchemaDataGenerator::createFaker(1));
+            $keywords = array_map(static fn($mutation): string => $mutation->keyword, $mutations);
+            $this->assertContains($keyword, $keywords, "missing invalid strategy for {$keyword}");
+        }
+    }
+
+    #[Test]
+    public function generates_discriminator_selected_composition_branches(): void
+    {
+        $cat = [
+            'type' => 'object',
+            'required' => ['kind', 'meows'],
+            'properties' => ['kind' => ['const' => 'cat'], 'meows' => ['type' => 'boolean']],
+        ];
+        $dog = [
+            'type' => 'object',
+            'required' => ['kind', 'barks'],
+            'properties' => ['kind' => ['const' => 'dog'], 'barks' => ['type' => 'boolean']],
+        ];
+        $root = ['components' => ['schemas' => ['Cat' => $cat, 'Dog' => $dog]]];
+        $converted = OpenApiSchemaConverter::convert([
+            'oneOf' => [$cat, $dog],
+            'discriminator' => [
+                'propertyName' => 'kind',
+                'mapping' => ['cat' => 'Cat', 'dog' => 'Dog'],
+            ],
+        ], OpenApiVersion::V3_1, SchemaContext::Request, new DiscriminatorContext($root, true));
+
+        $values = SchemaDataGenerator::generate($converted, 2, seed: 1);
+
+        $this->assertSame('cat', $values[0]['kind']);
+        $this->assertArrayHasKey('meows', $values[0]);
+        $this->assertSame('dog', $values[1]['kind']);
+        $this->assertArrayHasKey('barks', $values[1]);
+    }
+
+    #[Test]
+    public function self_validation_reports_an_internal_generator_defect_before_dispatch(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Internal fuzz generator defect');
+
+        SchemaDataGenerator::generate(['type' => 'string', 'pattern' => '^impossible-literal$'], 1, seed: 1);
     }
 
     #[Test]
@@ -445,5 +633,25 @@ class SchemaDataGeneratorTest extends TestCase
 
         $this->assertSame('fixed', $value[0]);
         $this->assertIsInt($value[1]);
+    }
+
+    #[Test]
+    public function native_prefix_items_honor_array_boundaries(): void
+    {
+        $schema = [
+            'type' => 'array',
+            'minItems' => 1,
+            'maxItems' => 2,
+            'prefixItems' => [
+                ['const' => 'fixed'],
+                ['type' => 'integer'],
+            ],
+            'items' => false,
+        ];
+
+        $values = SchemaDataGenerator::generate($schema, 2, seed: 1);
+
+        $this->assertCount(1, $values[0]);
+        $this->assertCount(2, $values[1]);
     }
 }

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -23,6 +23,7 @@ use function array_filter;
 use function array_map;
 use function array_values;
 use function count;
+use function fmod;
 use function json_decode;
 use function json_encode;
 use function preg_match;
@@ -484,6 +485,30 @@ class SchemaDataGeneratorTest extends TestCase
         $this->assertGreaterThanOrEqual(2, $minimumValues[1]);
         $this->assertSame(-2, $maximumValues[1]);
         $this->assertLessThanOrEqual(-2, $maximumValues[0]);
+    }
+
+    #[Test]
+    public function integer_generation_preserves_fractional_multiple_of_semantics(): void
+    {
+        $onePointFive = SchemaDataGenerator::generate([
+            'type' => 'integer',
+            'multipleOf' => 1.5,
+        ], 3, seed: 1);
+        $twoPointFive = SchemaDataGenerator::generate([
+            'type' => 'integer',
+            'multipleOf' => 2.5,
+        ], 3, seed: 1);
+
+        foreach ($onePointFive as $value) {
+            $this->assertIsInt($value);
+            $this->assertSame(0.0, fmod((float) $value, 1.5));
+        }
+        foreach ($twoPointFive as $value) {
+            $this->assertIsInt($value);
+            $this->assertSame(0.0, fmod((float) $value, 2.5));
+        }
+        $this->assertSame(3, $onePointFive[0]);
+        $this->assertSame(5, $twoPointFive[0]);
     }
 
     #[Test]

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -86,6 +86,24 @@ class SchemaDataGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function number_generation_honors_multiple_of_after_boundary_cases(): void
+    {
+        $schema = [
+            'type' => 'number',
+            'minimum' => 0,
+            'maximum' => 10,
+            'multipleOf' => 2,
+        ];
+
+        $values = SchemaDataGenerator::generate($schema, 30, seed: 1);
+
+        foreach ($values as $value) {
+            $this->assertIsFloat($value);
+            $this->assertSame(0.0, fmod($value, 2.0));
+        }
+    }
+
+    #[Test]
     public function generates_booleans(): void
     {
         $values = SchemaDataGenerator::generate(['type' => 'boolean'], 4, seed: 1);
@@ -711,7 +729,7 @@ class SchemaDataGeneratorTest extends TestCase
                 ['type' => 'integer'],
             ],
             'items' => false,
-        ], faker: null, iteration: 0);
+        ], faker: null, iteration: 1);
 
         $this->assertSame('fixed', $value[0]);
         $this->assertIsInt($value[1]);
@@ -735,5 +753,26 @@ class SchemaDataGeneratorTest extends TestCase
 
         $this->assertCount(1, $values[0]);
         $this->assertCount(2, $values[1]);
+    }
+
+    #[Test]
+    public function prefix_items_do_not_imply_minimum_length_and_respect_max_items(): void
+    {
+        $schema = [
+            'type' => 'array',
+            'maxItems' => 1,
+            'prefixItems' => [
+                ['type' => 'string'],
+                ['type' => 'integer'],
+                ['type' => 'boolean'],
+            ],
+        ];
+
+        $values = SchemaDataGenerator::generate($schema, 6, seed: 1);
+
+        $this->assertSame([], $values[0]);
+        foreach ($values as $value) {
+            $this->assertLessThanOrEqual(1, count($value));
+        }
     }
 }

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -19,7 +19,9 @@ use Studio\OpenApiContractTesting\SchemaContext;
 use Studio\OpenApiContractTesting\Spec\OpenApiSchemaConverter;
 use Studio\OpenApiContractTesting\Validation\Support\DiscriminatorContext;
 
+use function array_filter;
 use function array_map;
+use function array_values;
 use function count;
 use function json_decode;
 use function json_encode;
@@ -467,6 +469,24 @@ class SchemaDataGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function integer_inclusive_fractional_bounds_round_in_the_contract_safe_direction(): void
+    {
+        $minimumValues = SchemaDataGenerator::generate([
+            'type' => 'integer',
+            'minimum' => 1.5,
+        ], 2, seed: 1);
+        $maximumValues = SchemaDataGenerator::generate([
+            'type' => 'integer',
+            'maximum' => -1.5,
+        ], 2, seed: 1);
+
+        $this->assertSame(2, $minimumValues[0]);
+        $this->assertGreaterThanOrEqual(2, $minimumValues[1]);
+        $this->assertSame(-2, $maximumValues[1]);
+        $this->assertLessThanOrEqual(-2, $maximumValues[0]);
+    }
+
+    #[Test]
     public function emits_array_and_object_size_boundaries(): void
     {
         $arrays = SchemaDataGenerator::generate([
@@ -569,6 +589,43 @@ class SchemaDataGeneratorTest extends TestCase
             $keywords = array_map(static fn($mutation): string => $mutation->keyword, $mutations);
             $this->assertContains($keyword, $keywords, "missing invalid strategy for {$keyword}");
         }
+    }
+
+    #[Test]
+    public function integer_multiple_of_mutation_preserves_integer_type_and_other_constraints(): void
+    {
+        $schema = [
+            'type' => 'integer',
+            'minimum' => 0,
+            'maximum' => 10,
+            'multipleOf' => 2,
+        ];
+        $withoutMultipleOf = $schema;
+        unset($withoutMultipleOf['multipleOf']);
+
+        $mutations = SchemaMutationGenerator::generate($schema, 100, SchemaDataGenerator::createFaker(1));
+        $multipleOf = array_values(array_filter(
+            $mutations,
+            static fn($mutation): bool => $mutation->keyword === 'multipleOf',
+        ));
+
+        $this->assertCount(1, $multipleOf);
+        $this->assertIsInt($multipleOf[0]->value);
+        $this->assertTrue(SchemaValueValidator::isValid($multipleOf[0]->value, $withoutMultipleOf));
+        $this->assertFalse(SchemaValueValidator::isValid($multipleOf[0]->value, $schema));
+    }
+
+    #[Test]
+    public function integer_multiple_of_one_omits_impossible_single_constraint_mutation(): void
+    {
+        $mutations = SchemaMutationGenerator::generate(
+            ['type' => 'integer', 'multipleOf' => 1],
+            100,
+            SchemaDataGenerator::createFaker(1),
+        );
+        $keywords = array_map(static fn($mutation): string => $mutation->keyword, $mutations);
+
+        $this->assertNotContains('multipleOf', $keywords);
     }
 
     #[Test]

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -460,6 +460,20 @@ class SchemaDataGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function pattern_generation_preserves_pattern_after_minimum_length_adjustment(): void
+    {
+        $schema = ['type' => 'string', 'pattern' => '^a+$', 'minLength' => 2, 'maxLength' => 5];
+
+        $values = SchemaDataGenerator::generate($schema, 3, seed: 1);
+
+        foreach ($values as $value) {
+            $this->assertMatchesRegularExpression('/^a+$/', $value);
+            $this->assertGreaterThanOrEqual(2, strlen($value));
+            $this->assertLessThanOrEqual(5, strlen($value));
+        }
+    }
+
+    #[Test]
     public function emits_numeric_boundaries_that_honor_exclusive_and_multiple_of(): void
     {
         $schema = [
@@ -617,6 +631,41 @@ class SchemaDataGeneratorTest extends TestCase
             $this->assertLessThanOrEqual(5, strlen($value['name']));
             $this->assertGreaterThanOrEqual(3, strlen($value['profile']['nickname']));
             $this->assertLessThanOrEqual(6, strlen($value['profile']['nickname']));
+        }
+    }
+
+    #[Test]
+    public function allof_combines_multiple_of_constraints(): void
+    {
+        $schema = [
+            'allOf' => [
+                ['type' => 'integer', 'multipleOf' => 2],
+                ['multipleOf' => 3],
+            ],
+        ];
+
+        $values = SchemaDataGenerator::generate($schema, 6, seed: 1);
+
+        foreach ($values as $value) {
+            $this->assertIsInt($value);
+            $this->assertSame(0, $value % 6);
+        }
+    }
+
+    #[Test]
+    public function allof_combines_decimal_multiple_of_constraints(): void
+    {
+        $schema = [
+            'allOf' => [
+                ['type' => 'number', 'multipleOf' => 1.5],
+                ['multipleOf' => 2.5],
+            ],
+        ];
+
+        $values = SchemaDataGenerator::generate($schema, 6, seed: 1);
+
+        foreach ($values as $value) {
+            $this->assertSame(0.0, fmod($value, 7.5));
         }
     }
 

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -671,6 +671,52 @@ class SchemaDataGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function allof_combines_array_size_boundaries(): void
+    {
+        $schema = [
+            'allOf' => [
+                [
+                    'type' => 'array',
+                    'items' => ['type' => 'string'],
+                    'minItems' => 3,
+                    'maxItems' => 8,
+                ],
+                ['minItems' => 1, 'maxItems' => 5],
+            ],
+        ];
+
+        $values = SchemaDataGenerator::generate($schema, 3, seed: 1);
+
+        $this->assertCount(3, $values[0]);
+        $this->assertCount(5, $values[1]);
+        foreach ($values as $value) {
+            $this->assertGreaterThanOrEqual(3, count($value));
+            $this->assertLessThanOrEqual(5, count($value));
+        }
+    }
+
+    #[Test]
+    public function allof_combines_object_size_boundaries(): void
+    {
+        $schema = [
+            'allOf' => [
+                ['type' => 'object', 'minProperties' => 3, 'maxProperties' => 8],
+                ['minProperties' => 1, 'maxProperties' => 5],
+            ],
+        ];
+
+        $values = SchemaDataGenerator::generate($schema, 3, seed: 1);
+
+        $this->assertCount(3, $values[0]);
+        $this->assertCount(5, $values[1]);
+        foreach ($values as $value) {
+            $this->assertIsArray($value);
+            $this->assertGreaterThanOrEqual(3, count($value));
+            $this->assertLessThanOrEqual(5, count($value));
+        }
+    }
+
+    #[Test]
     public function invalid_mutations_each_name_and_violate_the_target_constraint(): void
     {
         $schema = [

--- a/tests/Unit/Laravel/ExploresOpenApiEndpointTest.php
+++ b/tests/Unit/Laravel/ExploresOpenApiEndpointTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\Attribute\OpenApiSpec;
+use Studio\OpenApiContractTesting\Fuzz\ExplorationCaseKind;
 use Studio\OpenApiContractTesting\Fuzz\ExplorationCases;
 use Studio\OpenApiContractTesting\Fuzz\ExploredCase;
 use Studio\OpenApiContractTesting\Fuzz\OpenApiSpecExploration;
@@ -53,6 +54,18 @@ class ExploresOpenApiEndpointTest extends TestCase
         $cases = $this->exploreEndpoint('POST', '/v1/pets', cases: 5, seed: 1);
 
         $this->assertCount(5, $cases);
+    }
+
+    #[Test]
+    public function exposes_negative_endpoint_exploration(): void
+    {
+        $cases = $this->exploreInvalidEndpoint('POST', '/v1/pets', [4], cases: 2, seed: 1);
+
+        $this->assertCount(2, $cases);
+        foreach ($cases as $case) {
+            $this->assertSame(ExplorationCaseKind::Invalid, $case->kind);
+            $this->assertSame([4], $case->expectedStatusClasses);
+        }
     }
 
     #[Test]

--- a/tests/Unit/Spec/OpenApiSchemaConverterTest.php
+++ b/tests/Unit/Spec/OpenApiSchemaConverterTest.php
@@ -184,6 +184,49 @@ class OpenApiSchemaConverterTest extends TestCase
     }
 
     #[Test]
+    public function v30_boolean_exclusive_bounds_are_lowered_to_draft07_numeric_bounds(): void
+    {
+        $result = OpenApiSchemaConverter::convert([
+            'type' => 'number',
+            'minimum' => 0,
+            'exclusiveMinimum' => true,
+            'maximum' => 10,
+            'exclusiveMaximum' => true,
+        ], OpenApiVersion::V3_0);
+
+        $this->assertArrayNotHasKey('minimum', $result);
+        $this->assertArrayNotHasKey('maximum', $result);
+        $this->assertSame(0, $result['exclusiveMinimum']);
+        $this->assertSame(10, $result['exclusiveMaximum']);
+    }
+
+    #[Test]
+    public function v30_false_exclusive_bounds_keep_inclusive_bounds(): void
+    {
+        $result = OpenApiSchemaConverter::convert([
+            'type' => 'number',
+            'minimum' => 0,
+            'exclusiveMinimum' => false,
+        ], OpenApiVersion::V3_0);
+
+        $this->assertSame(0, $result['minimum']);
+        $this->assertArrayNotHasKey('exclusiveMinimum', $result);
+    }
+
+    #[Test]
+    public function v31_numeric_exclusive_bounds_remain_native(): void
+    {
+        $result = OpenApiSchemaConverter::convert([
+            'type' => 'number',
+            'exclusiveMinimum' => 0.5,
+            'exclusiveMaximum' => 9.5,
+        ], OpenApiVersion::V3_1);
+
+        $this->assertSame(0.5, $result['exclusiveMinimum']);
+        $this->assertSame(9.5, $result['exclusiveMaximum']);
+    }
+
+    #[Test]
     public function v30_default_version_when_omitted(): void
     {
         $schema = [


### PR DESCRIPTION
Closes #280.

## What changed

- add deterministic valid-boundary generation for string, numeric, array, object, nullable, format, and enum constraints
- add composition generation for `oneOf`, `anyOf`, `allOf`, `not`, conditionals, and discriminator-selected request bodies
- self-validate every generated valid body and parameter before dispatch
- add targeted invalid mutations with explicit expected HTTP status classes for endpoint and whole-spec exploration
- add stable replay metadata, PHP/curl reproduction output, and classification-preserving body reduction
- correctly lower OpenAPI 3.0 boolean exclusive bounds to Draft 07 numeric bounds
- document the exact supported strategy matrix and remaining gaps without claiming Schemathesis parity

The implementation follows the official [OpenAPI 3.0.4 schema semantics](https://spec.openapis.org/oas/v3.0.4.html#schema-object), [OpenAPI 3.1.1 JSON Schema integration](https://spec.openapis.org/oas/v3.1.1.html#schema-object), and [JSON Schema Draft 2020-12 validation vocabulary](https://json-schema.org/draft/2020-12/json-schema-validation).

## User impact

Valid fuzz cases now exercise contract boundaries and fail locally if the generator produces an invalid value. Negative cases identify their targeted keyword and require callers to declare accepted response classes, avoiding a permissive “anything except 5xx” assertion. Failures can be replayed or reduced while preserving their classification.

## Verification

- `vendor/bin/phpunit tests/Unit/Fuzz tests/Unit/Spec/OpenApiSchemaConverterTest.php tests/Unit/Laravel/ExploresOpenApiEndpointTest.php` — 205 tests, 862 assertions
- applicable full PHPUnit suite — 2,011 tests, 4,824 assertions
- Markdown renderer lint tests with writable npm cache — 2 tests, 2 assertions
- `vendor/bin/phpstan analyse --no-progress --debug --memory-limit=1G` — no errors
- PHP-CS-Fixer sequential run — clean
- `markdownlint-cli2 docs/fuzzing.md` — clean
- `git diff --check` — clean

The four existing stack-trace path tests remain excluded only in this temporary checkout because they depend on the checkout directory being named exactly `openapi-contract-testing`; they are unchanged and run normally in GitHub Actions.
