### PR TITLE
test(compatibility): capture v1.9 CLI contracts

### DIFF
--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -293,6 +293,11 @@ Exit codes are `0` for a usable contract, `1` for diagnostic failure, and `2`
 for invalid usage. JSON uses `schemaVersion: 1`; issue fields are `severity`,
 `category`, `spec`, `message`, and nullable `suggestion`.
 
+Migration status: unchanged. The exact v1.9 help and invalid-usage output are
+captured under `tests/fixtures/compatibility/` and exercised through the
+installed-style binary integration test, including exit code and output
+channel.
+
 ### Coverage merge
 
 Executable: `openapi-coverage-merge`.
@@ -308,6 +313,11 @@ Accepted options:
 
 Exit codes are `0` for success or a warn-only result, `1` for data, gate, or
 write failure, and `2` for invalid configuration or usage.
+
+Migration status: unchanged. The exact v1.9 help and invalid-usage output are
+captured under `tests/fixtures/compatibility/` and exercised through the
+installed-style binary integration test, including exit code and output
+channel.
 
 ## Versioned and machine-readable formats
 

--- a/tests/Integration/CoverageMergeCliIntegrationTest.php
+++ b/tests/Integration/CoverageMergeCliIntegrationTest.php
@@ -135,20 +135,27 @@ class CoverageMergeCliIntegrationTest extends TestCase
     #[Test]
     public function bin_help_flag_prints_usage_and_exits_zero(): void
     {
-        [$exit, $stdout] = $this->runCli(['--help']);
+        [$exit, $stdout, $stderr] = $this->runCli(['--help']);
 
         $this->assertSame(0, $exit);
-        $this->assertStringContainsString('openapi-coverage-merge', $stdout);
-        $this->assertStringContainsString('--spec-base-path', $stdout);
+        $this->assertSame('', $stderr);
+        $this->assertSame(
+            file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v1.9-openapi-coverage-merge-help.txt'),
+            $stdout,
+        );
     }
 
     #[Test]
     public function bin_exits_two_when_spec_base_path_is_missing(): void
     {
-        [$exit, , $stderr] = $this->runCli(['--specs=petstore-3.0']);
+        [$exit, $stdout, $stderr] = $this->runCli(['--specs=petstore-3.0']);
 
         $this->assertSame(2, $exit);
-        $this->assertStringContainsString('--spec-base-path is required', $stderr);
+        $this->assertSame('', $stdout);
+        $this->assertSame(
+            file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v1.9-openapi-coverage-merge-usage-error.txt'),
+            $stderr,
+        );
     }
 
     #[Test]

--- a/tests/Integration/DoctorCliIntegrationTest.php
+++ b/tests/Integration/DoctorCliIntegrationTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\TestCase;
 use function dirname;
 use function escapeshellarg;
 use function fclose;
+use function file_get_contents;
 use function is_resource;
 use function json_decode;
 use function proc_close;
@@ -88,11 +89,27 @@ class DoctorCliIntegrationTest extends TestCase
     #[Test]
     public function composer_bin_help_documents_exit_codes(): void
     {
-        [$exit, $stdout] = $this->runCli(['doctor', '--help']);
+        [$exit, $stdout, $stderr] = $this->runCli(['doctor', '--help']);
 
         $this->assertSame(0, $exit);
-        $this->assertStringContainsString('Exit codes:', $stdout);
-        $this->assertStringContainsString('--spec', $stdout);
+        $this->assertSame('', $stderr);
+        $this->assertSame(
+            file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v1.9-openapi-contract-help.txt'),
+            $stdout,
+        );
+    }
+
+    #[Test]
+    public function composer_bin_missing_spec_matches_v1_9_usage_error(): void
+    {
+        [$exit, $stdout, $stderr] = $this->runCli(['doctor']);
+
+        $this->assertSame(2, $exit);
+        $this->assertSame('', $stdout);
+        $this->assertSame(
+            file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v1.9-openapi-contract-usage-error.txt'),
+            $stderr,
+        );
     }
 
     /**

--- a/tests/fixtures/compatibility/v1.9-openapi-contract-help.txt
+++ b/tests/fixtures/compatibility/v1.9-openapi-contract-help.txt
@@ -1,0 +1,18 @@
+openapi-contract doctor — check whether this package can load and enforce your contract.
+
+Usage:
+  openapi-contract doctor --spec=<path> [--spec=<path> ...] [options]
+
+Options:
+  --spec=<path[,path]>       JSON/YAML entry document. Repeat for multiple specs.
+  --strip-prefix=<prefix>    Request-path prefix used by PHPUnit. Repeat as needed.
+  --format=text|json         Output format (default: text).
+  --allow-remote-refs        Resolve HTTP(S) refs with an installed Guzzle or
+                             Symfony PSR-18 implementation.
+  --phpunit-snippet          Include the equivalent PHPUnit extension XML.
+  --help                     Show this message.
+
+Exit codes:
+  0  All specs are compatible (warnings/skipped features may be present).
+  1  A spec cannot be loaded or enforced.
+  2  Command-line usage is invalid.

--- a/tests/fixtures/compatibility/v1.9-openapi-contract-usage-error.txt
+++ b/tests/fixtures/compatibility/v1.9-openapi-contract-usage-error.txt
@@ -1,0 +1,20 @@
+[OpenAPI Doctor] At least one --spec is required.
+
+openapi-contract doctor — check whether this package can load and enforce your contract.
+
+Usage:
+  openapi-contract doctor --spec=<path> [--spec=<path> ...] [options]
+
+Options:
+  --spec=<path[,path]>       JSON/YAML entry document. Repeat for multiple specs.
+  --strip-prefix=<prefix>    Request-path prefix used by PHPUnit. Repeat as needed.
+  --format=text|json         Output format (default: text).
+  --allow-remote-refs        Resolve HTTP(S) refs with an installed Guzzle or
+                             Symfony PSR-18 implementation.
+  --phpunit-snippet          Include the equivalent PHPUnit extension XML.
+  --help                     Show this message.
+
+Exit codes:
+  0  All specs are compatible (warnings/skipped features may be present).
+  1  A spec cannot be loaded or enforced.
+  2  Command-line usage is invalid.

--- a/tests/fixtures/compatibility/v1.9-openapi-coverage-merge-help.txt
+++ b/tests/fixtures/compatibility/v1.9-openapi-coverage-merge-help.txt
@@ -1,0 +1,31 @@
+openapi-coverage-merge — combine paratest worker sidecars into one coverage report.
+
+Usage:
+  openapi-coverage-merge --spec-base-path=<path> [options]
+
+Options:
+  --spec-base-path=<path>       Path to bundled spec directory (required).
+  --specs=<a,b>                 Comma-separated spec names. Defaults to "front".
+  --strip-prefixes=<a,b>        Comma-separated request-path prefixes to strip.
+  --sidecar-dir=<path>          Worker sidecar directory. Defaults to
+                                sys_get_temp_dir()/openapi-coverage-sidecars.
+  --output-file=<path>          Markdown report output path.
+  --junit-output=<path>         JUnit XML report output path (for CI dashboards
+                                like GitLab CI test reports, Jenkins, SonarQube).
+  --json-output=<path>          JSON report output path (machine-readable; see
+                                docs/coverage-json-schema.md for the schema).
+  --html-output=<path>          Self-contained HTML report output path (for PR
+                                comments, CI artifact preview, offline review).
+  --github-step-summary=<path>  Append Markdown report to this file (also
+                                consults GITHUB_STEP_SUMMARY env var).
+  --console-output=<mode>       default | all | uncovered_only.
+  --min-endpoint-coverage=<pct> Fail-fast (with --min-coverage-strict) when fully-
+                                covered-endpoint percent is below this value (0-100).
+  --min-response-coverage=<pct> Same, at (method, path, status, content-type) granularity.
+  --min-coverage-strict[=BOOL]  Treat threshold misses as exit non-zero (default
+                                warn-only).
+  --strict-required=<mode>      off | warn | fail. Aggregate worker observations
+                                and assert no schema under-description drift
+                                (Issue #224 / #226). Defaults to off.
+  --no-cleanup                  Keep sidecar files after merge (default: cleanup).
+  --help                        Show this message.

--- a/tests/fixtures/compatibility/v1.9-openapi-coverage-merge-usage-error.txt
+++ b/tests/fixtures/compatibility/v1.9-openapi-coverage-merge-usage-error.txt
@@ -1,0 +1,1 @@
+[OpenAPI Coverage] FATAL: --spec-base-path is required


### PR DESCRIPTION
## Summary

- capture the exact v1.9 help output for `openapi-contract doctor` and `openapi-coverage-merge`
- capture representative invalid-usage stderr output and its exit code/channel contract
- record the CLI baseline status in the v2 compatibility inventory

## Why

Gesso v2 will rename both CLI entry points. Golden fixtures give the migration a reviewable baseline and prevent accidental changes to flags, help text, exit codes, or stdout/stderr routing while the new commands are introduced.

This PR only records the v1.9 behavior; it does not rename commands or change runtime behavior.

## Validation

- `vendor/bin/phpunit tests/Integration/DoctorCliIntegrationTest.php tests/Integration/CoverageMergeCliIntegrationTest.php`
- `vendor/bin/php-cs-fixer fix --dry-run --diff --sequential`
- `vendor/bin/php-cs-fixer fix --dry-run --diff --sequential --config=.php-cs-fixer.pest.dist.php`
- `vendor/bin/phpstan analyse --debug tests/Integration/DoctorCliIntegrationTest.php tests/Integration/CoverageMergeCliIntegrationTest.php`
- `npm run docs:build`
- `git diff --check`
