### PR TITLE
fix(laravel): keep large route parity JSON observable

### DIFF
--- a/docs/laravel-route-parity.md
+++ b/docs/laravel-route-parity.md
@@ -97,6 +97,20 @@ Use stable machine-readable output in CI:
 php artisan openapi:routes --format=json
 ```
 
+For large applications, capture the formatted JSON as a CI artifact instead
+of relying only on the job log:
+
+```yaml
+- name: Compare Laravel routes with OpenAPI
+  run: php artisan openapi:routes --format=json > route-parity.json
+
+- name: Upload route parity report
+  uses: actions/upload-artifact@v4
+  with:
+    name: openapi-route-parity
+    path: route-parity.json
+```
+
 The top-level `schema_version` is currently `1`. The payload contains the
 selected `specs`, a `summary`, and these result arrays:
 

--- a/src/Laravel/Commands/OpenApiRoutesCommand.php
+++ b/src/Laravel/Commands/OpenApiRoutesCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Laravel\Commands;
 
+use const JSON_PRETTY_PRINT;
 use const JSON_THROW_ON_ERROR;
 use const JSON_UNESCAPED_SLASHES;
 
@@ -84,7 +85,10 @@ final class OpenApiRoutesCommand extends Command
 
         if ($format === 'json') {
             try {
-                $this->line((string) json_encode($result, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES));
+                $this->line((string) json_encode(
+                    $result,
+                    JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES,
+                ));
             } catch (JsonException $e) {
                 $this->components->error($e->getMessage());
 

--- a/tests/Integration/Laravel/OpenApiRoutesCommandIntegrationTest.php
+++ b/tests/Integration/Laravel/OpenApiRoutesCommandIntegrationTest.php
@@ -13,8 +13,13 @@ use PHPUnit\Framework\Attributes\Test;
 use Studio\OpenApiContractTesting\Laravel\OpenApiContractTestingServiceProvider;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 
+use function array_map;
+use function count;
 use function dirname;
+use function explode;
 use function json_decode;
+use function max;
+use function strlen;
 use function trim;
 
 final class OpenApiRoutesCommandIntegrationTest extends TestCase
@@ -73,6 +78,28 @@ final class OpenApiRoutesCommandIntegrationTest extends TestCase
         $this->assertSame(1, $decoded['summary']['documented_but_not_registered']);
         $this->assertSame(1, $decoded['summary']['registered_but_undocumented']);
         $this->assertSame(0, $decoded['summary']['ambiguous']);
+    }
+
+    #[Test]
+    public function large_json_output_is_split_across_observable_lines(): void
+    {
+        for ($index = 0; $index < 250; $index++) {
+            Route::get("/api/v1/undocumented-{$index}", static fn() => null)
+                ->name("undocumented.{$index}");
+        }
+
+        $exitCode = Artisan::call('openapi:routes', [
+            '--format' => 'json',
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $output = trim(Artisan::output());
+        $decoded = json_decode($output, true, flags: JSON_THROW_ON_ERROR);
+        $lines = explode("\n", $output);
+
+        $this->assertSame(1, $decoded['schema_version']);
+        $this->assertGreaterThan(1_000, count($lines));
+        $this->assertLessThan(1_000, max(array_map(strlen(...), $lines)));
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- pretty-print `openapi:routes --format=json` output so large reports remain visible in CI logs
- preserve the versioned JSON schema and existing field values
- add a large-output regression test that verifies valid multi-line JSON with bounded line lengths
- document saving the JSON report and uploading it as a GitHub Actions artifact

## Root cause

The command encoded the complete parity result without `JSON_PRETTY_PRINT` and sent it to the console as one line. Real applications can produce lines larger than CI log limits, causing an otherwise successful report to disappear from the log.

## Verification

- `vendor/bin/phpunit tests/Integration/Laravel/OpenApiRoutesCommandIntegrationTest.php`
- `vendor/bin/phpunit --testsuite Integration`
- `vendor/bin/phpstan analyse --debug src/Laravel/Commands/OpenApiRoutesCommand.php tests/Integration/Laravel/OpenApiRoutesCommandIntegrationTest.php`
- `vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --dry-run --diff` for both changed PHP files
- `git diff --check`

Closes #301
