### PR TITLE
feat(fuzz): include operation context in generation failures

### DIFF
--- a/src/Fuzz/ExploredOperation.php
+++ b/src/Fuzz/ExploredOperation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Studio\OpenApiContractTesting\Fuzz;
 
+use function implode;
 use function sprintf;
 use function var_export;
 
@@ -35,6 +36,25 @@ final readonly class ExploredOperation
             var_export($this->specName, true),
             var_export($this->method, true),
             var_export($this->path, true),
+            $caseIndex + 1,
+            $this->seed,
+            $caseIndex,
+        );
+    }
+
+    /**
+     * Return a minimal expression that regenerates the exact negative input case.
+     *
+     * @param list<int> $expectedStatusClasses
+     */
+    public function replayInvalidSnippet(int $caseIndex, array $expectedStatusClasses): string
+    {
+        return sprintf(
+            'OpenApiEndpointExplorer::exploreInvalid(%s, %s, %s, expectedStatusClasses: [%s], cases: %d, seed: %d)->cases[%d]',
+            var_export($this->specName, true),
+            var_export($this->method, true),
+            var_export($this->path, true),
+            implode(', ', $expectedStatusClasses),
             $caseIndex + 1,
             $this->seed,
             $caseIndex,

--- a/src/Fuzz/FuzzGenerationException.php
+++ b/src/Fuzz/FuzzGenerationException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Fuzz;
+
+use RuntimeException;
+
+/** @internal */
+final class FuzzGenerationException extends RuntimeException
+{
+    public function __construct(
+        string $message,
+        public readonly int $caseIndex,
+    ) {
+        parent::__construct($message);
+    }
+}

--- a/src/Fuzz/OpenApiSpecExploration.php
+++ b/src/Fuzz/OpenApiSpecExploration.php
@@ -280,6 +280,8 @@ final class OpenApiSpecExploration
                     $skips[] = new ExplorationSkip($operation, $e->getMessage());
 
                     continue;
+                } catch (Throwable $e) {
+                    throw new RuntimeException($this->generationFailureMessage($operation, $e), 0, $e);
                 }
 
                 $this->runOperation($operation, $cases, $executedCases);
@@ -476,5 +478,35 @@ final class OpenApiSpecExploration
             $caseIndex,
             $case->replaySnippet($operation->specName),
         );
+    }
+
+    private function generationFailureMessage(ExploredOperation $operation, Throwable $failure): string
+    {
+        $caseIndex = $failure instanceof FuzzGenerationException ? $failure->caseIndex : null;
+        $case = $caseIndex === null ? '(unknown)' : (string) $caseIndex;
+        $replay = $caseIndex === null
+            ? '(unavailable before a case index was assigned)'
+            : $this->generationReplaySnippet($operation, $caseIndex);
+
+        return sprintf(
+            "Whole-spec input generation failed.\nSpec: %s\nOperation: %s\nMethod/path: %s %s\nGlobal seed: %d\nOperation seed: %d\nCase: %s\nReplay: %s",
+            $operation->specName,
+            $operation->operationId ?? '(none)',
+            $operation->method,
+            $operation->path,
+            $this->seed,
+            $operation->seed,
+            $case,
+            $replay,
+        );
+    }
+
+    private function generationReplaySnippet(ExploredOperation $operation, int $caseIndex): string
+    {
+        if ($this->negativeExpectedStatusClasses !== null) {
+            return $operation->replayInvalidSnippet($caseIndex, $this->negativeExpectedStatusClasses);
+        }
+
+        return $operation->replaySnippet($caseIndex);
     }
 }

--- a/src/Fuzz/SchemaValueValidator.php
+++ b/src/Fuzz/SchemaValueValidator.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Studio\OpenApiContractTesting\Fuzz;
 
 use Opis\JsonSchema\Validator;
-use RuntimeException;
 
 use function json_decode;
 use function json_encode;
@@ -31,9 +30,9 @@ final class SchemaValueValidator
             return;
         }
 
-        throw new RuntimeException(sprintf(
+        throw new FuzzGenerationException(sprintf(
             'Internal fuzz generator defect: valid case %d does not satisfy its converted JSON Schema.',
             $iteration,
-        ));
+        ), $iteration);
     }
 }

--- a/tests/Unit/Fuzz/OpenApiSpecExplorerTest.php
+++ b/tests/Unit/Fuzz/OpenApiSpecExplorerTest.php
@@ -12,6 +12,7 @@ use Studio\OpenApiContractTesting\Fuzz\ExplorationCaseKind;
 use Studio\OpenApiContractTesting\Fuzz\ExplorationSkip;
 use Studio\OpenApiContractTesting\Fuzz\ExploredCase;
 use Studio\OpenApiContractTesting\Fuzz\ExploredOperation;
+use Studio\OpenApiContractTesting\Fuzz\FuzzGenerationException;
 use Studio\OpenApiContractTesting\Fuzz\OpenApiSpecExplorer;
 use Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader;
 
@@ -278,6 +279,52 @@ class OpenApiSpecExplorerTest extends TestCase
             $this->assertStringContainsString('Global seed: 77', $e->getMessage());
             $this->assertStringContainsString('OpenApiEndpointExplorer::explore(', $e->getMessage());
             $this->assertSame('application failure', $e->getPrevious()?->getMessage());
+        }
+    }
+
+    #[Test]
+    public function valid_generation_failure_contains_operation_context_before_dispatch(): void
+    {
+        $dispatched = false;
+
+        try {
+            OpenApiSpecExplorer::explore('fuzz-generation-failure', casesPerOperation: 1, seed: 77)
+                ->dispatchUsing(static function () use (&$dispatched): null {
+                    $dispatched = true;
+
+                    return null;
+                })
+                ->assertResponses();
+            $this->fail('Expected whole-spec input generation to fail.');
+        } catch (RuntimeException $e) {
+            $this->assertStringContainsString('Whole-spec input generation failed.', $e->getMessage());
+            $this->assertStringContainsString('Spec: fuzz-generation-failure', $e->getMessage());
+            $this->assertStringContainsString('Operation: createBrokenResource', $e->getMessage());
+            $this->assertStringContainsString('Method/path: POST /broken', $e->getMessage());
+            $this->assertStringContainsString('Global seed: 77', $e->getMessage());
+            $this->assertStringContainsString('Operation seed:', $e->getMessage());
+            $this->assertStringContainsString('Case: 0', $e->getMessage());
+            $this->assertStringContainsString("OpenApiEndpointExplorer::explore('fuzz-generation-failure'", $e->getMessage());
+            $this->assertInstanceOf(FuzzGenerationException::class, $e->getPrevious());
+            $this->assertStringContainsString('Internal fuzz generator defect: valid case 0', $e->getPrevious()?->getMessage());
+            $this->assertFalse($dispatched);
+        }
+    }
+
+    #[Test]
+    public function negative_generation_failure_contains_negative_replay_context(): void
+    {
+        try {
+            OpenApiSpecExplorer::explore('fuzz-generation-failure', casesPerOperation: 1, seed: 78)
+                ->negativeCases([4])
+                ->dispatchUsing(static fn(): null => null)
+                ->assertResponses();
+            $this->fail('Expected whole-spec negative input generation to fail.');
+        } catch (RuntimeException $e) {
+            $this->assertStringContainsString('Case: 0', $e->getMessage());
+            $this->assertStringContainsString("OpenApiEndpointExplorer::exploreInvalid('fuzz-generation-failure'", $e->getMessage());
+            $this->assertStringContainsString('expectedStatusClasses: [4]', $e->getMessage());
+            $this->assertInstanceOf(FuzzGenerationException::class, $e->getPrevious());
         }
     }
 

--- a/tests/Unit/Fuzz/OpenApiSpecExplorerTest.php
+++ b/tests/Unit/Fuzz/OpenApiSpecExplorerTest.php
@@ -306,7 +306,7 @@ class OpenApiSpecExplorerTest extends TestCase
             $this->assertStringContainsString('Case: 0', $e->getMessage());
             $this->assertStringContainsString("OpenApiEndpointExplorer::explore('fuzz-generation-failure'", $e->getMessage());
             $this->assertInstanceOf(FuzzGenerationException::class, $e->getPrevious());
-            $this->assertStringContainsString('Internal fuzz generator defect: valid case 0', $e->getPrevious()?->getMessage());
+            $this->assertStringContainsString('Internal fuzz generator defect: valid case 0', $e->getPrevious()->getMessage());
             $this->assertFalse($dispatched);
         }
     }

--- a/tests/fixtures/specs/fuzz-generation-failure.json
+++ b/tests/fixtures/specs/fuzz-generation-failure.json
@@ -1,0 +1,30 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Whole-spec generation failure fixture",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/broken": {
+      "post": {
+        "operationId": "createBrokenResource",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string",
+                "enum": [1]
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Created"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add spec, operation, method/path, global seed, operation seed, case index, and replay context to whole-spec input generation failures
- preserve the original generation exception through exception chaining
- emit the correct replay expression for both valid and negative exploration
- keep intentionally unsupported generation cases as skips

## Why

Whole-spec fuzz exploration previously surfaced generation defects without identifying the failing operation. In large OpenAPI documents, this required rerunning operations individually to locate the source.

## Impact

Generation failures now identify the exact operation and deterministic replay command without exposing request data, credentials, or absolute filesystem paths. Failures occur before `dispatchUsing()` is called.

## Verification

- `php84 vendor/bin/phpunit` — 2,038 tests, 5,114 assertions
- targeted fuzz tests — 66 tests, 698 assertions
- `php84 vendor/bin/phpstan analyse --debug --no-progress --memory-limit=512M ...` — no errors
- PHP-CS-Fixer dry run — clean
- `git diff --check` — clean

Closes #303