### PR TITLE
docs(versioning): define v1 maintenance lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, 1.x]
   pull_request:
-    branches: [main]
+    branches: [main, 1.x]
   workflow_call:
 
 jobs:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 1.x
 
 permissions:
   contents: write
@@ -16,5 +17,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
+          target-branch: ${{ github.ref_name }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,10 @@ PHPUnit 11/12/13.
 1. Open an issue describing the problem before starting non-trivial work.
    For bug fixes that come with a failing test, jumping straight to a PR
    is fine.
-2. Fork, branch from `main`, name the branch with the convention
-   `feat/<topic>`, `fix/<topic>`, `docs/<topic>`, etc.
+2. Fork and choose the correct base branch: use `main` for normal work; after
+   the `1.x` maintenance branch exists, use `1.x` for a v1-only fix. Name the
+   branch with the convention `feat/<topic>`, `fix/<topic>`, `docs/<topic>`,
+   etc.
 3. Write tests first when the change is observable behaviour. The test
    suite uses snake_case method names and PHPUnit `#[Test]` attributes.
 4. Run `composer ci` locally before pushing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,27 @@ version per package path; this repo is single-package so it stays
 `{ ".": "X.Y.Z" }`. The `.` key is the bot's package-root identifier; do
 not rename or duplicate it.
 
+### Maintenance branches and backports
+
+After v1.10.0 is released, `main` is the v2 development branch and `1.x` is the
+v1 maintenance branch. The support windows and accepted change classes are
+defined in [`docs/versioning.md`](docs/versioning.md#v1-maintenance-lifecycle).
+
+For a fix shared by both majors:
+
+1. Merge and verify the fix on `main`.
+2. Create a branch from the latest `1.x` and cherry-pick the squashed `main`
+   commit. Resolve only differences required by the v1 codebase.
+3. Open a separate PR targeting `1.x`, using the same Conventional Commit title
+   when it still describes the backport.
+4. Run the normal checks. Do not merge `main` into `1.x` or group unrelated
+   backports in one PR.
+
+A v1-only fix may start directly from `1.x`. release-please runs independently
+for pushes to `main` and `1.x`; merge the release PR for the branch whose line
+you intend to publish. Tags and `CHANGELOG.md` remain release-please-owned on
+both branches.
+
 ### Discipline
 
 - **Never push a `v*` tag manually.** The release-please manifest tracks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,10 +83,12 @@ this section covers the mechanical flow.
 
 How it works:
 
-1. Every push to `main` runs the `release-please` workflow.
-2. The bot scans the Conventional Commits since the last release tag and
-   either opens or updates a "release PR" titled `chore(main): release X.Y.Z`.
-   The PR diff bumps `CHANGELOG.md` and `.release-please-manifest.json`.
+1. Every push to a configured target branch runs the `release-please` workflow.
+   This is `main` for v2 and, after v1.10.0, `1.x` for v1 maintenance.
+2. For the branch that triggered the workflow, the bot scans the Conventional
+   Commits since that line's last release and either opens or updates a release
+   PR titled `chore(<branch>): release X.Y.Z`. The PR diff bumps that branch's
+   `CHANGELOG.md` and `.release-please-manifest.json`.
 3. The proposed version is derived from the commit prefixes:
    - `fix:` → patch bump (`X.Y.Z` → `X.Y.(Z+1)`)
    - `feat:` → minor bump (`X.Y.Z` → `X.(Y+1).0`)
@@ -95,14 +97,16 @@ How it works:
 4. When a maintainer merges the release PR, the bot creates the git tag and
    publishes the GitHub Release with notes generated from the changelog
    entry. Packagist syncs automatically from the tag webhook.
-5. The release PR is **kept fresh by the bot** — every push to `main` after
-   the initial release PR opens rebases its branch and rewrites the
-   CHANGELOG diff in place. There is never more than one open release PR.
+5. Each release PR is **kept fresh by the bot** — every push to its target
+   branch after the initial release PR opens rebases the bot-managed PR branch
+   and rewrites the CHANGELOG diff in place. There is at most one open release
+   PR per target branch, so `main` and `1.x` may have two release PRs open at
+   the same time.
 
 The manifest file `.release-please-manifest.json` records the last released
-version per package path; this repo is single-package so it stays
-`{ ".": "X.Y.Z" }`. The `.` key is the bot's package-root identifier; do
-not rename or duplicate it.
+version per package path on each target branch; this repo is single-package so
+it stays `{ ".": "X.Y.Z" }`. The value may differ between `main` and `1.x`.
+The `.` key is the bot's package-root identifier; do not rename or duplicate it.
 
 ### Maintenance branches and backports
 
@@ -165,7 +169,7 @@ than a body footer.
 
 If a `fix:`-only batch should ship as a minor release (e.g., the fix is
 behaviourally significant), use a `Release-As: X.Y.Z` footer in a commit
-message body on `main`:
+message body on the branch being released:
 
 ```
 fix(validator): rewire something important
@@ -179,16 +183,16 @@ must live in a **commit message body** for the same reason as
 
 ### Recovery scenarios
 
-- **Bad release published.** Revert the release commit on `main` via a
-  fresh `revert:` PR. The released tag and Packagist version cannot be
-  unpublished; treat the next release as a bugfix. If the next release PR
-  proposes a version that you want to skip, add `Release-As: X.Y.Z` to
-  the next non-revert commit on `main` to force the bot's hand.
+- **Bad release published.** Revert the release commit via a fresh `revert:` PR
+  targeting the target branch that produced it. The released tag and Packagist
+  version cannot be unpublished; treat the next release on that line as a
+  bugfix. If its next release PR proposes a version that you want to skip, add
+  `Release-As: X.Y.Z` to the next non-revert commit on the same target branch.
 - **Manifest drift suspected** (e.g., someone bypassed `tag-guard` with
   admin rights and pushed a manual tag). Edit `.release-please-manifest.json`
-  via a `chore:` PR to set the `"."` value to the actual latest released
-  version, then merge. The next release PR will re-derive the proposed
-  version from that point.
+  on the affected target branch via a `chore:` PR to set the `"."` value to
+  that line's actual latest released version, then merge. The next release PR
+  for that branch will re-derive the proposed version from that point.
 - **Bot-authored commits do not trigger downstream Actions** by default
   (GitHub's loop-prevention). The current pipeline is fine because tag
   publication and Packagist sync are both handled by the bot's own action

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,15 +2,18 @@
 
 ## Supported Versions
 
-Only the latest minor of v1.x receives security fixes. There is no LTS
-branch for older minors — upgrade to the latest minor of v1.x to receive
-fixes. v0.x is no longer supported now that v1.0 has shipped.
+Only the latest minor of each maintained major receives security fixes. There
+is no support branch for older v1 minors — upgrade to v1.10.x to receive fixes.
+The v1 security-support period ends on 2027-06-30; v1 is end-of-life from
+2027-07-01. See the [versioning policy](docs/versioning.md#v1-maintenance-lifecycle)
+for the active-maintenance and security-only phases. v0.x is unsupported.
 
-| Version  | Supported |
-| -------- | --------- |
-| 1.x (latest minor) | ✓ |
-| 1.x (older minors) | ✗ — upgrade to the latest minor |
-| 0.x      | ✗ — upgrade to v1.x |
+| Version | Supported |
+| --- | --- |
+| 2.x (latest minor, after stable release) | ✓ |
+| 1.10.x | ✓ through 2027-06-30 |
+| 1.x (older minors) | ✗ — upgrade to v1.10.x |
+| 0.x | ✗ — upgrade to a maintained version |
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,16 +3,18 @@
 ## Supported Versions
 
 Only the latest minor of each maintained major receives security fixes. There
-is no support branch for older v1 minors — upgrade to v1.10.x to receive fixes.
-The v1 security-support period ends on 2027-06-30; v1 is end-of-life from
-2027-07-01. See the [versioning policy](docs/versioning.md#v1-maintenance-lifecycle)
-for the active-maintenance and security-only phases. v0.x is unsupported.
+is no support branch for older v1 minors — upgrade to the latest published v1
+minor to receive fixes. After v1.10.0 is published, that supported line is
+v1.10.x. The v1 security-support period ends on 2027-06-30; v1 is end-of-life
+from 2027-07-01. See the
+[versioning policy](docs/versioning.md#v1-maintenance-lifecycle) for the
+active-maintenance and security-only phases. v0.x is unsupported.
 
 | Version | Supported |
 | --- | --- |
 | 2.x (latest minor, after stable release) | ✓ |
-| 1.10.x | ✓ through 2027-06-30 |
-| 1.x (older minors) | ✗ — upgrade to v1.10.x |
+| 1.x (latest published minor) | ✓ through 2027-06-30 |
+| 1.x (older minors) | ✗ — upgrade to the latest published minor |
 | 0.x | ✗ — upgrade to a maintained version |
 
 ## Reporting a Vulnerability

--- a/docs/adr/0001-gesso-v2-identity.md
+++ b/docs/adr/0001-gesso-v2-identity.md
@@ -105,15 +105,16 @@ Before the first breaking rename is merged:
    proves lazy aliases and records their identity limits; whether aliases ship
    remains a release-policy decision.
 5. Define the v1 maintenance branch and end-of-support date before v2
-   pre-releases begin.
+   pre-releases begin. The completed
+   [v1 maintenance lifecycle](../versioning.md#v1-maintenance-lifecycle) fixes
+   the `1.x` branch workflow, accepted changes, and 2027-07-01 EOL date.
 
 ## Open decisions
 
 The following require evidence or maintainer approval before this ADR becomes
 Accepted:
 
-- whether the final transition release is v1.10.0 and which Gesso aliases it
-  can safely provide;
+- which forward `Studio\\Gesso\\` aliases v1.10.0 can safely provide;
 - whether any legacy PHP namespace shim ships in v2, and its exact removal
   version;
 - whether `gesso coverage:merge` replaces the standalone binary immediately or
@@ -122,7 +123,6 @@ Accepted:
 - which machine-readable formats require a schema-version increment;
 - the PHP minimum version and supported PHPUnit matrix at the planned v2 GA
   date;
-- the duration and scope of v1 security or critical-fix support.
 
 ## Consequences
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -82,9 +82,11 @@ Bug fixes and security updates land on the latest minor of v1.x. There is no LTS
 
 v1.10.0 is the final planned feature minor of the original
 `studio-design/openapi-contract-testing` package. It may add backward-compatible
-migration aids and deprecations for Gesso 2.0; SemVer requires deprecations to
-ship in a minor release before removal in a major release. After v1.10.0, the
-v1 line receives patches from the `1.x` maintenance branch:
+migration aids and deprecations for Gesso 2.0. SemVer requires a minor bump when
+public API is deprecated and a major bump for its incompatible removal. This
+project additionally requires migration deprecations to ship in v1.10.0 before
+removal in v2. After v1.10.0, the v1 line receives patches from the `1.x`
+maintenance branch:
 
 | Period | Dates | Accepted changes |
 | --- | --- | --- |

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -5,6 +5,7 @@ This library follows [Semantic Versioning 2.0](https://semver.org/). v1.0.0 is t
 - [What's covered by SemVer in v1.x](#whats-covered-by-semver-in-v1x)
 - [What's NOT covered by SemVer](#whats-not-covered-by-semver)
 - [Support policy](#support-policy)
+- [v1 maintenance lifecycle](#v1-maintenance-lifecycle)
 - [Release checklist](#release-checklist)
 
 ## What's covered by SemVer in v1.x
@@ -76,6 +77,55 @@ See [UPGRADING.md](https://github.com/studio-design/gesso/blob/main/UPGRADING.md
 | Laravel (optional adapter) | Whatever `orchestra/testbench` `^9 || ^10 || ^11` supports. |
 
 Bug fixes and security updates land on the latest minor of v1.x. There is no LTS branch for older minors — upgrade to the latest minor to receive fixes.
+
+## v1 maintenance lifecycle
+
+v1.10.0 is the final planned feature minor of the original
+`studio-design/openapi-contract-testing` package. It may add backward-compatible
+migration aids and deprecations for Gesso 2.0; SemVer requires deprecations to
+ship in a minor release before removal in a major release. After v1.10.0, the
+v1 line receives patches from the `1.x` maintenance branch:
+
+| Period | Dates | Accepted changes |
+| --- | --- | --- |
+| Active maintenance | through 2026-12-31 | Security fixes, backward-compatible bug fixes, and critical ecosystem interoperability fixes |
+| Security maintenance | 2027-01-01 through 2027-06-30 | Security fixes only; non-security changes require evidence that they are necessary to ship a security fix safely |
+| End of life | from 2027-07-01 | No releases or support commitment; migrate to `studio-design/gesso` |
+
+These dates are calendar deadlines in UTC and do not move automatically if the
+v2 schedule changes. If v2 stable is not available before active maintenance
+ends, the maintainers must publish a revised calendar before 2026-12-31 rather
+than silently extending or shortening support.
+
+The v1 Composer PHP constraint remains `^8.2`; a patch release does not raise
+the declared floor. [PHP 8.2 reaches upstream security EOL][php-support] on
+2026-12-31.
+Compatibility checks may continue during v1 security maintenance, but Gesso
+cannot provide fixes for vulnerabilities in an EOL PHP runtime. Consumers
+should run v1 on a PHP branch still supported by the PHP project.
+
+The `1.x` branch is created from the v1.10.0 release commit only after its tag
+and GitHub release have been produced by release-please. `main` then becomes the
+v2 development line. Both branches use release-please independently; v1 patch
+tags remain `v1.10.z` and v2 tags use `v2.y.z`.
+
+Changes that affect both majors land on `main` first, then are cherry-picked
+from the squashed commit into a new branch based on `1.x` and reviewed in a
+separate PR targeting `1.x`. A v1-only compatibility or security fix may target
+`1.x` directly when no equivalent v2 change is needed. Never merge `main` into
+`1.x`, and never combine unrelated backports. The maintenance PR must preserve
+the v1 public compatibility surface and pass the same required checks as a
+`main` PR.
+
+The old Composer package remains installable throughout this lifecycle. It is
+[marked abandoned][composer-abandoned] with `studio-design/gesso` as its
+suggested replacement only after the v2 stable package is installable and its
+migration path has been verified. Abandonment is a migration signal, not
+permission to remove existing v1 tags. The package remains supported according
+to the dates above even if the abandonment notice is added earlier.
+
+[composer-abandoned]: https://getcomposer.org/doc/04-schema.md#abandoned
+[php-support]: https://www.php.net/supported-versions.php
 
 ## Release checklist
 


### PR DESCRIPTION
## Summary

- define v1.10.0 as the final planned v1 feature minor
- set active maintenance through 2026-12-31, security-only maintenance through 2027-06-30, and EOL on 2027-07-01
- document the `1.x` branch and backport workflow
- run CI and release-please independently for `main` and `1.x`
- close the corresponding v2 ADR preparation decision

## Why

Gesso v2 development needs a predictable v1 support boundary before prereleases begin. The repository previously documented support for only the latest v1 minor, but did not define branch ownership, accepted maintenance changes, backport mechanics, or an end-of-support date after `main` moves to v2.

The dates align active maintenance with PHP 8.2's upstream security EOL and provide an additional six-month security-only window.

## Impact

Maintainers get an explicit two-branch release process. Consumers can plan migration to `studio-design/gesso` against fixed v1 support dates. No runtime API or package behavior changes in this PR.

## Verification

- `npm run docs:build`
- `npm run docs:links`
- Workflow YAML parsed successfully with Ruby Psych
- `git diff --check`

`actionlint` could not run because the local mise shim has no configured actionlint version.
