### PR TITLE
test(compatibility): verify namespace alias strategy

### DIFF
--- a/docs/adr/0001-gesso-v2-identity.md
+++ b/docs/adr/0001-gesso-v2-identity.md
@@ -100,7 +100,10 @@ Before the first breaking rename is merged:
 4. Verify any proposed namespace compatibility mechanism across classes,
    interfaces, traits, enums, attributes, reflection, serialization, and
    Composer optimized autoloading. Do not assume `class_alias()` covers every
-   supported use case without tests.
+   supported use case without tests. The completed
+   [namespace compatibility spike](../migration/v2-namespace-compatibility-spike.md)
+   proves lazy aliases and records their identity limits; whether aliases ship
+   remains a release-policy decision.
 5. Define the v1 maintenance branch and end-of-support date before v2
    pre-releases begin.
 
@@ -171,5 +174,7 @@ Gesso 2.0 is not ready for stable release until all of the following pass:
 - [Composer repositories and package renaming](https://getcomposer.org/doc/05-repositories.md)
 - [Packagist package naming](https://packagist.org/about)
 - [PSR-4 autoloading](https://www.php-fig.org/psr/psr-4/)
+- [PHP `class_alias()`](https://www.php.net/class-alias)
+- [Composer autoloader optimization](https://getcomposer.org/doc/articles/autoloader-optimization.md)
 - [Symfony backward compatibility promise](https://symfony.com/doc/current/contributing/code/bc.html)
 - [Laminas migration tooling](https://docs.laminas.dev/migration/)

--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -393,6 +393,12 @@ must be decided explicitly.
 | Coverage | v1 JSON and sidecar | v2 output | v1 worker payload merged by v2 reader |
 | Doctor/routes | schema v1 consumers | v2 identity | incompatible field change requires version bump |
 
+The PHP row now has an executable
+[namespace compatibility spike](v2-namespace-compatibility-spike.md). It proves
+that a lazy alias loader works under Composer's authoritative classmap and pins
+the observable reflection and serialization limits. It does not yet add a shim
+to the released package.
+
 ## Change-control checklist
 
 For every v2 identity PR:

--- a/docs/migration/v2-namespace-compatibility-spike.md
+++ b/docs/migration/v2-namespace-compatibility-spike.md
@@ -1,0 +1,77 @@
+# v2 namespace compatibility spike
+
+This spike verifies the behavior and limits of a temporary namespace alias
+mechanism before the v2 source rename. It does not add aliases to the released
+package.
+
+## Candidate mechanism
+
+The candidate is a small autoloader registered from Composer's `autoload.files`:
+
+1. Ignore symbols outside `Studio\OpenApiContractTesting\`.
+2. Replace that prefix with `Studio\Gesso\`.
+3. Ask Composer to autoload the canonical symbol.
+4. Create the requested legacy alias with `class_alias()`.
+
+Registration is lazy. In particular, it does not load Laravel, Symfony, Pest,
+or other optional adapters merely because `vendor/autoload.php` was included.
+Composer loads `autoload.files` after registering its own autoloader, so the
+alias loader can delegate the canonical lookup back to Composer.
+
+The executable fixture in
+`tests/fixtures/namespace-compatibility` rebuilds an isolated package with
+`composer dump-autoload --classmap-authoritative`. It verifies classes,
+interfaces, traits, enums, attributes, shared static state, reflection,
+serialization, legacy serialized input, and an unloaded optional adapter.
+
+## Proven behavior
+
+- Classes, interfaces, traits, enums, and attributes can be resolved through
+  the legacy name on the PHP 8.2+ support line.
+- Both names refer to the same runtime type and share static state.
+- A legacy class name embedded in a serialized object can be resolved during
+  `unserialize()` when the alias loader is active.
+- The mechanism works with Composer's optimized authoritative classmap because
+  only the canonical Gesso symbols need classmap entries.
+- Unknown legacy names remain unknown, and optional integrations are not loaded
+  eagerly.
+
+## Compatibility limits
+
+An alias provides source compatibility, not two independent class identities:
+
+- `get_class()` and reflection return the canonical declared FQCN.
+- `serialize()` writes the canonical declared FQCN.
+- Code or snapshots comparing literal FQCN strings can therefore still change
+  across the canonical rename.
+- PHP functions, namespace constants, Composer package requirements, PHPUnit
+  XML, Laravel configuration, commands, and machine-readable branding are not
+  covered by `class_alias()`.
+
+The v1 public inventory contains types rather than public namespaced functions,
+so the PHP-symbol portion is technically aliasable. The other surfaces still
+need their dedicated migration steps.
+
+## Recommendation
+
+Use this mechanism only as a time-bounded migration aid, not as a permanent
+second public identity. The lowest-risk sequence is:
+
+1. In the final v1 minor, optionally expose lazy `Studio\Gesso\` aliases whose
+   canonical declarations remain under `Studio\OpenApiContractTesting\`.
+2. Tell consumers that reflection and serialized output keep the v1 canonical
+   name until v2; do not promise literal-FQCN identity stability through aliases.
+3. In v2, declare only `Studio\Gesso\` as canonical. If a reverse legacy shim is
+   approved, give it an explicit removal release and test it with this fixture.
+4. Do not keep reverse aliases by default when the goal is a complete identity
+   migration; the major-version boundary already provides the source-breaking
+   migration point.
+
+This leaves the exact decision to ship aliases in v1 or v2 as a release-policy
+choice, while removing uncertainty about the mechanism itself.
+
+## Sources
+
+- [PHP `class_alias()`](https://www.php.net/class-alias)
+- [Composer autoload `files`](https://getcomposer.org/doc/04-schema.md#files)
+- [Composer autoloader optimization](https://getcomposer.org/doc/articles/autoloader-optimization.md)

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -39,6 +39,12 @@ parameters:
         - src/Pest/Autoload.php
         - tests/Pest.php
         - tests/Integration/Pest
+        # This is an isolated Composer package that deliberately resolves the
+        # old namespace at runtime and contains an optional adapter whose base
+        # class must stay unavailable. Its integration test remains analysed;
+        # analysing the fixture itself would require stubs that invalidate the
+        # behavior being tested.
+        - tests/fixtures/namespace-compatibility
         # EnumScanner fixture dir holds intentionally-unused trait/abstract
         # files so the scanner can walk past them; PHPStan would otherwise
         # flag them as `trait.unused`.

--- a/tests/Integration/NamespaceCompatibilityIntegrationTest.php
+++ b/tests/Integration/NamespaceCompatibilityIntegrationTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Integration;
+
+use const JSON_THROW_ON_ERROR;
+
+use FilesystemIterator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+use function copy;
+use function dirname;
+use function escapeshellarg;
+use function fclose;
+use function is_dir;
+use function is_resource;
+use function json_decode;
+use function mkdir;
+use function proc_close;
+use function proc_open;
+use function realpath;
+use function rmdir;
+use function sprintf;
+use function stream_get_contents;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+final class NamespaceCompatibilityIntegrationTest extends TestCase
+{
+    private string $fixtureDirectory;
+    private string $temporaryDirectory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $repoRoot = realpath(__DIR__ . '/../..') ?: dirname(__DIR__, 2);
+        $this->fixtureDirectory = $repoRoot . '/tests/fixtures/namespace-compatibility';
+        $this->temporaryDirectory = sys_get_temp_dir() . '/gesso-namespace-compatibility-' . uniqid('', true);
+        $this->copyDirectory($this->fixtureDirectory, $this->temporaryDirectory);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->temporaryDirectory);
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function lazy_aliases_work_with_composer_authoritative_classmaps_and_expose_identity_limits(): void
+    {
+        [$dumpExit, $dumpStdout, $dumpStderr] = $this->runProcess('composer dump-autoload --classmap-authoritative --no-interaction');
+        $this->assertSame(0, $dumpExit, "stderr: {$dumpStderr}\nstdout: {$dumpStdout}");
+
+        [$consumerExit, $stdout, $stderr] = $this->runProcess(sprintf('php %s', escapeshellarg($this->temporaryDirectory . '/consumer.php')));
+        $this->assertSame(0, $consumerExit, "stderr: {$stderr}\nstdout: {$stdout}");
+
+        $result = json_decode($stdout, true, flags: JSON_THROW_ON_ERROR);
+        $canonical = 'Studio\\Gesso\\Example';
+
+        $this->assertSame(['example' => false, 'optional_adapter' => false], $result['lazy']);
+        $this->assertSame([
+            'label' => 'example',
+            'canonical_instance' => true,
+            'legacy_instance' => true,
+            'shared_static_state' => 1,
+        ], $result['class']);
+        $this->assertSame('consumer', $result['interface']);
+        $this->assertSame('trait', $result['trait']);
+        $this->assertSame('strict', $result['enum']);
+        $this->assertSame('legacy', $result['attribute']);
+        $this->assertSame([
+            'runtime_class' => $canonical,
+            'reflection_class' => $canonical,
+            'serialized' => 'O:20:"Studio\\Gesso\\Example":0:{}',
+            'legacy_payload_restored_as' => 'Studio\\Gesso\\SerializedExample',
+        ], $result['identity']);
+        $this->assertFalse($result['optional_adapter_loaded']);
+        $this->assertFalse($result['unknown_legacy_exists']);
+    }
+
+    /** @return array{0: int, 1: string, 2: string} */
+    private function runProcess(string $command): array
+    {
+        $process = proc_open($command, [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes, $this->temporaryDirectory);
+        if (!is_resource($process)) {
+            $this->fail("failed to run: {$command}");
+        }
+
+        $stdout = (string) stream_get_contents($pipes[1]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        foreach ($pipes as $pipe) {
+            fclose($pipe);
+        }
+
+        return [proc_close($process), $stdout, $stderr];
+    }
+
+    private function copyDirectory(string $source, string $destination): void
+    {
+        mkdir($destination, 0o755, recursive: true);
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($source, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::SELF_FIRST,
+        );
+
+        foreach ($iterator as $item) {
+            $target = $destination . '/' . $iterator->getSubPathname();
+            if ($item->isDir()) {
+                mkdir($target, 0o755, recursive: true);
+            } else {
+                copy($item->getPathname(), $target);
+            }
+        }
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($iterator as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($directory);
+    }
+}

--- a/tests/fixtures/namespace-compatibility/composer.json
+++ b/tests/fixtures/namespace-compatibility/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "studio-design/gesso-namespace-compatibility-fixture",
+    "description": "Isolated fixture for the Gesso namespace compatibility spike",
+    "type": "library",
+    "license": "MIT",
+    "require": {
+        "php": "^8.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "Studio\\Gesso\\": "src/"
+        },
+        "files": [
+            "src/Compatibility/legacy_namespace.php"
+        ]
+    }
+}

--- a/tests/fixtures/namespace-compatibility/consumer.php
+++ b/tests/fixtures/namespace-compatibility/consumer.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GessoNamespaceCompatibilityFixture;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
+use const PHP_EOL;
+
+use ReflectionAttribute;
+use ReflectionClass;
+use Studio\Gesso\Example as CanonicalExample;
+use Studio\Gesso\Marker as CanonicalMarker;
+use Studio\OpenApiContractTesting\Contract as LegacyContract;
+use Studio\OpenApiContractTesting\Example as LegacyExample;
+use Studio\OpenApiContractTesting\Marker as LegacyMarker;
+use Studio\OpenApiContractTesting\Mode as LegacyMode;
+use Studio\OpenApiContractTesting\ReusableTrait as LegacyReusableTrait;
+use Studio\OpenApiContractTesting\SerializedExample as LegacySerializedExample;
+
+use function class_exists;
+use function json_encode;
+use function serialize;
+use function sprintf;
+use function strlen;
+use function unserialize;
+
+require __DIR__ . '/vendor/autoload.php';
+
+$beforeLegacyLookup = [
+    'example' => class_exists(CanonicalExample::class, false),
+    'optional_adapter' => class_exists(Studio\Gesso\OptionalAdapter::class, false),
+];
+
+final class LegacyConsumer implements LegacyContract
+{
+    use LegacyReusableTrait;
+
+    public function label(): string
+    {
+        return 'consumer';
+    }
+}
+
+#[LegacyMarker('legacy')]
+final class LegacyAttributedConsumer {}
+
+$legacy = new LegacyExample();
+$legacySerializedPayload = sprintf(
+    'O:%d:"%s":0:{}',
+    strlen(LegacySerializedExample::class),
+    LegacySerializedExample::class,
+);
+$restoredLegacy = unserialize($legacySerializedPayload, ['allowed_classes' => true]);
+
+$result = [
+    'lazy' => $beforeLegacyLookup,
+    'class' => [
+        'label' => $legacy->label(),
+        'canonical_instance' => $legacy instanceof CanonicalExample,
+        'legacy_instance' => $legacy instanceof LegacyExample,
+        'shared_static_state' => CanonicalExample::calls(),
+    ],
+    'interface' => (new LegacyConsumer())->label(),
+    'trait' => (new LegacyConsumer())->traitLabel(),
+    'enum' => LegacyMode::Strict->value,
+    'attribute' => (new ReflectionClass(LegacyAttributedConsumer::class))
+        ->getAttributes(CanonicalMarker::class, ReflectionAttribute::IS_INSTANCEOF)[0]
+        ->newInstance()
+        ->value,
+    'identity' => [
+        'runtime_class' => $legacy::class,
+        'reflection_class' => (new ReflectionClass(LegacyExample::class))->getName(),
+        'serialized' => serialize($legacy),
+        'legacy_payload_restored_as' => $restoredLegacy::class,
+    ],
+    'optional_adapter_loaded' => class_exists(Studio\Gesso\OptionalAdapter::class, false),
+    'unknown_legacy_exists' => class_exists(Studio\OpenApiContractTesting\MissingType::class),
+];
+
+echo json_encode($result, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT) . PHP_EOL;

--- a/tests/fixtures/namespace-compatibility/src/Compatibility/legacy_namespace.php
+++ b/tests/fixtures/namespace-compatibility/src/Compatibility/legacy_namespace.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Compatibility;
+
+use function class_alias;
+use function class_exists;
+use function enum_exists;
+use function interface_exists;
+use function spl_autoload_register;
+use function str_starts_with;
+use function strlen;
+use function substr;
+use function trait_exists;
+
+spl_autoload_register(static function (string $legacy): void {
+    $legacyPrefix = 'Studio\\OpenApiContractTesting\\';
+    if (!str_starts_with($legacy, $legacyPrefix)) {
+        return;
+    }
+
+    $canonical = 'Studio\\Gesso\\' . substr($legacy, strlen($legacyPrefix));
+    if (!class_exists($canonical) &&
+        !interface_exists($canonical) &&
+        !trait_exists($canonical) &&
+        !enum_exists($canonical)) {
+        return;
+    }
+
+    class_alias($canonical, $legacy);
+});

--- a/tests/fixtures/namespace-compatibility/src/Contract.php
+++ b/tests/fixtures/namespace-compatibility/src/Contract.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso;
+
+interface Contract
+{
+    public function label(): string;
+}

--- a/tests/fixtures/namespace-compatibility/src/Example.php
+++ b/tests/fixtures/namespace-compatibility/src/Example.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso;
+
+#[Marker('canonical')]
+final class Example implements Contract
+{
+    use ReusableTrait;
+    private static int $calls = 0;
+
+    public static function calls(): int
+    {
+        return self::$calls;
+    }
+
+    public function label(): string
+    {
+        self::$calls++;
+
+        return 'example';
+    }
+}

--- a/tests/fixtures/namespace-compatibility/src/Marker.php
+++ b/tests/fixtures/namespace-compatibility/src/Marker.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class Marker
+{
+    public function __construct(public string $value) {}
+}

--- a/tests/fixtures/namespace-compatibility/src/Mode.php
+++ b/tests/fixtures/namespace-compatibility/src/Mode.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso;
+
+enum Mode: string
+{
+    case Strict = 'strict';
+}

--- a/tests/fixtures/namespace-compatibility/src/OptionalAdapter.php
+++ b/tests/fixtures/namespace-compatibility/src/OptionalAdapter.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso;
+
+final class OptionalAdapter extends MissingOptionalFrameworkBase {}

--- a/tests/fixtures/namespace-compatibility/src/ReusableTrait.php
+++ b/tests/fixtures/namespace-compatibility/src/ReusableTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso;
+
+trait ReusableTrait
+{
+    public function traitLabel(): string
+    {
+        return 'trait';
+    }
+}

--- a/tests/fixtures/namespace-compatibility/src/SerializedExample.php
+++ b/tests/fixtures/namespace-compatibility/src/SerializedExample.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso;
+
+final class SerializedExample {}


### PR DESCRIPTION
## Summary

- add an isolated Composer fixture for a lazy namespace alias autoloader
- verify classes, interfaces, traits, enums, attributes, reflection, serialization, and optional adapters
- exercise the fixture with Composer's authoritative classmap
- document the proven behavior, identity limitations, and recommended migration policy
- record completion of the namespace compatibility preparation step in the v2 ADR and inventory

## Why

Before renaming the canonical PHP namespace to `Studio\Gesso\`, the v2 ADR
requires evidence that any proposed compatibility mechanism works across the
complete public type surface and optimized Composer autoloading.

The spike shows that a lazy `class_alias()` loader is viable as a time-bounded
migration aid, while also pinning its limits: runtime reflection and serialized
output use the canonical declared FQCN, and aliases do not cover Composer
requirements or non-PHP compatibility surfaces.

No namespace shim is added to the released package in this PR.

## Validation

- `vendor/bin/phpunit tests/Integration/NamespaceCompatibilityIntegrationTest.php` — 1 test, 11 assertions
- `vendor/bin/phpstan analyse --debug --memory-limit=512M --configuration=/tmp/gesso-namespace-phpstan.neon tests/Integration/NamespaceCompatibilityIntegrationTest.php`
- `vendor/bin/php-cs-fixer fix --dry-run --diff --sequential`
- `vendor/bin/php-cs-fixer fix --dry-run --diff --sequential --config=.php-cs-fixer.pest.dist.php`
- `composer validate --strict --working-dir=tests/fixtures/namespace-compatibility`
- `npm run docs:build`
- `npm run docs:links`
- `git diff --check`

The full local PHPStan run is currently blocked by eight pre-existing
`Nyholm\Psr7` missing-class errors in `OpenApiPsr7ValidatorTest.php`; the changed
integration test passes focused analysis.
