### PR TITLE
feat(compatibility): add gesso namespace aliases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
             "Studio\\OpenApiContractTesting\\": "src/"
         },
         "files": [
+            "src/Compatibility/GessoAliasLoader.php",
             "src/Pest/Autoload.php"
         ]
     },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -63,7 +63,10 @@ export default defineConfig({
       },
       {
         text: 'Migration',
-        items: [{ text: 'From other validators', link: '/migration/from-other-validators' }]
+        items: [
+          { text: 'Prepare for Gesso 2.0', link: '/migration/v2' },
+          { text: 'From other validators', link: '/migration/from-other-validators' }
+        ]
       },
       {
         text: 'Reference',

--- a/docs/adr/0001-gesso-v2-identity.md
+++ b/docs/adr/0001-gesso-v2-identity.md
@@ -71,6 +71,20 @@ The migration will follow these rules:
 7. Release v2 through pre-release stages and dogfood it in the repository's
    framework examples before general availability.
 
+### Namespace transition policy
+
+V1.10.0 exposes lazy `Studio\Gesso\` aliases for every non-`@internal` public
+v1 type. The aliases are an explicit allowlist checked against the public API
+inventory; they do not make internal types part of the new public surface. This
+lets consumers migrate PHP imports while the v1 declarations and Composer
+package remain canonical.
+
+Gesso v2 declares `Studio\Gesso\` as canonical and does not ship a reverse
+`Studio\OpenApiContractTesting\` namespace shim. The major boundary is where
+the legacy PHP identity is removed. Reflection, serialization, configuration,
+commands, and package requirements are not made portable by the v1 aliases and
+must follow their documented migration steps.
+
 ## Scope boundaries
 
 The v2 identity migration does not by itself authorize unrelated redesigns.
@@ -102,8 +116,8 @@ Before the first breaking rename is merged:
    Composer optimized autoloading. Do not assume `class_alias()` covers every
    supported use case without tests. The completed
    [namespace compatibility spike](../migration/v2-namespace-compatibility-spike.md)
-   proves lazy aliases and records their identity limits; whether aliases ship
-   remains a release-policy decision.
+   proves lazy aliases and records their identity limits. The namespace
+   transition policy above fixes their v1 scope and excludes a reverse v2 shim.
 5. Define the v1 maintenance branch and end-of-support date before v2
    pre-releases begin. The completed
    [v1 maintenance lifecycle](../versioning.md#v1-maintenance-lifecycle) fixes
@@ -114,9 +128,6 @@ Before the first breaking rename is merged:
 The following require evidence or maintainer approval before this ADR becomes
 Accepted:
 
-- which forward `Studio\\Gesso\\` aliases v1.10.0 can safely provide;
-- whether any legacy PHP namespace shim ships in v2, and its exact removal
-  version;
 - whether `gesso coverage:merge` replaces the standalone binary immediately or
   keeps a deprecated executable shim;
 - how conflicts between old and new Laravel configuration are reported;

--- a/docs/migration/v2-namespace-compatibility-spike.md
+++ b/docs/migration/v2-namespace-compatibility-spike.md
@@ -1,8 +1,10 @@
 # v2 namespace compatibility spike
 
 This spike verifies the behavior and limits of a temporary namespace alias
-mechanism before the v2 source rename. It does not add aliases to the released
-package.
+mechanism before the v2 source rename. The release policy now uses the proven
+mechanism in the opposite direction for the v1.10 migration aid: a requested
+`Studio\Gesso\` public type aliases its canonical
+`Studio\OpenApiContractTesting\` declaration.
 
 ## Candidate mechanism
 
@@ -52,23 +54,23 @@ The v1 public inventory contains types rather than public namespaced functions,
 so the PHP-symbol portion is technically aliasable. The other surfaces still
 need their dedicated migration steps.
 
-## Recommendation
+## Release decision
 
 Use this mechanism only as a time-bounded migration aid, not as a permanent
-second public identity. The lowest-risk sequence is:
+second public identity. The approved sequence is:
 
-1. In the final v1 minor, optionally expose lazy `Studio\Gesso\` aliases whose
-   canonical declarations remain under `Studio\OpenApiContractTesting\`.
+1. In v1.10, expose lazy `Studio\Gesso\` aliases for every non-`@internal`
+   public type. Canonical declarations remain under
+   `Studio\OpenApiContractTesting\`.
 2. Tell consumers that reflection and serialized output keep the v1 canonical
    name until v2; do not promise literal-FQCN identity stability through aliases.
-3. In v2, declare only `Studio\Gesso\` as canonical. If a reverse legacy shim is
-   approved, give it an explicit removal release and test it with this fixture.
-4. Do not keep reverse aliases by default when the goal is a complete identity
-   migration; the major-version boundary already provides the source-breaking
-   migration point.
+3. In v2, declare only `Studio\Gesso\` as canonical and do not ship a reverse
+   legacy namespace shim. The major-version boundary provides the
+   source-breaking migration point.
 
-This leaves the exact decision to ship aliases in v1 or v2 as a release-policy
-choice, while removing uncertainty about the mechanism itself.
+The production allowlist is checked against the public API inventory. Internal
+and unknown types remain unresolved so the migration layer cannot expand the
+supported API accidentally.
 
 ## Sources
 

--- a/docs/migration/v2.md
+++ b/docs/migration/v2.md
@@ -1,0 +1,65 @@
+# Prepare for Gesso 2.0
+
+Gesso 2.0 will change the Composer package and PHP namespace so the technical
+identity matches the project name. The final v1 minor provides a staged path:
+move PHP imports first on v1.10, then change packages and the remaining
+integration surfaces when v2 is available.
+
+## Stage 1: move PHP imports on v1.10
+
+Upgrade the existing package to v1.10 before changing namespaces:
+
+```bash
+composer require --dev studio-design/openapi-contract-testing:^1.10
+```
+
+Then replace the public namespace prefix in application and test code:
+
+```diff
+-use Studio\OpenApiContractTesting\OpenApiResponseValidator;
++use Studio\Gesso\OpenApiResponseValidator;
+```
+
+v1.10 lazily aliases every non-`@internal` public type from
+`Studio\Gesso\...` to its v1 declaration. Classes, interfaces, traits, enums,
+and attributes are covered. The allowlist is checked against the public API
+inventory so a newly added public v1 type cannot silently miss its migration
+alias.
+
+Run the complete test suite after replacing imports. This stage isolates source
+changes from the later Composer and integration changes.
+
+### What the v1 aliases do not change
+
+The aliases cover PHP type references only. On v1.10, continue using the v1:
+
+- Composer package `studio-design/openapi-contract-testing`;
+- commands `openapi-contract` and `openapi-coverage-merge`;
+- Laravel configuration key and file `openapi-contract-testing`;
+- Laravel service provider discovery and PHPUnit extension configuration;
+- machine-readable tool identity and supported wire-format versions.
+
+The declared v1 type remains canonical at runtime. Consequently,
+`get_class()`, reflection, and newly serialized objects still contain
+`Studio\OpenApiContractTesting\...` on v1.10. Do not rewrite persisted class
+names or snapshots during this stage.
+
+Internal types are intentionally not aliased. Code using an `@internal` type
+must migrate away from that unsupported dependency rather than replace its
+namespace.
+
+## Stage 2: install v2
+
+After `studio-design/gesso` v2 is published, replace the root Composer
+requirement instead of treating the package as an in-place update. The exact
+pre-release and stable commands will be added here after the new package is
+registered and verified.
+
+V2 declares `Studio\Gesso\` as its only product namespace and does not provide
+a reverse `Studio\OpenApiContractTesting\` shim. Complete Stage 1 before the
+package switch. The remaining CLI, Laravel, PHPUnit XML, and machine-readable
+format migrations will be documented as their v2 contracts are finalized.
+
+See [ADR 0001](../adr/0001-gesso-v2-identity.md) for the complete identity
+decision and [the namespace compatibility spike](v2-namespace-compatibility-spike.md)
+for the tested behavior and identity limits of `class_alias()`.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -88,6 +88,13 @@ project additionally requires migration deprecations to ship in v1.10.0 before
 removal in v2. After v1.10.0, the v1 line receives patches from the `1.x`
 maintenance branch:
 
+V1.10.0 also provides lazy `Studio\Gesso\` aliases for all non-`@internal`
+public PHP types. Consumers should use these aliases to migrate imports before
+changing Composer packages. The aliases do not cover configuration, commands,
+wire formats, or literal class-name identity, and v2 does not provide a reverse
+legacy namespace shim. Follow the [staged v2 migration guide](migration/v2.md)
+for these boundaries.
+
 | Period | Dates | Accepted changes |
 | --- | --- | --- |
 | Active maintenance | through 2026-12-31 | Security fixes, backward-compatible bug fixes, and critical ecosystem interoperability fixes |

--- a/src/Compatibility/GessoAliasLoader.php
+++ b/src/Compatibility/GessoAliasLoader.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Compatibility;
+
+use function class_alias;
+use function class_exists;
+use function enum_exists;
+use function interface_exists;
+use function spl_autoload_register;
+use function str_starts_with;
+use function strlen;
+use function substr;
+use function trait_exists;
+
+/**
+ * Registers the time-bounded v1-to-v2 namespace migration aliases.
+ *
+ * @internal Composer autoload bootstrap; not part of the library API.
+ */
+final class GessoAliasLoader
+{
+    /**
+     * Public v1 types that consumers may reference through the future Gesso
+     * namespace before upgrading to the v2 package.
+     *
+     * Keep this allowlist aligned with the non-@internal public API inventory.
+     * Internal types are deliberately excluded so the migration aid does not
+     * promote implementation details into a new public contract.
+     *
+     * @var array<string, true>
+     */
+    private const PUBLIC_TYPES = [
+        'Attribute\\BoundToOpenApiEnum' => true,
+        'Attribute\\OpenApiSpec' => true,
+        'Attribute\\SkipOpenApi' => true,
+        'Coverage\\ConsoleCoverageRenderer' => true,
+        'Coverage\\CoverageSidecarEnvelope' => true,
+        'Coverage\\CoverageSidecarReader' => true,
+        'Coverage\\CoverageSidecarWriter' => true,
+        'Coverage\\CoverageThresholdEvaluator' => true,
+        'Coverage\\EndpointCoverageState' => true,
+        'Coverage\\HtmlCoverageRenderer' => true,
+        'Coverage\\InvalidCoverageOutputPathException' => true,
+        'Coverage\\InvalidThresholdConfigurationException' => true,
+        'Coverage\\JUnitCoverageRenderer' => true,
+        'Coverage\\JsonCoverageRenderer' => true,
+        'Coverage\\MarkdownCoverageRenderer' => true,
+        'Coverage\\OpenApiCoverageTracker' => true,
+        'Coverage\\ResponseCoverageState' => true,
+        'DecodedBody' => true,
+        'Exception\\EnumBindingException' => true,
+        'Exception\\EnumBindingReason' => true,
+        'Exception\\EnumDriftException' => true,
+        'Exception\\InvalidOpenApiSpecException' => true,
+        'Exception\\InvalidOpenApiSpecReason' => true,
+        'Exception\\SpecFileNotFoundException' => true,
+        'Exception\\StrictRequiredDriftException' => true,
+        'Fuzz\\ExplorationCaseKind' => true,
+        'Fuzz\\ExplorationCases' => true,
+        'Fuzz\\ExplorationSkip' => true,
+        'Fuzz\\ExploredCase' => true,
+        'Fuzz\\ExploredOperation' => true,
+        'Fuzz\\FailureReducer' => true,
+        'Fuzz\\OpenApiEndpointExplorer' => true,
+        'Fuzz\\OpenApiSpecExploration' => true,
+        'Fuzz\\OpenApiSpecExplorer' => true,
+        'Fuzz\\SpecExplorationSummary' => true,
+        'HttpMethod' => true,
+        'Laravel\\Commands\\OpenApiRoutesCommand' => true,
+        'Laravel\\ExploresOpenApiEndpoint' => true,
+        'Laravel\\OpenApiContractTestingServiceProvider' => true,
+        'Laravel\\ValidatesOpenApiSchema' => true,
+        'OpenApiRequestValidator' => true,
+        'OpenApiResponseValidator' => true,
+        'OpenApiValidationOutcome' => true,
+        'OpenApiValidationResult' => true,
+        'OpenApiVersion' => true,
+        'PHPUnit\\AssertsNoEnumDrift' => true,
+        'PHPUnit\\ConsoleOutput' => true,
+        'PHPUnit\\InvalidStrictRequiredConfigurationException' => true,
+        'PHPUnit\\OpenApiCoverageExtension' => true,
+        'Pest\\Expectations' => true,
+        'Psr7\\OpenApiAssertions' => true,
+        'Psr7\\OpenApiPsr7ValidationResult' => true,
+        'Psr7\\OpenApiPsr7Validator' => true,
+        'Schema\\EnumDriftAsserter' => true,
+        'Schema\\EnumDriftReport' => true,
+        'SchemaContext' => true,
+        'SkipOpenApiResolver' => true,
+        'Spec\\OpenApiSpecLoader' => true,
+        'Spec\\OpenApiSpecResolver' => true,
+        'Symfony\\OpenApiAssertions' => true,
+        'Validation\\Strict\\StrictRequiredAsserter' => true,
+        'Validation\\Strict\\StrictRequiredMode' => true,
+        'Validation\\Strict\\StrictRequiredPerCallMode' => true,
+        'Validation\\Strict\\StrictRequiredReport' => true,
+        'Validation\\Strict\\StrictRequiredTracker' => true,
+    ];
+    private static bool $registered = false;
+
+    public static function register(): void
+    {
+        if (self::$registered) {
+            return;
+        }
+        self::$registered = true;
+
+        spl_autoload_register(static function (string $gessoType): void {
+            $gessoPrefix = 'Studio\\Gesso\\';
+            if (!str_starts_with($gessoType, $gessoPrefix)) {
+                return;
+            }
+
+            $relativeType = substr($gessoType, strlen($gessoPrefix));
+            if (!isset(self::PUBLIC_TYPES[$relativeType])) {
+                return;
+            }
+
+            $v1Type = 'Studio\\OpenApiContractTesting\\' . $relativeType;
+            if (!class_exists($v1Type) &&
+                !interface_exists($v1Type) &&
+                !trait_exists($v1Type) &&
+                !enum_exists($v1Type)) {
+                return;
+            }
+
+            class_alias($v1Type, $gessoType);
+        });
+    }
+}
+
+GessoAliasLoader::register();

--- a/src/Compatibility/GessoAliasLoader.php
+++ b/src/Compatibility/GessoAliasLoader.php
@@ -5,14 +5,10 @@ declare(strict_types=1);
 namespace Studio\OpenApiContractTesting\Compatibility;
 
 use function class_alias;
-use function class_exists;
-use function enum_exists;
-use function interface_exists;
 use function spl_autoload_register;
 use function str_starts_with;
 use function strlen;
 use function substr;
-use function trait_exists;
 
 /**
  * Registers the time-bounded v1-to-v2 namespace migration aliases.
@@ -119,13 +115,8 @@ final class GessoAliasLoader
             }
 
             $v1Type = 'Studio\\OpenApiContractTesting\\' . $relativeType;
-            if (!class_exists($v1Type) &&
-                !interface_exists($v1Type) &&
-                !trait_exists($v1Type) &&
-                !enum_exists($v1Type)) {
-                return;
-            }
-
+            // The public-API inventory test guarantees that every allowlisted
+            // declaration exists; class_alias() autoloads its concrete kind.
             class_alias($v1Type, $gessoType);
         });
     }

--- a/tests/Unit/Compatibility/GessoAliasesTest.php
+++ b/tests/Unit/Compatibility/GessoAliasesTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Compatibility;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Studio\OpenApiContractTesting\Tests\Helpers\PublicApiInventory;
+
+use function class_exists;
+use function dirname;
+use function enum_exists;
+use function interface_exists;
+use function str_replace;
+use function trait_exists;
+
+final class GessoAliasesTest extends TestCase
+{
+    #[Test]
+    public function every_public_v1_type_has_a_forward_gesso_alias(): void
+    {
+        $root = dirname(__DIR__, 3);
+        $inventory = PublicApiInventory::capture(
+            $root . '/src',
+            'Studio\\OpenApiContractTesting\\',
+        );
+
+        foreach ($inventory as $v1Type => $description) {
+            $gessoType = str_replace('Studio\\OpenApiContractTesting\\', 'Studio\\Gesso\\', $v1Type);
+
+            $this->assertTrue(
+                $this->typeExists($gessoType, $description['kind']),
+                "Missing forward namespace alias for {$v1Type}",
+            );
+            $this->assertSame(
+                $v1Type,
+                (new ReflectionClass($gessoType))->getName(),
+                "The v1 declaration must remain canonical for {$gessoType}",
+            );
+        }
+    }
+
+    #[Test]
+    public function internal_and_unknown_types_are_not_aliased(): void
+    {
+        $this->assertFalse(class_exists('Studio\\Gesso\\Internal\\StackTraceFilter'));
+        $this->assertFalse(class_exists('Studio\\Gesso\\MissingType'));
+    }
+
+    private function typeExists(string $type, string $kind): bool
+    {
+        return match ($kind) {
+            'class' => class_exists($type),
+            'enum' => enum_exists($type),
+            'interface' => interface_exists($type),
+            'trait' => trait_exists($type),
+            default => throw new InvalidArgumentException("Unsupported public API type kind: {$kind}"),
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- expose lazy `Studio\Gesso\` aliases for every non-`@internal` public v1 type
- keep internal and unknown types outside the migration surface
- document the staged v1.10-to-v2 namespace migration and confirm that v2 will not ship a reverse legacy namespace shim

## Why

Consumers need a low-risk way to separate PHP import changes from the Composer package and integration-surface migration. Shipping forward aliases in v1.10 lets applications move source references first while the v1 package remains canonical.

The explicit allowlist is checked against the public API inventory, preventing newly added public types from silently missing an alias and preventing internal implementation types from becoming supported APIs.

## Impact

On v1.10, consumers may replace `Studio\OpenApiContractTesting\...` imports with `Studio\Gesso\...`. Reflection, serialization, Composer package names, CLI commands, Laravel configuration, PHPUnit XML, and machine-readable identities remain on the v1 contract until their dedicated v2 migration steps.

## Verification

- `composer test` — 2055 tests, 5300 assertions
- `vendor/bin/phpstan analyse --no-progress --debug --memory-limit=1G`
- PHP-CS-Fixer checks (sequential mode)
- `composer validate --strict`
- `composer audit --abandoned=fail`
- `composer dump-autoload --classmap-authoritative --no-interaction`
- focused namespace compatibility tests — 5 tests, 150 assertions
- `npm run docs:build`
- `npm run docs:links`
