### PR TITLE
test(compatibility): capture v1.9 Laravel contracts

### DIFF
--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -274,6 +274,12 @@ The `openapi:routes` command accepts `--spec`, `--prefix`, `--middleware`,
 `--fail-on-undocumented`, and `--fail-on-unimplemented`. It uses Laravel's
 standard success (`0`), failure (`1`), and invalid usage (`2`) exit codes.
 
+Migration status: unchanged. The complete v1.9 configuration defaults,
+provider configuration key/publish tag/destination, and versioned route-parity
+JSON are captured under `tests/fixtures/compatibility/` and exercised through
+Laravel consumer-level integration tests. Text output remains covered
+semantically because Laravel owns its cross-version console table rendering.
+
 ## CLI contracts
 
 ### Doctor

--- a/tests/Integration/Laravel/LaravelCompatibilityBaselineIntegrationTest.php
+++ b/tests/Integration/Laravel/LaravelCompatibilityBaselineIntegrationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Integration\Laravel;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+
+use Illuminate\Support\ServiceProvider;
+use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Studio\OpenApiContractTesting\Laravel\OpenApiContractTestingServiceProvider;
+
+use function config_path;
+use function dirname;
+use function file_get_contents;
+use function json_encode;
+
+final class LaravelCompatibilityBaselineIntegrationTest extends TestCase
+{
+    #[Test]
+    public function configuration_matches_the_v1_9_compatibility_fixture(): void
+    {
+        /** @var array<string, mixed> $configuration */
+        $configuration = require dirname(__DIR__, 3) . '/src/Laravel/config.php';
+        $expected = file_get_contents(
+            dirname(__DIR__, 2) . '/fixtures/compatibility/v1.9-laravel-config.json',
+        );
+
+        $this->assertIsString($expected);
+        $this->assertSame(
+            $expected,
+            json_encode(
+                $configuration,
+                JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES,
+            ) . "\n",
+        );
+        $this->assertSame($configuration, config('openapi-contract-testing'));
+    }
+
+    #[Test]
+    public function provider_publishes_the_v1_9_config_destination_and_tag(): void
+    {
+        $source = dirname(__DIR__, 3) . '/src/Laravel/config.php';
+
+        $this->assertSame(
+            [$source => config_path('openapi-contract-testing.php')],
+            ServiceProvider::pathsToPublish(
+                OpenApiContractTestingServiceProvider::class,
+                'openapi-contract-testing',
+            ),
+        );
+    }
+
+    /** @return array<int, class-string> */
+    protected function getPackageProviders($app): array
+    {
+        return [OpenApiContractTestingServiceProvider::class];
+    }
+}

--- a/tests/Integration/Laravel/OpenApiRoutesCommandIntegrationTest.php
+++ b/tests/Integration/Laravel/OpenApiRoutesCommandIntegrationTest.php
@@ -17,6 +17,7 @@ use function array_map;
 use function count;
 use function dirname;
 use function explode;
+use function file_get_contents;
 use function json_decode;
 use function max;
 use function strlen;
@@ -78,6 +79,27 @@ final class OpenApiRoutesCommandIntegrationTest extends TestCase
         $this->assertSame(1, $decoded['summary']['documented_but_not_registered']);
         $this->assertSame(1, $decoded['summary']['registered_but_undocumented']);
         $this->assertSame(0, $decoded['summary']['ambiguous']);
+    }
+
+    #[Test]
+    public function json_output_matches_the_v1_9_compatibility_fixture(): void
+    {
+        $exitCode = Artisan::call('openapi:routes', [
+            '--spec' => ['route-parity', 'route-parity-admin'],
+            '--prefix' => 'api',
+            '--middleware' => ['api'],
+            '--domain' => ['api.example.test'],
+            '--exclude-route' => ['internal.*'],
+            '--format' => 'json',
+        ]);
+
+        $expected = file_get_contents(
+            dirname(__DIR__, 2) . '/fixtures/compatibility/v1.9-laravel-route-parity.json',
+        );
+
+        $this->assertIsString($expected);
+        $this->assertSame(0, $exitCode);
+        $this->assertSame(trim($expected), trim(Artisan::output()));
     }
 
     #[Test]

--- a/tests/fixtures/compatibility/v1.9-laravel-config.json
+++ b/tests/fixtures/compatibility/v1.9-laravel-config.json
@@ -1,0 +1,18 @@
+{
+    "default_spec": "",
+    "spec_base_path": "openapi",
+    "strip_prefixes": [],
+    "max_errors": 20,
+    "enforce_discriminator": true,
+    "auto_assert": false,
+    "auto_validate_request": false,
+    "auto_inject_dummy_credentials": false,
+    "auto_inject_dummy_bearer": false,
+    "skip_response_codes": [
+        "5\\d\\d"
+    ],
+    "skip_request_validation_response_codes": [
+        "422",
+        "400"
+    ]
+}

--- a/tests/fixtures/compatibility/v1.9-laravel-route-parity.json
+++ b/tests/fixtures/compatibility/v1.9-laravel-route-parity.json
@@ -1,0 +1,88 @@
+{
+    "schema_version": 1,
+    "specs": [
+        "route-parity",
+        "route-parity-admin"
+    ],
+    "summary": {
+        "matched": 6,
+        "documented_but_not_registered": 1,
+        "registered_but_undocumented": 1,
+        "ambiguous": 0,
+        "unsupported": 0
+    },
+    "matched": [
+        {
+            "spec": "route-parity",
+            "method": "GET",
+            "openapi_path": "/v1/pets",
+            "operation_id": "listPets",
+            "route_uri": "/api/v1/pets",
+            "route_name": "pets.index",
+            "domain": "api.example.test"
+        },
+        {
+            "spec": "route-parity-admin",
+            "method": "GET",
+            "openapi_path": "/v1/pets",
+            "operation_id": "adminListPets",
+            "route_uri": "/api/v1/pets",
+            "route_name": "pets.index",
+            "domain": "api.example.test"
+        },
+        {
+            "spec": "route-parity",
+            "method": "POST",
+            "openapi_path": "/v1/pets",
+            "operation_id": "createPet",
+            "route_uri": "/api/v1/pets",
+            "route_name": "pets.index",
+            "domain": "api.example.test"
+        },
+        {
+            "spec": "route-parity",
+            "method": "GET",
+            "openapi_path": "/v1/pets/{petId}",
+            "operation_id": "showPet",
+            "route_uri": "/api/v1/pets/{pet}",
+            "route_name": "pets.show",
+            "domain": "api.example.test"
+        },
+        {
+            "spec": "route-parity",
+            "method": "GET",
+            "openapi_path": "/v1/optional",
+            "operation_id": "listOptional",
+            "route_uri": "/api/v1/optional",
+            "route_name": "optional.show",
+            "domain": "api.example.test"
+        },
+        {
+            "spec": "route-parity",
+            "method": "GET",
+            "openapi_path": "/v1/optional/{optionalId}",
+            "operation_id": "showOptional",
+            "route_uri": "/api/v1/optional/{optional?}",
+            "route_name": "optional.show",
+            "domain": "api.example.test"
+        }
+    ],
+    "documented_but_not_registered": [
+        {
+            "spec": "route-parity",
+            "method": "DELETE",
+            "openapi_path": "/v1/missing",
+            "operation_id": "deleteMissing"
+        }
+    ],
+    "registered_but_undocumented": [
+        {
+            "method": "GET",
+            "route_uri": "/api/v1/undocumented",
+            "route_name": "undocumented",
+            "domain": "api.example.test"
+        }
+    ],
+    "ambiguous": [],
+    "unsupported": []
+}


### PR DESCRIPTION
## Summary

- capture the complete v1.9 Laravel configuration defaults as a golden fixture
- verify the legacy service provider config key, publish tag, and destination
- capture the complete versioned `openapi:routes --format=json` payload
- record the Laravel compatibility baseline status in the v2 inventory

## Why

The Gesso v2 identity migration will rename Laravel-facing identifiers. These
consumer-level fixtures make the existing v1.9 contract explicit before any
breaking rename, so configuration and route-parity changes can be reviewed
deliberately.

This PR changes tests and migration inventory only; production behavior is
unchanged.

## Validation

- `vendor/bin/phpunit tests/Integration/Laravel` (37 tests, 128 assertions)
- `vendor/bin/phpstan analyse --debug tests/Integration/Laravel/LaravelCompatibilityBaselineIntegrationTest.php tests/Integration/Laravel/OpenApiRoutesCommandIntegrationTest.php`
- `composer cs-check -- --sequential`
- `npm run docs:build`
- `git diff --check`
