### PR TITLE
fix(fuzz): generate common phone number patterns

### DIFF
--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -143,7 +143,7 @@ fuzz generator defect` diagnostic instead of sending invalid data to the API.
 | Strategy | Valid generation | Targeted invalid mutation |
 |---|---|---|
 | Scalars | `type`, `const`, `enum`, nullable branches | wrong type, const/enum miss |
-| Strings | min/max length, common regex patterns (including anchored character classes with fixed quantifiers and FQDN labels with a fixed domain suffix), Unicode code points, Faker-backed email/UUID/date/time/URI/host/IP formats | below/above length, pattern miss, invalid recognized format |
+| Strings | min/max length, common regex patterns (including anchored character classes with fixed quantifiers, FQDN labels with a fixed domain suffix, and phone-number alternations), Unicode code points, Faker-backed email/UUID/date/time/URI/host/IP formats | below/above length, pattern miss, invalid recognized format |
 | Numbers | inclusive/exclusive bounds and `multipleOf`, including OAS 3.0 boolean-exclusive lowering | outside/equal-exclusive bound, non-multiple |
 | Arrays | `items`, `prefixItems`, min/max items, `uniqueItems` | too few/many or duplicate items |
 | Objects | properties, required, min/max properties, schema-valued/default additional properties | missing required, extra forbidden, too few/many properties, nested property constraint |

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -839,6 +839,11 @@ final class SchemaDataGenerator
             return $fixedQuantifierValue;
         }
 
+        $phoneNumberValue = self::generatePhoneNumberPattern($pattern, $schema);
+        if ($phoneNumberValue !== null) {
+            return $phoneNumberValue;
+        }
+
         $hostnameValue = self::generateHostnamePattern($pattern, $schema);
         if ($hostnameValue !== null) {
             return $hostnameValue;
@@ -864,6 +869,55 @@ final class SchemaDataGenerator
                     @preg_match($delimiter . $escaped . $delimiter . 'u', $value) === 1) {
                     return $value;
                 }
+            }
+        }
+
+        return null;
+    }
+
+    /** @param array<string, mixed> $schema */
+    private static function generatePhoneNumberPattern(string $pattern, array $schema): ?string
+    {
+        $prefix = '^(\\d{';
+        $suffix = '}|(?=[\\d-]{12,13}$)\\d{2,4}-\\d{2,4}-\\d{3,4})$';
+        if (!str_starts_with($pattern, $prefix) || !str_ends_with($pattern, $suffix)) {
+            return null;
+        }
+
+        $quantifier = substr($pattern, strlen($prefix), -strlen($suffix));
+        if (preg_match('/^([0-9]+),([0-9]+)$/D', $quantifier, $matches) !== 1) {
+            return null;
+        }
+
+        $digitMinimum = (int) $matches[1];
+        $digitMaximum = (int) $matches[2];
+        if ($digitMinimum < 1 || $digitMaximum < $digitMinimum ||
+            $digitMinimum > self::MAX_SYNTHESIZED_PATTERN_LENGTH) {
+            return null;
+        }
+
+        $minimum = isset($schema['minLength']) && is_int($schema['minLength']) ? max(0, $schema['minLength']) : null;
+        $maximum = isset($schema['maxLength']) && is_int($schema['maxLength']) ? max(0, $schema['maxLength']) : null;
+        $candidates = [];
+        $digitLength = max($digitMinimum, $minimum ?? 0);
+        if ($digitLength <= $digitMaximum &&
+            $digitLength <= self::MAX_SYNTHESIZED_PATTERN_LENGTH &&
+            ($maximum === null || $digitLength <= $maximum)) {
+            $candidates[] = str_repeat('0', $digitLength);
+        }
+        $candidates[] = '000-000-0000';
+        $candidates[] = '0000-000-0000';
+
+        $delimiter = '~';
+        $escaped = str_replace($delimiter, '\\' . $delimiter, $pattern);
+        foreach ($candidates as $candidate) {
+            $length = self::unicodeLength($candidate);
+            if (($minimum !== null && $length < $minimum) ||
+                ($maximum !== null && $length > $maximum)) {
+                continue;
+            }
+            if (@preg_match($delimiter . $escaped . $delimiter . 'u', $candidate) === 1) {
+                return $candidate;
             }
         }
 

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -524,6 +524,40 @@ class SchemaDataGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function generates_common_phone_number_patterns_deterministically(): void
+    {
+        $schema = [
+            'type' => 'string',
+            'pattern' => '^(\\d{10,11}|(?=[\\d-]{12,13}$)\\d{2,4}-\\d{2,4}-\\d{3,4})$',
+        ];
+
+        $first = SchemaDataGenerator::generate($schema, 3, seed: 1);
+        $second = SchemaDataGenerator::generate($schema, 3, seed: 999);
+
+        $this->assertSame([str_repeat('0', 10), str_repeat('0', 10), str_repeat('0', 10)], $first);
+        $this->assertSame($first, $second);
+        foreach ($first as $value) {
+            $this->assertTrue(SchemaValueValidator::isValid($value, $schema));
+        }
+    }
+
+    #[Test]
+    public function phone_number_pattern_generation_honors_length_constraints(): void
+    {
+        $schema = [
+            'type' => 'string',
+            'minLength' => 12,
+            'maxLength' => 12,
+            'pattern' => '^(\\d{10,11}|(?=[\\d-]{12,13}$)\\d{2,4}-\\d{2,4}-\\d{3,4})$',
+        ];
+
+        $value = SchemaDataGenerator::generate($schema, 1, seed: 1)[0];
+
+        $this->assertSame('000-000-0000', $value);
+        $this->assertTrue(SchemaValueValidator::isValid($value, $schema));
+    }
+
+    #[Test]
     public function emits_numeric_boundaries_that_honor_exclusive_and_multiple_of(): void
     {
         $schema = [


### PR DESCRIPTION
## Summary

- generate deterministic valid values for the phone-number alternation used by studio-api
- honor `minLength` and `maxLength` while preferring the shortest digits-only branch
- validate synthesized candidates against the complete regex before returning them
- document the supported phone-number pattern family

## Root cause

Whole-spec exploration only supported a deliberately narrow regex synthesis subset. The Japanese phone-number alternation in studio-api was outside that subset, so the affected operation was skipped before dispatch.

This adds targeted support for that common pattern shape without attempting arbitrary regex synthesis or changing unsupported-pattern diagnostics.

## Impact

The studio-api operation using `^(\d{10,11}|(?=[\d-]{12,13}$)\d{2,4}-\d{2,4}-\d{3,4})$` can now participate in deterministic whole-spec exploration.

## Verification

- `vendor/bin/phpunit --filter phone_number_pattern tests/Unit/Fuzz/SchemaDataGeneratorTest.php` — 2 tests, 7 assertions
- `composer test` — 2042 tests, 5128 assertions
- PHPStan — no errors
- PHP-CS-Fixer checks for the default and Pest configurations — no changes required
- `git diff --check` — clean

Closes #313
