### PR TITLE
docs(versioning): define v2 phpunit xml migration

### DIFF
--- a/docs/adr/0001-gesso-v2-identity.md
+++ b/docs/adr/0001-gesso-v2-identity.md
@@ -100,6 +100,38 @@ identity that the major release exists to remove. Command options, exit codes,
 and command-specific output remain compatible unless a separately documented
 v2 change requires otherwise.
 
+### PHPUnit extension transition policy
+
+PHPUnit consumers keep the existing XML structure and replace only the
+extension namespace when installing v2:
+
+```diff
+ <extensions>
+-    <bootstrap class="Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension">
++    <bootstrap class="Studio\Gesso\PHPUnit\OpenApiCoverageExtension">
+         <!-- existing parameter elements remain unchanged -->
+     </bootstrap>
+ </extensions>
+```
+
+`OpenApiCoverageExtension` describes the extension's OpenAPI coverage role, so
+its short class name remains unchanged. Every existing parameter name, default,
+accepted value, validation rule, path-resolution rule, and environment input
+also remains unchanged. The v2 identity migration therefore does not require a
+second configuration block or parameter renames.
+
+V1.10 documentation continues to show the v1 extension FQCN. Consumers update
+the XML in the same change that replaces the Composer package: v2 does not ship
+a reverse namespace shim, so the legacy FQCN fails during PHPUnit extension
+loading instead of silently selecting a compatibility path. PHPUnit's
+`--migrate-configuration` command updates PHPUnit's own configuration schema;
+it is not a substitute for changing this package-owned class name.
+
+The v2 consumer fixture must boot PHPUnit with the Gesso FQCN and representative
+parameters, then prove that the legacy FQCN is rejected. Existing parameter
+unit tests continue to pin all missing, empty, invalid, and supported-value
+behavior independently of the namespace migration.
+
 ### Laravel configuration transition policy
 
 V1.10 continues to own only the `openapi-contract-testing` configuration key,
@@ -286,6 +318,8 @@ Gesso 2.0 is not ready for stable release until all of the following pass:
 - [Semantic Versioning 2.0.0](https://semver.org/)
 - [PHP supported versions](https://www.php.net/supported-versions.php)
 - [PHPUnit supported versions](https://phpunit.de/supported-versions.html)
+- [PHPUnit extension XML configuration](https://docs.phpunit.de/en/12.5/configuration.html#the-extensions-element)
+- [PHPUnit configuration migration option](https://docs.phpunit.de/en/12.5/cli-options.html#configuration)
 - [Pest support policy](https://pestphp.com/docs/support-policy)
 - [Pest 4 upgrade guide](https://pestphp.com/docs/upgrade-guide)
 - [JSON Schema 2020-12 validation keyword: `const`](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.3)

--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -249,6 +249,21 @@ Environment inputs:
 - `TEST_TOKEN` selects the paratest worker sidecar path and suppresses final
   report writes from workers.
 
+V2 renames only the extension namespace:
+
+```text
+Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension
+  -> Studio\Gesso\PHPUnit\OpenApiCoverageExtension
+```
+
+Migration status: contract fixed; implementation pending the v2 development
+line. The short class name, XML structure, parameters, defaults, accepted
+values, validation behavior, relative-path behavior, and environment inputs
+remain unchanged. The v2 package does not provide the legacy FQCN. Its consumer
+fixture must prove that the Gesso FQCN boots with representative parameters and
+that the legacy FQCN fails extension loading; the existing parameter tests keep
+covering the complete missing, empty, invalid, and supported-value matrix.
+
 ## Laravel configuration and command
 
 The v1 service provider merges and publishes configuration under

--- a/docs/migration/v2.md
+++ b/docs/migration/v2.md
@@ -114,8 +114,28 @@ both keys exist or silently accept the old key.
 V2 declares `Studio\Gesso\` as its only product namespace and does not provide
 a reverse `Studio\OpenApiContractTesting\` shim. It also exposes only the
 unified `gesso` binary; the two legacy standalone binaries are removed. Complete
-Stage 1 before the package switch. The remaining PHPUnit XML migration will be
-documented when its v2 contract is finalized.
+Stage 1 before the package switch.
+
+### Update the PHPUnit extension FQCN
+
+In the same change that replaces the Composer package, update the extension
+class in `phpunit.xml` or `phpunit.xml.dist`:
+
+```diff
+ <extensions>
+-    <bootstrap class="Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension">
++    <bootstrap class="Studio\Gesso\PHPUnit\OpenApiCoverageExtension">
+         <parameter name="spec_base_path" value="tests/fixtures/specs"/>
+         <!-- keep the rest of the existing parameters unchanged -->
+     </bootstrap>
+ </extensions>
+```
+
+Do not register both FQCNs. Gesso v2 does not contain the legacy namespace, and
+the extension short name, XML structure, parameter names, defaults, accepted
+values, path handling, and environment variables are unchanged. PHPUnit's
+`--migrate-configuration` command migrates PHPUnit's configuration schema, not
+this package-owned class name, so make this replacement explicitly.
 
 ### Update coverage JSON consumers
 


### PR DESCRIPTION
## Summary

- define the PHPUnit extension FQCN transition for Gesso v2
- preserve the existing XML structure, parameter contract, path behavior, and environment inputs
- document the package-switch migration step and the required v2 consumer fixture

## Why

The v2 migration guide still left the PHPUnit XML contract unresolved. Fixing this boundary now keeps the identity migration limited to the namespace change and gives the later v2 implementation an explicit positive and negative verification gate.

## Impact

Consumers will replace only `Studio\OpenApiContractTesting\PHPUnit\OpenApiCoverageExtension` with `Studio\Gesso\PHPUnit\OpenApiCoverageExtension` when switching Composer packages. Existing extension parameters remain unchanged.

## Verification

- `npm run docs:verify-base`
- `npm run docs:verify-version`
- `npm run docs:build`
- `npm run docs:links`
- `git diff --check`
