### PR TITLE
fix(fuzz): generate simple fixed-quantifier regex patterns

### DIFF
--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -143,7 +143,7 @@ fuzz generator defect` diagnostic instead of sending invalid data to the API.
 | Strategy | Valid generation | Targeted invalid mutation |
 |---|---|---|
 | Scalars | `type`, `const`, `enum`, nullable branches | wrong type, const/enum miss |
-| Strings | min/max length, common regex patterns, Unicode code points, Faker-backed email/UUID/date/time/URI/host/IP formats | below/above length, pattern miss, invalid recognized format |
+| Strings | min/max length, common regex patterns (including anchored character classes and `\d` with fixed quantifiers, such as `^[a-f0-9]{64}$`), Unicode code points, Faker-backed email/UUID/date/time/URI/host/IP formats | below/above length, pattern miss, invalid recognized format |
 | Numbers | inclusive/exclusive bounds and `multipleOf`, including OAS 3.0 boolean-exclusive lowering | outside/equal-exclusive bound, non-multiple |
 | Arrays | `items`, `prefixItems`, min/max items, `uniqueItems` | too few/many or duplicate items |
 | Objects | properties, required, min/max properties, schema-valued/default additional properties | missing required, extra forbidden, too few/many properties, nested property constraint |
@@ -152,8 +152,8 @@ fuzz generator defect` diagnostic instead of sending invalid data to the API.
 Arbitrary regex synthesis, recursive schemas, `contains`,
 `patternProperties`, `dependentSchemas`, and `unevaluated*` generation are not
 currently strategies. Those keywords remain validator features; an operation
-whose valid value cannot be synthesized fails locally or is an explicit
-whole-spec skip.
+whose valid value cannot be synthesized fails locally with a supported-subset
+diagnostic or is an explicit whole-spec skip carrying that reason.
 
 - Optional object properties alternate between included and omitted across cases, so each batch exercises both required-only and required+optional shapes.
 - Required keys are always emitted.

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -65,6 +65,8 @@ use function trigger_error;
  */
 final class SchemaDataGenerator
 {
+    private const MAX_SYNTHESIZED_PATTERN_LENGTH = 10_000;
+
     /**
      * Per-process record of formats already announced as "faker missing".
      * Keyed by format name; we only warn once per format to avoid spamming
@@ -408,6 +410,11 @@ final class SchemaDataGenerator
             if ($patternValue !== null) {
                 return $patternValue;
             }
+
+            throw new InvalidArgumentException(sprintf(
+                "String pattern '%s' is outside the fuzz generator's supported synthesis subset.",
+                $schema['pattern'],
+            ));
         }
 
         if ($faker !== null) {
@@ -823,6 +830,11 @@ final class SchemaDataGenerator
     /** @param array<string, mixed> $schema */
     private static function generateCommonPattern(string $pattern, array $schema, int $iteration): ?string
     {
+        $fixedQuantifierValue = self::generateFixedQuantifierPattern($pattern, $schema);
+        if ($fixedQuantifierValue !== null) {
+            return $fixedQuantifierValue;
+        }
+
         $candidates = ['a', 'A', '0', 'abc', 'ABC', '123', 'test-' . $iteration, 'é', '日本語'];
         $minimum = isset($schema['minLength']) && is_int($schema['minLength']) ? max(0, $schema['minLength']) : null;
         $maximum = isset($schema['maxLength']) && is_int($schema['maxLength']) ? max(0, $schema['maxLength']) : null;
@@ -843,6 +855,53 @@ final class SchemaDataGenerator
                     @preg_match($delimiter . $escaped . $delimiter . 'u', $value) === 1) {
                     return $value;
                 }
+            }
+        }
+
+        return null;
+    }
+
+    /** @param array<string, mixed> $schema */
+    private static function generateFixedQuantifierPattern(string $pattern, array $schema): ?string
+    {
+        if (preg_match('/^\^(\[[^]]+]|\\\\d)\{([0-9]+)\}\$$/D', $pattern, $matches) !== 1) {
+            return null;
+        }
+
+        $length = (int) $matches[2];
+        $minimum = isset($schema['minLength']) && is_int($schema['minLength']) ? max(0, $schema['minLength']) : null;
+        $maximum = isset($schema['maxLength']) && is_int($schema['maxLength']) ? max(0, $schema['maxLength']) : null;
+        if ($length > self::MAX_SYNTHESIZED_PATTERN_LENGTH ||
+            ($minimum !== null && $length < $minimum) ||
+            ($maximum !== null && $length > $maximum)) {
+            return null;
+        }
+
+        $atom = $matches[1];
+        $character = $atom === '\\d' ? '0' : self::characterMatchingClass($atom);
+        if ($character === null) {
+            return null;
+        }
+
+        $value = str_repeat($character, $length);
+        $delimiter = '~';
+        $escaped = str_replace($delimiter, '\\' . $delimiter, $pattern);
+
+        return @preg_match($delimiter . $escaped . $delimiter . 'u', $value) === 1 ? $value : null;
+    }
+
+    private static function characterMatchingClass(string $characterClass): ?string
+    {
+        $delimiter = '~';
+        $escaped = str_replace($delimiter, '\\' . $delimiter, $characterClass);
+        $expression = $delimiter . '^' . $escaped . '$' . $delimiter . 'u';
+        $candidates = self::unicodeCharacters(
+            'aA0abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_- ',
+        );
+
+        foreach ($candidates as $candidate) {
+            if (@preg_match($expression, $candidate) === 1) {
+                return $candidate;
             }
         }
 

--- a/tests/Unit/Fuzz/OpenApiEndpointExplorerTest.php
+++ b/tests/Unit/Fuzz/OpenApiEndpointExplorerTest.php
@@ -18,6 +18,7 @@ use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 
 use function json_decode;
 use function json_encode;
+use function str_repeat;
 
 class OpenApiEndpointExplorerTest extends TestCase
 {
@@ -135,6 +136,22 @@ class OpenApiEndpointExplorerTest extends TestCase
             }
         }
         $this->assertTrue($sawValue, 'at least one case should generate the dryRun query param');
+    }
+
+    #[Test]
+    public function generates_fixed_quantifier_pattern_for_query_parameter(): void
+    {
+        $cases = OpenApiEndpointExplorer::explore(
+            'fuzz-fixed-quantifier-query',
+            'GET',
+            '/oauth/callback',
+            cases: 1,
+            seed: 1,
+        );
+
+        foreach ($cases as $case) {
+            $this->assertSame(str_repeat('a', 64), $case->query['state']);
+        }
     }
 
     #[Test]

--- a/tests/Unit/Fuzz/OpenApiSpecExplorerTest.php
+++ b/tests/Unit/Fuzz/OpenApiSpecExplorerTest.php
@@ -104,6 +104,20 @@ class OpenApiSpecExplorerTest extends TestCase
     }
 
     #[Test]
+    public function skips_unsupported_query_pattern_without_aborting_supported_operations(): void
+    {
+        $summary = OpenApiSpecExplorer::explore('fuzz-fixed-quantifier-query', casesPerOperation: 1, seed: 1)
+            ->dispatchUsing(static fn(): null => null)
+            ->assertResponses();
+
+        $this->assertSame(1, $summary->executedOperations);
+        $this->assertSame(1, $summary->executedCases);
+        $this->assertCount(1, $summary->skips);
+        $this->assertSame('unsupportedPattern', $summary->skips[0]->operation->operationId);
+        $this->assertStringContainsString('supported synthesis subset', $summary->skips[0]->reason);
+    }
+
+    #[Test]
     public function custom_method_filters_are_case_sensitive(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -10,7 +10,6 @@ use InvalidArgumentException;
 use Opis\JsonSchema\Validator;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
 use stdClass;
 use Studio\OpenApiContractTesting\Fuzz\SchemaDataGenerator;
 use Studio\OpenApiContractTesting\Fuzz\SchemaMutationGenerator;
@@ -30,6 +29,7 @@ use function json_encode;
 use function preg_match;
 use function restore_error_handler;
 use function set_error_handler;
+use function str_repeat;
 use function strlen;
 
 class SchemaDataGeneratorTest extends TestCase
@@ -475,6 +475,20 @@ class SchemaDataGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function generates_simple_anchored_patterns_with_fixed_quantifiers(): void
+    {
+        $schemas = [
+            ['type' => 'string', 'pattern' => '^[a-f0-9]{64}$'],
+            ['type' => 'string', 'pattern' => '^[A-Z]{2}$'],
+            ['type' => 'string', 'pattern' => '^\\d{6}$'],
+        ];
+
+        $this->assertSame(str_repeat('a', 64), SchemaDataGenerator::generate($schemas[0], 1, seed: 1)[0]);
+        $this->assertSame('AA', SchemaDataGenerator::generate($schemas[1], 1, seed: 1)[0]);
+        $this->assertSame('000000', SchemaDataGenerator::generate($schemas[2], 1, seed: 1)[0]);
+    }
+
+    #[Test]
     public function emits_numeric_boundaries_that_honor_exclusive_and_multiple_of(): void
     {
         $schema = [
@@ -886,10 +900,10 @@ class SchemaDataGeneratorTest extends TestCase
     }
 
     #[Test]
-    public function self_validation_reports_an_internal_generator_defect_before_dispatch(): void
+    public function unsupported_pattern_reports_an_explicit_generation_limitation(): void
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Internal fuzz generator defect');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('supported synthesis subset');
 
         SchemaDataGenerator::generate(['type' => 'string', 'pattern' => '^impossible-literal$'], 1, seed: 1);
     }

--- a/tests/fixtures/specs/fuzz-fixed-quantifier-query.json
+++ b/tests/fixtures/specs/fuzz-fixed-quantifier-query.json
@@ -1,0 +1,51 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "Fixed-quantifier query fuzz fixture",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/oauth/callback": {
+            "get": {
+                "operationId": "oauthCallback",
+                "parameters": [
+                    {
+                        "name": "state",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[a-f0-9]{64}$"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/unsupported": {
+            "get": {
+                "operationId": "unsupportedPattern",
+                "parameters": [
+                    {
+                        "name": "value",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^(foo|bar)$"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- synthesize deterministic values for anchored character classes and `\\d` with fixed quantifiers
- report unsupported regex synthesis as an explicit limitation so whole-spec exploration records a skip instead of an internal generator defect
- cover the real query-parameter path and document the supported subset

## Root cause

The common-pattern generator only repeated a small set of candidate strings at their existing length or at `minLength` / `maxLength`. A pattern such as `^[a-f0-9]{64}$` therefore never received a 64-character candidate and the generated fallback failed its schema self-check.

## Impact

OAuth callback query parameters such as a 64-character hexadecimal `state` can now be explored without aborting before dispatch. Regex constructs outside the supported synthesis subset are surfaced as whole-spec skips with an actionable reason.

Closes #302.

## Verification

- `vendor/bin/phpunit tests/Unit/Fuzz/SchemaDataGeneratorTest.php tests/Unit/Fuzz/OpenApiEndpointExplorerTest.php tests/Unit/Fuzz/OpenApiSpecExplorerTest.php` (82 tests, 761 assertions)
- `vendor/bin/phpunit` (2036 tests, 5099 assertions)
- `vendor/bin/phpstan analyse --debug --memory-limit=512M ...` (no errors)
- `vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --dry-run --diff ...` (clean)
- `git diff --check`
