### PR TITLE
docs(versioning): define sidecar compatibility

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -205,7 +205,10 @@ in v1.0.0 is covered by SemVer for the v1.x line.
   `OpenApiCoverageTracker::reset/exportState/importState`,
   `ValidatesOpenApiSchema::resetValidatorCache`, and
   `OpenApiSchemaConverter::resetWarningStateForTesting`.
-- The shape of paratest sidecar JSON (versioned via `STATE_FORMAT_VERSION`).
+- The `@internal` PHP methods used to import and export paratest state are not
+  frozen as PHP API. The versioned payloads accepted by the released merge CLI
+  remain a compatibility surface; see
+  [`docs/versioning.md`](docs/versioning.md#versioned-sidecar-compatibility).
 - Internal helper classes under `Internal/`, `Validation/Support/` (the
   classes themselves are not user-callable).
 - Error messages from validators (we may improve them).

--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -344,11 +344,11 @@ states and unexpected observations. Laravel route parity JSON includes `specs`,
 `summary`, `matched`, `documented_but_not_registered`,
 `registered_but_undocumented`, `ambiguous`, and `unsupported`.
 
-There is a documentation ambiguity to resolve before v2: the versioning policy
-treats the sidecar wire format as part of the supported merge CLI, while older
-upgrade text describes the sidecar shape as non-frozen. The safe migration
-assumption is that the PHP import/export methods are internal but the released
-CLI must continue reading supported versioned v1 payloads.
+The sidecar compatibility boundary is now explicit in the
+[versioning policy](../versioning.md#versioned-sidecar-compatibility): the PHP
+import/export methods are internal, but versioned payloads accepted by the
+released merge CLI are compatibility inputs. A newer reader preserves the
+documented older inputs, while unknown or lossy formats fail loudly.
 
 Migration status: the exact v1.9 coverage JSON report and sidecar envelope are
 captured under `tests/fixtures/compatibility/`. The sidecar fixture pins coverage

--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -58,6 +58,23 @@ trivial CI step has no extra config to keep in sync. Set `sidecar_dir` (in
 `phpunit.xml`) and `--sidecar-dir=` (on the merge CLI) to the same custom
 path if `sys_get_temp_dir()` is unavailable in your runner.
 
+## Sidecar compatibility
+
+Sidecars are a versioned worker-to-merge protocol, separate from the coverage
+report produced by `json_output`. The current writer emits an
+`envelopeVersion: 2` envelope containing coverage state `version: 1` and
+strict-required state `version: 2`. The merge reader also accepts the older
+bare coverage state `version: 1`, so coverage can still be combined while a
+worker fleet is being upgraded. That legacy payload has no strict-required
+observations, so a strict-required gate cannot be evaluated from it.
+
+Unknown envelope or tracker versions fail the merge rather than being guessed.
+Strict-required state `version: 1` is also rejected because merging it with the
+current nested-pointer shape would silently lose information. Keep workers on
+one version when using the strict-required gate. See the complete
+[versioning policy](versioning.md#versioned-sidecar-compatibility) before
+changing a sidecar shape or filename pattern.
+
 ## Notes
 
 - **Sequential runs are unchanged.** Without `TEST_TOKEN` the extension

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -14,11 +14,46 @@ This library follows [Semantic Versioning 2.0](https://semver.org/). v1.0.0 is t
 - Public constants and their values
 - Enum cases (additions are minor; removals or renames are major)
 - The `OpenApiValidationResult` shape (`outcome()`, `errors()`, `matchedPath()`, `skipReason()`, `isValid()`, `isSkipped()`)
-- The CLI surface of `bin/openapi-coverage-merge` (flags, exit codes, sidecar JSON wire format via `STATE_FORMAT_VERSION`)
+- The CLI surface of `bin/openapi-coverage-merge` (flags, exit codes, and the versioned sidecar inputs and filename patterns it accepts)
 - The Laravel `openapi:routes` command surface (flags, exit codes, and versioned JSON output)
 - The `OpenApiCoverageExtension` PHPUnit configuration parameters (`spec_base_path`, `strip_prefixes`, `specs`, `output_file`, `console_output`, …)
 - The Laravel `ValidatesOpenApiSchema` trait's public methods
 - The category prefixes used in `E_USER_WARNING` messages (`[security]`, `[OpenAPI Schema]`, and the `[OpenAPI 3.2 ...]` categories)
+
+### Versioned sidecar compatibility
+
+The PHP methods that produce and consume sidecar state (`exportState()` and
+`importState()`) are `@internal`; their signatures are not a public PHP API.
+The persisted payloads accepted by the released merge CLI are nevertheless a
+compatibility surface because workers and the merge step can run different
+installed versions during an upgrade.
+
+The v1.9 writer emits a sidecar envelope with `envelopeVersion: 2`, containing
+coverage state `version: 1` and strict-required state `version: 2`. The v1.9
+reader accepts that envelope and the legacy bare coverage state `version: 1`.
+It recognises `part-*.json` sidecars and `failed-*.json` failure markers.
+
+The compatibility rules are:
+
+- A newer merge reader keeps support for the explicitly documented older
+  payloads within the same major line.
+- A format owner bumps its version for an incompatible shape change. Envelope,
+  coverage state, and strict-required state versions evolve independently.
+- An older reader is not required to accept payloads written by a future
+  version. Unknown versions and unrecognised shapes fail loudly instead of
+  being guessed or partially merged.
+- A legacy payload may be rejected when accepting it would silently lose data.
+  In particular, strict-required state `version: 1` is not accepted by the
+  v1.9 reader because it cannot represent nested pointer observations from
+  `version: 2`.
+
+For the Gesso v2 migration, the v2 merge reader will retain the v1.9 inputs
+listed above. Any later major-version cutoff must be called out in that
+version's upgrade guide; it must not appear as an unversioned shape change.
+
+These rules apply to the worker-to-merge protocol only. The coverage report
+written by `json_output` has its own `schema_version` contract documented in
+[`coverage-json-schema.md`](coverage-json-schema.md).
 
 ## What's NOT covered by SemVer
 

--- a/src/Coverage/CoverageSidecarEnvelope.php
+++ b/src/Coverage/CoverageSidecarEnvelope.php
@@ -27,7 +27,7 @@ use function sprintf;
  * {
  *   "envelopeVersion": 2,
  *   "coverage":       { "version": 1, "specs":        { ... } },
- *   "strictRequired": { "version": 1, "observations": { ... } }
+ *   "strictRequired": { "version": 2, "observations": { ... } }
  * }
  * ```
  *


### PR DESCRIPTION
## Summary

- clarify that the internal PHP import/export methods are not public API while released sidecar payloads remain merge CLI compatibility inputs
- document the reader/writer compatibility rules, independently versioned envelope/tracker payloads, and loud failure for unknown or lossy formats
- require the Gesso v2 merge reader to retain the documented v1.9 inputs
- document the current parallel sidecar versions and correct the strict-required envelope example from version 1 to version 2
- mark the v2 compatibility-inventory ambiguity as resolved

## Why

The versioning policy treated sidecar JSON as part of the supported merge CLI, while the older upgrade guide described its shape as non-frozen. That ambiguity could allow a v2 identity migration to break rolling worker/merge upgrades without a deliberate compatibility decision.

## Impact

This is a documentation and code-comment clarification only. Runtime behavior is unchanged. The v2 implementation now has an explicit requirement to read the captured v1.9 envelope and legacy bare coverage payloads.

## Verification

- `vendor/bin/phpunit tests/Unit/Compatibility` — 6 tests, 18 assertions
- `npm run docs:build`
- `npm run docs:links`
- `composer cs-check -- --sequential`
- `git diff --check`
