### PR TITLE
fix(docs): stabilize PSR-7 interface link

### DIFF
--- a/docs/psr7.md
+++ b/docs/psr7.md
@@ -120,7 +120,7 @@ returning. Empty, scalar, object/array, and literal JSON `null` bodies remain
 distinct.
 
 A non-seekable JSON stream cannot be read and then restored through the
-[PSR-7 `StreamInterface`](https://www.php-fig.org/psr/psr-7/#34-psrhttpmessagestreaminterface).
+[PSR-7 `StreamInterface`](https://github.com/php-fig/http-message/blob/2.0/src/StreamInterface.php).
 The adapter therefore returns a failure without reading it. Buffer or decorate
 the body with a seekable/caching stream before validation when the application
 uses a one-pass stream. Non-JSON bodies are not consumed; the core validator


### PR DESCRIPTION
## Summary

- replace the flaky PHP-FIG website link with the tag-pinned official `php-fig/http-message` source
- keep the PSR-7 `StreamInterface` reference stable and version-specific

## Root cause

The documentation link check on `main` received `Status: 0` from the PHP-FIG website even though the target content remains valid. The external site response made the otherwise-green CI matrix fail.

## Verification

- `./node_modules/.bin/markdown-link-check --config .markdown-link-check.json docs/psr7.md`
