### PR TITLE
feat(cli): add gesso command entry point

### DIFF
--- a/bin/gesso
+++ b/bin/gesso
@@ -1,0 +1,64 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Studio\OpenApiContractTesting\Cli\DoctorCommand;
+use Studio\OpenApiContractTesting\Coverage\CoverageMergeCommand;
+
+$autoloadCandidates = [
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../autoload.php',
+];
+
+$autoload = null;
+foreach ($autoloadCandidates as $candidate) {
+    if (file_exists($candidate)) {
+        $autoload = $candidate;
+
+        break;
+    }
+}
+
+if ($autoload === null) {
+    fwrite(STDERR, "[Gesso] FATAL: could not locate Composer autoload.\n");
+    exit(1);
+}
+
+require $autoload;
+
+$usage = <<<'USAGE'
+    Gesso — OpenAPI contract testing for PHP.
+
+    Usage:
+      gesso <command> [options]
+
+    Commands:
+      doctor           Check whether Gesso can load and enforce a contract.
+      coverage:merge   Combine parallel-worker coverage sidecars.
+
+    Run `gesso <command> --help` for command-specific options.
+
+    USAGE;
+
+$argv = $_SERVER['argv'] ?? [];
+array_shift($argv);
+$commandName = array_shift($argv);
+
+if ($commandName === null || $commandName === 'list' || $commandName === '--help' || $commandName === '-h') {
+    fwrite(STDOUT, $usage);
+    exit(0);
+}
+
+if ($commandName === 'doctor') {
+    $command = new DoctorCommand(invocation: 'gesso doctor');
+    exit($command->run(DoctorCommand::parseArgv($argv)));
+}
+
+if ($commandName === 'coverage:merge') {
+    $command = new CoverageMergeCommand(invocation: 'gesso coverage:merge');
+    exit($command->run(CoverageMergeCommand::parseArgv($argv)));
+}
+
+fwrite(STDERR, "[Gesso] Unknown command: {$commandName}\n\n{$usage}");
+exit(2);

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         ]
     },
     "bin": [
+        "bin/gesso",
         "bin/openapi-contract",
         "bin/openapi-coverage-merge"
     ],

--- a/docs/adr/0001-gesso-v2-identity.md
+++ b/docs/adr/0001-gesso-v2-identity.md
@@ -85,6 +85,21 @@ the legacy PHP identity is removed. Reflection, serialization, configuration,
 commands, and package requirements are not made portable by the v1 aliases and
 must follow their documented migration steps.
 
+### CLI transition policy
+
+V1.10.0 adds the `gesso` Composer binary with `doctor` and
+`coverage:merge` subcommands. The existing `openapi-contract` and
+`openapi-coverage-merge` binaries remain unchanged throughout v1 maintenance.
+Consumers can therefore migrate CI and local scripts separately from the v2
+Composer package switch.
+
+Gesso v2 ships only the unified `gesso` binary. It does not retain deprecated
+standalone executable shims. Keeping the old binaries in v1.10 provides the
+overlap period; carrying them into v2 would preserve the legacy technical
+identity that the major release exists to remove. Command options, exit codes,
+and command-specific output remain compatible unless a separately documented
+v2 change requires otherwise.
+
 ## Scope boundaries
 
 The v2 identity migration does not by itself authorize unrelated redesigns.
@@ -128,8 +143,6 @@ Before the first breaking rename is merged:
 The following require evidence or maintainer approval before this ADR becomes
 Accepted:
 
-- whether `gesso coverage:merge` replaces the standalone binary immediately or
-  keeps a deprecated executable shim;
 - how conflicts between old and new Laravel configuration are reported;
 - which machine-readable formats require a schema-version increment;
 - the PHP minimum version and supported PHPUnit matrix at the planned v2 GA

--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -52,7 +52,7 @@ members marked `@internal` are excluded.
 | Package | `studio-design/openapi-contract-testing` | Explicit root requirement migration to `studio-design/gesso` |
 | PSR-4 | `Studio\OpenApiContractTesting\` → `src/` | Map `Studio\Gesso\` and verify optimized autoloading |
 | Autoload file | `src/Pest/Autoload.php` | Rename imports and preserve no-Pest guard behavior |
-| Binaries | `bin/openapi-contract`, `bin/openapi-coverage-merge` | Replace with the ADR-approved `gesso` command surface |
+| Binaries | `bin/openapi-contract`, `bin/openapi-coverage-merge`; v1.10 adds `bin/gesso` | Remove the legacy binaries and retain the unified `gesso` command surface |
 | Laravel discovery | `Studio\OpenApiContractTesting\Laravel\OpenApiContractTestingServiceProvider` | Point discovery to the Gesso provider |
 | PHP requirement | `^8.2` | Decide from the v2 GA date, not from the rename alone |
 | PHPUnit requirement | `^11.0 || ^12.0 || ^13.0` | Update only with an explicit support decision |
@@ -282,6 +282,11 @@ semantically because Laravel owns its cross-version console table rendering.
 
 ## CLI contracts
 
+V1.10 adds the forward-compatible `gesso` entry point. It dispatches
+`gesso doctor` and `gesso coverage:merge` to the same implementations while
+rendering the new invocation names in help and usage output. The legacy
+binaries remain the v1.9-compatible paths until the v1 line reaches EOL.
+
 ### Doctor
 
 Executable and command: `openapi-contract doctor`.
@@ -389,7 +394,7 @@ must be decided explicitly.
 | Laravel | published old config/provider | Gesso config/provider | both configs present with conflicting values |
 | Pest | old trait wiring | Gesso trait wiring | Pest absent and partially available |
 | PSR-7/Symfony | old imports | Gesso imports | equivalent exchange produces equivalent result/coverage |
-| CLI | old commands and golden output | Gesso commands | flags, exit codes, stdout/stderr parity |
+| CLI | old commands plus v1.10 `gesso` aliases and golden output | `gesso` only | flags, exit codes, stdout/stderr parity; legacy binaries absent |
 | Coverage | v1 JSON and sidecar | v2 output | v1 worker payload merged by v2 reader |
 | Doctor/routes | schema v1 consumers | v2 identity | incompatible field change requires version bump |
 

--- a/docs/migration/v2.md
+++ b/docs/migration/v2.md
@@ -29,12 +29,27 @@ alias.
 Run the complete test suite after replacing imports. This stage isolates source
 changes from the later Composer and integration changes.
 
+Move scripts and CI to the unified command while still on v1.10:
+
+```diff
+-vendor/bin/openapi-contract doctor --spec=openapi.json
++vendor/bin/gesso doctor --spec=openapi.json
+
+-vendor/bin/openapi-coverage-merge --spec-base-path=tests/fixtures/specs
++vendor/bin/gesso coverage:merge --spec-base-path=tests/fixtures/specs
+```
+
+V1.10 supports both forms with the same command options and exit-code
+semantics. Migrating here avoids combining CLI changes with the later Composer
+package replacement.
+
 ### What the v1 aliases do not change
 
 The aliases cover PHP type references only. On v1.10, continue using the v1:
 
 - Composer package `studio-design/openapi-contract-testing`;
-- commands `openapi-contract` and `openapi-coverage-merge`;
+- legacy commands `openapi-contract` and `openapi-coverage-merge` (the forward
+  `gesso` command is also available);
 - Laravel configuration key and file `openapi-contract-testing`;
 - Laravel service provider discovery and PHPUnit extension configuration;
 - machine-readable tool identity and supported wire-format versions.
@@ -56,9 +71,11 @@ pre-release and stable commands will be added here after the new package is
 registered and verified.
 
 V2 declares `Studio\Gesso\` as its only product namespace and does not provide
-a reverse `Studio\OpenApiContractTesting\` shim. Complete Stage 1 before the
-package switch. The remaining CLI, Laravel, PHPUnit XML, and machine-readable
-format migrations will be documented as their v2 contracts are finalized.
+a reverse `Studio\OpenApiContractTesting\` shim. It also exposes only the
+unified `gesso` binary; the two legacy standalone binaries are removed. Complete
+Stage 1 before the package switch. The remaining Laravel, PHPUnit XML, and
+machine-readable format migrations will be documented as their v2 contracts
+are finalized.
 
 See [ADR 0001](../adr/0001-gesso-v2-identity.md) for the complete identity
 decision and [the namespace compatibility spike](v2-namespace-compatibility-spike.md)

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -15,7 +15,9 @@ This library follows [Semantic Versioning 2.0](https://semver.org/). v1.0.0 is t
 - Public constants and their values
 - Enum cases (additions are minor; removals or renames are major)
 - The `OpenApiValidationResult` shape (`outcome()`, `errors()`, `matchedPath()`, `skipReason()`, `isValid()`, `isSkipped()`)
-- The CLI surface of `bin/openapi-coverage-merge` (flags, exit codes, and the versioned sidecar inputs and filename patterns it accepts)
+- The CLI surfaces of `bin/openapi-contract`, `bin/openapi-coverage-merge`, and
+  the v1.10 `bin/gesso` entry point (commands, flags, exit codes, and versioned
+  inputs and output where applicable)
 - The Laravel `openapi:routes` command surface (flags, exit codes, and versioned JSON output)
 - The `OpenApiCoverageExtension` PHPUnit configuration parameters (`spec_base_path`, `strip_prefixes`, `specs`, `output_file`, `console_output`, …)
 - The Laravel `ValidatesOpenApiSchema` trait's public methods
@@ -90,10 +92,12 @@ maintenance branch:
 
 V1.10.0 also provides lazy `Studio\Gesso\` aliases for all non-`@internal`
 public PHP types. Consumers should use these aliases to migrate imports before
-changing Composer packages. The aliases do not cover configuration, commands,
-wire formats, or literal class-name identity, and v2 does not provide a reverse
-legacy namespace shim. Follow the [staged v2 migration guide](migration/v2.md)
-for these boundaries.
+changing Composer packages. The aliases do not cover configuration, wire
+formats, or literal class-name identity, and v2 does not provide a reverse
+legacy namespace shim. V1.10 adds `gesso doctor` and `gesso coverage:merge` so
+command invocations can move before the package switch; the v1 standalone
+binaries remain supported until v1 EOL and are removed in v2. Follow the
+[staged v2 migration guide](migration/v2.md) for these boundaries.
 
 | Period | Dates | Accepted changes |
 | --- | --- | --- |

--- a/src/Cli/DoctorCommand.php
+++ b/src/Cli/DoctorCommand.php
@@ -73,7 +73,8 @@ use function substr;
  * @phpstan-type DoctorIssue array{severity: 'error'|'warning'|'skipped', category: string, spec: ?string, message: string, suggestion: ?string}
  * @phpstan-type SpecResult array{path: string, name: string, openapi: string, dialect: string, operations: int, responses: int}
  *
- * @internal The `openapi-contract doctor` CLI is the supported API.
+ * @internal The `openapi-contract doctor` and `gesso doctor` CLI surfaces are
+ *           the supported APIs.
  */
 final class DoctorCommand
 {
@@ -87,6 +88,7 @@ final class DoctorCommand
         private mixed $stdoutWriter = null,
         private mixed $stderrWriter = null,
         private mixed $remoteTransportFactory = null,
+        private readonly string $invocation = 'openapi-contract doctor',
     ) {}
 
     /**
@@ -152,13 +154,13 @@ final class DoctorCommand
         return $options;
     }
 
-    public static function usage(): string
+    public static function usage(string $invocation = 'openapi-contract doctor'): string
     {
-        return <<<'USAGE'
-            openapi-contract doctor — check whether this package can load and enforce your contract.
+        return <<<USAGE
+            {$invocation} — check whether this package can load and enforce your contract.
 
             Usage:
-              openapi-contract doctor --spec=<path> [--spec=<path> ...] [options]
+              {$invocation} --spec=<path> [--spec=<path> ...] [options]
 
             Options:
               --spec=<path[,path]>       JSON/YAML entry document. Repeat for multiple specs.
@@ -181,7 +183,7 @@ final class DoctorCommand
     public function run(array $options): int
     {
         if (($options['help'] ?? false) === true) {
-            $this->writeStdout(self::usage());
+            $this->writeStdout(self::usage($this->invocation));
 
             return self::EXIT_OK;
         }
@@ -192,7 +194,7 @@ final class DoctorCommand
             $message = $invalid !== []
                 ? 'Unknown argument(s): ' . implode(', ', $invalid)
                 : (($options['specs'] ?? []) === [] ? 'At least one --spec is required.' : "Unsupported --format={$format}.");
-            $this->writeStderr("[OpenAPI Doctor] {$message}\n\n" . self::usage());
+            $this->writeStderr("[OpenAPI Doctor] {$message}\n\n" . self::usage($this->invocation));
 
             return self::EXIT_USAGE;
         }

--- a/src/Coverage/CoverageMergeCommand.php
+++ b/src/Coverage/CoverageMergeCommand.php
@@ -72,9 +72,10 @@ use function unlink;
  * }
  *
  * @internal Not part of the package's public API. Do not use from user code.
- *           The CLI surface of `bin/openapi-coverage-merge` is the documented
- *           invocation path; this class's constructor / methods may change in
- *           any release without a SemVer bump.
+ *           The `openapi-coverage-merge` and `gesso coverage:merge` CLI
+ *           surfaces are the documented invocation paths; this class's
+ *           constructor / methods may change in any release without a SemVer
+ *           bump.
  */
 final class CoverageMergeCommand
 {
@@ -84,6 +85,7 @@ final class CoverageMergeCommand
     public function __construct(
         private mixed $stderrWriter = null,
         private mixed $stdoutWriter = null,
+        private readonly string $invocation = 'openapi-coverage-merge',
     ) {}
 
     /**
@@ -155,13 +157,13 @@ final class CoverageMergeCommand
         return $opts;
     }
 
-    public static function usage(): string
+    public static function usage(string $invocation = 'openapi-coverage-merge'): string
     {
         return <<<USAGE
-            openapi-coverage-merge — combine paratest worker sidecars into one coverage report.
+            {$invocation} — combine paratest worker sidecars into one coverage report.
 
             Usage:
-              openapi-coverage-merge --spec-base-path=<path> [options]
+              {$invocation} --spec-base-path=<path> [options]
 
             Options:
               --spec-base-path=<path>       Path to bundled spec directory (required).
@@ -201,7 +203,7 @@ final class CoverageMergeCommand
     public function run(array $options): int
     {
         if (($options['help'] ?? false) === true) {
-            $this->writeStdout(self::usage());
+            $this->writeStdout(self::usage($this->invocation));
 
             return 0;
         }

--- a/tests/Integration/GessoCliIntegrationTest.php
+++ b/tests/Integration/GessoCliIntegrationTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Integration;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function dirname;
+use function escapeshellarg;
+use function fclose;
+use function file_get_contents;
+use function is_resource;
+use function proc_close;
+use function proc_open;
+use function realpath;
+use function sprintf;
+use function str_replace;
+use function stream_get_contents;
+
+final class GessoCliIntegrationTest extends TestCase
+{
+    private string $repoRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repoRoot = realpath(__DIR__ . '/../..') ?: dirname(__DIR__, 2);
+    }
+
+    /** @return iterable<string, array{0: list<string>}> */
+    public static function provideRoot_help_lists_the_v1_10_gesso_commandsCases(): iterable
+    {
+        yield 'no arguments' => [[]];
+        yield 'list' => [['list']];
+        yield 'long help' => [['--help']];
+        yield 'short help' => [['-h']];
+    }
+
+    /** @param list<string> $arguments */
+    #[Test]
+    #[DataProvider('provideRoot_help_lists_the_v1_10_gesso_commandsCases')]
+    public function root_help_lists_the_v1_10_gesso_commands(array $arguments): void
+    {
+        [$exit, $stdout, $stderr] = $this->runCli($arguments);
+
+        $this->assertSame(0, $exit);
+        $this->assertSame('', $stderr);
+        $this->assertSame(
+            file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v1.10-gesso-help.txt'),
+            $stdout,
+        );
+    }
+
+    #[Test]
+    public function doctor_uses_the_gesso_invocation_in_help_and_usage_errors(): void
+    {
+        [$helpExit, $helpStdout, $helpStderr] = $this->runCli(['doctor', '--help']);
+        [$errorExit, $errorStdout, $errorStderr] = $this->runCli(['doctor']);
+
+        $this->assertSame(0, $helpExit);
+        $this->assertSame('', $helpStderr);
+        $this->assertSame(
+            str_replace(
+                'openapi-contract doctor',
+                'gesso doctor',
+                (string) file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v1.9-openapi-contract-help.txt'),
+            ),
+            $helpStdout,
+        );
+        $this->assertSame(2, $errorExit);
+        $this->assertSame('', $errorStdout);
+        $this->assertSame(
+            str_replace(
+                'openapi-contract doctor',
+                'gesso doctor',
+                (string) file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v1.9-openapi-contract-usage-error.txt'),
+            ),
+            $errorStderr,
+        );
+    }
+
+    #[Test]
+    public function coverage_merge_uses_the_gesso_invocation_in_help_and_usage_errors(): void
+    {
+        [$helpExit, $helpStdout, $helpStderr] = $this->runCli(['coverage:merge', '--help']);
+        [$errorExit, $errorStdout, $errorStderr] = $this->runCli([
+            'coverage:merge',
+            '--specs=petstore-3.0',
+        ]);
+
+        $this->assertSame(0, $helpExit);
+        $this->assertSame('', $helpStderr);
+        $this->assertSame(
+            str_replace(
+                'openapi-coverage-merge',
+                'gesso coverage:merge',
+                (string) file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v1.9-openapi-coverage-merge-help.txt'),
+            ),
+            $helpStdout,
+        );
+        $this->assertSame(2, $errorExit);
+        $this->assertSame('', $errorStdout);
+        $this->assertSame(
+            str_replace(
+                'openapi-coverage-merge',
+                'gesso coverage:merge',
+                (string) file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v1.9-openapi-coverage-merge-usage-error.txt'),
+            ),
+            $errorStderr,
+        );
+    }
+
+    #[Test]
+    public function unknown_command_is_a_usage_error(): void
+    {
+        [$exit, $stdout, $stderr] = $this->runCli(['unknown']);
+
+        $this->assertSame(2, $exit);
+        $this->assertSame('', $stdout);
+        $this->assertSame(
+            '[Gesso] Unknown command: unknown' . "\n\n"
+                . file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v1.10-gesso-help.txt'),
+            $stderr,
+        );
+    }
+
+    /**
+     * @param list<string> $args
+     *
+     * @return array{0: int, 1: string, 2: string}
+     */
+    private function runCli(array $args): array
+    {
+        $command = sprintf('php %s', escapeshellarg($this->repoRoot . '/bin/gesso'));
+        foreach ($args as $arg) {
+            $command .= ' ' . escapeshellarg($arg);
+        }
+
+        $process = proc_open($command, [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes, $this->repoRoot);
+        if (!is_resource($process)) {
+            $this->fail('failed to spawn Gesso CLI');
+        }
+        $stdout = (string) stream_get_contents($pipes[1]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        foreach ($pipes as $pipe) {
+            fclose($pipe);
+        }
+
+        return [proc_close($process), $stdout, $stderr];
+    }
+}

--- a/tests/fixtures/compatibility/v1.10-gesso-help.txt
+++ b/tests/fixtures/compatibility/v1.10-gesso-help.txt
@@ -1,0 +1,10 @@
+Gesso — OpenAPI contract testing for PHP.
+
+Usage:
+  gesso <command> [options]
+
+Commands:
+  doctor           Check whether Gesso can load and enforce a contract.
+  coverage:merge   Combine parallel-worker coverage sidecars.
+
+Run `gesso <command> --help` for command-specific options.


### PR DESCRIPTION
## Summary

- add the `gesso` Composer binary with `doctor` and `coverage:merge` subcommands
- preserve the existing v1 binaries while rendering Gesso invocation names in help and usage output
- document the CLI transition policy: migrate commands on v1.10, then remove the legacy standalone binaries in v2
- add golden and integration coverage for root help, dispatch, usage errors, and exit codes

## Why

Providing the unified command in v1.10 separates CLI migration from the v2 Composer package switch. Consumers can update CI and local scripts before installing v2, while existing v1 invocations remain compatible.

## Impact

- v1.10 adds `vendor/bin/gesso` without removing or changing `openapi-contract` and `openapi-coverage-merge`
- v2 will expose only the unified `gesso` binary
- no production dependency is added

## Validation

- PHPUnit: 2062 tests, 5327 assertions
- focused CLI integration: 20 tests, 68 assertions
- PHPStan
- PHP-CS-Fixer with both configurations
- `composer validate --strict`
- `composer audit --abandoned=fail`
- documentation base/version checks, build, and link check
- `git diff --check`
