### PR TITLE
feat(runtime)!: require php 8.3 and maintained test runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,25 +15,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '8.2'
-            phpunit: '11'
+          - php: '8.3'
+            phpunit: '12'
             deps: highest
-          - php: '8.2'
-            phpunit: '11'
+          - php: '8.3'
+            phpunit: '12'
             deps: lowest
-          - php: '8.3'
-            phpunit: '11'
-            deps: highest
-          - php: '8.3'
-            phpunit: '12'
-            deps: highest
-          - php: '8.4'
-            phpunit: '11'
-            deps: highest
           - php: '8.4'
             phpunit: '12'
             deps: highest
           - php: '8.4'
+            phpunit: '13'
+            deps: highest
+          - php: '8.5'
+            phpunit: '12'
+            deps: highest
+          - php: '8.5'
             phpunit: '13'
             deps: highest
 
@@ -61,22 +58,19 @@ jobs:
   pest:
     name: Pest plugin smoke (PHP ${{ matrix.php }})
     runs-on: ubuntu-latest
-    # Pest 3 requires PHPUnit ^11; the mainline matrix also runs PHPUnit
-    # 12/13 for which Pest has no compatible major yet. Keeping this job on
-    # the PHPUnit 11 floor isolates the Pest plugin without forcing the rest
-    # of the matrix to drop newer PHPUnit versions. Pest is added on demand
+    # Pest 4 requires PHPUnit ^12; the mainline matrix also runs PHPUnit 13.
+    # Keeping this job on PHPUnit 12 isolates the Pest plugin without forcing
+    # the rest of the matrix to drop PHPUnit 13. Pest is added on demand
     # rather than to require-dev so the regular composer install used by the
     # matrix above stays Pest-free.
     #
-    # The 2-cell matrix (PHP 8.3 + 8.4) catches PHP-version regressions on
+    # The matrix covers the full supported PHP range and catches regressions on
     # the Pest internals the dispatcher depends on (HigherOrderTapProxy,
-    # PendingCalls\TestCall, dynamic property access). PHP 8.2 is excluded
-    # because Pest 3 dropped PHP 8.2 support around v3.5; bumping the upper
-    # Pest version (Pest 4 / PHPUnit ^12) is tracked separately.
+    # PendingCalls\TestCall, dynamic property access).
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.3', '8.4']
+        php: ['8.3', '8.4', '8.5']
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -86,12 +80,12 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: none
 
-      - name: Install dependencies (with Pest 3)
+      - name: Install dependencies (with Pest 4)
         # Single resolve: any version conflict surfaces as one dependency
         # tree in the CI log, not as a "no-update succeeded but update
         # failed" two-step that obscures which constraint introduced the
         # conflict.
-        run: composer require --dev "phpunit/phpunit:^11.0" "pestphp/pest:^3.0" --prefer-dist --no-interaction --no-progress
+        run: composer require --dev "pestphp/pest:^4.0" --prefer-dist --no-interaction --no-progress
 
       - name: Run Pest smoke tests
         run: composer test:pest
@@ -130,7 +124,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
 
       - name: Install example dependencies
@@ -149,11 +143,11 @@ jobs:
       matrix:
         include:
           - example: core
-            php: '8.2'
+            php: '8.3'
           - example: laravel
-            php: '8.2'
+            php: '8.3'
           - example: symfony
-            php: '8.2'
+            php: '8.3'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -232,7 +226,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
 
       - name: Install dependencies
@@ -251,9 +245,9 @@ jobs:
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           # Run on the lowest supported PHP so any constraint mismatch
-          # between composer.json's `php: ^8.2` and the resolved lock
+          # between composer.json's `php: ^8.3` and the resolved dependencies
           # surfaces here, not at install time on a downstream consumer.
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
 
       - name: Validate composer.json + composer.lock
@@ -271,7 +265,7 @@ jobs:
           # Same rationale as composer-validate: the audit itself is
           # platform-independent, but installing on the lowest PHP catches
           # platform-constraint regressions in dependencies.
-          php-version: '8.2'
+          php-version: '8.3'
           coverage: none
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require --dev "phpunit/phpunit:^${{ matrix.phpunit }}.0" --no-interaction --no-update
           if [ "${{ matrix.deps }}" = "lowest" ]; then
-            composer update --prefer-lowest --prefer-dist --no-interaction --no-progress
+            composer update --with "phpunit/phpunit:^${{ matrix.phpunit }}.0" --prefer-lowest --prefer-dist --no-interaction --no-progress
           else
-            composer update --prefer-dist --no-interaction --no-progress
+            composer update --with "phpunit/phpunit:^${{ matrix.phpunit }}.0" --prefer-dist --no-interaction --no-progress
           fi
 
       - name: Run tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ that agent's local configuration instead.
 
 ## Project scope
 
-`studio-design/openapi-contract-testing` is a PHP 8.2+ test-time library for
+`studio-design/openapi-contract-testing` is a PHP 8.3+ test-time library for
 validating requests and responses against OpenAPI 3.0, 3.1, and 3.2. Its core is
 framework-agnostic; adapters support PHPUnit, Laravel, Symfony, and Pest. It also
 provides endpoint/response coverage, schema-driven exploration, enum-drift and
@@ -96,10 +96,10 @@ composer cs
 ```
 
 `composer ci` runs both PHP-CS-Fixer configurations, PHPStan, and PHPUnit. CI also
-tests PHP 8.2-8.4 with PHPUnit 11-13, lowest dependencies, the optional Pest
+tests PHP 8.3-8.5 with PHPUnit 12-13, lowest dependencies, the optional Pest
 integration and example, Composer validation/audit, and generated Markdown lint.
 When changing one of those surfaces, run its focused check and rely on the matrix
-for combinations unavailable locally. Pest tests require Pest 3 and PHPUnit 11;
+for combinations unavailable locally. Pest tests require Pest 4 and PHPUnit 12;
 follow `composer.json` and `examples/pest/README.md` rather than adding Pest to the
 normal dependency set.
 
@@ -107,7 +107,7 @@ normal dependency set.
 
 - Follow PSR-4 under `Studio\OpenApiContractTesting\` and start PHP files with
   `declare(strict_types=1);`.
-- Keep code compatible with the PHP 8.2 floor.
+- Keep code compatible with the PHP 8.3 floor.
 - PHP-CS-Fixer is authoritative: PER-CS2.0, strict comparisons, explicit global
   function/constant imports, ordered imports/elements, and snake_case PHPUnit
   test methods. Pest callbacks are the intentional exception to `static_lambda`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,8 @@ composer install
 composer ci   # runs cs-check + stan + test
 ```
 
-PHP 8.2 or newer is required. The CI matrix runs PHP 8.2/8.3/8.4 with
-PHPUnit 11/12/13.
+PHP 8.3 or newer is required. The CI matrix runs PHP 8.3/8.4/8.5 with
+PHPUnit 12/13.
 
 ## Local checks
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Choose based on the workflow you need rather than on a single yes/no feature cou
 | Schema-driven exploration | [Deterministic endpoint + whole-spec generation](docs/fuzzing.md) | — | — | — | — |
 | Drift / under-description checks | [Enum drift](docs/enum-drift.md), [strict required](docs/strict-required.md) | — | — | — | — |
 | First-class integration | [PSR-7](docs/psr7.md), [Laravel, Symfony, Pest](docs/setup.md) | [Laravel][spectator] | [PSR-7, PSR-15 middleware][league-middleware] | [HttpFoundation, PSR-7][osteel-readme] | [Laravel auto-validation][kirschbaum-readme] |
-| Declared runtime floor | PHP 8.2 core; [Testbench 9–11](composer.json) ([Laravel 11–12][testbench-compat]; [Laravel 13 / PHP 8.3][testbench-11-composer]) | [PHP 8.3, Laravel 12][spectator-composer] | [PHP 7.2][league-composer] | [PHP 8.0, HttpFoundation 5–8][osteel-composer] | [PHP 8.0, Illuminate 10–13][kirschbaum-composer] |
+| Declared runtime floor | PHP 8.3 core; [Testbench 9–11](composer.json) ([Laravel 11–12][testbench-compat]; [Laravel 13 / PHP 8.3][testbench-11-composer]) | [PHP 8.3, Laravel 12][spectator-composer] | [PHP 7.2][league-composer] | [PHP 8.0, HttpFoundation 5–8][osteel-composer] | [PHP 8.0, Illuminate 10–13][kirschbaum-composer] |
 
 **Legend**: ✅ supported · — no equivalent feature documented. “Not documented” is intentionally different from “unsupported”.
 
@@ -90,8 +90,8 @@ Choose based on the workflow you need rather than on a single yes/no feature cou
 
 ## Requirements
 
-- PHP 8.2+
-- PHPUnit 11, 12, or 13
+- PHP 8.3+
+- PHPUnit 12 or 13
 - A PSR-18 HTTP client + PSR-17 request factory (e.g. Guzzle, Symfony HttpClient) — only required when resolving HTTP(S) `$ref`s
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,9 @@
     "license": "MIT",
     "type": "library",
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "opis/json-schema": "^2.6",
-        "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
+        "phpunit/phpunit": "^12.0 || ^13.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0 || ^2.0"
@@ -91,7 +91,7 @@
     },
     "scripts-descriptions": {
         "test": "Run the full PHPUnit test suite.",
-        "test:pest": "Run the Pest plugin test suite (requires `composer require --dev pestphp/pest:^3.0`).",
+        "test:pest": "Run the Pest plugin test suite (requires `composer require --dev pestphp/pest:^4.0`).",
         "stan": "Run PHPStan static analysis.",
         "cs": "Run PHP-CS-Fixer in fix mode (rewrites files).",
         "cs-check": "Run PHP-CS-Fixer in dry-run mode (CI gate).",

--- a/docs/pest-plugin.md
+++ b/docs/pest-plugin.md
@@ -6,15 +6,15 @@ Pest tests can use the same validator pipeline as PHPUnit through a custom-expec
 - [Wiring the trait into Pest tests](#wiring-the-trait-into-pest-tests)
 - [`expect(...)->toMatchOpenApiResponseSchema()`](#expect-tomatchopenapiresponseschema)
 - [`expect(...)->toMatchOpenApiRequestSchema()`](#expect-tomatchopenapirequestschema)
-- [Constraints (v1)](#constraints-v1)
+- [Constraints (v2)](#constraints-v2)
 
 ## Installation
 
 ```bash
-composer require --dev pestphp/pest:^3.0
+composer require --dev pestphp/pest:^4.0
 ```
 
-The plugin is auto-loaded via Composer's `autoload.files`. No further wiring needed at install time. Pest 4 (PHPUnit ^12) support is tracked separately.
+The plugin is auto-loaded via Composer's `autoload.files`. No further wiring needed at install time. Pest 4 uses PHPUnit 12; PHPUnit 13 remains supported by Gesso's PHPUnit integration but is not compatible with the Pest runner.
 
 ## Wiring the trait into Pest tests
 
@@ -75,8 +75,8 @@ it('accepts a documented request body shape', function () {
 
 The same `spec: / method: / path:` keyword arguments are accepted. The request bridge always runs (it bypasses the `auto_validate_request` config gate and `#[SkipOpenApi]`) because the explicit expectation reads as the user's direct intent. The response side warns when `#[SkipOpenApi]` and an explicit `assertResponseMatchesOpenApiSchema()` collide; the request side has no auto-vs-explicit advisory pattern to mirror, so silence on `expect($request)->toMatchOpenApiRequestSchema()` is the deliberate behaviour.
 
-## Constraints (v1)
+## Constraints (v2)
 
 - **Laravel only**. The expectations require the running Pest test class to use `ValidatesOpenApiSchema`. Standalone (Symfony / framework-less) Pest support against PSR-7 messages is tracked as a follow-up to [#109](https://github.com/studio-design/gesso/issues/109).
-- **Pest 3**. Pest 4 (PHPUnit ^12) is not yet in the CI matrix.
+- **Pest 4 / PHPUnit 12**. The Pest integration is tested on PHP 8.3, 8.4, and 8.5. Use the regular PHPUnit integration when running PHPUnit 13.
 - **Pest discovery contract**. The plugin guards against a missing Pest install at autoload time, so it is safe to leave installed in projects that don't actually use Pest. If `pestphp/pest` is absent, the bootstrap is a true no-op.

--- a/examples/core/composer.json
+++ b/examples/core/composer.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "type": "project",
   "require": {
-    "php": "^8.2",
+    "php": "^8.3",
     "studio-design/openapi-contract-testing": "@dev"
   },
   "autoload-dev": { "psr-4": { "Examples\\Core\\Tests\\": "tests/" } },

--- a/examples/laravel/composer.json
+++ b/examples/laravel/composer.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "type": "project",
   "require": {
-    "php": "^8.2",
+    "php": "^8.3",
     "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
     "studio-design/openapi-contract-testing": "@dev"
   },

--- a/examples/pest/composer.json
+++ b/examples/pest/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.3",
         "studio-design/openapi-contract-testing": "@dev",
         "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
-        "pestphp/pest": "^3.0"
+        "pestphp/pest": "^4.0"
     },
     "config": {
         "sort-packages": true,

--- a/examples/psr7/composer.json
+++ b/examples/psr7/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "type": "project",
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "guzzlehttp/psr7": "^2.7",
         "studio-design/openapi-contract-testing": "@dev"
     },

--- a/examples/symfony/composer.json
+++ b/examples/symfony/composer.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "type": "project",
   "require": {
-    "php": "^8.2",
+    "php": "^8.3",
     "studio-design/openapi-contract-testing": "@dev",
     "symfony/http-foundation": "^6.4 || ^7.0 || ^8.0",
     "symfony/http-kernel": "^6.4 || ^7.0 || ^8.0"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,8 +15,8 @@ parameters:
     paths:
         - src
         - tests
-    # Pest is intentionally not in require-dev (Pest 3 conflicts with the
-    # PHPUnit ^12 / ^13 cells of the matrix). Without this stub PHPStan
+    # Pest is intentionally not in require-dev (Pest 4 requires PHPUnit ^12
+    # while the matrix also covers PHPUnit ^13). Without this stub PHPStan
     # would surface "unknown class" / "unknown function" errors on every
     # Pest-flavoured file. The stub declares Pest\Expectation, the
     # HigherOrderTapProxy / TestCall wrappers, and the global

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,7 +28,7 @@
                 Pest tests are dispatched by the Pest CLI (`composer test:pest`),
                 which runs them through its own pipeline. Excluding them here
                 keeps the PHPUnit `composer test` suite Pest-free so the main
-                CI matrix (PHPUnit 11/12/13) does not need a Pest dependency.
+                CI matrix (PHPUnit 12/13) does not need a Pest dependency.
             -->
             <exclude>tests/Integration/Pest</exclude>
         </testsuite>

--- a/scripts/check-pest.php
+++ b/scripts/check-pest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 /*
  * Composer-script guard invoked before `composer test:pest`.
  *
- * Pest is intentionally not listed in require-dev because Pest 3 requires
- * PHPUnit ^11 — incompatible with the PHPUnit ^12 / ^13 cells of the main
+ * Pest is intentionally not listed in require-dev because Pest 4 requires
+ * PHPUnit ^12 — incompatible with the PHPUnit ^13 cells of the main
  * test matrix. So a fresh `composer install` does NOT bring Pest in.
  *
  * Without this guard, `composer test:pest` against a Pest-free vendor/
@@ -24,11 +24,11 @@ fwrite(
     STDERR,
     "\nERROR: vendor/bin/pest not found.\n"
     . "\n"
-    . "composer test:pest requires Pest 3+. Install it with:\n"
-    . "  composer require --dev pestphp/pest:^3.0\n"
+    . "composer test:pest requires Pest 4. Install it with:\n"
+    . "  composer require --dev pestphp/pest:^4.0\n"
     . "\n"
-    . "Pest is intentionally not in require-dev because Pest 3 conflicts\n"
-    . "with PHPUnit ^12 / ^13 from the mainline test matrix.\n"
+    . "Pest is intentionally not in require-dev because Pest 4 requires\n"
+    . "PHPUnit ^12 while the mainline matrix also covers PHPUnit ^13.\n"
     . "\n",
 );
 

--- a/src/Internal/PartialRunDecision.php
+++ b/src/Internal/PartialRunDecision.php
@@ -28,7 +28,7 @@ use function implode;
  * resolved by `TestSuiteBuilder` before the filter pipeline. Issue
  * #221's primary reproducer is the CLI path-arg case, so we read the
  * `Configuration` structured getters instead, which cover every
- * selection mechanism uniformly across PHPUnit 11/12/13.
+ * selection mechanism uniformly across PHPUnit 12/13.
  *
  * Constructed from primitives (not from a real `Configuration` object)
  * because PHPUnit's `Configuration` is `final readonly` with 150+

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -380,7 +380,7 @@ final class OpenApiCoverageExtension implements Extension
     /**
      * Read the `defaultTestSuite` xml attribute via PHPUnit's
      * {@see Configuration} accessors. Both `hasDefaultTestSuite()` and
-     * `defaultTestSuite()` exist on PHPUnit 11/12/13, so a direct call is
+     * `defaultTestSuite()` exists on PHPUnit 12/13, so a direct call is
      * safe across the CI matrix (unlike {@see readTestSuiteList()}, which
      * needs the dynamic dispatch because PHPUnit 13 dropped the singular
      * `includeTestSuite()` accessor). The `hasDefaultTestSuite()` guard is
@@ -433,7 +433,7 @@ final class OpenApiCoverageExtension implements Extension
      * selection. PHPUnit 13 exposes only the plural array form, PHPUnit
      * 11 exposes only the singular comma-joined string form, and
      * PHPUnit 12 happens to ship both — so picking one at compile time
-     * would break the matrix CI (PHP 8.2/8.3/8.4 × PHPUnit 11/12/13).
+     * would break the matrix CI (PHP 8.3/8.4/8.5 × PHPUnit 12/13).
      * The dynamic method call also avoids a static analysis error on
      * whichever PHPUnit version PHPStan is resolving against locally.
      *

--- a/stubs/pest.stub
+++ b/stubs/pest.stub
@@ -9,7 +9,8 @@ declare(strict_types=1);
  * tests/Integration/Pest/ reference Pest classes and global functions
  * (Pest\Expectation, expect(), test(), it(), uses(), HigherOrderTapProxy,
  * PendingCalls\TestCall). Pest is intentionally absent from require-dev
- * — Pest 3 conflicts with PHPUnit ^12 / ^13 from the mainline test
+ * — Pest 4 requires PHPUnit ^12 while the mainline test matrix also covers
+ * PHPUnit ^13
  * matrix — so the static-analysis CI job has no real Pest classes
  * available and would otherwise surface false "unknown class / function"
  * errors on every Pest-flavoured file.

--- a/tests/Helpers/PublicApiInventory.php
+++ b/tests/Helpers/PublicApiInventory.php
@@ -5,6 +5,11 @@ declare(strict_types=1);
 namespace Studio\OpenApiContractTesting\Tests\Helpers;
 
 use const DIRECTORY_SEPARATOR;
+use const T_COMMENT;
+use const T_DOC_COMMENT;
+use const T_FUNCTION;
+use const T_STRING;
+use const T_WHITESPACE;
 
 use BackedEnum;
 use RecursiveDirectoryIterator;
@@ -23,12 +28,15 @@ use function array_diff;
 use function array_map;
 use function array_values;
 use function class_exists;
+use function count;
 use function enum_exists;
+use function file_get_contents;
 use function interface_exists;
 use function is_array;
 use function is_object;
 use function is_scalar;
 use function ksort;
+use function ltrim;
 use function method_exists;
 use function realpath;
 use function sort;
@@ -37,6 +45,7 @@ use function str_ends_with;
 use function str_replace;
 use function strlen;
 use function substr;
+use function token_get_all;
 use function trait_exists;
 use function usort;
 
@@ -208,10 +217,120 @@ final class PublicApiInventory
             'final' => $method->isFinal(),
             'abstract' => $method->isAbstract(),
             'returns_reference' => $method->returnsReference(),
-            'return_type' => $method->hasReturnType() ? (string) $method->getReturnType() : null,
+            'return_type' => self::describeReturnType($method),
             'attributes' => self::describeAttributes($method->getAttributes()),
             'parameters' => array_map(self::describeParameter(...), $method->getParameters()),
         ];
+    }
+
+    private static function describeReturnType(ReflectionMethod $method): ?string
+    {
+        if (!$method->hasReturnType()) {
+            return null;
+        }
+
+        $returnType = (string) $method->getReturnType();
+        $declaringClass = $method->getDeclaringClass()->getName();
+        if (ltrim($returnType, '?') !== $declaringClass) {
+            return $returnType;
+        }
+
+        $sourceReturnType = self::sourceReturnType($method);
+
+        return $sourceReturnType === 'self' || $sourceReturnType === '?self'
+            ? $sourceReturnType
+            : $returnType;
+    }
+
+    /**
+     * PHP 8.5 resolves `self` to the declaring class name in Reflection's
+     * string representation. Read the declared spelling only for that
+     * ambiguous case so a real `self` -> FQCN source change remains visible.
+     */
+    private static function sourceReturnType(ReflectionMethod $method): ?string
+    {
+        $file = $method->getFileName();
+        if ($file === false) {
+            return null;
+        }
+
+        $source = file_get_contents($file);
+        if ($source === false) {
+            return null;
+        }
+
+        $tokens = token_get_all($source);
+        $tokenCount = count($tokens);
+        for ($index = 0; $index < $tokenCount; $index++) {
+            $token = $tokens[$index];
+            if (!is_array($token) || $token[0] !== T_FUNCTION) {
+                continue;
+            }
+
+            $nameIndex = $index + 1;
+            while ($nameIndex < $tokenCount) {
+                $nameToken = $tokens[$nameIndex];
+                if ($nameToken === '(') {
+                    break;
+                }
+                if (is_array($nameToken) && $nameToken[0] === T_STRING) {
+                    break;
+                }
+                $nameIndex++;
+            }
+
+            if ($nameIndex >= $tokenCount || !is_array($tokens[$nameIndex]) ||
+                $tokens[$nameIndex][1] !== $method->getName()) {
+                continue;
+            }
+
+            $parameterIndex = $nameIndex + 1;
+            while ($parameterIndex < $tokenCount && $tokens[$parameterIndex] !== '(') {
+                $parameterIndex++;
+            }
+            if ($parameterIndex >= $tokenCount) {
+                return null;
+            }
+
+            $depth = 1;
+            for (++$parameterIndex; $parameterIndex < $tokenCount && $depth > 0; $parameterIndex++) {
+                if ($tokens[$parameterIndex] === '(') {
+                    $depth++;
+                } elseif ($tokens[$parameterIndex] === ')') {
+                    $depth--;
+                }
+            }
+
+            while ($parameterIndex < $tokenCount && self::isIgnorableToken($tokens[$parameterIndex])) {
+                $parameterIndex++;
+            }
+            if ($parameterIndex >= $tokenCount || $tokens[$parameterIndex] !== ':') {
+                return null;
+            }
+
+            $declaredType = '';
+            for (++$parameterIndex; $parameterIndex < $tokenCount; $parameterIndex++) {
+                $typeToken = $tokens[$parameterIndex];
+                if ($typeToken === '{' || $typeToken === ';') {
+                    break;
+                }
+                if (self::isIgnorableToken($typeToken)) {
+                    continue;
+                }
+
+                $declaredType .= is_array($typeToken) ? $typeToken[1] : $typeToken;
+            }
+
+            return $declaredType === '' ? null : $declaredType;
+        }
+
+        return null;
+    }
+
+    /** @param array{int, string, int}|string $token */
+    private static function isIgnorableToken(array|string $token): bool
+    {
+        return is_array($token) && ($token[0] === T_WHITESPACE || $token[0] === T_COMMENT || $token[0] === T_DOC_COMMENT);
     }
 
     /** @return array<string, mixed> */

--- a/tests/Unit/Build/RuntimeSupportPolicyTest.php
+++ b/tests/Unit/Build/RuntimeSupportPolicyTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Build;
+
+use const JSON_THROW_ON_ERROR;
+
+use JsonException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function file_get_contents;
+use function json_decode;
+
+final class RuntimeSupportPolicyTest extends TestCase
+{
+    /**
+     * @throws JsonException
+     */
+    #[Test]
+    public function root_package_requires_the_v2_runtime_and_phpunit_lines(): void
+    {
+        $composer = self::composerJson(__DIR__ . '/../../../composer.json');
+
+        $this->assertSame('^8.3', $composer['require']['php'] ?? null);
+        $this->assertSame('^12.0 || ^13.0', $composer['require']['phpunit/phpunit'] ?? null);
+    }
+
+    /**
+     * @throws JsonException
+     */
+    #[Test]
+    public function runnable_examples_share_the_v2_php_floor(): void
+    {
+        foreach (['core', 'laravel', 'pest', 'psr7', 'symfony'] as $example) {
+            $composer = self::composerJson(__DIR__ . '/../../../examples/' . $example . '/composer.json');
+
+            $this->assertSame('^8.3', $composer['require']['php'] ?? null, $example);
+        }
+    }
+
+    /**
+     * @throws JsonException
+     */
+    #[Test]
+    public function pest_example_uses_the_phpunit_12_compatible_major(): void
+    {
+        $composer = self::composerJson(__DIR__ . '/../../../examples/pest/composer.json');
+
+        $this->assertSame('^4.0', $composer['require']['pestphp/pest'] ?? null);
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @throws JsonException
+     */
+    private static function composerJson(string $path): array
+    {
+        $contents = file_get_contents($path);
+
+        self::assertNotFalse($contents, $path);
+
+        $composer = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($composer);
+
+        return $composer;
+    }
+}

--- a/tests/Unit/Build/RuntimeSupportPolicyTest.php
+++ b/tests/Unit/Build/RuntimeSupportPolicyTest.php
@@ -51,6 +51,19 @@ final class RuntimeSupportPolicyTest extends TestCase
         $this->assertSame('^4.0', $composer['require']['pestphp/pest'] ?? null);
     }
 
+    #[Test]
+    public function ci_selects_phpunit_without_rewriting_the_root_constraint(): void
+    {
+        $workflow = file_get_contents(__DIR__ . '/../../../.github/workflows/ci.yml');
+
+        $this->assertNotFalse($workflow);
+        $this->assertStringContainsString(
+            'composer update --with "phpunit/phpunit:^${{ matrix.phpunit }}.0"',
+            $workflow,
+        );
+        $this->assertStringNotContainsString('composer require --dev "phpunit/phpunit:', $workflow);
+    }
+
     /**
      * @return array<string, mixed>
      *

--- a/tests/Unit/Compatibility/Fixture/PublicApiReturnTypeFixture.php
+++ b/tests/Unit/Compatibility/Fixture/PublicApiReturnTypeFixture.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\OpenApiContractTesting\Tests\Unit\Compatibility\Fixture;
+
+use Studio\OpenApiContractTesting\Tests\Unit\Compatibility\Fixture\PublicApiReturnTypeFixture as ExplicitReturnType;
+
+final class PublicApiReturnTypeFixture
+{
+    public function declaredAsSelf(): self
+    {
+        return $this;
+    }
+
+    public function declaredAsClassName(): ExplicitReturnType
+    {
+        return $this;
+    }
+}

--- a/tests/Unit/Compatibility/PublicApiBaselineTest.php
+++ b/tests/Unit/Compatibility/PublicApiBaselineTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 use Studio\OpenApiContractTesting\Coverage\ConsoleCoverageRenderer;
 use Studio\OpenApiContractTesting\Coverage\HtmlCoverageRenderer;
 use Studio\OpenApiContractTesting\Tests\Helpers\PublicApiInventory;
+use Studio\OpenApiContractTesting\Tests\Unit\Compatibility\Fixture\PublicApiReturnTypeFixture;
 
 use function dirname;
 use function file_get_contents;
@@ -18,6 +19,22 @@ use function json_decode;
 
 final class PublicApiBaselineTest extends TestCase
 {
+    #[Test]
+    public function inventory_normalises_self_without_hiding_explicit_class_names(): void
+    {
+        $inventory = PublicApiInventory::capture(
+            __DIR__ . '/Fixture',
+            'Studio\\OpenApiContractTesting\\Tests\\Unit\\Compatibility\\Fixture\\',
+        );
+        $methods = $inventory[PublicApiReturnTypeFixture::class]['methods'];
+
+        $this->assertSame('self', $methods['declaredAsSelf']['return_type']);
+        $this->assertSame(
+            PublicApiReturnTypeFixture::class,
+            $methods['declaredAsClassName']['return_type'],
+        );
+    }
+
     #[Test]
     public function inventory_records_constructor_availability_and_visibility(): void
     {

--- a/tests/Unit/PHPUnit/CoverageReportSubscriberWorkerModeTest.php
+++ b/tests/Unit/PHPUnit/CoverageReportSubscriberWorkerModeTest.php
@@ -588,7 +588,7 @@ class CoverageReportSubscriberWorkerModeTest extends TestCase
      * Build a stub `ExecutionFinished` without invoking its constructor. The
      * subscriber's `notify()` does not read the event, so a structurally
      * valid stand-in is enough — and the real Telemetry constructor signature
-     * has churned across PHPUnit 11/12/13, which would force version-gated
+     * has churned across PHPUnit 12/13, which would force version-gated
      * stub builders that add no test value.
      */
     private function fakeExecutionFinished(): ExecutionFinished


### PR DESCRIPTION
## Summary

- raise the Gesso v2 runtime floor from PHP 8.2 to PHP 8.3
- support PHPUnit 12 and 13, removing the unsupported PHPUnit 11 line
- cover PHP 8.3, 8.4, and 8.5 in CI, including the PHP 8.3 lowest-dependency lane
- migrate the optional Pest integration and runnable example to Pest 4 / PHPUnit 12
- keep Composer constraints, examples, contributor guidance, user documentation, and internal compatibility comments aligned
- add a regression test that pins the v2 Composer runtime policy

## Why

Gesso v2 is the compatibility boundary for dropping runtime and test-runner versions that no longer provide a useful support runway. PHP 8.3 preserves a broad installation base while remaining upstream-supported, PHPUnit 12 covers PHP 8.3, and PHPUnit 13 covers PHP 8.4 and later. Pest 4 is the maintained Pest line and uses PHPUnit 12.

## Breaking change

- PHP 8.2 is no longer supported.
- PHPUnit 11 is no longer supported.
- Pest integrations require Pest 4 with PHPUnit 12.

## Validation

- `composer validate --strict`
- `composer audit --abandoned=fail`
- highest and lowest Composer dependency resolution on PHP 8.3
- PHPUnit 12: 2,067 existing tests / 5,469 assertions
- runtime policy regression test: 3 tests / 22 assertions
- Pest 4: 15 tests / 41 assertions
- PHPStan: no errors
- PHP-CS-Fixer dry-run for the regular and Pest configurations
- VitePress build, base-path verification, and rendered-version verification
- `git diff --check`

`composer ci` could not use PHP-CS-Fixer/PHPStan parallel workers in the local sandbox because loopback sockets are unavailable, so the equivalent checks were run sequentially. GitHub Actions will exercise the normal parallel configuration and the PHP 8.3-8.5 matrix.
