### PR TITLE
test(compatibility): define v2 resolver provenance

### DIFF
--- a/docs/adr/0001-gesso-v2-identity.md
+++ b/docs/adr/0001-gesso-v2-identity.md
@@ -203,6 +203,41 @@ defines a fixed value as the equivalent of a single-value enum, so changing the
 documented tool name is an incompatible value constraint even though no member
 is added or removed.
 
+### Resolver provenance extension transition policy
+
+V1's eager `$ref` resolver attaches
+`x-studio-openapi-contract-testing-implicit-schema-name` to a directly
+referenced `oneOf` or `anyOf` alternative. This preserves the component name
+needed to implement an implicit discriminator mapping after the Reference
+Object has been replaced by its target. Although the marker can appear in the
+array returned by the public spec loader, it is resolver-owned provenance: a
+same-named field authored in an OpenAPI Description is removed and is never
+accepted as mapping authority.
+
+Gesso v2 renames the generated marker to
+`x-studio-gesso-implicit-schema-name`. It removes both the legacy and Gesso
+keys from input before resolving a node, and only writes the Gesso key after it
+has successfully resolved a direct local component-schema reference. The v2
+schema converter consumes and strips only resolver-generated Gesso provenance.
+The discriminator behavior and the resulting validation schema otherwise stay
+unchanged.
+
+There is no dual-read period for this marker. A legacy field supplied as input
+cannot be distinguished from a spoofed user-authored extension, so trusting it
+would undo the resolver's existing integrity boundary. Consumers migrate the
+original OpenAPI Description, not a persisted post-resolution array. V1.10
+continues emitting its existing marker; v2 emits only the Gesso marker and does
+not expose a user configuration switch for either name.
+
+[OpenAPI Specification Extensions](https://spec.openapis.org/oas/v3.2.0.html#specification-extensions)
+allow implementation-specific `x-` fields and reserve `x-oai-` and `x-oas-`
+for the OpenAPI Initiative. The Gesso marker keeps an implementation-specific
+prefix, while the additional `studio-gesso` namespace limits collisions and
+makes its ownership explicit. V2 regression tests must prove that both authored
+names are removed, only a real direct component `$ref` can create the new
+marker, and implicit discriminator behavior remains equivalent to the v1
+baseline.
+
 ### Runtime and test-runner support policy
 
 Gesso v2 requires PHP `^8.3` and supports PHPUnit `^12.0 || ^13.0`. The v2 CI

--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -417,8 +417,19 @@ Other stable operational prefixes that require rename or parity tests include:
 
 The OpenAPI vendor extension
 `x-studio-openapi-contract-testing-implicit-schema-name` is embedded in spec
-input rather than PHP source. Its Gesso replacement and any dual-read period
-must be decided explicitly.
+resolution output rather than PHP source. It is resolver-owned provenance, not
+an accepted user extension: an authored value is removed before resolution to
+prevent spoofed discriminator mappings. The exact v1 output is pinned by a
+compatibility fixture.
+
+V2 decision: the resolver generates
+`x-studio-gesso-implicit-schema-name`, removes both old and new names from
+input, and consumes only the newly generated Gesso marker. There is no
+dual-read period because a legacy input field cannot be authenticated as
+resolver output. Consumers must carry the original OpenAPI Description across
+the upgrade rather than persist and reload a resolved array. The validation
+semantics remain unchanged; v2 tests must cover direct-reference generation,
+both spoofed input names, and implicit discriminator parity.
 
 ## v2 migration verification matrix
 

--- a/tests/Unit/Compatibility/ResolverProvenanceBaselineTest.php
+++ b/tests/Unit/Compatibility/ResolverProvenanceBaselineTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Compatibility;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\OpenApiContractTesting\Spec\OpenApiRefResolver;
+
+use function dirname;
+use function file_get_contents;
+use function json_encode;
+
+final class ResolverProvenanceBaselineTest extends TestCase
+{
+    #[Test]
+    public function resolved_composition_matches_the_v1_9_provenance_fixture(): void
+    {
+        $legacyMarker = 'x-studio-openapi-contract-testing-implicit-schema-name';
+        $resolved = OpenApiRefResolver::resolve([
+            'components' => ['schemas' => [
+                'Cat' => ['type' => 'object', 'required' => ['meow']],
+            ]],
+            'schema' => [
+                'oneOf' => [
+                    ['$ref' => '#/components/schemas/Cat'],
+                    ['type' => 'object', $legacyMarker => 'Spoofed'],
+                ],
+            ],
+        ]);
+
+        $this->assertSame($legacyMarker, OpenApiRefResolver::IMPLICIT_SCHEMA_NAME_EXTENSION);
+        $this->assertSame(
+            $this->fixture(),
+            json_encode(
+                $resolved,
+                JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+            ) . "\n",
+        );
+    }
+
+    private function fixture(): string
+    {
+        $contents = file_get_contents(
+            dirname(__DIR__, 2) . '/fixtures/compatibility/v1.9-resolver-provenance.json',
+        );
+        $this->assertIsString($contents);
+
+        return $contents;
+    }
+}

--- a/tests/fixtures/compatibility/v1.9-resolver-provenance.json
+++ b/tests/fixtures/compatibility/v1.9-resolver-provenance.json
@@ -1,0 +1,26 @@
+{
+    "components": {
+        "schemas": {
+            "Cat": {
+                "type": "object",
+                "required": [
+                    "meow"
+                ]
+            }
+        }
+    },
+    "schema": {
+        "oneOf": [
+            {
+                "type": "object",
+                "required": [
+                    "meow"
+                ],
+                "x-studio-openapi-contract-testing-implicit-schema-name": "Cat"
+            },
+            {
+                "type": "object"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Summary

- define the Gesso v2 resolver provenance extension as `x-studio-gesso-implicit-schema-name`
- reject a dual-read transition so authored legacy markers cannot spoof implicit discriminator mappings
- capture the v1.9 resolved provenance output in a compatibility fixture

## Why

The eager resolver exposes an implementation-owned marker in resolved spec arrays. The v2 identity migration needs an explicit rename and trust boundary before the breaking namespace work begins. OpenAPI permits implementation-specific `x-` fields, while the existing resolver already removes authored marker values before generating provenance from a real direct component `$ref`.

## Impact

There is no v1 runtime behavior change. Gesso v2 will remove both authored marker names, generate only the Gesso marker, and preserve existing discriminator validation semantics. Consumers should migrate original OpenAPI descriptions rather than persisted post-resolution arrays.

## Verification

- `vendor/bin/phpunit tests/Unit/Compatibility tests/Unit/Spec/OpenApiRefResolverTest.php` (58 tests, 221 assertions)
- `vendor/bin/phpstan analyse --debug tests/Unit/Compatibility/ResolverProvenanceBaselineTest.php`
- PHP-CS-Fixer focused dry run
- `npm run docs:verify-base`
- `npm run docs:verify-version`
- `npm run docs:build`
- `npm run docs:links`
- `jq empty tests/fixtures/compatibility/v1.9-resolver-provenance.json`
- `git diff --check`
