### PR TITLE
test(compatibility): capture v1.9 coverage formats

### DIFF
--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -350,6 +350,11 @@ upgrade text describes the sidecar shape as non-frozen. The safe migration
 assumption is that the PHP import/export methods are internal but the released
 CLI must continue reading supported versioned v1 payloads.
 
+Migration status: the exact v1.9 coverage JSON report and sidecar envelope are
+captured under `tests/fixtures/compatibility/`. The sidecar fixture pins coverage
+tracker state v1 and strict-required tracker state v2, and consumer-style tests
+verify both the envelope reader and the legacy bare-coverage reader path.
+
 ## Diagnostic categories and embedded identifiers
 
 The v1 policy explicitly protects these `E_USER_WARNING` category families:

--- a/tests/Unit/Compatibility/MachineReadableFormatsBaselineTest.php
+++ b/tests/Unit/Compatibility/MachineReadableFormatsBaselineTest.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Compatibility;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Coverage\CoverageSidecarEnvelope;
+use Studio\OpenApiContractTesting\Coverage\EndpointCoverageState;
+use Studio\OpenApiContractTesting\Coverage\JsonCoverageRenderer;
+use Studio\OpenApiContractTesting\Coverage\OpenApiCoverageTracker;
+use Studio\OpenApiContractTesting\Coverage\ResponseCoverageState;
+use Studio\OpenApiContractTesting\Validation\Strict\StrictRequiredTracker;
+
+use function dirname;
+use function file_get_contents;
+use function json_decode;
+use function json_encode;
+
+/**
+ * Consumer-style golden tests for the versioned payloads that must remain
+ * readable while v1 workers and v2 merge/report tooling overlap.
+ *
+ * @phpstan-import-type CoverageResult from OpenApiCoverageTracker
+ */
+final class MachineReadableFormatsBaselineTest extends TestCase
+{
+    #[Test]
+    public function coverage_json_matches_the_v1_9_fixture(): void
+    {
+        /** @var array<string, CoverageResult> $results */
+        $results = [
+            'front' => [
+                'endpoints' => [
+                    [
+                        'endpoint' => 'GET /v1/pets',
+                        'method' => 'GET',
+                        'path' => '/v1/pets',
+                        'operationId' => 'listPets',
+                        'state' => EndpointCoverageState::Partial,
+                        'requestReached' => true,
+                        'responses' => [
+                            [
+                                'statusKey' => '200',
+                                'contentTypeKey' => 'application/json',
+                                'state' => ResponseCoverageState::Validated,
+                                'hits' => 2,
+                                'skipReason' => null,
+                            ],
+                            [
+                                'statusKey' => '503',
+                                'contentTypeKey' => '*',
+                                'state' => ResponseCoverageState::Skipped,
+                                'hits' => 1,
+                                'skipReason' => 'status 503 matched skip pattern 5\\d\\d',
+                            ],
+                        ],
+                        'coveredResponseCount' => 1,
+                        'skippedResponseCount' => 1,
+                        'totalResponseCount' => 2,
+                        'unexpectedObservations' => [
+                            ['statusKey' => '418', 'contentTypeKey' => 'application/json'],
+                        ],
+                    ],
+                    [
+                        'endpoint' => 'POST /v1/pets',
+                        'method' => 'POST',
+                        'path' => '/v1/pets',
+                        'operationId' => null,
+                        'state' => EndpointCoverageState::RequestOnly,
+                        'requestReached' => true,
+                        'responses' => [
+                            [
+                                'statusKey' => '201',
+                                'contentTypeKey' => 'application/json',
+                                'state' => ResponseCoverageState::Uncovered,
+                                'hits' => 0,
+                                'skipReason' => null,
+                            ],
+                        ],
+                        'coveredResponseCount' => 0,
+                        'skippedResponseCount' => 0,
+                        'totalResponseCount' => 1,
+                        'unexpectedObservations' => [],
+                    ],
+                ],
+                'endpointTotal' => 2,
+                'endpointFullyCovered' => 0,
+                'endpointPartial' => 1,
+                'endpointUncovered' => 0,
+                'endpointRequestOnly' => 1,
+                'responseTotal' => 3,
+                'responseCovered' => 1,
+                'responseSkipped' => 1,
+                'responseUncovered' => 1,
+            ],
+        ];
+
+        $rendered = JsonCoverageRenderer::render(
+            $results,
+            new DateTimeImmutable('2026-07-14T00:00:00+00:00'),
+        );
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode($rendered, true, flags: JSON_THROW_ON_ERROR);
+        /** @var array{name: string, version: string} $tool */
+        $tool = $payload['tool'];
+        $tool['version'] = '<runtime-version>';
+        $payload['tool'] = $tool;
+
+        $this->assertSame(
+            $this->fixture('v1.9-coverage-report.json'),
+            json_encode(
+                $payload,
+                JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+            ) . "\n",
+        );
+    }
+
+    #[Test]
+    public function sidecar_envelope_matches_the_v1_9_fixture(): void
+    {
+        $envelope = $this->buildSidecarEnvelope();
+
+        $this->assertSame(
+            $this->fixture('v1.9-coverage-sidecar-envelope.json'),
+            json_encode(
+                $envelope,
+                JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+            ) . "\n",
+        );
+    }
+
+    #[Test]
+    public function v1_9_sidecar_fixture_is_consumable_by_the_reader_and_trackers(): void
+    {
+        /** @var array<string, mixed> $fixture */
+        $fixture = json_decode(
+            $this->fixture('v1.9-coverage-sidecar-envelope.json'),
+            true,
+            flags: JSON_THROW_ON_ERROR,
+        );
+        $parsed = CoverageSidecarEnvelope::parse($fixture);
+
+        $coverage = new OpenApiCoverageTracker();
+        $coverage->importStateOn($parsed['coverage']);
+        $this->assertSame($fixture['coverage'], $coverage->exportStateOn());
+
+        $this->assertIsArray($parsed['strictRequired']);
+        $strictRequired = new StrictRequiredTracker();
+        $strictRequired->importStateOn($parsed['strictRequired']);
+        $this->assertSame($fixture['strictRequired'], $strictRequired->exportStateOn());
+    }
+
+    #[Test]
+    public function embedded_coverage_state_remains_accepted_as_a_legacy_bare_sidecar(): void
+    {
+        /** @var array{coverage: array<string, mixed>} $fixture */
+        $fixture = json_decode(
+            $this->fixture('v1.9-coverage-sidecar-envelope.json'),
+            true,
+            flags: JSON_THROW_ON_ERROR,
+        );
+
+        $parsed = CoverageSidecarEnvelope::parse($fixture['coverage']);
+
+        $this->assertSame($fixture['coverage'], $parsed['coverage']);
+        $this->assertNull($parsed['strictRequired']);
+    }
+
+    /** @return array<string, mixed> */
+    private function buildSidecarEnvelope(): array
+    {
+        $coverage = new OpenApiCoverageTracker();
+        $coverage->recordRequestOn('front', 'GET', '/v1/pets');
+        $coverage->recordResponseOn(
+            'front',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        $coverage->recordResponseOn(
+            'front',
+            'GET',
+            '/v1/pets',
+            '503',
+            null,
+            schemaValidated: false,
+            skipReason: 'status 503 matched skip pattern 5\\d\\d',
+        );
+
+        $strictRequired = new StrictRequiredTracker();
+        $strictRequired->recordOn('front', 'GET', '/v1/pets', '200', 'application/json', [
+            '/' => ['data', 'meta'],
+            '/data' => ['id', 'name'],
+        ]);
+        $strictRequired->recordOn('front', 'GET', '/v1/pets', '200', 'application/json', [
+            '/' => ['data'],
+            '/data' => ['extra', 'id', 'name'],
+        ]);
+
+        return CoverageSidecarEnvelope::build(
+            $coverage->exportStateOn(),
+            $strictRequired->exportStateOn(),
+        );
+    }
+
+    private function fixture(string $name): string
+    {
+        $path = dirname(__DIR__, 2) . '/fixtures/compatibility/' . $name;
+        $contents = file_get_contents($path);
+
+        $this->assertIsString($contents, "Unable to read {$path}");
+
+        return $contents;
+    }
+}

--- a/tests/fixtures/compatibility/v1.9-coverage-report.json
+++ b/tests/fixtures/compatibility/v1.9-coverage-report.json
@@ -1,0 +1,90 @@
+{
+    "schema_version": 1,
+    "generated_at": "2026-07-14T00:00:00+00:00",
+    "tool": {
+        "name": "studio-design/openapi-contract-testing",
+        "version": "<runtime-version>"
+    },
+    "aggregate": {
+        "endpoint_total": 2,
+        "endpoint_fully_covered": 0,
+        "endpoint_partial": 1,
+        "endpoint_uncovered": 0,
+        "endpoint_request_only": 1,
+        "response_total": 3,
+        "response_covered": 1,
+        "response_skipped": 1,
+        "response_uncovered": 1
+    },
+    "specs": {
+        "front": {
+            "aggregates": {
+                "endpoint_total": 2,
+                "endpoint_fully_covered": 0,
+                "endpoint_partial": 1,
+                "endpoint_uncovered": 0,
+                "endpoint_request_only": 1,
+                "response_total": 3,
+                "response_covered": 1,
+                "response_skipped": 1,
+                "response_uncovered": 1
+            },
+            "endpoints": [
+                {
+                    "endpoint": "GET /v1/pets",
+                    "method": "GET",
+                    "path": "/v1/pets",
+                    "operation_id": "listPets",
+                    "endpoint_state": "partial",
+                    "request_reached": true,
+                    "responses": [
+                        {
+                            "status_key": "200",
+                            "content_type_key": "application/json",
+                            "response_state": "validated",
+                            "hits": 2,
+                            "skip_reason": null
+                        },
+                        {
+                            "status_key": "503",
+                            "content_type_key": "*",
+                            "response_state": "skipped",
+                            "hits": 1,
+                            "skip_reason": "status 503 matched skip pattern 5\\d\\d"
+                        }
+                    ],
+                    "covered_response_count": 1,
+                    "skipped_response_count": 1,
+                    "total_response_count": 2,
+                    "unexpected_observations": [
+                        {
+                            "status_key": "418",
+                            "content_type_key": "application/json"
+                        }
+                    ]
+                },
+                {
+                    "endpoint": "POST /v1/pets",
+                    "method": "POST",
+                    "path": "/v1/pets",
+                    "operation_id": null,
+                    "endpoint_state": "request-only",
+                    "request_reached": true,
+                    "responses": [
+                        {
+                            "status_key": "201",
+                            "content_type_key": "application/json",
+                            "response_state": "uncovered",
+                            "hits": 0,
+                            "skip_reason": null
+                        }
+                    ],
+                    "covered_response_count": 0,
+                    "skipped_response_count": 0,
+                    "total_response_count": 1,
+                    "unexpected_observations": []
+                }
+            ]
+        }
+    }
+}

--- a/tests/fixtures/compatibility/v1.9-coverage-sidecar-envelope.json
+++ b/tests/fixtures/compatibility/v1.9-coverage-sidecar-envelope.json
@@ -1,0 +1,47 @@
+{
+    "envelopeVersion": 2,
+    "coverage": {
+        "version": 1,
+        "specs": {
+            "front": {
+                "GET /v1/pets": {
+                    "requestReached": true,
+                    "requestSkipReason": null,
+                    "responses": {
+                        "200:application/json": {
+                            "state": "validated",
+                            "hits": 1,
+                            "skipReason": null
+                        },
+                        "503:*": {
+                            "state": "skipped",
+                            "hits": 1,
+                            "skipReason": "status 503 matched skip pattern 5\\d\\d"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "strictRequired": {
+        "version": 2,
+        "observations": {
+            "front": {
+                "GET /v1/pets": {
+                    "200:application/json": {
+                        "hits": 2,
+                        "pointers": {
+                            "/": [
+                                "data"
+                            ],
+                            "/data": [
+                                "id",
+                                "name"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- capture the exact v1.9 coverage JSON report as a compatibility fixture
- capture the v2 sidecar envelope containing coverage state v1 and strict-required state v2
- verify the current reader and tracker import paths consume the captured payloads
- preserve the legacy bare coverage sidecar reader path for mixed-version runs
- record the completed baseline in the v2 compatibility inventory

## Why

The Gesso v2 identity migration will change tool-facing identifiers while v1 workers and v2 merge/report tooling may overlap. Golden consumer fixtures make those versioned contracts explicit before the rename begins and catch accidental wire-format drift.

Production behavior is unchanged.

## Verification

- `vendor/bin/phpunit tests/Unit/Compatibility` — 6 tests, 18 assertions
- focused coverage and strict-required tests — 74 tests, 150 assertions
- focused PHPStan — no errors
- `composer cs-check -- --sequential`
- `npm run docs:build`
- `git diff --check`
