### PR TITLE
test(compatibility): define v2 diagnostic prefixes

### DIFF
--- a/docs/adr/0001-gesso-v2-identity.md
+++ b/docs/adr/0001-gesso-v2-identity.md
@@ -260,10 +260,12 @@ the legacy spelling; v2 changes both occurrences together and does not emit
 duplicate legacy-prefixed messages. Consumers that route either channel by its
 prefix must update that rule during the package switch.
 
-The v1.9 prefix inventory is pinned by a compatibility fixture so a new branded
-occurrence cannot be added without an explicit migration decision. V2 tests
-must prove that no `[openapi-contract-testing]` diagnostic remains in `src/`,
-that both branded channels use `[Gesso]`, and that the identity-neutral
+The v1.9 prefix inventory pins every protected category and its emitted-string
+occurrence count per source file. A compatibility test tokenizes PHP string
+literals so comments cannot substitute for a removed runtime diagnostic, and a
+new branded occurrence cannot be added without an explicit migration decision.
+V2 tests must prove that no `[openapi-contract-testing]` diagnostic remains in
+`src/`, that both branded channels use `[Gesso]`, and that the identity-neutral
 categories retain parity.
 
 ### Runtime and test-runner support policy

--- a/docs/adr/0001-gesso-v2-identity.md
+++ b/docs/adr/0001-gesso-v2-identity.md
@@ -238,6 +238,34 @@ names are removed, only a real direct component `$ref` can create the new
 marker, and implicit discriminator behavior remains equivalent to the v1
 baseline.
 
+### Diagnostic prefix transition policy
+
+Diagnostic prefixes that describe an OpenAPI feature remain unchanged in v2:
+
+- `[OpenAPI Coverage]`
+- `[OpenAPI Doctor]`
+- `[OpenAPI Enum Drift]`
+- `[OpenAPI Strict Required]`
+- `[OpenAPI Strict Required per-call]`
+
+These are routing categories rather than the legacy product identity. Renaming
+them would create log-parser churn without making Gesso's technical identity
+clearer. The existing `[security]`, `[OpenAPI Schema]`, and `[OpenAPI 3.2 ...]`
+warning categories also remain unchanged.
+
+The branded `[openapi-contract-testing]` prefix changes to `[Gesso]` in v2.
+V1.9 uses it in two channels: the missing-optional-Faker `E_USER_WARNING` and
+the Laravel contradictory-intent deprecation written to stderr. V1.10 retains
+the legacy spelling; v2 changes both occurrences together and does not emit
+duplicate legacy-prefixed messages. Consumers that route either channel by its
+prefix must update that rule during the package switch.
+
+The v1.9 prefix inventory is pinned by a compatibility fixture so a new branded
+occurrence cannot be added without an explicit migration decision. V2 tests
+must prove that no `[openapi-contract-testing]` diagnostic remains in `src/`,
+that both branded channels use `[Gesso]`, and that the identity-neutral
+categories retain parity.
+
 ### Runtime and test-runner support policy
 
 Gesso v2 requires PHP `^8.3` and supports PHPUnit `^12.0 || ^13.0`. The v2 CI

--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -416,9 +416,11 @@ Other stable operational prefixes that require rename or parity tests include:
 - `[openapi-contract-testing]` for the missing-optional-Faker warning and the
   Laravel deprecation stderr channel
 
-Migration status: the operational prefix set and both source locations of the
-legacy branded prefix are captured in
-`tests/fixtures/compatibility/v1.9-diagnostic-prefixes.json`.
+Migration status: every protected category and its emitted-string occurrence
+count per source file are captured in
+`tests/fixtures/compatibility/v1.9-diagnostic-prefixes.json`. The test tokenizes
+PHP string literals rather than counting comments, so a removed runtime
+category cannot be replaced by documentary text.
 
 V2 decision: feature-oriented prefixes remain unchanged because they are
 identity-neutral log-routing categories. Both `[openapi-contract-testing]`

--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -413,7 +413,20 @@ Other stable operational prefixes that require rename or parity tests include:
 - `[OpenAPI Enum Drift]`
 - `[OpenAPI Strict Required]`
 - `[OpenAPI Strict Required per-call]`
-- `[openapi-contract-testing]` for the Laravel deprecation channel
+- `[openapi-contract-testing]` for the missing-optional-Faker warning and the
+  Laravel deprecation stderr channel
+
+Migration status: the operational prefix set and both source locations of the
+legacy branded prefix are captured in
+`tests/fixtures/compatibility/v1.9-diagnostic-prefixes.json`.
+
+V2 decision: feature-oriented prefixes remain unchanged because they are
+identity-neutral log-routing categories. Both `[openapi-contract-testing]`
+occurrences change to `[Gesso]` together. V2 does not dual-emit warnings; log
+consumers update the branded routing rule as part of the major-version
+migration. A source-level regression test must prove that the legacy branded
+prefix is absent from v2 while parity tests retain every identity-neutral
+category.
 
 The OpenAPI vendor extension
 `x-studio-openapi-contract-testing-implicit-schema-name` is embedded in spec

--- a/docs/migration/v2.md
+++ b/docs/migration/v2.md
@@ -166,6 +166,20 @@ older sidecar payloads documented in the
 [versioning policy](../versioning.md#versioned-sidecar-compatibility), so a
 branding-only migration does not make supported worker data unreadable.
 
+### Update branded diagnostic log rules
+
+Gesso v2 changes the two branded diagnostic prefixes from
+`[openapi-contract-testing]` to `[Gesso]`. Update log routing or assertions for:
+
+- the warning emitted when the optional `fakerphp/faker` package is missing;
+- the Laravel contradictory-intent deprecation written to stderr.
+
+Feature-oriented categories such as `[OpenAPI Coverage]`, `[OpenAPI Doctor]`,
+`[OpenAPI Enum Drift]`, `[OpenAPI Strict Required]`, and
+`[OpenAPI Strict Required per-call]` do not change. Keep existing rules for
+those categories. V2 emits only the Gesso-branded form rather than duplicating
+each warning under both names.
+
 See [ADR 0001](../adr/0001-gesso-v2-identity.md) for the complete identity
 decision and [the namespace compatibility spike](v2-namespace-compatibility-spike.md)
 for the tested behavior and identity limits of `class_alias()`.

--- a/tests/Unit/Compatibility/DiagnosticPrefixesBaselineTest.php
+++ b/tests/Unit/Compatibility/DiagnosticPrefixesBaselineTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Compatibility;
+
+use const JSON_THROW_ON_ERROR;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+use function dirname;
+use function file_get_contents;
+use function json_decode;
+use function sort;
+use function str_contains;
+
+final class DiagnosticPrefixesBaselineTest extends TestCase
+{
+    #[Test]
+    public function diagnostic_prefixes_match_the_v1_9_inventory(): void
+    {
+        /** @var array{
+         *     identity_neutral_prefixes: list<string>,
+         *     legacy_branded_prefix_occurrences: array<string, list<string>>
+         * } $fixture
+         */
+        $fixture = json_decode(
+            $this->fixture(),
+            true,
+            flags: JSON_THROW_ON_ERROR,
+        );
+        $sources = $this->sourceFiles();
+
+        foreach ($fixture['identity_neutral_prefixes'] as $prefix) {
+            $this->assertTrue(
+                $this->sourceContains($sources, $prefix),
+                "Expected the v1 diagnostic prefix {$prefix} to remain present.",
+            );
+        }
+
+        foreach ($fixture['legacy_branded_prefix_occurrences'] as $prefix => $expectedFiles) {
+            $actualFiles = [];
+            foreach ($sources as $file => $contents) {
+                if (str_contains($contents, $prefix)) {
+                    $actualFiles[] = $file;
+                }
+            }
+
+            sort($actualFiles);
+            sort($expectedFiles);
+            $this->assertSame($expectedFiles, $actualFiles);
+        }
+    }
+
+    /** @param array<string, string> $sources */
+    private function sourceContains(array $sources, string $prefix): bool
+    {
+        foreach ($sources as $contents) {
+            if (str_contains($contents, $prefix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** @return array<string, string> */
+    private function sourceFiles(): array
+    {
+        $projectRoot = dirname(__DIR__, 3);
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($projectRoot . '/src'),
+        );
+        $sources = [];
+
+        /** @var SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $contents = file_get_contents($file->getPathname());
+            $this->assertIsString($contents);
+            $relativePath = 'src/' . $iterator->getSubPathname();
+            $sources[$relativePath] = $contents;
+        }
+
+        return $sources;
+    }
+
+    private function fixture(): string
+    {
+        $contents = file_get_contents(
+            dirname(__DIR__, 2) . '/fixtures/compatibility/v1.9-diagnostic-prefixes.json',
+        );
+        $this->assertIsString($contents);
+
+        return $contents;
+    }
+}

--- a/tests/Unit/Compatibility/DiagnosticPrefixesBaselineTest.php
+++ b/tests/Unit/Compatibility/DiagnosticPrefixesBaselineTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Studio\OpenApiContractTesting\Tests\Unit\Compatibility;
 
 use const JSON_THROW_ON_ERROR;
+use const T_CONSTANT_ENCAPSED_STRING;
+use const T_ENCAPSED_AND_WHITESPACE;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -12,60 +14,68 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
 
+use function array_fill_keys;
+use function array_keys;
 use function dirname;
 use function file_get_contents;
+use function in_array;
+use function is_array;
 use function json_decode;
-use function sort;
-use function str_contains;
+use function ksort;
+use function str_replace;
+use function substr_count;
+use function token_get_all;
 
 final class DiagnosticPrefixesBaselineTest extends TestCase
 {
     #[Test]
     public function diagnostic_prefixes_match_the_v1_9_inventory(): void
     {
-        /** @var array{
-         *     identity_neutral_prefixes: list<string>,
-         *     legacy_branded_prefix_occurrences: array<string, list<string>>
-         * } $fixture
-         */
+        /** @var array<string, array<string, positive-int>> $fixture */
         $fixture = json_decode(
             $this->fixture(),
             true,
             flags: JSON_THROW_ON_ERROR,
         );
-        $sources = $this->sourceFiles();
+        /** @var array<string, array<string, positive-int>> $actual */
+        $actual = array_fill_keys(array_keys($fixture), []);
 
-        foreach ($fixture['identity_neutral_prefixes'] as $prefix) {
-            $this->assertTrue(
-                $this->sourceContains($sources, $prefix),
-                "Expected the v1 diagnostic prefix {$prefix} to remain present.",
-            );
-        }
+        foreach ($this->sourceFiles() as $file => $contents) {
+            foreach (token_get_all($contents) as $token) {
+                if (!is_array($token) || !in_array(
+                    $token[0],
+                    [T_CONSTANT_ENCAPSED_STRING, T_ENCAPSED_AND_WHITESPACE],
+                    true,
+                )) {
+                    continue;
+                }
 
-        foreach ($fixture['legacy_branded_prefix_occurrences'] as $prefix => $expectedFiles) {
-            $actualFiles = [];
-            foreach ($sources as $file => $contents) {
-                if (str_contains($contents, $prefix)) {
-                    $actualFiles[] = $file;
+                // PHP token text retains the escape in a double-quoted
+                // `\$self`; normalize it to the emitted diagnostic prefix.
+                $literal = str_replace('\\$', '$', $token[1]);
+                foreach (array_keys($fixture) as $prefix) {
+                    $count = substr_count($literal, $prefix);
+                    if ($count === 0) {
+                        continue;
+                    }
+
+                    $actual[$prefix][$file] = ($actual[$prefix][$file] ?? 0) + $count;
                 }
             }
-
-            sort($actualFiles);
-            sort($expectedFiles);
-            $this->assertSame($expectedFiles, $actualFiles);
-        }
-    }
-
-    /** @param array<string, string> $sources */
-    private function sourceContains(array $sources, string $prefix): bool
-    {
-        foreach ($sources as $contents) {
-            if (str_contains($contents, $prefix)) {
-                return true;
-            }
         }
 
-        return false;
+        ksort($fixture);
+        ksort($actual);
+        foreach ($fixture as &$files) {
+            ksort($files);
+        }
+        unset($files);
+        foreach ($actual as &$files) {
+            ksort($files);
+        }
+        unset($files);
+
+        $this->assertSame($fixture, $actual);
     }
 
     /** @return array<string, string> */

--- a/tests/fixtures/compatibility/v1.9-diagnostic-prefixes.json
+++ b/tests/fixtures/compatibility/v1.9-diagnostic-prefixes.json
@@ -1,0 +1,15 @@
+{
+    "identity_neutral_prefixes": [
+        "[OpenAPI Coverage]",
+        "[OpenAPI Doctor]",
+        "[OpenAPI Enum Drift]",
+        "[OpenAPI Strict Required]",
+        "[OpenAPI Strict Required per-call]"
+    ],
+    "legacy_branded_prefix_occurrences": {
+        "[openapi-contract-testing]": [
+            "src/Fuzz/SchemaDataGenerator.php",
+            "src/Laravel/ValidatesOpenApiSchema.php"
+        ]
+    }
+}

--- a/tests/fixtures/compatibility/v1.9-diagnostic-prefixes.json
+++ b/tests/fixtures/compatibility/v1.9-diagnostic-prefixes.json
@@ -1,15 +1,48 @@
 {
-    "identity_neutral_prefixes": [
-        "[OpenAPI Coverage]",
-        "[OpenAPI Doctor]",
-        "[OpenAPI Enum Drift]",
-        "[OpenAPI Strict Required]",
-        "[OpenAPI Strict Required per-call]"
-    ],
-    "legacy_branded_prefix_occurrences": {
-        "[openapi-contract-testing]": [
-            "src/Fuzz/SchemaDataGenerator.php",
-            "src/Laravel/ValidatesOpenApiSchema.php"
-        ]
+    "[OpenAPI 3.2 $self]": {
+        "src/Spec/OpenApiSpecLoader.php": 1
+    },
+    "[OpenAPI 3.2 discriminator]": {
+        "src/Spec/OpenApiSchemaConverter.php": 1
+    },
+    "[OpenAPI 3.2 querystring]": {
+        "src/Validation/Request/QueryParameterValidator.php": 1
+    },
+    "[OpenAPI Coverage]": {
+        "src/Coverage/CoverageMergeCommand.php": 15,
+        "src/Coverage/CoverageThresholdEvaluator.php": 1,
+        "src/Coverage/OpenApiCoverageTracker.php": 2,
+        "src/PHPUnit/ConsoleOutput.php": 2,
+        "src/PHPUnit/CoverageReportSubscriber.php": 9,
+        "src/PHPUnit/OpenApiCoverageExtension.php": 8
+    },
+    "[OpenAPI Doctor]": {
+        "src/Cli/DoctorCommand.php": 1
+    },
+    "[OpenAPI Enum Drift]": {
+        "src/PHPUnit/OpenApiCoverageExtension.php": 7,
+        "src/Schema/EnumDriftAsserter.php": 1
+    },
+    "[OpenAPI Schema]": {
+        "src/Spec/OpenApiSchemaConverter.php": 4
+    },
+    "[OpenAPI Strict Required per-call]": {
+        "src/PHPUnit/OpenApiCoverageExtension.php": 1,
+        "src/Validation/Strict/StrictRequiredPerCallChecker.php": 4
+    },
+    "[OpenAPI Strict Required]": {
+        "src/Coverage/CoverageMergeCommand.php": 3,
+        "src/OpenApiResponseValidator.php": 1,
+        "src/PHPUnit/CoverageReportSubscriber.php": 3,
+        "src/PHPUnit/OpenApiCoverageExtension.php": 2,
+        "src/Validation/Strict/StrictRequiredAsserter.php": 1,
+        "src/Validation/Strict/StrictRequiredTracker.php": 1
+    },
+    "[openapi-contract-testing]": {
+        "src/Fuzz/SchemaDataGenerator.php": 1,
+        "src/Laravel/ValidatesOpenApiSchema.php": 1
+    },
+    "[security]": {
+        "src/Validation/Request/SecurityValidator.php": 8
     }
 }


### PR DESCRIPTION
## Summary

- capture the v1.9 operational diagnostic-prefix baseline
- keep identity-neutral OpenAPI categories unchanged in v2
- rename only the legacy branded prefix to `[Gesso]` in the v2 policy and migration guide
- include both existing branded channels: the optional Faker warning and Laravel deprecation stderr output

## Why

Diagnostic prefixes are compatibility surfaces for log routing and assertions. The inventory previously mentioned only the Laravel occurrence and did not define which prefixes should change with the Gesso identity. Pinning the current source locations prevents new legacy-branded diagnostics from being introduced without an explicit migration decision.

## Impact

This PR does not change runtime output in v1. It defines the v2 migration contract: feature-oriented prefixes remain stable, while both `[openapi-contract-testing]` occurrences change together to `[Gesso]` without dual emission.

## Verification

- `vendor/bin/phpunit tests/Unit/Compatibility`
- `vendor/bin/phpstan analyse --debug tests/Unit/Compatibility/DiagnosticPrefixesBaselineTest.php`
- `vendor/bin/php-cs-fixer fix --dry-run --diff tests/Unit/Compatibility/DiagnosticPrefixesBaselineTest.php`
- `jq empty tests/fixtures/compatibility/v1.9-diagnostic-prefixes.json`
- `npm run docs:verify-base`
- `npm run docs:verify-version`
- `npm run docs:build`
- `npm run docs:links`
- `git diff --check`
