### PR TITLE
test(compatibility): capture the v1.9 public API baseline

### DIFF
--- a/docs/adr/0001-gesso-v2-identity.md
+++ b/docs/adr/0001-gesso-v2-identity.md
@@ -1,0 +1,175 @@
+# ADR 0001: Align the v2 technical identity with Gesso
+
+- Status: Proposed
+- Date: 2026-07-13
+- Owners: Gesso maintainers
+
+## Context
+
+The project is already presented publicly as **Gesso**. The GitHub repository,
+documentation site, visual identity, package description, and support URLs use
+the Gesso name. Version 1.x deliberately retains the original technical
+identifiers for backward compatibility:
+
+- Composer package: `studio-design/openapi-contract-testing`
+- PHP namespace: `Studio\OpenApiContractTesting\`
+- executables: `openapi-contract` and `openapi-coverage-merge`
+- Laravel configuration file and key: `openapi-contract-testing`
+- PHPUnit extension and framework adapter FQCNs under the original namespace
+- versioned and machine-readable output containing the original package name
+
+These identifiers are part of the documented v1 public compatibility surface.
+Replacing them in a minor release would break source code, Composer manifests,
+PHPUnit XML, Laravel configuration, CI commands, or downstream output parsers.
+
+Packagist package names are immutable. Publishing `studio-design/gesso`
+therefore creates a new package identity rather than renaming the existing
+package in place. Existing consumers will need an explicit migration.
+
+## Decision
+
+Gesso 2.0 will make the Gesso identity canonical across the complete supported
+surface:
+
+| Surface | v1 identifier | v2 canonical identifier |
+| --- | --- | --- |
+| Composer package | `studio-design/openapi-contract-testing` | `studio-design/gesso` |
+| PHP namespace | `Studio\OpenApiContractTesting\` | `Studio\Gesso\` |
+| Primary CLI | `openapi-contract` | `gesso` |
+| Coverage merge CLI | `openapi-coverage-merge` | `gesso coverage:merge` |
+| Laravel config file/key | `openapi-contract-testing` | `gesso` |
+| Laravel service provider | `OpenApiContractTestingServiceProvider` | `GessoServiceProvider` |
+| PHPUnit extension | original namespace FQCN | `Studio\Gesso\PHPUnit\...` |
+| Machine-readable tool identity | `studio-design/openapi-contract-testing` | `studio-design/gesso` |
+
+Class names that describe the OpenAPI domain, such as
+`OpenApiResponseValidator`, remain unchanged. They are domain terminology, not
+legacy branding.
+
+The migration will follow these rules:
+
+1. Publish a final v1 minor release that introduces every safe migration aid,
+   documents deprecations, and allows consumers to prepare their application
+   before installing v2.
+2. Treat Composer package migration separately from source migration. Do not
+   present `composer update` as sufficient when the root requirement must
+   change.
+3. Do not use an unconstrained Composer `replace` entry for the old package.
+   It could incorrectly satisfy dependencies that require an incompatible v1
+   release. The exact `conflict` or constrained `replace` policy must be proven
+   with dependency-resolution fixtures before publication.
+4. Register `studio-design/gesso` as a new Packagist package. Mark the old
+   package abandoned with `studio-design/gesso` as its replacement only after
+   the v2 stable package is installable and verified.
+5. Keep readers compatible with supported older wire formats where practical.
+   A branding field change does not by itself justify making parallel coverage
+   data unreadable. Writers may move to a new schema version when the documented
+   format requires it.
+6. Provide a documented, reviewable migration procedure for Composer
+   requirements, PHP imports, PHPUnit XML, Laravel configuration, CLI commands,
+   CI scripts, and machine-readable output consumers.
+7. Release v2 through pre-release stages and dogfood it in the repository's
+   framework examples before general availability.
+
+## Scope boundaries
+
+The v2 identity migration does not by itself authorize unrelated redesigns.
+The following are separate decisions and should not be bundled into the rename:
+
+- splitting the repository into multiple Composer packages;
+- a major upgrade of `opis/json-schema` or another production dependency;
+- implementing OpenAPI diff as a new product area;
+- rewriting the validator, coverage engine, or framework adapters wholesale;
+- changing OpenAPI validation semantics solely because a major version is
+  available.
+
+Small breaking cleanups that already have evidence and cannot be completed in
+v1 may be included as separately reviewable changes. Each must have its own
+migration note and regression coverage.
+
+## Required preparation
+
+Before the first breaking rename is merged:
+
+1. Record the complete v1 public compatibility surface, including PHP symbols,
+   configuration, commands, exit codes, warning categories, and versioned
+   output formats.
+2. Add golden or consumer-level fixtures for each non-PHP compatibility surface.
+3. Resolve the current documentation ambiguity around whether the coverage
+   sidecar shape is a SemVer compatibility surface.
+4. Verify any proposed namespace compatibility mechanism across classes,
+   interfaces, traits, enums, attributes, reflection, serialization, and
+   Composer optimized autoloading. Do not assume `class_alias()` covers every
+   supported use case without tests.
+5. Define the v1 maintenance branch and end-of-support date before v2
+   pre-releases begin.
+
+## Open decisions
+
+The following require evidence or maintainer approval before this ADR becomes
+Accepted:
+
+- whether the final transition release is v1.10.0 and which Gesso aliases it
+  can safely provide;
+- whether any legacy PHP namespace shim ships in v2, and its exact removal
+  version;
+- whether `gesso coverage:merge` replaces the standalone binary immediately or
+  keeps a deprecated executable shim;
+- how conflicts between old and new Laravel configuration are reported;
+- which machine-readable formats require a schema-version increment;
+- the PHP minimum version and supported PHPUnit matrix at the planned v2 GA
+  date;
+- the duration and scope of v1 security or critical-fix support.
+
+## Consequences
+
+### Positive
+
+- Installation, namespaces, commands, documentation, and output consistently
+  identify the project as Gesso.
+- Future APIs no longer extend a legacy product namespace.
+- The explicit migration boundary makes compatibility costs visible and
+  testable.
+
+### Negative
+
+- Every existing consumer must update at least its Composer requirement and PHP
+  imports.
+- Two Packagist package identities must be managed during the transition.
+- Migration fixtures and temporary compatibility code add release overhead.
+
+### Risks
+
+- An overly broad Composer replacement rule can silently resolve incompatible
+  dependency constraints.
+- Permanent aliases can leave Gesso carrying two public identities indefinitely.
+- Combining the rename with unrelated architecture work can make regressions
+  difficult to isolate.
+- Machine-readable branding changes can break downstream tooling even when the
+  surrounding JSON shape is unchanged.
+
+## Verification gates
+
+Gesso 2.0 is not ready for stable release until all of the following pass:
+
+- strict Composer validation and a clean install of `studio-design/gesso`;
+- supported PHP, PHPUnit, lowest-dependency, Pest, Laravel, Symfony, and PSR-7
+  matrices;
+- optimized Composer autoload checks for the canonical namespace;
+- a clean v1-to-v2 consumer migration fixture;
+- PHPUnit XML and Laravel published-config migration fixtures;
+- CLI help, flags, exit-code, stdout, and stderr golden tests;
+- backward-reader tests for supported coverage sidecars and other wire formats;
+- documentation builds, links, examples, and migration commands;
+- Packagist metadata, abandonment replacement, GitHub tag, and release manifest
+  consistency.
+
+## References
+
+- [Semantic Versioning 2.0.0](https://semver.org/)
+- [Composer package links and `replace`](https://getcomposer.org/doc/04-schema.md#package-links)
+- [Composer repositories and package renaming](https://getcomposer.org/doc/05-repositories.md)
+- [Packagist package naming](https://packagist.org/about)
+- [PSR-4 autoloading](https://www.php-fig.org/psr/psr-4/)
+- [Symfony backward compatibility promise](https://symfony.com/doc/current/contributing/code/bc.html)
+- [Laminas migration tooling](https://docs.laminas.dev/migration/)

--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -1,0 +1,388 @@
+# Gesso v2 compatibility inventory
+
+This document records the v1.9.0 compatibility surface that must be considered
+when migrating the project to the Gesso v2 identity. It is an implementation
+checklist for [ADR 0001](../adr/0001-gesso-v2-identity.md), not a promise that
+every legacy identifier will remain available in v2.
+
+Baseline:
+
+- release: `v1.9.0`
+- commit: `57920818e5677835ca681a499a8140ea651ea060`
+- Composer package: `studio-design/openapi-contract-testing`
+- root namespace: `Studio\OpenApiContractTesting\`
+
+## Inventory rules
+
+- A PHP type is in the v1 public API when its declaration is not marked
+  `@internal`.
+- Public members marked `@internal` are excluded even when their declaring type
+  is public.
+- Public method signatures, public constant values, enum cases, attributes,
+  and trait methods are part of the source contract.
+- CLI binaries, PHPUnit parameters, Laravel configuration, environment
+  variables, warning prefixes, and documented machine-readable formats require
+  separate tests because PHP API tools cannot detect changes to them.
+- Validator error prose is not stable, but structured categories and documented
+  warning prefixes are.
+
+Reflection against the optimized v1.9 autoload map finds 65 non-internal PHP
+types: 46 classes, 12 enums, and 7 traits. Member signatures remain
+authoritative in the v1.9 source; this list prevents a type from disappearing
+during the namespace migration.
+
+The machine-readable baseline lives at
+[`tests/fixtures/compatibility/v1.9-public-api.json`](../../tests/fixtures/compatibility/v1.9-public-api.json).
+`PublicApiBaselineTest` compares it with the current source. After an
+intentional, documented API change, regenerate it with:
+
+```bash
+php scripts/export-public-api.php --write
+```
+
+The snapshot includes type kind/modifiers, parent and directly introduced
+interfaces/traits, attributes, enum backing types and cases, public constants,
+public properties, and declared public method signatures. Declarations or
+members marked `@internal` are excluded.
+
+## Composer and autoload identity
+
+| Surface | v1.9 contract | v2 migration responsibility |
+| --- | --- | --- |
+| Package | `studio-design/openapi-contract-testing` | Explicit root requirement migration to `studio-design/gesso` |
+| PSR-4 | `Studio\OpenApiContractTesting\` → `src/` | Map `Studio\Gesso\` and verify optimized autoloading |
+| Autoload file | `src/Pest/Autoload.php` | Rename imports and preserve no-Pest guard behavior |
+| Binaries | `bin/openapi-contract`, `bin/openapi-coverage-merge` | Replace with the ADR-approved `gesso` command surface |
+| Laravel discovery | `Studio\OpenApiContractTesting\Laravel\OpenApiContractTestingServiceProvider` | Point discovery to the Gesso provider |
+| PHP requirement | `^8.2` | Decide from the v2 GA date, not from the rename alone |
+| PHPUnit requirement | `^11.0 || ^12.0 || ^13.0` | Update only with an explicit support decision |
+| Opis requirement | `opis/json-schema:^2.6` | Keep independent from the identity migration |
+| PSR requirements | `psr/http-client:^1.0`, `psr/http-factory:^1.0`, `psr/http-message:^1.0 || ^2.0` | Preserve unless separately justified |
+
+Packagist migration must be tested with a clean project. The new package must
+not declare an unconstrained replacement that silently satisfies a dependency
+requiring the old package's `^1` API.
+
+## PHP public types
+
+Every type below maps by replacing the prefix
+`Studio\OpenApiContractTesting\` with `Studio\Gesso\`. Renaming or removing
+the domain-level short names is not part of the identity migration.
+
+### Core and attributes
+
+```text
+Studio\OpenApiContractTesting\DecodedBody
+Studio\OpenApiContractTesting\HttpMethod
+Studio\OpenApiContractTesting\OpenApiRequestValidator
+Studio\OpenApiContractTesting\OpenApiResponseValidator
+Studio\OpenApiContractTesting\OpenApiValidationOutcome
+Studio\OpenApiContractTesting\OpenApiValidationResult
+Studio\OpenApiContractTesting\OpenApiVersion
+Studio\OpenApiContractTesting\SchemaContext
+Studio\OpenApiContractTesting\SkipOpenApiResolver
+Studio\OpenApiContractTesting\Attribute\BoundToOpenApiEnum
+Studio\OpenApiContractTesting\Attribute\OpenApiSpec
+Studio\OpenApiContractTesting\Attribute\SkipOpenApi
+```
+
+`OpenApiValidationResult` additionally freezes its success, failure, and
+skipped factories and these accessors: `outcome()`, `isValid()`, `isSkipped()`,
+`errors()`, `errorMessage()`, `matchedPath()`, `skipReason()`,
+`matchedStatusCode()`, and `matchedContentType()`.
+
+### Exceptions
+
+```text
+Studio\OpenApiContractTesting\Exception\EnumBindingException
+Studio\OpenApiContractTesting\Exception\EnumBindingReason
+Studio\OpenApiContractTesting\Exception\EnumDriftException
+Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecException
+Studio\OpenApiContractTesting\Exception\InvalidOpenApiSpecReason
+Studio\OpenApiContractTesting\Exception\SpecFileNotFoundException
+Studio\OpenApiContractTesting\Exception\StrictRequiredDriftException
+```
+
+The cases of `EnumBindingReason` and `InvalidOpenApiSpecReason`, including
+deprecated cases, must be included in the PHP API snapshot.
+
+### Spec loading
+
+```text
+Studio\OpenApiContractTesting\Spec\OpenApiSpecLoader
+Studio\OpenApiContractTesting\Spec\OpenApiSpecResolver
+```
+
+The loader's static configuration, base paths, strip prefixes, local/remote
+reference inputs, cache behavior exposed through non-internal methods, and
+exception taxonomy are observable contracts.
+
+### Coverage
+
+```text
+Studio\OpenApiContractTesting\Coverage\ConsoleCoverageRenderer
+Studio\OpenApiContractTesting\Coverage\CoverageSidecarEnvelope
+Studio\OpenApiContractTesting\Coverage\CoverageSidecarReader
+Studio\OpenApiContractTesting\Coverage\CoverageSidecarWriter
+Studio\OpenApiContractTesting\Coverage\CoverageThresholdEvaluator
+Studio\OpenApiContractTesting\Coverage\EndpointCoverageState
+Studio\OpenApiContractTesting\Coverage\HtmlCoverageRenderer
+Studio\OpenApiContractTesting\Coverage\InvalidCoverageOutputPathException
+Studio\OpenApiContractTesting\Coverage\InvalidThresholdConfigurationException
+Studio\OpenApiContractTesting\Coverage\JUnitCoverageRenderer
+Studio\OpenApiContractTesting\Coverage\JsonCoverageRenderer
+Studio\OpenApiContractTesting\Coverage\MarkdownCoverageRenderer
+Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker
+Studio\OpenApiContractTesting\Coverage\ResponseCoverageState
+```
+
+The inventory must preserve the enum values, renderer entry points, threshold
+semantics, `OpenApiCoverageTracker::ANY_CONTENT_TYPE`, and all non-internal
+tracker methods. The sidecar constants and filename conventions are separately
+listed under wire formats.
+
+### Schema and strict-required APIs
+
+```text
+Studio\OpenApiContractTesting\Schema\EnumDriftAsserter
+Studio\OpenApiContractTesting\Schema\EnumDriftReport
+Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredAsserter
+Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredMode
+Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredPerCallMode
+Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredReport
+Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredTracker
+```
+
+Modes and enum values are stable inputs. Tracker import/export methods are
+marked internal at member level, but their versioned payload is consumed by the
+supported parallel merge workflow and therefore remains a migration concern.
+
+### Fuzzing and exploration
+
+```text
+Studio\OpenApiContractTesting\Fuzz\ExplorationCaseKind
+Studio\OpenApiContractTesting\Fuzz\ExplorationCases
+Studio\OpenApiContractTesting\Fuzz\ExplorationSkip
+Studio\OpenApiContractTesting\Fuzz\ExploredCase
+Studio\OpenApiContractTesting\Fuzz\ExploredOperation
+Studio\OpenApiContractTesting\Fuzz\FailureReducer
+Studio\OpenApiContractTesting\Fuzz\OpenApiEndpointExplorer
+Studio\OpenApiContractTesting\Fuzz\OpenApiSpecExploration
+Studio\OpenApiContractTesting\Fuzz\OpenApiSpecExplorer
+Studio\OpenApiContractTesting\Fuzz\SpecExplorationSummary
+```
+
+This includes constructor shapes, readonly DTO fields, fluent filter and hook
+methods, replay/cURL snippets, replay tokens, iterator behavior, and negative
+case configuration introduced through v1.9.
+
+### PHPUnit and Pest
+
+```text
+Studio\OpenApiContractTesting\PHPUnit\AssertsNoEnumDrift
+Studio\OpenApiContractTesting\PHPUnit\ConsoleOutput
+Studio\OpenApiContractTesting\PHPUnit\InvalidStrictRequiredConfigurationException
+Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension
+Studio\OpenApiContractTesting\Pest\Expectations
+```
+
+The Pest autoload file registers these expectation names and argument shapes:
+
+- `toMatchOpenApiResponseSchema($spec, $method, $path, $skipResponseCodes)`
+- `toMatchOpenApiRequestSchema($spec, $method, $path)`
+
+They remain dormant when Pest is unavailable.
+
+### Framework and PSR-7 adapters
+
+```text
+Studio\OpenApiContractTesting\Laravel\Commands\OpenApiRoutesCommand
+Studio\OpenApiContractTesting\Laravel\ExploresOpenApiEndpoint
+Studio\OpenApiContractTesting\Laravel\OpenApiContractTestingServiceProvider
+Studio\OpenApiContractTesting\Laravel\ValidatesOpenApiSchema
+Studio\OpenApiContractTesting\Psr7\OpenApiAssertions
+Studio\OpenApiContractTesting\Psr7\OpenApiPsr7ValidationResult
+Studio\OpenApiContractTesting\Psr7\OpenApiPsr7Validator
+Studio\OpenApiContractTesting\Symfony\OpenApiAssertions
+```
+
+Trait methods, explicit-spec precedence, validation defaults, assertion
+behavior, PSR-7 stream handling, and automatic coverage recording require
+consumer-level fixtures rather than namespace-only checks.
+
+## PHPUnit extension configuration
+
+The extension FQCN and every accepted parameter name are public configuration.
+Defaults shown here are the missing-parameter behavior.
+
+| Parameter | v1.9 default or domain |
+| --- | --- |
+| `spec_base_path` | absent; required for named spec loading in normal use |
+| `enum_spec_base_path` | absent; falls back to the spec base path |
+| `strip_prefixes` | empty list |
+| `specs` | `front` |
+| `output_file` | absent; Markdown file not written |
+| `junit_output` | absent |
+| `json_output` | absent |
+| `html_output` | absent |
+| `console_output` | `default`; also `all`, `uncovered_only`, `active_only` |
+| `sidecar_dir` | system temp plus `openapi-coverage-sidecars` |
+| `min_endpoint_coverage` | no gate; otherwise 0–100 |
+| `min_response_coverage` | no gate; otherwise 0–100 |
+| `min_coverage_strict` | `false` |
+| `default_testsuite_as_full` | `false` |
+| `strict_required` | `off`; also `warn`, `fail` |
+| `strict_required_per_call` | `off`; also `warn` |
+| `enforce_discriminator` | `true` |
+| `enum_drift_enabled` | `false` |
+| `enum_drift_scan_namespaces` | empty; required when enum drift is enabled |
+| `enum_drift_fail_on_drift` | `true` |
+
+Relative paths resolve from the current working directory. Empty values,
+boolean-compatible strings, invalid thresholds, and invalid mode handling are
+observable and already covered by extension tests.
+
+Environment inputs:
+
+- `OPENAPI_CONSOLE_OUTPUT` overrides `console_output`.
+- `GITHUB_STEP_SUMMARY` enables Markdown summary output.
+- `TEST_TOKEN` selects the paratest worker sidecar path and suppresses final
+  report writes from workers.
+
+## Laravel configuration and command
+
+The v1 service provider merges and publishes configuration under
+`openapi-contract-testing`; the publish tag and destination filename use the
+same string.
+
+| Config key | v1.9 default |
+| --- | --- |
+| `default_spec` | empty string |
+| `spec_base_path` | `openapi` |
+| `strip_prefixes` | empty list |
+| `max_errors` | `20` |
+| `enforce_discriminator` | `true` |
+| `auto_assert` | `false` |
+| `auto_validate_request` | `false` |
+| `auto_inject_dummy_credentials` | `false` |
+| `auto_inject_dummy_bearer` | `false` |
+| `skip_response_codes` | `['5\\d\\d']` |
+| `skip_request_validation_response_codes` | `['422', '400']` |
+
+The `openapi:routes` command accepts `--spec`, `--prefix`, `--middleware`,
+`--domain`, `--exclude-route`, `--format=text|json`,
+`--fail-on-undocumented`, and `--fail-on-unimplemented`. It uses Laravel's
+standard success (`0`), failure (`1`), and invalid usage (`2`) exit codes.
+
+## CLI contracts
+
+### Doctor
+
+Executable and command: `openapi-contract doctor`.
+
+Accepted options:
+
+- repeated `--spec=<path[,path]>`;
+- repeated `--strip-prefix=<prefix>`;
+- `--format=text|json`;
+- `--allow-remote-refs`;
+- `--phpunit-snippet`;
+- `--help` / `-h`.
+
+Exit codes are `0` for a usable contract, `1` for diagnostic failure, and `2`
+for invalid usage. JSON uses `schemaVersion: 1`; issue fields are `severity`,
+`category`, `spec`, `message`, and nullable `suggestion`.
+
+### Coverage merge
+
+Executable: `openapi-coverage-merge`.
+
+Accepted options:
+
+- `--spec-base-path`, `--specs`, `--strip-prefixes`, `--sidecar-dir`;
+- `--output-file`, `--junit-output`, `--json-output`, `--html-output`;
+- `--github-step-summary`, `--console-output`;
+- `--min-endpoint-coverage`, `--min-response-coverage`;
+- `--min-coverage-strict`, `--strict-required`;
+- `--no-cleanup`, `--help`, and `-h`.
+
+Exit codes are `0` for success or a warn-only result, `1` for data, gate, or
+write failure, and `2` for invalid configuration or usage.
+
+## Versioned and machine-readable formats
+
+| Format | v1.9 version | Compatibility responsibility |
+| --- | ---: | --- |
+| Coverage JSON report | `schema_version: 1` | Preserve documented fields or bump on removal/rename/shape change |
+| Coverage JSON tool identity | `studio-design/openapi-contract-testing` | Change deliberately and test downstream detection |
+| Coverage tracker state | `version: 1` | v2 merge reader should accept supported v1 payloads |
+| Strict-required tracker state | `version: 2` | Preserve mixed-worker import or document a hard boundary |
+| Sidecar envelope | `envelopeVersion: 2` | Continue accepting legacy bare coverage v1 payloads |
+| Laravel route parity JSON | `schema_version: 1` | Preserve fields or bump for incompatible changes |
+| Doctor JSON | `schemaVersion: 1` | Preserve stable fields/categories or bump |
+| Sidecar filenames | `part-*.json`, failure marker `failed-*` | Keep reader compatibility during mixed runs |
+
+Coverage JSON v1 documents `generated_at`, `tool`, `aggregate`, and `specs`.
+The per-spec contract includes aggregate counts and endpoint rows with response
+states and unexpected observations. Laravel route parity JSON includes `specs`,
+`summary`, `matched`, `documented_but_not_registered`,
+`registered_but_undocumented`, `ambiguous`, and `unsupported`.
+
+There is a documentation ambiguity to resolve before v2: the versioning policy
+treats the sidecar wire format as part of the supported merge CLI, while older
+upgrade text describes the sidecar shape as non-frozen. The safe migration
+assumption is that the PHP import/export methods are internal but the released
+CLI must continue reading supported versioned v1 payloads.
+
+## Diagnostic categories and embedded identifiers
+
+The v1 policy explicitly protects these `E_USER_WARNING` category families:
+
+- `[security]`
+- `[OpenAPI Schema]`
+- `[OpenAPI 3.2 querystring]`
+- `[OpenAPI 3.2 $self]`
+- `[OpenAPI 3.2 discriminator]`
+
+Other stable operational prefixes that require rename or parity tests include:
+
+- `[OpenAPI Coverage]`
+- `[OpenAPI Doctor]`
+- `[OpenAPI Enum Drift]`
+- `[OpenAPI Strict Required]`
+- `[OpenAPI Strict Required per-call]`
+- `[openapi-contract-testing]` for the Laravel deprecation channel
+
+The OpenAPI vendor extension
+`x-studio-openapi-contract-testing-implicit-schema-name` is embedded in spec
+input rather than PHP source. Its Gesso replacement and any dual-read period
+must be decided explicitly.
+
+## v2 migration verification matrix
+
+| Consumer | Old fixture | New fixture | Mixed/negative fixture |
+| --- | --- | --- | --- |
+| Composer | old package `^1.10` | `studio-design/gesso:^2` | dual-install conflict and transitive old `^1` requirement |
+| PHP | old namespace consumer | Gesso namespace consumer | optimized autoload, reflection, serialization, attributes, traits, enums |
+| PHPUnit | old Extension FQCN/XML | Gesso FQCN/XML | every invalid/empty parameter behavior |
+| Laravel | published old config/provider | Gesso config/provider | both configs present with conflicting values |
+| Pest | old trait wiring | Gesso trait wiring | Pest absent and partially available |
+| PSR-7/Symfony | old imports | Gesso imports | equivalent exchange produces equivalent result/coverage |
+| CLI | old commands and golden output | Gesso commands | flags, exit codes, stdout/stderr parity |
+| Coverage | v1 JSON and sidecar | v2 output | v1 worker payload merged by v2 reader |
+| Doctor/routes | schema v1 consumers | v2 identity | incompatible field change requires version bump |
+
+## Change-control checklist
+
+For every v2 identity PR:
+
+1. Mark each affected row in this inventory as unchanged, renamed, shimmed, or
+   intentionally removed.
+2. Add or update the corresponding consumer/golden fixture.
+3. Keep domain behavior unchanged unless the PR has a separate behavioral
+   rationale and migration note.
+4. Search for both `openapi-contract-testing` and
+   `Studio\\OpenApiContractTesting` after the change; any remaining occurrence
+   must be a documented compatibility input, migration example, or historical
+   reference.
+5. Update `UPGRADING.md` in the same PR when a consumer action changes.

--- a/scripts/export-public-api.php
+++ b/scripts/export-public-api.php
@@ -1,0 +1,36 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Studio\OpenApiContractTesting\Tests\Helpers\PublicApiInventory;
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+$arguments = $_SERVER['argv'] ?? [];
+array_shift($arguments);
+
+if ($arguments !== [] && !in_array('--write', $arguments, true)) {
+    fwrite(STDERR, "Usage: php scripts/export-public-api.php [--write]\n");
+    exit(2);
+}
+
+$inventory = PublicApiInventory::capture(
+    $root . '/src',
+    'Studio\\OpenApiContractTesting\\',
+);
+$json = json_encode($inventory, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+
+if (in_array('--write', $arguments, true)) {
+    $path = $root . '/tests/fixtures/compatibility/v1.9-public-api.json';
+    if (file_put_contents($path, $json) === false) {
+        fwrite(STDERR, "Failed to write {$path}\n");
+        exit(1);
+    }
+
+    fwrite(STDERR, "Wrote {$path}\n");
+    exit(0);
+}
+
+echo $json;

--- a/tests/Helpers/PublicApiInventory.php
+++ b/tests/Helpers/PublicApiInventory.php
@@ -161,6 +161,8 @@ final class PublicApiInventory
             'final' => $reflection->isFinal(),
             'abstract' => $reflection->isAbstract(),
             'readonly' => $reflection->isReadOnly(),
+            'instantiable' => $reflection->isInstantiable(),
+            'constructor' => self::describeConstructor($reflection),
             'parent' => $parent === false ? null : $parent->getName(),
             'interfaces' => $interfaces,
             'traits' => $traits,
@@ -170,6 +172,31 @@ final class PublicApiInventory
             'constants' => $constants,
             'properties' => $properties,
             'methods' => $methods,
+        ];
+    }
+
+    /**
+     * @param ReflectionClass<object> $reflection
+     *
+     * @return null|array<string, mixed>
+     */
+    private static function describeConstructor(ReflectionClass $reflection): ?array
+    {
+        $constructor = $reflection->getConstructor();
+        if ($constructor === null) {
+            if ($reflection->isInterface() || $reflection->isTrait() || $reflection->isEnum()) {
+                return null;
+            }
+
+            return [
+                'kind' => 'implicit',
+                'visibility' => 'public',
+            ];
+        }
+
+        return [
+            'kind' => $constructor->getDeclaringClass()->getName() === $reflection->getName() ? 'declared' : 'inherited',
+            'visibility' => $constructor->isPublic() ? 'public' : ($constructor->isProtected() ? 'protected' : 'private'),
         ];
     }
 

--- a/tests/Helpers/PublicApiInventory.php
+++ b/tests/Helpers/PublicApiInventory.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Helpers;
+
+use const DIRECTORY_SEPARATOR;
+
+use BackedEnum;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionAttribute;
+use ReflectionClass;
+use ReflectionClassConstant;
+use ReflectionEnum;
+use ReflectionMethod;
+use ReflectionParameter;
+use ReflectionProperty;
+use RuntimeException;
+use UnitEnum;
+
+use function array_diff;
+use function array_map;
+use function array_values;
+use function class_exists;
+use function enum_exists;
+use function interface_exists;
+use function is_array;
+use function is_object;
+use function is_scalar;
+use function ksort;
+use function method_exists;
+use function realpath;
+use function sort;
+use function str_contains;
+use function str_ends_with;
+use function str_replace;
+use function strlen;
+use function substr;
+use function trait_exists;
+use function usort;
+
+/**
+ * Reflection-based snapshot of the package's non-@internal PHP API.
+ *
+ * @internal Build-time compatibility helper; not part of the library API.
+ */
+final class PublicApiInventory
+{
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public static function capture(string $sourceDirectory, string $namespacePrefix): array
+    {
+        $root = realpath($sourceDirectory);
+        if ($root === false) {
+            throw new RuntimeException("Source directory does not exist: {$sourceDirectory}");
+        }
+
+        $symbols = [];
+        $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
+        foreach ($iterator as $file) {
+            if (!$file->isFile() || !str_ends_with($file->getFilename(), '.php')) {
+                continue;
+            }
+
+            $path = $file->getPathname();
+            $relative = substr($path, strlen($root) + 1, -4);
+            $symbol = $namespacePrefix . str_replace(DIRECTORY_SEPARATOR, '\\', $relative);
+
+            if (!class_exists($symbol) && !interface_exists($symbol) && !trait_exists($symbol) && !enum_exists($symbol)) {
+                continue;
+            }
+
+            $reflection = new ReflectionClass($symbol);
+            if (self::isInternal($reflection->getDocComment())) {
+                continue;
+            }
+
+            $symbols[$symbol] = self::describe($reflection);
+        }
+
+        ksort($symbols);
+
+        return $symbols;
+    }
+
+    /**
+     * @param ReflectionClass<object> $reflection
+     *
+     * @return array<string, mixed>
+     */
+    private static function describe(ReflectionClass $reflection): array
+    {
+        $parent = $reflection->getParentClass();
+        $interfaces = $reflection->getInterfaceNames();
+        if ($parent !== false) {
+            $interfaces = array_values(array_diff($interfaces, $parent->getInterfaceNames()));
+        }
+        sort($interfaces);
+
+        $traits = $reflection->getTraitNames();
+        if ($parent !== false) {
+            $traits = array_values(array_diff($traits, $parent->getTraitNames()));
+        }
+        sort($traits);
+
+        $methods = [];
+        foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+            if ($method->getDeclaringClass()->getName() !== $reflection->getName() ||
+                self::isInternal($method->getDocComment())) {
+                continue;
+            }
+
+            $methods[$method->getName()] = self::describeMethod($method);
+        }
+        ksort($methods);
+
+        $properties = [];
+        foreach ($reflection->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+            if ($property->getDeclaringClass()->getName() !== $reflection->getName() ||
+                self::isInternal($property->getDocComment())) {
+                continue;
+            }
+
+            $properties[$property->getName()] = [
+                'type' => $property->hasType() ? (string) $property->getType() : null,
+                'static' => $property->isStatic(),
+                'readonly' => $property->isReadOnly(),
+                'default' => $property->hasDefaultValue() ? self::normaliseValue($property->getDefaultValue()) : ['unavailable' => true],
+            ];
+        }
+        ksort($properties);
+
+        $constants = [];
+        foreach ($reflection->getReflectionConstants(ReflectionClassConstant::IS_PUBLIC) as $constant) {
+            if ($constant->getDeclaringClass()->getName() !== $reflection->getName() ||
+                $constant->isEnumCase() ||
+                self::isInternal($constant->getDocComment())) {
+                continue;
+            }
+
+            $constants[$constant->getName()] = self::normaliseValue($constant->getValue());
+        }
+        ksort($constants);
+
+        $cases = [];
+        $backingType = null;
+        if ($reflection->isEnum()) {
+            $enum = new ReflectionEnum($reflection->getName());
+            $backingType = $enum->isBacked() ? (string) $enum->getBackingType() : null;
+            foreach ($enum->getCases() as $case) {
+                $cases[$case->getName()] = method_exists($case, 'getBackingValue')
+                    ? self::normaliseValue($case->getBackingValue())
+                    : null;
+            }
+        }
+
+        return [
+            'kind' => $reflection->isTrait() ? 'trait' : ($reflection->isInterface() ? 'interface' : ($reflection->isEnum() ? 'enum' : 'class')),
+            'final' => $reflection->isFinal(),
+            'abstract' => $reflection->isAbstract(),
+            'readonly' => $reflection->isReadOnly(),
+            'parent' => $parent === false ? null : $parent->getName(),
+            'interfaces' => $interfaces,
+            'traits' => $traits,
+            'attributes' => self::describeAttributes($reflection->getAttributes()),
+            'backing_type' => $backingType,
+            'cases' => $cases,
+            'constants' => $constants,
+            'properties' => $properties,
+            'methods' => $methods,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private static function describeMethod(ReflectionMethod $method): array
+    {
+        return [
+            'static' => $method->isStatic(),
+            'final' => $method->isFinal(),
+            'abstract' => $method->isAbstract(),
+            'returns_reference' => $method->returnsReference(),
+            'return_type' => $method->hasReturnType() ? (string) $method->getReturnType() : null,
+            'attributes' => self::describeAttributes($method->getAttributes()),
+            'parameters' => array_map(self::describeParameter(...), $method->getParameters()),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private static function describeParameter(ReflectionParameter $parameter): array
+    {
+        $default = ['unavailable' => true];
+        if ($parameter->isDefaultValueAvailable()) {
+            $constant = $parameter->getDefaultValueConstantName();
+            $default = $constant === null
+                ? self::normaliseValue($parameter->getDefaultValue())
+                : ['constant' => $constant, 'value' => self::normaliseValue($parameter->getDefaultValue())];
+        }
+
+        return [
+            'name' => $parameter->getName(),
+            'type' => $parameter->hasType() ? (string) $parameter->getType() : null,
+            'optional' => $parameter->isOptional(),
+            'variadic' => $parameter->isVariadic(),
+            'by_reference' => $parameter->isPassedByReference(),
+            'default' => $default,
+            'attributes' => self::describeAttributes($parameter->getAttributes()),
+        ];
+    }
+
+    /**
+     * @param list<ReflectionAttribute<object>> $attributes
+     *
+     * @return list<array{name: string, arguments: array<mixed>}>
+     */
+    private static function describeAttributes(array $attributes): array
+    {
+        $described = array_map(
+            static fn(ReflectionAttribute $attribute): array => [
+                'name' => $attribute->getName(),
+                'arguments' => self::normaliseValue($attribute->getArguments()),
+            ],
+            $attributes,
+        );
+
+        usort($described, static fn(array $left, array $right): int => $left['name'] <=> $right['name']);
+
+        return $described;
+    }
+
+    private static function isInternal(false|string $docComment): bool
+    {
+        return $docComment !== false && str_contains($docComment, '@internal');
+    }
+
+    private static function normaliseValue(mixed $value): mixed
+    {
+        if ($value === null || is_scalar($value)) {
+            return $value;
+        }
+        if (is_array($value)) {
+            $normalised = [];
+            foreach ($value as $key => $item) {
+                $normalised[$key] = self::normaliseValue($item);
+            }
+
+            return $normalised;
+        }
+        if ($value instanceof BackedEnum) {
+            return ['enum' => $value::class . '::' . $value->name, 'value' => $value->value];
+        }
+        if ($value instanceof UnitEnum) {
+            return ['enum' => $value::class . '::' . $value->name];
+        }
+        if (is_object($value)) {
+            return ['object' => $value::class];
+        }
+
+        throw new RuntimeException('Unsupported reflected value.');
+    }
+}

--- a/tests/Unit/Compatibility/PublicApiBaselineTest.php
+++ b/tests/Unit/Compatibility/PublicApiBaselineTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Compatibility;
+
+use const JSON_THROW_ON_ERROR;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Tests\Helpers\PublicApiInventory;
+
+use function dirname;
+use function file_get_contents;
+use function json_decode;
+
+final class PublicApiBaselineTest extends TestCase
+{
+    #[Test]
+    public function public_php_api_matches_the_v1_9_baseline(): void
+    {
+        $root = dirname(__DIR__, 3);
+        $baselinePath = $root . '/tests/fixtures/compatibility/v1.9-public-api.json';
+        $baselineJson = file_get_contents($baselinePath);
+
+        $this->assertNotFalse($baselineJson, "Unable to read {$baselinePath}");
+
+        /** @var array<string, array<string, mixed>> $expected */
+        $expected = json_decode($baselineJson, true, flags: JSON_THROW_ON_ERROR);
+        $actual = PublicApiInventory::capture(
+            $root . '/src',
+            'Studio\\OpenApiContractTesting\\',
+        );
+
+        $this->assertSame(
+            $expected,
+            $actual,
+            'The non-@internal PHP API changed. If intentional, document the migration first, '
+            . 'then regenerate with `php scripts/export-public-api.php --write`.',
+        );
+    }
+}

--- a/tests/Unit/Compatibility/PublicApiBaselineTest.php
+++ b/tests/Unit/Compatibility/PublicApiBaselineTest.php
@@ -8,6 +8,8 @@ use const JSON_THROW_ON_ERROR;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Coverage\ConsoleCoverageRenderer;
+use Studio\OpenApiContractTesting\Coverage\HtmlCoverageRenderer;
 use Studio\OpenApiContractTesting\Tests\Helpers\PublicApiInventory;
 
 use function dirname;
@@ -16,6 +18,28 @@ use function json_decode;
 
 final class PublicApiBaselineTest extends TestCase
 {
+    #[Test]
+    public function inventory_records_constructor_availability_and_visibility(): void
+    {
+        $root = dirname(__DIR__, 3);
+        $inventory = PublicApiInventory::capture(
+            $root . '/src',
+            'Studio\\OpenApiContractTesting\\',
+        );
+
+        $implicitConstructor = $inventory[ConsoleCoverageRenderer::class];
+        $this->assertTrue($implicitConstructor['instantiable']);
+        $this->assertSame(
+            ['kind' => 'implicit', 'visibility' => 'public'],
+            $implicitConstructor['constructor'],
+        );
+
+        $privateConstructor = $inventory[HtmlCoverageRenderer::class];
+        $this->assertFalse($privateConstructor['instantiable']);
+        $this->assertSame('declared', $privateConstructor['constructor']['kind']);
+        $this->assertSame('private', $privateConstructor['constructor']['visibility']);
+    }
+
     #[Test]
     public function public_php_api_matches_the_v1_9_baseline(): void
     {

--- a/tests/fixtures/compatibility/v1.9-public-api.json
+++ b/tests/fixtures/compatibility/v1.9-public-api.json
@@ -1,0 +1,6995 @@
+{
+    "Studio\\OpenApiContractTesting\\Attribute\\BoundToOpenApiEnum": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [
+            {
+                "name": "Attribute",
+                "arguments": [
+                    1
+                ]
+            }
+        ],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": {
+            "specPath": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specPath",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Attribute\\OpenApiSpec": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [
+            {
+                "name": "Attribute",
+                "arguments": [
+                    5
+                ]
+            }
+        ],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": {
+            "name": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Attribute\\SkipOpenApi": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [
+            {
+                "name": "Attribute",
+                "arguments": [
+                    5
+                ]
+            }
+        ],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": {
+            "reason": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "reason",
+                        "type": "string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": "",
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Coverage\\ConsoleCoverageRenderer": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "render": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "string",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "results",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "consoleOutput",
+                        "type": "Studio\\OpenApiContractTesting\\PHPUnit\\ConsoleOutput",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "constant": "Studio\\OpenApiContractTesting\\PHPUnit\\ConsoleOutput::DEFAULT",
+                            "value": {
+                                "enum": "Studio\\OpenApiContractTesting\\PHPUnit\\ConsoleOutput::DEFAULT",
+                                "value": "default"
+                            }
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Coverage\\CoverageSidecarEnvelope": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": {
+            "ENVELOPE_VERSION": 2
+        },
+        "properties": [],
+        "methods": {
+            "build": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "coverageState",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "strictRequiredState",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "parse": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Coverage\\CoverageSidecarReader": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "listFailureMarkerPaths": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "sidecarDir",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "listPaths": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "sidecarDir",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "readDir": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "sidecarDir",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Coverage\\CoverageSidecarWriter": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": {
+            "FAILURE_MARKER_PREFIX": "failed-",
+            "FILENAME_PREFIX": "part-",
+            "FILENAME_SUFFIX": ".json"
+        },
+        "properties": [],
+        "methods": {
+            "write": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "string",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "sidecarDir",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "testToken",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "state",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "writeFailureMarker": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "?string",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "sidecarDir",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "testToken",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "reason",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Coverage\\CoverageThresholdEvaluator": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "evaluate": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "results",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "minEndpointPct",
+                        "type": "?float",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "minResponsePct",
+                        "type": "?float",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "strict",
+                        "type": "bool",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Coverage\\EndpointCoverageState": {
+        "kind": "enum",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [
+            "BackedEnum",
+            "UnitEnum"
+        ],
+        "traits": [],
+        "attributes": [],
+        "backing_type": "string",
+        "cases": {
+            "AllCovered": "all-covered",
+            "Partial": "partial",
+            "Uncovered": "uncovered",
+            "RequestOnly": "request-only"
+        },
+        "constants": [],
+        "properties": {
+            "name": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "value": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "cases": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": []
+            },
+            "from": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "static",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "string|int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "tryFrom": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "?static",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "string|int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Coverage\\HtmlCoverageRenderer": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "render": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "string",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "results",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Coverage\\InvalidCoverageOutputPathException": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": "RuntimeException",
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": {
+            "parameterName": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "parameterName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "message",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "previous",
+                        "type": "?Throwable",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Coverage\\InvalidThresholdConfigurationException": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": "RuntimeException",
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": {
+            "parameterName": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "parameterName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "message",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "previous",
+                        "type": "?Throwable",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Coverage\\JUnitCoverageRenderer": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "render": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "string",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "results",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Coverage\\JsonCoverageRenderer": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": {
+            "SCHEMA_VERSION": 1
+        },
+        "properties": [],
+        "methods": {
+            "render": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "string",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "results",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "generatedAt",
+                        "type": "?DateTimeImmutable",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Coverage\\MarkdownCoverageRenderer": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "render": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "string",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "results",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Coverage\\OpenApiCoverageTracker": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": {
+            "ANY_CONTENT_TYPE": "*",
+            "STATE_FORMAT_VERSION": 1
+        },
+        "properties": [],
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": []
+            },
+            "computeCoverage": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "computeCoverageOn": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "exportStateOn": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": []
+            },
+            "getCovered": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": []
+            },
+            "getCoveredOn": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": []
+            },
+            "hasAnyCoverage": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "bool",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "hasAnyCoverageOn": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "bool",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "importStateOn": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "state",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "recordRequest": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "method",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "skipReason",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            },
+            "recordRequestOn": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "method",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "skipReason",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            },
+            "recordResponse": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "method",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "statusKey",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "contentTypeKey",
+                        "type": "?string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "schemaValidated",
+                        "type": "bool",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "skipReason",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            },
+            "recordResponseOn": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "method",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "statusKey",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "contentTypeKey",
+                        "type": "?string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "schemaValidated",
+                        "type": "bool",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "skipReason",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            },
+            "resetOn": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": []
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Coverage\\ResponseCoverageState": {
+        "kind": "enum",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [
+            "BackedEnum",
+            "UnitEnum"
+        ],
+        "traits": [],
+        "attributes": [],
+        "backing_type": "string",
+        "cases": {
+            "Validated": "validated",
+            "Skipped": "skipped",
+            "Uncovered": "uncovered"
+        },
+        "constants": [],
+        "properties": {
+            "name": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "value": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "cases": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": []
+            },
+            "from": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "static",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "string|int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "tryFrom": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "?static",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "string|int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\DecodedBody": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": true,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": {
+            "present": {
+                "type": "bool",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "value": {
+                "type": "mixed",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "absent": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": []
+            },
+            "fromLegacy": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "body",
+                        "type": "mixed",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "present": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "mixed",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Exception\\EnumBindingException": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": "RuntimeException",
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": {
+            "enumFqcn": {
+                "type": "?string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "reason": {
+                "type": "Studio\\OpenApiContractTesting\\Exception\\EnumBindingReason",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "specPath": {
+                "type": "?string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "reason",
+                        "type": "Studio\\OpenApiContractTesting\\Exception\\EnumBindingReason",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "message",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "enumFqcn",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "specPath",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "previous",
+                        "type": "?Throwable",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            },
+            "forBinding": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "reason",
+                        "type": "Studio\\OpenApiContractTesting\\Exception\\EnumBindingReason",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "message",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "enumFqcn",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "specPath",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "previous",
+                        "type": "?Throwable",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            },
+            "forConfig": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "reason",
+                        "type": "Studio\\OpenApiContractTesting\\Exception\\EnumBindingReason",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "message",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "previous",
+                        "type": "?Throwable",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            },
+            "forScan": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "reason",
+                        "type": "Studio\\OpenApiContractTesting\\Exception\\EnumBindingReason",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "message",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "previous",
+                        "type": "?Throwable",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Exception\\EnumBindingReason": {
+        "kind": "enum",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [
+            "UnitEnum"
+        ],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": {
+            "TargetIsNotEnum": null,
+            "TargetIsNotBackedEnum": null,
+            "ReflectionFailed": null,
+            "AttributeMissing": null,
+            "BasePathNotConfigured": null,
+            "EnumBasePathNotFound": null,
+            "EnumSpecBasePathOrphaned": null,
+            "SpecFileNotFound": null,
+            "MalformedJson": null,
+            "NonMappingRoot": null,
+            "EnumKeyMissing": null,
+            "EnumKeyNotArray": null,
+            "EnumValueUnsupported": null,
+            "ScanNamespaceUnresolvable": null,
+            "ScanComposerLoaderUnavailable": null,
+            "NoNamespacesConfigured": null
+        },
+        "constants": [],
+        "properties": {
+            "name": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "cases": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": []
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Exception\\EnumDriftException": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": "RuntimeException",
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": {
+            "reports": {
+                "type": "array",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "reports",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "message",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Exception\\InvalidOpenApiSpecException": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": "RuntimeException",
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": {
+            "reason": {
+                "type": "Studio\\OpenApiContractTesting\\Exception\\InvalidOpenApiSpecReason",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "ref": {
+                "type": "?string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "specName": {
+                "type": "?string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "reason",
+                        "type": "Studio\\OpenApiContractTesting\\Exception\\InvalidOpenApiSpecReason",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "message",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "ref",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "specName",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "previous",
+                        "type": "?Throwable",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            },
+            "withSpecName": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Exception\\InvalidOpenApiSpecReason": {
+        "kind": "enum",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [
+            "UnitEnum"
+        ],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": {
+            "ExternalRef": null,
+            "LocalRefNotFound": null,
+            "LocalRefUnreadable": null,
+            "LocalRefRequiresSourceFile": null,
+            "RemoteRefNotImplemented": null,
+            "RemoteRefDisallowed": null,
+            "RemoteRefFetchFailed": null,
+            "HttpClientNotConfigured": null,
+            "FileSchemeNotSupported": null,
+            "EmptyRef": null,
+            "CircularRef": null,
+            "UnresolvableRef": null,
+            "NonStringRef": null,
+            "BareFragmentRef": null,
+            "RootPointerRef": null,
+            "NonObjectRefTarget": null,
+            "MalformedJson": null,
+            "MalformedYaml": null,
+            "NonMappingRoot": null,
+            "YamlLibraryMissing": null,
+            "UnsupportedExtension": null,
+            "UnsupportedVersion": null,
+            "UnsupportedJsonSchemaDialect": null,
+            "BasePathNotConfigured": null
+        },
+        "constants": [],
+        "properties": {
+            "name": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "cases": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": []
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Exception\\SpecFileNotFoundException": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": "RuntimeException",
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": {
+            "basePath": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "specName": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "basePath",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "message",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "previous",
+                        "type": "?Throwable",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Exception\\StrictRequiredDriftException": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": "RuntimeException",
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": {
+            "reports": {
+                "type": "array",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "reports",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "message",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Fuzz\\ExplorationCaseKind": {
+        "kind": "enum",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [
+            "BackedEnum",
+            "UnitEnum"
+        ],
+        "traits": [],
+        "attributes": [],
+        "backing_type": "string",
+        "cases": {
+            "Valid": "valid",
+            "Invalid": "invalid"
+        },
+        "constants": [],
+        "properties": {
+            "name": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "value": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "cases": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": []
+            },
+            "from": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "static",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "string|int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "tryFrom": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "?static",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "string|int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Fuzz\\ExplorationCases": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": true,
+        "parent": null,
+        "interfaces": [
+            "Countable",
+            "IteratorAggregate",
+            "Traversable"
+        ],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": {
+            "cases": {
+                "type": "array",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "cases",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "count": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "int",
+                "attributes": [],
+                "parameters": []
+            },
+            "each": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "callback",
+                        "type": "callable",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "getIterator": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "Traversable",
+                "attributes": [],
+                "parameters": []
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Fuzz\\ExplorationSkip": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": true,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": {
+            "operation": {
+                "type": "Studio\\OpenApiContractTesting\\Fuzz\\ExploredOperation",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "reason": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "operation",
+                        "type": "Studio\\OpenApiContractTesting\\Fuzz\\ExploredOperation",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "reason",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Fuzz\\ExploredCase": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": true,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": {
+            "body": {
+                "type": "mixed",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "caseIndex": {
+                "type": "?int",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "expectedStatusClasses": {
+                "type": "array",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "headers": {
+                "type": "array",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "kind": {
+                "type": "Studio\\OpenApiContractTesting\\Fuzz\\ExplorationCaseKind",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "matchedPath": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "method": {
+                "type": "Studio\\OpenApiContractTesting\\HttpMethod",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "pathParams": {
+                "type": "array",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "query": {
+                "type": "array",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "seed": {
+                "type": "?int",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "targetKeyword": {
+                "type": "?string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "targetPointer": {
+                "type": "?string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "body",
+                        "type": "mixed",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "query",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "headers",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "pathParams",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "method",
+                        "type": "Studio\\OpenApiContractTesting\\HttpMethod",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "matchedPath",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "kind",
+                        "type": "Studio\\OpenApiContractTesting\\Fuzz\\ExplorationCaseKind",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "constant": "Studio\\OpenApiContractTesting\\Fuzz\\ExplorationCaseKind::Valid",
+                            "value": {
+                                "enum": "Studio\\OpenApiContractTesting\\Fuzz\\ExplorationCaseKind::Valid",
+                                "value": "valid"
+                            }
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "targetKeyword",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "targetPointer",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "expectedStatusClasses",
+                        "type": "array",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": [],
+                        "attributes": []
+                    },
+                    {
+                        "name": "seed",
+                        "type": "?int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "caseIndex",
+                        "type": "?int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            },
+            "curlSnippet": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "string",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "baseUrl",
+                        "type": "string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": "",
+                        "attributes": []
+                    }
+                ]
+            },
+            "replaySnippet": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "string",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "replayToken": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "string",
+                "attributes": [],
+                "parameters": []
+            },
+            "withBody": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "body",
+                        "type": "mixed",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "withHeaders": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "headers",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "withPathParams": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "pathParams",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "withQuery": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "query",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Fuzz\\ExploredOperation": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": true,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": {
+            "deprecated": {
+                "type": "bool",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "method": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "operationId": {
+                "type": "?string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "path": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "seed": {
+                "type": "int",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "specName": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "tags": {
+                "type": "array",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "method",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "operationId",
+                        "type": "?string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "tags",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "deprecated",
+                        "type": "bool",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "seed",
+                        "type": "int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "coverageKey": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "string",
+                "attributes": [],
+                "parameters": []
+            },
+            "replayInvalidSnippet": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "string",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "caseIndex",
+                        "type": "int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "expectedStatusClasses",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "replaySnippet": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "string",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "caseIndex",
+                        "type": "int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Fuzz\\FailureReducer": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "reduce": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "Studio\\OpenApiContractTesting\\Fuzz\\ExploredCase",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "case",
+                        "type": "Studio\\OpenApiContractTesting\\Fuzz\\ExploredCase",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "classify",
+                        "type": "callable",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Fuzz\\OpenApiEndpointExplorer": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "explore": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "Studio\\OpenApiContractTesting\\Fuzz\\ExplorationCases",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "method",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "cases",
+                        "type": "int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": 30,
+                        "attributes": []
+                    },
+                    {
+                        "name": "seed",
+                        "type": "?int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            },
+            "exploreInvalid": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "Studio\\OpenApiContractTesting\\Fuzz\\ExplorationCases",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "method",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "expectedStatusClasses",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "cases",
+                        "type": "int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": 30,
+                        "attributes": []
+                    },
+                    {
+                        "name": "seed",
+                        "type": "?int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Fuzz\\OpenApiSpecExploration": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "casesPerOperation",
+                        "type": "int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "seed",
+                        "type": "int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "assertResponseUsing": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "callback",
+                        "type": "callable",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "assertResponses": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "Studio\\OpenApiContractTesting\\Fuzz\\SpecExplorationSummary",
+                "attributes": [],
+                "parameters": []
+            },
+            "authenticateUsing": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "callback",
+                        "type": "callable",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "dispatchUsing": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "callback",
+                        "type": "callable",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "excludeMethods": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "methods",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "excludeOperations": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "operationIds",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "excludePaths": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "paths",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "excludeTags": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "tags",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "includeDeprecated": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "include",
+                        "type": "bool",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": true,
+                        "attributes": []
+                    }
+                ]
+            },
+            "includeMethods": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "methods",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "includeOperations": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "operationIds",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "includePaths": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "paths",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "includeTags": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "tags",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "mutateCasesUsing": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "callback",
+                        "type": "callable",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "negativeCases": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "expectedStatusClasses",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "setUpUsing": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "callback",
+                        "type": "callable",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "tearDownUsing": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "callback",
+                        "type": "callable",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Fuzz\\OpenApiSpecExplorer": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "explore": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "Studio\\OpenApiContractTesting\\Fuzz\\OpenApiSpecExploration",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "casesPerOperation",
+                        "type": "int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": 30,
+                        "attributes": []
+                    },
+                    {
+                        "name": "seed",
+                        "type": "int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": 1,
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Fuzz\\SpecExplorationSummary": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": true,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": {
+            "executedCases": {
+                "type": "int",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "executedOperations": {
+                "type": "int",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "operations": {
+                "type": "array",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "skips": {
+                "type": "array",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "executedOperations",
+                        "type": "int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "executedCases",
+                        "type": "int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "operations",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "skips",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "hasSkips": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "bool",
+                "attributes": [],
+                "parameters": []
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\HttpMethod": {
+        "kind": "enum",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [
+            "BackedEnum",
+            "UnitEnum"
+        ],
+        "traits": [],
+        "attributes": [],
+        "backing_type": "string",
+        "cases": {
+            "GET": "GET",
+            "POST": "POST",
+            "PUT": "PUT",
+            "PATCH": "PATCH",
+            "DELETE": "DELETE",
+            "QUERY": "QUERY"
+        },
+        "constants": [],
+        "properties": {
+            "name": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "value": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "cases": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": []
+            },
+            "from": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "static",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "string|int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "tryFrom": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "?static",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "string|int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Laravel\\Commands\\OpenApiRoutesCommand": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": "Illuminate\\Console\\Command",
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "handle": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "int",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "application",
+                        "type": "Illuminate\\Contracts\\Foundation\\Application",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "router",
+                        "type": "Illuminate\\Routing\\Router",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "analyzer",
+                        "type": "Studio\\OpenApiContractTesting\\Laravel\\RouteParity\\LaravelRouteParityAnalyzer",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Laravel\\ExploresOpenApiEndpoint": {
+        "kind": "trait",
+        "final": false,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [
+            "Studio\\OpenApiContractTesting\\Laravel\\ResolvesOpenApiSpec"
+        ],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "exploreEndpoint": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "Studio\\OpenApiContractTesting\\Fuzz\\ExplorationCases",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "method",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "cases",
+                        "type": "int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": 30,
+                        "attributes": []
+                    },
+                    {
+                        "name": "seed",
+                        "type": "?int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            },
+            "exploreInvalidEndpoint": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "Studio\\OpenApiContractTesting\\Fuzz\\ExplorationCases",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "method",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "expectedStatusClasses",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "cases",
+                        "type": "int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": 30,
+                        "attributes": []
+                    },
+                    {
+                        "name": "seed",
+                        "type": "?int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            },
+            "exploreSpec": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "Studio\\OpenApiContractTesting\\Fuzz\\OpenApiSpecExploration",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "casesPerOperation",
+                        "type": "int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": 30,
+                        "attributes": []
+                    },
+                    {
+                        "name": "seed",
+                        "type": "int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": 1,
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Laravel\\OpenApiContractTestingServiceProvider": {
+        "kind": "class",
+        "final": false,
+        "abstract": false,
+        "readonly": false,
+        "parent": "Illuminate\\Support\\ServiceProvider",
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "boot": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": []
+            },
+            "register": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": []
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Laravel\\ValidatesOpenApiSchema": {
+        "kind": "trait",
+        "final": false,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [
+            "Studio\\OpenApiContractTesting\\Laravel\\ResolvesOpenApiSpec",
+            "Studio\\OpenApiContractTesting\\SkipOpenApiResolver"
+        ],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "skipResponseCode": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "static",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "codes",
+                        "type": "array|string|int",
+                        "optional": true,
+                        "variadic": true,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "withoutRequestValidation": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "static",
+                "attributes": [],
+                "parameters": []
+            },
+            "withoutResponseValidation": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "static",
+                "attributes": [],
+                "parameters": []
+            },
+            "withoutValidation": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "static",
+                "attributes": [],
+                "parameters": []
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\OpenApiRequestValidator": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": {
+            "DEFAULT_SKIP_REQUEST_VALIDATION_RESPONSE_CODES": [
+                "422",
+                "400"
+            ]
+        },
+        "properties": [],
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "maxErrors",
+                        "type": "int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": 20,
+                        "attributes": []
+                    },
+                    {
+                        "name": "skipRequestValidationResponseCodes",
+                        "type": "array",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": [],
+                        "attributes": []
+                    }
+                ]
+            },
+            "validate": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "Studio\\OpenApiContractTesting\\OpenApiValidationResult",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "method",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "requestPath",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "queryParams",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "headers",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "requestBody",
+                        "type": "mixed",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "contentType",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "cookies",
+                        "type": "array",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": [],
+                        "attributes": []
+                    },
+                    {
+                        "name": "responseStatusCode",
+                        "type": "?int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\OpenApiResponseValidator": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": {
+            "DEFAULT_SKIP_RESPONSE_CODES": [
+                "5\\d\\d"
+            ]
+        },
+        "properties": [],
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "maxErrors",
+                        "type": "int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": 20,
+                        "attributes": []
+                    },
+                    {
+                        "name": "skipResponseCodes",
+                        "type": "array",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "constant": "self::DEFAULT_SKIP_RESPONSE_CODES",
+                            "value": [
+                                "5\\d\\d"
+                            ]
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "strictRequiredTracker",
+                        "type": "?Studio\\OpenApiContractTesting\\Validation\\Strict\\StrictRequiredTracker",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            },
+            "validate": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "Studio\\OpenApiContractTesting\\OpenApiValidationResult",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "method",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "requestPath",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "statusCode",
+                        "type": "int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "responseBody",
+                        "type": "mixed",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "responseContentType",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "responseHeaders",
+                        "type": "?array",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\OpenApiValidationOutcome": {
+        "kind": "enum",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [
+            "BackedEnum",
+            "UnitEnum"
+        ],
+        "traits": [],
+        "attributes": [],
+        "backing_type": "string",
+        "cases": {
+            "Success": "success",
+            "Failure": "failure",
+            "Skipped": "skipped"
+        },
+        "constants": [],
+        "properties": {
+            "name": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "value": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "cases": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": []
+            },
+            "from": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "static",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "string|int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "tryFrom": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "?static",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "string|int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\OpenApiValidationResult": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": true,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "errorMessage": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "string",
+                "attributes": [],
+                "parameters": []
+            },
+            "errors": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": []
+            },
+            "failure": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "errors",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "matchedPath",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "matchedStatusCode",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "matchedContentType",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            },
+            "isSkipped": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "bool",
+                "attributes": [],
+                "parameters": []
+            },
+            "isValid": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "bool",
+                "attributes": [],
+                "parameters": []
+            },
+            "matchedContentType": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "?string",
+                "attributes": [],
+                "parameters": []
+            },
+            "matchedPath": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "?string",
+                "attributes": [],
+                "parameters": []
+            },
+            "matchedStatusCode": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "?string",
+                "attributes": [],
+                "parameters": []
+            },
+            "outcome": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "Studio\\OpenApiContractTesting\\OpenApiValidationOutcome",
+                "attributes": [],
+                "parameters": []
+            },
+            "skipReason": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "?string",
+                "attributes": [],
+                "parameters": []
+            },
+            "skipped": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "matchedPath",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "reason",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "matchedStatusCode",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "matchedContentType",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            },
+            "success": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "matchedPath",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "matchedStatusCode",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "matchedContentType",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\OpenApiVersion": {
+        "kind": "enum",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [
+            "BackedEnum",
+            "UnitEnum"
+        ],
+        "traits": [],
+        "attributes": [],
+        "backing_type": "string",
+        "cases": {
+            "V3_0": "3.0",
+            "V3_1": "3.1",
+            "V3_2": "3.2"
+        },
+        "constants": [],
+        "properties": {
+            "name": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "value": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "cases": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": []
+            },
+            "from": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "static",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "string|int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "fromSpec": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "spec",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "tryFrom": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "?static",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "string|int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\PHPUnit\\AssertsNoEnumDrift": {
+        "kind": "trait",
+        "final": false,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "assertNoEnumDrift": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "enumFqcns",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\PHPUnit\\ConsoleOutput": {
+        "kind": "enum",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [
+            "BackedEnum",
+            "UnitEnum"
+        ],
+        "traits": [],
+        "attributes": [],
+        "backing_type": "string",
+        "cases": {
+            "DEFAULT": "default",
+            "ALL": "all",
+            "UNCOVERED_ONLY": "uncovered_only",
+            "ACTIVE_ONLY": "active_only"
+        },
+        "constants": [],
+        "properties": {
+            "name": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "value": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "cases": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": []
+            },
+            "from": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "static",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "string|int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "resolve": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "parameterValue",
+                        "type": "?string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "tryFrom": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "?static",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "string|int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\PHPUnit\\InvalidStrictRequiredConfigurationException": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": "RuntimeException",
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "message",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "previous",
+                        "type": "?Throwable",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\PHPUnit\\OpenApiCoverageExtension": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [
+            "PHPUnit\\Runner\\Extension\\Extension"
+        ],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": {
+            "DEFAULT_SIDECAR_SUBDIR": "openapi-coverage-sidecars"
+        },
+        "properties": [],
+        "methods": {
+            "bootstrap": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "configuration",
+                        "type": "PHPUnit\\TextUI\\Configuration\\Configuration",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "facade",
+                        "type": "PHPUnit\\Runner\\Extension\\Facade",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "parameters",
+                        "type": "PHPUnit\\Runner\\Extension\\ParameterCollection",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "defaultSidecarDir": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "string",
+                "attributes": [],
+                "parameters": []
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Pest\\Expectations": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "matchRequest": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "mixed",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "spec",
+                        "type": "?string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "method",
+                        "type": "?string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "path",
+                        "type": "?string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "matchResponse": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "mixed",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "spec",
+                        "type": "?string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "method",
+                        "type": "?string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "path",
+                        "type": "?string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "skipResponseCodes",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Psr7\\OpenApiAssertions": {
+        "kind": "trait",
+        "final": false,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [
+            "Studio\\OpenApiContractTesting\\Spec\\OpenApiSpecResolver"
+        ],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "assertPsr7ExchangeMatchesOpenApiSchema": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "request",
+                        "type": "Psr\\Http\\Message\\RequestInterface",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "response",
+                        "type": "Psr\\Http\\Message\\ResponseInterface",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "assertPsr7RequestMatchesOpenApiSchema": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "request",
+                        "type": "Psr\\Http\\Message\\RequestInterface",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "responseStatusCode",
+                        "type": "?int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            },
+            "assertPsr7ResponseForOperationMatchesOpenApiSchema": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "method",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "requestPath",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "response",
+                        "type": "Psr\\Http\\Message\\ResponseInterface",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "assertPsr7ResponseMatchesOpenApiSchema": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "request",
+                        "type": "Psr\\Http\\Message\\RequestInterface",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "response",
+                        "type": "Psr\\Http\\Message\\ResponseInterface",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Psr7\\OpenApiPsr7ValidationResult": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": true,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "requestResult",
+                        "type": "Studio\\OpenApiContractTesting\\OpenApiValidationResult",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "responseResult",
+                        "type": "Studio\\OpenApiContractTesting\\OpenApiValidationResult",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "errorMessage": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "string",
+                "attributes": [],
+                "parameters": []
+            },
+            "errors": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": []
+            },
+            "isValid": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "bool",
+                "attributes": [],
+                "parameters": []
+            },
+            "requestResult": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "Studio\\OpenApiContractTesting\\OpenApiValidationResult",
+                "attributes": [],
+                "parameters": []
+            },
+            "responseResult": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "Studio\\OpenApiContractTesting\\OpenApiValidationResult",
+                "attributes": [],
+                "parameters": []
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Psr7\\OpenApiPsr7Validator": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "maxErrors",
+                        "type": "int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": 20,
+                        "attributes": []
+                    },
+                    {
+                        "name": "skipResponseCodes",
+                        "type": "array",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "constant": "Studio\\OpenApiContractTesting\\OpenApiResponseValidator::DEFAULT_SKIP_RESPONSE_CODES",
+                            "value": [
+                                "5\\d\\d"
+                            ]
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "skipRequestValidationResponseCodes",
+                        "type": "array",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "constant": "Studio\\OpenApiContractTesting\\OpenApiRequestValidator::DEFAULT_SKIP_REQUEST_VALIDATION_RESPONSE_CODES",
+                            "value": [
+                                "422",
+                                "400"
+                            ]
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "validateExchange": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "Studio\\OpenApiContractTesting\\Psr7\\OpenApiPsr7ValidationResult",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "request",
+                        "type": "Psr\\Http\\Message\\RequestInterface",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "response",
+                        "type": "Psr\\Http\\Message\\ResponseInterface",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "validateRequest": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "Studio\\OpenApiContractTesting\\OpenApiValidationResult",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "request",
+                        "type": "Psr\\Http\\Message\\RequestInterface",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "responseStatusCode",
+                        "type": "?int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            },
+            "validateResponse": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "Studio\\OpenApiContractTesting\\OpenApiValidationResult",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "request",
+                        "type": "Psr\\Http\\Message\\RequestInterface",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "response",
+                        "type": "Psr\\Http\\Message\\ResponseInterface",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "validateResponseForOperation": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "Studio\\OpenApiContractTesting\\OpenApiValidationResult",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "method",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "requestPath",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "response",
+                        "type": "Psr\\Http\\Message\\ResponseInterface",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\SchemaContext": {
+        "kind": "enum",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [
+            "UnitEnum"
+        ],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": {
+            "Request": null,
+            "Response": null
+        },
+        "constants": [],
+        "properties": {
+            "name": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "cases": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": []
+            },
+            "forbiddenKeyword": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "string",
+                "attributes": [],
+                "parameters": []
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Schema\\EnumDriftAsserter": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "assertNoDrift": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "enumFqcns",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "failOnDrift",
+                        "type": "bool",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": true,
+                        "attributes": []
+                    }
+                ]
+            },
+            "detectAll": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "enumFqcns",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Schema\\EnumDriftReport": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": {
+            "enumFqcn": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "phpOnly": {
+                "type": "array",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "specOnly": {
+                "type": "array",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "specPath": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "enumFqcn",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "specPath",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "phpOnly",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "specOnly",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "hasDrift": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "bool",
+                "attributes": [],
+                "parameters": []
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\SkipOpenApiResolver": {
+        "kind": "trait",
+        "final": false,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": []
+    },
+    "Studio\\OpenApiContractTesting\\Spec\\OpenApiSpecLoader": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "configure": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "basePath",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "stripPrefixes",
+                        "type": "array",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": [],
+                        "attributes": []
+                    },
+                    {
+                        "name": "httpClient",
+                        "type": "?Psr\\Http\\Client\\ClientInterface",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "requestFactory",
+                        "type": "?Psr\\Http\\Message\\RequestFactoryInterface",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "allowRemoteRefs",
+                        "type": "bool",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": false,
+                        "attributes": []
+                    },
+                    {
+                        "name": "enumBasePath",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            },
+            "getBasePath": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "string",
+                "attributes": [],
+                "parameters": []
+            },
+            "getEnumBasePath": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "?string",
+                "attributes": [],
+                "parameters": []
+            },
+            "getStripPrefixes": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": []
+            },
+            "load": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Spec\\OpenApiSpecResolver": {
+        "kind": "trait",
+        "final": false,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": []
+    },
+    "Studio\\OpenApiContractTesting\\Symfony\\OpenApiAssertions": {
+        "kind": "trait",
+        "final": false,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [
+            "Studio\\OpenApiContractTesting\\Spec\\OpenApiSpecResolver"
+        ],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "assertClientMatchesOpenApiSchema": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "client",
+                        "type": "Symfony\\Component\\HttpKernel\\HttpKernelBrowser",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "extraSkipResponseCodes",
+                        "type": "array",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": [],
+                        "attributes": []
+                    }
+                ]
+            },
+            "assertRequestMatchesOpenApiSchema": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "request",
+                        "type": "Symfony\\Component\\HttpFoundation\\Request",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "responseStatusCode",
+                        "type": "?int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            },
+            "assertResponseMatchesOpenApiSchema": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "request",
+                        "type": "Symfony\\Component\\HttpFoundation\\Request",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "response",
+                        "type": "Symfony\\Component\\HttpFoundation\\Response",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "extraSkipResponseCodes",
+                        "type": "array",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": [],
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Validation\\Strict\\StrictRequiredAsserter": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "assertNoDrift": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "mode",
+                        "type": "Studio\\OpenApiContractTesting\\Validation\\Strict\\StrictRequiredMode",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "detectAll": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "mode",
+                        "type": "Studio\\OpenApiContractTesting\\Validation\\Strict\\StrictRequiredMode",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Validation\\Strict\\StrictRequiredMode": {
+        "kind": "enum",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [
+            "BackedEnum",
+            "UnitEnum"
+        ],
+        "traits": [],
+        "attributes": [],
+        "backing_type": "string",
+        "cases": {
+            "Off": "off",
+            "Warn": "warn",
+            "Fail": "fail"
+        },
+        "constants": [],
+        "properties": {
+            "name": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "value": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "cases": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": []
+            },
+            "from": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "static",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "string|int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "fromConfigValue": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "?string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "isEnabled": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "bool",
+                "attributes": [],
+                "parameters": []
+            },
+            "tryFrom": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "?static",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "string|int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Validation\\Strict\\StrictRequiredPerCallMode": {
+        "kind": "enum",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [
+            "BackedEnum",
+            "UnitEnum"
+        ],
+        "traits": [],
+        "attributes": [],
+        "backing_type": "string",
+        "cases": {
+            "Off": "off",
+            "Warn": "warn"
+        },
+        "constants": [],
+        "properties": {
+            "name": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "value": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "cases": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": []
+            },
+            "from": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "static",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "string|int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "fromConfigValue": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "?string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "isEnabled": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "bool",
+                "attributes": [],
+                "parameters": []
+            },
+            "tryFrom": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "?static",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "string|int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Validation\\Strict\\StrictRequiredReport": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": {
+            "contentTypeKey": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "hits": {
+                "type": "int",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "method": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "missingFromRequired": {
+                "type": "array",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "path": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "schemaPointer": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "specName": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "statusKey": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "method",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "statusKey",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "contentTypeKey",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "missingFromRequired",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "hits",
+                        "type": "int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "schemaPointer",
+                        "type": "string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": "/",
+                        "attributes": []
+                    }
+                ]
+            },
+            "hasDrift": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "bool",
+                "attributes": [],
+                "parameters": []
+            }
+        }
+    },
+    "Studio\\OpenApiContractTesting\\Validation\\Strict\\StrictRequiredTracker": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": {
+            "ANY_CONTENT_TYPE": "*",
+            "STATE_FORMAT_VERSION": 2
+        },
+        "properties": [],
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": []
+            },
+            "exportStateOn": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": []
+            },
+            "getObservationsOn": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "importStateOn": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "state",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "recordOn": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "method",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "statusKey",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "contentTypeKey",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "pointers",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "recordedSpecsOn": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": []
+            },
+            "resetOn": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "void",
+                "attributes": [],
+                "parameters": []
+            }
+        }
+    }
+}

--- a/tests/fixtures/compatibility/v1.9-public-api.json
+++ b/tests/fixtures/compatibility/v1.9-public-api.json
@@ -4,6 +4,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -57,6 +62,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -110,6 +120,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -161,6 +176,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "implicit",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -213,6 +233,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "private"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -284,6 +309,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "private"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -363,6 +393,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "private"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -469,6 +504,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "private"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -539,6 +579,8 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": null,
         "parent": null,
         "interfaces": [
             "BackedEnum",
@@ -631,6 +673,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "private"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -668,6 +715,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": "RuntimeException",
         "interfaces": [],
         "traits": [],
@@ -734,6 +786,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": "RuntimeException",
         "interfaces": [],
         "traits": [],
@@ -800,6 +857,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "implicit",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -837,6 +899,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "implicit",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -885,6 +952,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "implicit",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -922,6 +994,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -1365,6 +1442,8 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": null,
         "parent": null,
         "interfaces": [
             "BackedEnum",
@@ -1456,6 +1535,11 @@
         "final": true,
         "abstract": false,
         "readonly": true,
+        "instantiable": false,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "private"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -1540,6 +1624,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": "RuntimeException",
         "interfaces": [],
         "traits": [],
@@ -1783,6 +1872,8 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": null,
         "parent": null,
         "interfaces": [
             "UnitEnum"
@@ -1836,6 +1927,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": "RuntimeException",
         "interfaces": [],
         "traits": [],
@@ -1893,6 +1989,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": "RuntimeException",
         "interfaces": [],
         "traits": [],
@@ -2014,6 +2115,8 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": null,
         "parent": null,
         "interfaces": [
             "UnitEnum"
@@ -2075,6 +2178,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": "RuntimeException",
         "interfaces": [],
         "traits": [],
@@ -2160,6 +2268,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": "RuntimeException",
         "interfaces": [],
         "traits": [],
@@ -2217,6 +2330,8 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": null,
         "parent": null,
         "interfaces": [
             "BackedEnum",
@@ -2307,6 +2422,11 @@
         "final": true,
         "abstract": false,
         "readonly": true,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [
             "Countable",
@@ -2396,6 +2516,11 @@
         "final": true,
         "abstract": false,
         "readonly": true,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -2461,6 +2586,11 @@
         "final": true,
         "abstract": false,
         "readonly": true,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -2843,6 +2973,11 @@
         "final": true,
         "abstract": false,
         "readonly": true,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -3065,6 +3200,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "implicit",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -3113,6 +3253,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "implicit",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -3262,6 +3407,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -3664,6 +3814,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "implicit",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -3719,6 +3874,11 @@
         "final": true,
         "abstract": false,
         "readonly": true,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -3831,6 +3991,8 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": null,
         "parent": null,
         "interfaces": [
             "BackedEnum",
@@ -3925,6 +4087,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "inherited",
+            "visibility": "public"
+        },
         "parent": "Illuminate\\Console\\Command",
         "interfaces": [],
         "traits": [],
@@ -3984,6 +4151,8 @@
         "final": false,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": null,
         "parent": null,
         "interfaces": [],
         "traits": [
@@ -4141,6 +4310,11 @@
         "final": false,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "inherited",
+            "visibility": "public"
+        },
         "parent": "Illuminate\\Support\\ServiceProvider",
         "interfaces": [],
         "traits": [],
@@ -4175,6 +4349,8 @@
         "final": false,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": null,
         "parent": null,
         "interfaces": [],
         "traits": [
@@ -4242,6 +4418,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -4394,6 +4575,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -4539,6 +4725,8 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": null,
         "parent": null,
         "interfaces": [
             "BackedEnum",
@@ -4630,6 +4818,11 @@
         "final": true,
         "abstract": false,
         "readonly": true,
+        "instantiable": false,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "private"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -4858,6 +5051,8 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": null,
         "parent": null,
         "interfaces": [
             "BackedEnum",
@@ -4970,6 +5165,8 @@
         "final": false,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": null,
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -5007,6 +5204,8 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": null,
         "parent": null,
         "interfaces": [
             "BackedEnum",
@@ -5120,6 +5319,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": "RuntimeException",
         "interfaces": [],
         "traits": [],
@@ -5166,6 +5370,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "implicit",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [
             "PHPUnit\\Runner\\Extension\\Extension"
@@ -5238,6 +5447,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "implicit",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -5373,6 +5587,8 @@
         "final": false,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": null,
         "parent": null,
         "interfaces": [],
         "traits": [
@@ -5528,6 +5744,11 @@
         "final": true,
         "abstract": false,
         "readonly": true,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -5621,6 +5842,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -5833,6 +6059,8 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": null,
         "parent": null,
         "interfaces": [
             "UnitEnum"
@@ -5881,6 +6109,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "implicit",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -5948,6 +6181,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -6060,6 +6298,8 @@
         "final": false,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": null,
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -6075,6 +6315,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "implicit",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -6205,6 +6450,8 @@
         "final": false,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": null,
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -6220,6 +6467,8 @@
         "final": false,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": null,
         "parent": null,
         "interfaces": [],
         "traits": [
@@ -6339,6 +6588,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "private"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -6397,6 +6651,8 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": null,
         "parent": null,
         "interfaces": [
             "BackedEnum",
@@ -6518,6 +6774,8 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": false,
+        "constructor": null,
         "parent": null,
         "interfaces": [
             "BackedEnum",
@@ -6638,6 +6896,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],
@@ -6824,6 +7087,11 @@
         "final": true,
         "abstract": false,
         "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
         "parent": null,
         "interfaces": [],
         "traits": [],


### PR DESCRIPTION
## Summary

- record the proposed Gesso v2 technical identity and migration boundaries in an ADR
- inventory the v1.9 compatibility surfaces that must be handled intentionally in v2
- add a reflection-based exporter and PHPUnit regression test for the 65-type v1.9 public API baseline

## Why

The v2 rename will intentionally break several public surfaces. Capturing the current contract before implementation makes those changes reviewable and prevents accidental API removals or signature changes.

This PR is preparation only. It does not rename the Composer package, PHP namespace, CLI, Laravel integration, or runtime machine identity.

## Impact

No production runtime behavior changes. The new test compares the current public API against a generated v1.9 JSON fixture.

## Verification

- `vendor/bin/phpunit tests/Unit/Compatibility/PublicApiBaselineTest.php`
- scoped PHPStan analysis for the inventory helper and test
- PHP-CS-Fixer dry-run for the added PHP files
- documentation build and link checks
- Markdown coverage lint test with a temporary npm cache
- `git diff --check`

The complete Unit suite remains blocked by an existing dependency metadata mismatch: `nyholm/psr7` is declared in `composer.json` but absent from `composer.lock`. That unrelated lock-file issue is intentionally excluded from this PR.
