### PR TITLE
docs: surface v1.9 guides in navigation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -45,6 +45,15 @@ export default defineConfig({
         ]
       },
       {
+        text: 'Guides',
+        items: [
+          { text: 'Doctor command', link: '/doctor' },
+          { text: 'PSR-7 validation', link: '/psr7' },
+          { text: 'Laravel route parity', link: '/laravel-route-parity' },
+          { text: 'Schema-driven fuzzing', link: '/fuzzing' }
+        ]
+      },
+      {
         text: 'Recipes',
         items: [
           { text: 'GitHub Actions', link: '/recipes/github-actions' },


### PR DESCRIPTION
## Summary

- add a dedicated Guides section to the VitePress sidebar
- link the Doctor, PSR-7, Laravel route parity, and schema-driven fuzzing guides directly
- improve discovery of the major features shipping in v1.9.0

## Verification

- `npm run docs:build`
- `DOCS_VERSION=next npm run docs:verify-version`
- `npm run docs:verify-base`
- `npm run docs:links`
- `git diff --check`
