### PR TITLE
docs(versioning): define v2 machine-readable formats

### DIFF
--- a/docs/adr/0001-gesso-v2-identity.md
+++ b/docs/adr/0001-gesso-v2-identity.md
@@ -132,6 +132,42 @@ published to one application configuration file. Laravel documents that
 existing file values rather than reconstructing or recursively combining two
 configurations.
 
+### Machine-readable format transition policy
+
+Gesso v2 changes the coverage JSON report from `schema_version: 1` to
+`schema_version: 2`. The report's documented `tool.name` value changes from
+`studio-design/openapi-contract-testing` to `studio-design/gesso`; although the
+JSON object shape is unchanged, that fixed value is part of the contract and a
+consumer may validate or route reports by it. Schema version 2 otherwise keeps
+the version 1 fields, types, and meanings. The v2 writer emits only the Gesso
+identity rather than a second legacy identity field.
+
+The identity migration does not change the other versioned formats:
+
+| Format | Gesso v2 writer | Gesso v2 reader responsibility | Reason |
+| --- | ---: | --- | --- |
+| Coverage JSON report | `schema_version: 2` | N/A (output contract) | The documented fixed `tool.name` value changes |
+| Doctor JSON | `schemaVersion: 1` | N/A (output contract) | It contains no package or namespace identity and its shape is unchanged |
+| Laravel route parity JSON | `schema_version: 1` | N/A (output contract) | It contains no package or namespace identity and its shape is unchanged |
+| Sidecar envelope | `envelopeVersion: 2` | Continue accepting the documented v1.9 envelope and legacy bare coverage state | No persisted field changes for the rename |
+| Coverage tracker state | `version: 1` | Continue accepting version 1 | No persisted field changes for the rename |
+| Strict-required tracker state | `version: 2` | Continue accepting version 2 inside supported envelopes | No persisted field changes for the rename |
+
+Format versions describe their own contracts, not the Composer package major.
+They are therefore not synchronized to `2` merely because Gesso itself reaches
+2.0. A later removal, rename, type change, changed required value, or other
+incompatible semantic change requires the owning format version to advance;
+an unchanged format retains its existing version. Unknown versions continue to
+fail loudly rather than being interpreted as the nearest known shape.
+
+The implementation must pin the coverage JSON v2 document and Gesso tool
+identity with a golden fixture. It must also retain regression tests proving
+that Doctor and route parity still emit version 1 and that the v2 sidecar reader
+accepts every older payload promised by the versioning policy. JSON Schema
+defines a fixed value as the equivalent of a single-value enum, so changing the
+documented tool name is an incompatible value constraint even though no member
+is added or removed.
+
 ## Scope boundaries
 
 The v2 identity migration does not by itself authorize unrelated redesigns.
@@ -175,7 +211,6 @@ Before the first breaking rename is merged:
 The following require evidence or maintainer approval before this ADR becomes
 Accepted:
 
-- which machine-readable formats require a schema-version increment;
 - the PHP minimum version and supported PHPUnit matrix at the planned v2 GA
   date;
 
@@ -225,6 +260,7 @@ Gesso 2.0 is not ready for stable release until all of the following pass:
 ## References
 
 - [Semantic Versioning 2.0.0](https://semver.org/)
+- [JSON Schema 2020-12 validation keyword: `const`](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.3)
 - [Composer package links and `replace`](https://getcomposer.org/doc/04-schema.md#package-links)
 - [Composer repositories and package renaming](https://getcomposer.org/doc/05-repositories.md)
 - [Packagist package naming](https://packagist.org/about)

--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -343,13 +343,13 @@ channel.
 
 | Format | v1.9 version | Compatibility responsibility |
 | --- | ---: | --- |
-| Coverage JSON report | `schema_version: 1` | Preserve documented fields or bump on removal/rename/shape change |
-| Coverage JSON tool identity | `studio-design/openapi-contract-testing` | Change deliberately and test downstream detection |
-| Coverage tracker state | `version: 1` | v2 merge reader should accept supported v1 payloads |
-| Strict-required tracker state | `version: 2` | Preserve mixed-worker import or document a hard boundary |
-| Sidecar envelope | `envelopeVersion: 2` | Continue accepting legacy bare coverage v1 payloads |
-| Laravel route parity JSON | `schema_version: 1` | Preserve fields or bump for incompatible changes |
-| Doctor JSON | `schemaVersion: 1` | Preserve stable fields/categories or bump |
+| Coverage JSON report | `schema_version: 1` | V2 emits schema 2 because the documented fixed tool identity changes; all other fields retain their v1 meanings |
+| Coverage JSON tool identity | `studio-design/openapi-contract-testing` | V2 emits only `studio-design/gesso` and pins it in a golden fixture |
+| Coverage tracker state | `version: 1` | V2 retains version 1 and accepts supported v1 payloads |
+| Strict-required tracker state | `version: 2` | V2 retains version 2 and preserves the documented import boundary |
+| Sidecar envelope | `envelopeVersion: 2` | V2 retains version 2 and continues accepting legacy bare coverage v1 payloads |
+| Laravel route parity JSON | `schema_version: 1` | V2 retains version 1 because neither identity nor shape changes |
+| Doctor JSON | `schemaVersion: 1` | V2 retains version 1 because neither identity nor shape changes |
 | Sidecar filenames | `part-*.json`, failure marker `failed-*` | Keep reader compatibility during mixed runs |
 
 Coverage JSON v1 documents `generated_at`, `tool`, `aggregate`, and `specs`.
@@ -368,6 +368,13 @@ Migration status: the exact v1.9 coverage JSON report and sidecar envelope are
 captured under `tests/fixtures/compatibility/`. The sidecar fixture pins coverage
 tracker state v1 and strict-required tracker state v2, and consumer-style tests
 verify both the envelope reader and the legacy bare-coverage reader path.
+
+V2 decision: only coverage JSON advances its schema version. Its documented
+`tool.name` behaves as a fixed value, so changing it to `studio-design/gesso` is
+an incompatible contract change even though the surrounding object shape stays
+the same. Format versions are otherwise independent of the Composer major:
+Doctor JSON, route parity JSON, the sidecar envelope, and both tracker states do
+not carry the legacy identity and therefore retain their existing versions.
 
 ## Diagnostic categories and embedded identifiers
 

--- a/docs/migration/v2.md
+++ b/docs/migration/v2.md
@@ -106,9 +106,37 @@ both keys exist or silently accept the old key.
 V2 declares `Studio\Gesso\` as its only product namespace and does not provide
 a reverse `Studio\OpenApiContractTesting\` shim. It also exposes only the
 unified `gesso` binary; the two legacy standalone binaries are removed. Complete
-Stage 1 before the package switch. The remaining PHPUnit XML and
-machine-readable format migrations will be documented as their v2 contracts are
-finalized.
+Stage 1 before the package switch. The remaining PHPUnit XML migration will be
+documented when its v2 contract is finalized.
+
+### Update coverage JSON consumers
+
+Gesso v2 coverage JSON uses `schema_version: 2` and identifies the writer as
+`studio-design/gesso`:
+
+```json
+{
+  "schema_version": 2,
+  "tool": {
+    "name": "studio-design/gesso",
+    "version": "2.0.0"
+  }
+}
+```
+
+Update validators, routing rules, snapshots, and dashboards that require
+`schema_version: 1` or compare `tool.name` with the old package. The remaining
+coverage fields and meanings stay compatible with schema version 1; the version
+bump makes the documented fixed identity change visible instead of silently
+passing it through existing consumers.
+
+Do not update unrelated format checks solely because the Composer major
+changes. Doctor JSON remains at `schemaVersion: 1`, Laravel route parity JSON
+remains at `schema_version: 1`, and the sidecar envelope and tracker-state
+versions remain unchanged. Gesso v2's merge reader continues to accept the
+older sidecar payloads documented in the
+[versioning policy](../versioning.md#versioned-sidecar-compatibility), so a
+branding-only migration does not make supported worker data unreadable.
 
 See [ADR 0001](../adr/0001-gesso-v2-identity.md) for the complete identity
 decision and [the namespace compatibility spike](v2-namespace-compatibility-spike.md)


### PR DESCRIPTION
## Summary

- define the Gesso v2 schema-version policy for every documented machine-readable format
- bump only coverage JSON to schema version 2 because its fixed `tool.name` changes
- retain Doctor, Laravel route parity, sidecar envelope, and tracker-state versions when their contracts do not change
- add the downstream coverage JSON migration steps and implementation verification gates

## Why

Format versions describe their own contracts and should not be synchronized mechanically with the Composer package major. Coverage JSON is the exception because changing the documented fixed tool identity from `studio-design/openapi-contract-testing` to `studio-design/gesso` is an incompatible value constraint even though the surrounding JSON shape remains stable.

## Impact

Coverage JSON consumers must accept `schema_version: 2` and the Gesso tool identity when upgrading to v2. Consumers of Doctor JSON, Laravel route parity JSON, and supported sidecar payloads do not need branding-only schema changes.

## Validation

- `npm run docs:verify-base`
- `npm run docs:verify-version`
- `npm run docs:build`
- `npm run docs:links`
- `git diff --check`
