### PR TITLE
docs(laravel): define v2 configuration migration

### DIFF
--- a/docs/adr/0001-gesso-v2-identity.md
+++ b/docs/adr/0001-gesso-v2-identity.md
@@ -100,6 +100,38 @@ identity that the major release exists to remove. Command options, exit codes,
 and command-specific output remain compatible unless a separately documented
 v2 change requires otherwise.
 
+### Laravel configuration transition policy
+
+V1.10 continues to own only the `openapi-contract-testing` configuration key,
+publish tag, and `config/openapi-contract-testing.php` destination. It does not
+also register `gesso` as an alias. Claiming a second top-level configuration key
+in a minor release could collide with an application's existing configuration,
+and keeping two mutable copies synchronized would make runtime precedence
+ambiguous.
+
+Before installing v2, Laravel consumers rename the published file to
+`config/gesso.php` and update direct `config('openapi-contract-testing...')`
+lookups to `config('gesso...')`. They must clear any Laravel configuration cache
+before changing the Composer package, then rebuild it after the v2 application
+boots successfully.
+
+The v2 `GessoServiceProvider` merges defaults only under `gesso` and publishes
+only the `gesso` tag to `config/gesso.php`. If the legacy
+`openapi-contract-testing` top-level key is present when the provider registers,
+v2 throws an actionable configuration exception. This applies whether or not a
+`gesso` key is also present; v2 does not compare values, choose a winner, or
+silently fall back to the legacy key. A stale configuration cache therefore
+fails visibly instead of running validation with unintended settings.
+
+V2 provider tests must cover defaults with no published file, overrides from a
+`gesso` file, the new publish tag and destination, and rejection of both
+legacy-only and dual-key configurations. This follows Laravel's package
+configuration model: package defaults are merged under one application key and
+published to one application configuration file. Laravel documents that
+`mergeConfigFrom` merges only the first level, so the migration preserves the
+existing file values rather than reconstructing or recursively combining two
+configurations.
+
 ## Scope boundaries
 
 The v2 identity migration does not by itself authorize unrelated redesigns.
@@ -143,7 +175,6 @@ Before the first breaking rename is merged:
 The following require evidence or maintainer approval before this ADR becomes
 Accepted:
 
-- how conflicts between old and new Laravel configuration are reported;
 - which machine-readable formats require a schema-version increment;
 - the PHP minimum version and supported PHPUnit matrix at the planned v2 GA
   date;
@@ -200,5 +231,6 @@ Gesso 2.0 is not ready for stable release until all of the following pass:
 - [PSR-4 autoloading](https://www.php-fig.org/psr/psr-4/)
 - [PHP `class_alias()`](https://www.php.net/class-alias)
 - [Composer autoloader optimization](https://getcomposer.org/doc/articles/autoloader-optimization.md)
+- [Laravel package configuration](https://laravel.com/docs/packages#configuration)
 - [Symfony backward compatibility promise](https://symfony.com/doc/current/contributing/code/bc.html)
 - [Laminas migration tooling](https://docs.laminas.dev/migration/)

--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -280,6 +280,15 @@ JSON are captured under `tests/fixtures/compatibility/` and exercised through
 Laravel consumer-level integration tests. Text output remains covered
 semantically because Laravel owns its cross-version console table rendering.
 
+V1.10 intentionally does not register a `gesso` configuration alias. At the v2
+package boundary, consumers rename the published file and direct configuration
+lookups. The v2 provider owns only `gesso`; it rejects either a legacy-only
+`openapi-contract-testing` key or a dual-key configuration with an actionable
+exception instead of selecting precedence. The implementation gate includes
+provider tests for the new defaults, overrides, publish target, both rejection
+paths, and stale cached legacy configuration. See the
+[Laravel configuration transition policy](../adr/0001-gesso-v2-identity.md#laravel-configuration-transition-policy).
+
 ## CLI contracts
 
 V1.10 adds the forward-compatible `gesso` entry point. It dispatches

--- a/docs/migration/v2.md
+++ b/docs/migration/v2.md
@@ -70,12 +70,45 @@ requirement instead of treating the package as an in-place update. The exact
 pre-release and stable commands will be added here after the new package is
 registered and verified.
 
+### Migrate Laravel configuration before changing packages
+
+Laravel applications must rename the published configuration file while v1.10
+is still installed, then change the package without booting the application in
+between:
+
+```bash
+php artisan config:clear
+mv config/openapi-contract-testing.php config/gesso.php
+```
+
+Update any direct lookups in application or test code:
+
+```diff
+-config('openapi-contract-testing.default_spec')
++config('gesso.default_spec')
+```
+
+Then replace the Composer requirement and boot the application on v2. Once the
+application starts successfully, rebuild the configuration cache if the
+deployment uses one:
+
+```bash
+php artisan config:cache
+```
+
+Do not publish the v2 configuration with `--force` over the renamed file; the
+rename preserves project-specific values. V2 uses only the `gesso` key, the
+`gesso` publish tag, and `config/gesso.php`. If it detects the legacy top-level
+key (including in a stale configuration cache), its service provider stops with
+an actionable migration error. It deliberately does not guess precedence when
+both keys exist or silently accept the old key.
+
 V2 declares `Studio\Gesso\` as its only product namespace and does not provide
 a reverse `Studio\OpenApiContractTesting\` shim. It also exposes only the
 unified `gesso` binary; the two legacy standalone binaries are removed. Complete
-Stage 1 before the package switch. The remaining Laravel, PHPUnit XML, and
-machine-readable format migrations will be documented as their v2 contracts
-are finalized.
+Stage 1 before the package switch. The remaining PHPUnit XML and
+machine-readable format migrations will be documented as their v2 contracts are
+finalized.
 
 See [ADR 0001](../adr/0001-gesso-v2-identity.md) for the complete identity
 decision and [the namespace compatibility spike](v2-namespace-compatibility-spike.md)


### PR DESCRIPTION
## Summary

- define the Laravel configuration transition policy for Gesso v2
- keep v1.10 on the existing `openapi-contract-testing` key instead of introducing a risky dual-key alias
- document the config file rename, direct lookup updates, and configuration cache sequence
- require v2 to reject legacy-only and dual-key configurations with an actionable error
- record the provider-level verification gates for the v2 implementation

## Why

Laravel loads package configuration under application-wide top-level keys, and `mergeConfigFrom` only merges the first level. Supporting both the legacy and Gesso keys in v1.10 would risk collisions and ambiguous precedence. Defining one explicit package-boundary migration keeps v1 backward compatible and lets v2 use a single clean technical identity.

## Impact

This PR changes documentation and the accepted migration policy only. It does not change v1 runtime behavior. Laravel consumers will migrate the published config file and direct `config()` lookups immediately before replacing the Composer package with v2.

## Validation

- `npm run docs:verify-base`
- `npm run docs:verify-version`
- `npm run docs:build`
- `npm run docs:links`
- `git diff --check`
