### PR TITLE
test(composer): verify v2 package conflict policy

### DIFF
--- a/docs/adr/0001-gesso-v2-identity.md
+++ b/docs/adr/0001-gesso-v2-identity.md
@@ -54,10 +54,13 @@ The migration will follow these rules:
 2. Treat Composer package migration separately from source migration. Do not
    present `composer update` as sufficient when the root requirement must
    change.
-3. Do not use an unconstrained Composer `replace` entry for the old package.
-   It could incorrectly satisfy dependencies that require an incompatible v1
-   release. The exact `conflict` or constrained `replace` policy must be proven
-   with dependency-resolution fixtures before publication.
+3. Do not declare Composer `replace` for the old package. Gesso v2 does not
+   ship the v1 namespace or API, so claiming that it satisfies an old-package
+   requirement would let incompatible dependents resolve. Instead, v2 declares
+   `"conflict": {"studio-design/openapi-contract-testing": "*"}`. Offline
+   dependency-resolution fixtures prove that a clean Gesso install succeeds
+   while direct dual installation and a transitive old `^1.10` requirement
+   fail resolution.
 4. Register `studio-design/gesso` as a new Packagist package. Mark the old
    package abandoned with `studio-design/gesso` as its replacement only after
    the v2 stable package is installable and verified.
@@ -323,7 +326,7 @@ Gesso 2.0 is not ready for stable release until all of the following pass:
 - [Pest support policy](https://pestphp.com/docs/support-policy)
 - [Pest 4 upgrade guide](https://pestphp.com/docs/upgrade-guide)
 - [JSON Schema 2020-12 validation keyword: `const`](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.1.3)
-- [Composer package links and `replace`](https://getcomposer.org/doc/04-schema.md#package-links)
+- [Composer `conflict` and `replace` package links](https://getcomposer.org/doc/04-schema.md#package-links)
 - [Composer repositories and package renaming](https://getcomposer.org/doc/05-repositories.md)
 - [Packagist package naming](https://packagist.org/about)
 - [PSR-4 autoloading](https://www.php-fig.org/psr/psr-4/)

--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -60,8 +60,13 @@ members marked `@internal` are excluded.
 | PSR requirements | `psr/http-client:^1.0`, `psr/http-factory:^1.0`, `psr/http-message:^1.0 || ^2.0` | Preserve unless separately justified |
 
 Packagist migration must be tested with a clean project. The new package must
-not declare an unconstrained replacement that silently satisfies a dependency
-requiring the old package's `^1` API.
+declare `"conflict": {"studio-design/openapi-contract-testing": "*"}` and must
+not declare `replace`. Gesso v2 does not provide the v1 namespace, so it cannot
+safely satisfy a dependency that still requires the old package. The offline
+fixtures under `tests/fixtures/composer-migration/` prove that a Gesso-only
+project resolves and that both direct dual installation and a transitive old
+`^1.10` requirement fail dependency resolution. The conflict is added to the
+root `composer.json` only when `main` becomes the v2 development line.
 
 ## PHP public types
 

--- a/tests/Integration/ComposerPackageMigrationIntegrationTest.php
+++ b/tests/Integration/ComposerPackageMigrationIntegrationTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Integration;
+
+use FilesystemIterator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+use function copy;
+use function dirname;
+use function fclose;
+use function is_dir;
+use function is_resource;
+use function mkdir;
+use function proc_close;
+use function proc_open;
+use function realpath;
+use function rmdir;
+use function stream_get_contents;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+final class ComposerPackageMigrationIntegrationTest extends TestCase
+{
+    private string $temporaryDirectory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $repoRoot = realpath(__DIR__ . '/../..') ?: dirname(__DIR__, 2);
+        $fixtureDirectory = $repoRoot . '/tests/fixtures/composer-migration';
+        $this->temporaryDirectory = sys_get_temp_dir() . '/gesso-composer-migration-' . uniqid('', true);
+        $this->copyDirectory($fixtureDirectory, $this->temporaryDirectory);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->temporaryDirectory);
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function gesso_v2_resolves_without_the_legacy_package(): void
+    {
+        [$exit, $output] = $this->resolve('new-only');
+
+        $this->assertSame(0, $exit, $output);
+        $this->assertStringContainsString('studio-design/gesso (2.0.0)', $output);
+        $this->assertStringNotContainsString('studio-design/openapi-contract-testing (1.10.0)', $output);
+    }
+
+    #[Test]
+    public function gesso_v2_rejects_a_direct_dual_install(): void
+    {
+        [$exit, $output] = $this->resolve('dual-install');
+
+        $this->assertNotSame(0, $exit, $output);
+        $this->assertStringContainsString('studio-design/gesso 2.0.0 conflicts with studio-design/openapi-contract-testing', $output);
+    }
+
+    #[Test]
+    public function gesso_v2_does_not_satisfy_a_transitive_legacy_requirement(): void
+    {
+        [$exit, $output] = $this->resolve('transitive-legacy');
+
+        $this->assertNotSame(0, $exit, $output);
+        $this->assertStringContainsString('gesso-fixture/legacy-consumer 1.0.0 requires studio-design/openapi-contract-testing', $output);
+        $this->assertStringContainsString('studio-design/gesso 2.0.0 conflicts with studio-design/openapi-contract-testing', $output);
+    }
+
+    /** @return array{0: int, 1: string} */
+    private function resolve(string $scenario): array
+    {
+        $scenarioDirectory = $this->temporaryDirectory . '/' . $scenario;
+        $composerHome = $this->temporaryDirectory . '/composer-home';
+        $command = [
+            '/usr/bin/env',
+            'COMPOSER_HOME=' . $composerHome,
+            'COMPOSER_CACHE_DIR=' . $composerHome . '/cache',
+            'COMPOSER_DISABLE_NETWORK=1',
+            'composer',
+            'update',
+            '--dry-run',
+            '--no-ansi',
+            '--no-audit',
+            '--no-interaction',
+            '--no-plugins',
+            '--no-progress',
+            '--no-scripts',
+        ];
+
+        $process = proc_open($command, [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes, $scenarioDirectory);
+        if (!is_resource($process)) {
+            $this->fail('failed to run Composer dependency resolution fixture');
+        }
+
+        $stdout = (string) stream_get_contents($pipes[1]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        foreach ($pipes as $pipe) {
+            fclose($pipe);
+        }
+
+        return [proc_close($process), $stdout . $stderr];
+    }
+
+    private function copyDirectory(string $source, string $destination): void
+    {
+        mkdir($destination, 0o755, recursive: true);
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($source, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::SELF_FIRST,
+        );
+
+        foreach ($iterator as $item) {
+            $target = $destination . '/' . $iterator->getSubPathname();
+            if ($item->isDir()) {
+                mkdir($target, 0o755, recursive: true);
+            } else {
+                copy($item->getPathname(), $target);
+            }
+        }
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($iterator as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($directory);
+    }
+}

--- a/tests/fixtures/composer-migration/dual-install/composer.json
+++ b/tests/fixtures/composer-migration/dual-install/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "gesso-fixture/dual-install",
+    "type": "project",
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "../repository"
+        },
+        {
+            "packagist.org": false
+        }
+    ],
+    "require": {
+        "studio-design/gesso": "^2.0",
+        "studio-design/openapi-contract-testing": "^1.10"
+    }
+}

--- a/tests/fixtures/composer-migration/new-only/composer.json
+++ b/tests/fixtures/composer-migration/new-only/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "gesso-fixture/new-only",
+    "type": "project",
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "../repository"
+        },
+        {
+            "packagist.org": false
+        }
+    ],
+    "require": {
+        "studio-design/gesso": "^2.0"
+    }
+}

--- a/tests/fixtures/composer-migration/repository/packages.json
+++ b/tests/fixtures/composer-migration/repository/packages.json
@@ -1,0 +1,31 @@
+{
+    "packages": {
+        "studio-design/openapi-contract-testing": {
+            "1.10.0": {
+                "name": "studio-design/openapi-contract-testing",
+                "version": "1.10.0",
+                "type": "metapackage"
+            }
+        },
+        "studio-design/gesso": {
+            "2.0.0": {
+                "name": "studio-design/gesso",
+                "version": "2.0.0",
+                "type": "metapackage",
+                "conflict": {
+                    "studio-design/openapi-contract-testing": "*"
+                }
+            }
+        },
+        "gesso-fixture/legacy-consumer": {
+            "1.0.0": {
+                "name": "gesso-fixture/legacy-consumer",
+                "version": "1.0.0",
+                "type": "metapackage",
+                "require": {
+                    "studio-design/openapi-contract-testing": "^1.10"
+                }
+            }
+        }
+    }
+}

--- a/tests/fixtures/composer-migration/transitive-legacy/composer.json
+++ b/tests/fixtures/composer-migration/transitive-legacy/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "gesso-fixture/transitive-legacy",
+    "type": "project",
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "../repository"
+        },
+        {
+            "packagist.org": false
+        }
+    ],
+    "require": {
+        "gesso-fixture/legacy-consumer": "^1.0",
+        "studio-design/gesso": "^2.0"
+    }
+}


### PR DESCRIPTION
## Summary

- define Gesso v2 as conflicting with every version of the legacy Composer package
- avoid `replace` because v2 does not provide the legacy namespace or API
- add offline dependency-resolution fixtures for clean, direct-conflict, and transitive-conflict scenarios

## Why

The v2 identity ADR left the exact Composer `conflict` or constrained `replace` policy unresolved. Composer `replace` would allow dependencies requiring the old v1 package to resolve even though Gesso v2 removes that API. An explicit conflict makes those incompatible dependency paths fail during resolution.

## Impact

When `main` becomes the v2 development line, `studio-design/gesso` will declare a conflict with `studio-design/openapi-contract-testing:*`. Consumers and transitive dependencies must remove the old package requirement before installing v2.

## Verification

- `vendor/bin/phpunit tests/Integration/ComposerPackageMigrationIntegrationTest.php`
- `vendor/bin/phpunit --testsuite Integration`
- `vendor/bin/php-cs-fixer fix --dry-run --diff tests/Integration/ComposerPackageMigrationIntegrationTest.php`
- `vendor/bin/phpstan analyse --debug tests/Integration/ComposerPackageMigrationIntegrationTest.php`
- JSON fixture validation with `jq empty`
- `npm run docs:verify-base`
- `npm run docs:verify-version`
- `npm run docs:build`
- `npm run docs:links`
- `git diff --check`
