### PR TITLE
feat(fuzz): generate values for common hostname patterns

### DIFF
--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -143,7 +143,7 @@ fuzz generator defect` diagnostic instead of sending invalid data to the API.
 | Strategy | Valid generation | Targeted invalid mutation |
 |---|---|---|
 | Scalars | `type`, `const`, `enum`, nullable branches | wrong type, const/enum miss |
-| Strings | min/max length, common regex patterns (including anchored character classes and `\d` with fixed quantifiers, such as `^[a-f0-9]{64}$`), Unicode code points, Faker-backed email/UUID/date/time/URI/host/IP formats | below/above length, pattern miss, invalid recognized format |
+| Strings | min/max length, common regex patterns (including anchored character classes with fixed quantifiers and FQDN labels with a fixed domain suffix), Unicode code points, Faker-backed email/UUID/date/time/URI/host/IP formats | below/above length, pattern miss, invalid recognized format |
 | Numbers | inclusive/exclusive bounds and `multipleOf`, including OAS 3.0 boolean-exclusive lowering | outside/equal-exclusive bound, non-multiple |
 | Arrays | `items`, `prefixItems`, min/max items, `uniqueItems` | too few/many or duplicate items |
 | Objects | properties, required, min/max properties, schema-valued/default additional properties | missing required, extra forbidden, too few/many properties, nested property constraint |

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -886,15 +886,24 @@ final class SchemaDataGenerator
 
         $minimum = isset($schema['minLength']) && is_int($schema['minLength']) ? max(0, $schema['minLength']) : null;
         $maximum = isset($schema['maxLength']) && is_int($schema['maxLength']) ? max(0, $schema['maxLength']) : null;
-        $value = 'a.' . $suffix;
-        while ($minimum !== null && self::unicodeLength($value) < $minimum) {
-            if (self::unicodeLength($value) >= self::MAX_SYNTHESIZED_PATTERN_LENGTH ||
-                ($maximum !== null && self::unicodeLength($value) >= $maximum)) {
-                return null;
-            }
-            $value = 'a.' . $value;
+        $suffixLength = self::unicodeLength($suffix);
+        $prefixLength = max(2, ($minimum ?? 0) - $suffixLength);
+        if ($prefixLength + $suffixLength > self::MAX_SYNTHESIZED_PATTERN_LENGTH ||
+            ($maximum !== null && $prefixLength + $suffixLength > $maximum)) {
+            return null;
         }
 
+        $labelCount = (int) ceil($prefixLength / 64);
+        $remainingCharacters = $prefixLength - $labelCount;
+        $labels = [];
+        for ($index = 0; $index < $labelCount; $index++) {
+            $remainingLabels = $labelCount - $index - 1;
+            $labelLength = min(63, $remainingCharacters - $remainingLabels);
+            $labels[] = str_repeat('a', $labelLength);
+            $remainingCharacters -= $labelLength;
+        }
+
+        $value = implode('.', $labels) . '.' . $suffix;
         $length = self::unicodeLength($value);
         if ($length > self::MAX_SYNTHESIZED_PATTERN_LENGTH || ($maximum !== null && $length > $maximum)) {
             return null;

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -37,8 +37,12 @@ use function preg_match;
 use function preg_match_all;
 use function round;
 use function sprintf;
+use function str_ends_with;
 use function str_repeat;
 use function str_replace;
+use function str_starts_with;
+use function strlen;
+use function substr;
 use function trigger_error;
 
 /**
@@ -835,6 +839,11 @@ final class SchemaDataGenerator
             return $fixedQuantifierValue;
         }
 
+        $hostnameValue = self::generateHostnamePattern($pattern, $schema);
+        if ($hostnameValue !== null) {
+            return $hostnameValue;
+        }
+
         $candidates = ['a', 'A', '0', 'abc', 'ABC', '123', 'test-' . $iteration, 'é', '日本語'];
         $minimum = isset($schema['minLength']) && is_int($schema['minLength']) ? max(0, $schema['minLength']) : null;
         $maximum = isset($schema['maxLength']) && is_int($schema['maxLength']) ? max(0, $schema['maxLength']) : null;
@@ -859,6 +868,42 @@ final class SchemaDataGenerator
         }
 
         return null;
+    }
+
+    /** @param array<string, mixed> $schema */
+    private static function generateHostnamePattern(string $pattern, array $schema): ?string
+    {
+        $labelPrefix = '^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)+';
+        if (!str_starts_with($pattern, $labelPrefix) || !str_ends_with($pattern, '$')) {
+            return null;
+        }
+
+        $escapedSuffix = substr($pattern, strlen($labelPrefix), -1);
+        $suffix = str_replace('\\.', '.', $escapedSuffix);
+        if (preg_match('/^[a-z0-9-]+(?:\.[a-z0-9-]+)*$/Di', $suffix) !== 1) {
+            return null;
+        }
+
+        $minimum = isset($schema['minLength']) && is_int($schema['minLength']) ? max(0, $schema['minLength']) : null;
+        $maximum = isset($schema['maxLength']) && is_int($schema['maxLength']) ? max(0, $schema['maxLength']) : null;
+        $value = 'a.' . $suffix;
+        while ($minimum !== null && self::unicodeLength($value) < $minimum) {
+            if (self::unicodeLength($value) >= self::MAX_SYNTHESIZED_PATTERN_LENGTH ||
+                ($maximum !== null && self::unicodeLength($value) >= $maximum)) {
+                return null;
+            }
+            $value = 'a.' . $value;
+        }
+
+        $length = self::unicodeLength($value);
+        if ($length > self::MAX_SYNTHESIZED_PATTERN_LENGTH || ($maximum !== null && $length > $maximum)) {
+            return null;
+        }
+
+        $delimiter = '~';
+        $escaped = str_replace($delimiter, '\\' . $delimiter, $pattern);
+
+        return @preg_match($delimiter . $escaped . $delimiter . 'u', $value) === 1 ? $value : null;
     }
 
     /** @param array<string, mixed> $schema */

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -489,6 +489,25 @@ class SchemaDataGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function generates_common_hostname_patterns_with_a_fixed_domain_suffix(): void
+    {
+        $schema = [
+            'type' => 'string',
+            'maxLength' => 253,
+            'pattern' => '^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)+studio\\.design$',
+        ];
+
+        $first = SchemaDataGenerator::generate($schema, 3, seed: 1);
+        $second = SchemaDataGenerator::generate($schema, 3, seed: 999);
+
+        $this->assertSame(['a.studio.design', 'a.studio.design', 'a.studio.design'], $first);
+        $this->assertSame($first, $second);
+        foreach ($first as $value) {
+            $this->assertTrue(SchemaValueValidator::isValid($value, $schema));
+        }
+    }
+
+    #[Test]
     public function emits_numeric_boundaries_that_honor_exclusive_and_multiple_of(): void
     {
         $schema = [

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -508,6 +508,22 @@ class SchemaDataGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function hostname_pattern_generation_adjusts_length_one_character_at_a_time(): void
+    {
+        $schema = [
+            'type' => 'string',
+            'minLength' => 16,
+            'maxLength' => 16,
+            'pattern' => '^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)+studio\\.design$',
+        ];
+
+        $value = SchemaDataGenerator::generate($schema, 1, seed: 1)[0];
+
+        $this->assertSame('aa.studio.design', $value);
+        $this->assertTrue(SchemaValueValidator::isValid($value, $schema));
+    }
+
+    #[Test]
     public function emits_numeric_boundaries_that_honor_exclusive_and_multiple_of(): void
     {
         $schema = [


### PR DESCRIPTION
## Summary

- synthesize deterministic values for common FQDN patterns with fixed domain suffixes
- honor string length constraints and verify generated values against the original pattern
- document the supported strategy and add a regression test for the reported `studio.design` schema

## Why

Whole-spec fuzz exploration aborted on a satisfiable hostname schema because the fixed generic candidate list could not produce a matching value. Recognizing this common pattern keeps exploration deterministic while unsupported regex constructs continue to fail with the existing actionable limitation message.

## Validation

- `vendor/bin/phpunit tests/Unit/Fuzz` (92 tests, 784 assertions)
- PHPStan on the changed generator and test (no errors)
- PHP-CS-Fixer dry run in sequential mode (no changes)
- `git diff --check`

Closes #304
