### PR TITLE
feat(coverage)!: publish the gesso json contract

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -22,6 +22,12 @@ v2 discovers `Studio\Gesso\Laravel\GessoServiceProvider`, publishes with the
 guessing precedence. Rebuild the configuration cache only after the application
 boots successfully on v2.
 
+Coverage JSON consumers must accept `schema_version: 2` and the fixed
+`tool.name` value `studio-design/gesso`. The remaining coverage fields retain
+their v1 meanings. Doctor JSON, Laravel route parity JSON, sidecar envelopes,
+and tracker-state versions are unchanged; see the
+[v2 migration guide](docs/migration/v2.md#update-coverage-json-consumers).
+
 ## Within v1.x
 
 The v1.x line is covered end-to-end by SemVer (see "v0.x → v1.0.0"

--- a/docs/coverage-json-schema.md
+++ b/docs/coverage-json-schema.md
@@ -12,9 +12,9 @@ A sample document is committed at [`samples/coverage.json`](samples/coverage.jso
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `schema_version` | `integer` | Bumped on incompatible structural changes. The current version is `1`. Consumers SHOULD reject unknown values. |
+| `schema_version` | `integer` | Bumped on incompatible contract changes. The current version is `2`. Consumers SHOULD reject unknown values. |
 | `generated_at` | `string` | ISO-8601 timestamp (`DateTimeImmutable::ATOM`) for when the document was rendered. |
-| `tool` | `object` | `{ "name": "studio-design/openapi-contract-testing", "version": "<composer version or 'unknown'>" }`. Useful for downstream consumers diagnosing format drift. `"unknown"` is emitted when Composer's `InstalledVersions` metadata is unavailable (e.g. running from a vendored checkout without `composer install`, or `replace`d in a parent project); the field is always a string so downstream JSON schema validators do not need a nullable type. |
+| `tool` | `object` | `{ "name": "studio-design/gesso", "version": "<composer version or 'unknown'>" }`. Useful for downstream consumers diagnosing format drift. `"unknown"` is emitted when Composer's `InstalledVersions` metadata is unavailable (e.g. running from a vendored checkout without `composer install`, or `replace`d in a parent project); the field is always a string so downstream JSON schema validators do not need a nullable type. |
 | `aggregate` | `object` | Rollup across every spec in the document. Lets consumers read one "total" without re-summing. See [aggregate fields](#aggregate-fields). |
 | `specs` | `object` | Keyed by spec name. Each value is `{ "aggregates": …, "endpoints": [...] }`. |
 
@@ -72,8 +72,11 @@ Each entry in `specs.<name>.endpoints` has this shape:
 
 ## Compatibility policy
 
-- Additive changes (new fields, new enum values for `endpoint_state` / `response_state`) keep `schema_version` at `1`.
+- Additive changes (new fields, new enum values for `endpoint_state` / `response_state`) keep `schema_version` at `2`.
 - Removals, renames, or shape changes bump `schema_version`.
+- Schema version 2 retains the fields, types, and meanings from version 1. It
+  advances the contract because the fixed `tool.name` value changed from
+  `studio-design/openapi-contract-testing` to `studio-design/gesso`.
 - The wire format used by paratest worker sidecars is **separate** from this schema (it lives at `Coverage/OpenApiCoverageTracker::exportState()` and is versioned independently via `STATE_FORMAT_VERSION`). Do not consume sidecar payloads as if they were `json_output`; they have a different shape (no `operation_id`, no derived states, no `unexpected_observations`).
 
 ## Generating the file

--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -55,9 +55,9 @@ members marked `@internal` are excluded.
 | Binaries | `bin/openapi-contract`, `bin/openapi-coverage-merge`; v1.10 adds `bin/gesso` | Remove the legacy binaries and retain the unified `gesso` command surface |
 | Laravel discovery | `Studio\OpenApiContractTesting\Laravel\OpenApiContractTestingServiceProvider` | Point discovery to the Gesso provider |
 | PHP requirement | `^8.2` | Raise to `^8.3`; PHP 8.2 reaches security EOL at the end of 2026 |
-| PHPUnit requirement | `^11.0 || ^12.0 || ^13.0` | Support `^12.0 || ^13.0`; drop PHPUnit 11 after its bug-fix support ended |
+| PHPUnit requirement | `^11.0 \|\| ^12.0 \|\| ^13.0` | Support `^12.0 \|\| ^13.0`; drop PHPUnit 11 after its bug-fix support ended |
 | Opis requirement | `opis/json-schema:^2.6` | Keep independent from the identity migration |
-| PSR requirements | `psr/http-client:^1.0`, `psr/http-factory:^1.0`, `psr/http-message:^1.0 || ^2.0` | Preserve unless separately justified |
+| PSR requirements | `psr/http-client:^1.0`, `psr/http-factory:^1.0`, `psr/http-message:^1.0 \|\| ^2.0` | Preserve unless separately justified |
 
 Packagist migration must be tested with a clean project. The new package must
 declare `"conflict": {"studio-design/openapi-contract-testing": "*"}` and must
@@ -397,10 +397,12 @@ import/export methods are internal, but versioned payloads accepted by the
 released merge CLI are compatibility inputs. A newer reader preserves the
 documented older inputs, while unknown or lossy formats fail loudly.
 
-Migration status: the exact v1.9 coverage JSON report and sidecar envelope are
-captured under `tests/fixtures/compatibility/`. The sidecar fixture pins coverage
-tracker state v1 and strict-required tracker state v2, and consumer-style tests
-verify both the envelope reader and the legacy bare-coverage reader path.
+Migration status: the exact v1.9 coverage JSON report and sidecar envelope, plus
+the v2 coverage JSON report, are captured under
+`tests/fixtures/compatibility/`. The v2 report pins schema 2 and the Gesso tool
+identity. The sidecar fixture pins coverage tracker state v1 and strict-required
+tracker state v2, and consumer-style tests verify both the envelope reader and
+the legacy bare-coverage reader path.
 
 V2 decision: only coverage JSON advances its schema version. Its documented
 `tool.name` behaves as a fixed value, so changing it to `studio-design/gesso` is

--- a/src/Coverage/JsonCoverageRenderer.php
+++ b/src/Coverage/JsonCoverageRenderer.php
@@ -83,12 +83,9 @@ use function sprintf;
  */
 final class JsonCoverageRenderer
 {
-    public const SCHEMA_VERSION = 1;
-
-    // Schema v1 retains its fixed tool identity until the coverage-format
-    // migration; version lookup must still follow the installed v2 package.
+    public const SCHEMA_VERSION = 2;
     private const COMPOSER_PACKAGE_NAME = 'studio-design/gesso';
-    private const TOOL_NAME = 'studio-design/openapi-contract-testing';
+    private const TOOL_NAME = 'studio-design/gesso';
 
     /**
      * @param array<string, CoverageResult> $results

--- a/tests/Unit/Compatibility/MachineReadableFormatsBaselineTest.php
+++ b/tests/Unit/Compatibility/MachineReadableFormatsBaselineTest.php
@@ -33,7 +33,7 @@ use function json_encode;
 final class MachineReadableFormatsBaselineTest extends TestCase
 {
     #[Test]
-    public function coverage_json_matches_the_v1_9_fixture(): void
+    public function coverage_json_matches_the_v2_fixture(): void
     {
         /** @var array<string, CoverageResult> $results */
         $results = [
@@ -115,7 +115,7 @@ final class MachineReadableFormatsBaselineTest extends TestCase
         $payload['tool'] = $tool;
 
         $this->assertSame(
-            $this->fixture('v1.9-coverage-report.json'),
+            $this->fixture('v2-coverage-report.json'),
             json_encode(
                 $payload,
                 JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,

--- a/tests/Unit/Compatibility/PublicApiBaselineTest.php
+++ b/tests/Unit/Compatibility/PublicApiBaselineTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\Gesso\Coverage\ConsoleCoverageRenderer;
 use Studio\Gesso\Coverage\HtmlCoverageRenderer;
+use Studio\Gesso\Coverage\JsonCoverageRenderer;
 use Studio\Gesso\Tests\Helpers\PublicApiInventory;
 use Studio\Gesso\Tests\Unit\Compatibility\Fixture\PublicApiReturnTypeFixture;
 
@@ -83,7 +84,7 @@ final class PublicApiBaselineTest extends TestCase
     }
 
     #[Test]
-    public function v2_public_api_matches_the_documented_identity_renames(): void
+    public function v2_public_api_matches_the_documented_contract_changes(): void
     {
         $root = dirname(__DIR__, 3);
         $v1Json = file_get_contents($root . '/tests/fixtures/compatibility/v1.9-public-api.json');
@@ -104,6 +105,12 @@ final class PublicApiBaselineTest extends TestCase
             $v1Json,
         );
 
-        $this->assertJsonStringEqualsJsonString($mappedV1Json, $v2Json);
+        /** @var array<string, array<string, mixed>> $expected */
+        $expected = json_decode($mappedV1Json, true, flags: JSON_THROW_ON_ERROR);
+        $expected[JsonCoverageRenderer::class]['constants']['SCHEMA_VERSION'] = 2;
+        /** @var array<string, array<string, mixed>> $actual */
+        $actual = json_decode($v2Json, true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame($expected, $actual);
     }
 }

--- a/tests/Unit/Coverage/CoverageMergeCommandTest.php
+++ b/tests/Unit/Coverage/CoverageMergeCommandTest.php
@@ -363,8 +363,8 @@ class CoverageMergeCommandTest extends TestCase
 
         $decoded = json_decode((string) file_get_contents($jsonPath), true);
         $this->assertIsArray($decoded);
-        $this->assertSame(1, $decoded['schema_version']);
-        $this->assertSame('studio-design/openapi-contract-testing', $decoded['tool']['name']);
+        $this->assertSame(2, $decoded['schema_version']);
+        $this->assertSame('studio-design/gesso', $decoded['tool']['name']);
         $this->assertArrayHasKey('petstore-3.0', $decoded['specs']);
 
         @unlink($jsonPath);

--- a/tests/Unit/Coverage/JsonCoverageRendererTest.php
+++ b/tests/Unit/Coverage/JsonCoverageRendererTest.php
@@ -36,7 +36,7 @@ class JsonCoverageRendererTest extends TestCase
     {
         $payload = $this->decode($this->renderOneValidated());
 
-        $this->assertSame(1, $payload['schema_version']);
+        $this->assertSame(2, $payload['schema_version']);
         $this->assertSame(self::FIXED_TIMESTAMP, $payload['generated_at']);
     }
 
@@ -46,7 +46,7 @@ class JsonCoverageRendererTest extends TestCase
         $payload = $this->decode($this->renderOneValidated());
 
         $this->assertArrayHasKey('tool', $payload);
-        $this->assertSame('studio-design/openapi-contract-testing', $payload['tool']['name']);
+        $this->assertSame('studio-design/gesso', $payload['tool']['name']);
         $this->assertIsString($payload['tool']['version']);
         $this->assertNotSame('', $payload['tool']['version']);
         $this->assertNotSame('unknown', $payload['tool']['version']);

--- a/tests/Unit/PHPUnit/CoverageReportSubscriberWorkerModeTest.php
+++ b/tests/Unit/PHPUnit/CoverageReportSubscriberWorkerModeTest.php
@@ -322,7 +322,7 @@ class CoverageReportSubscriberWorkerModeTest extends TestCase
         $this->assertFileExists($jsonPath, 'sequential mode must write json_output when configured');
         $decoded = json_decode((string) file_get_contents($jsonPath), true);
         $this->assertIsArray($decoded);
-        $this->assertSame(1, $decoded['schema_version']);
+        $this->assertSame(2, $decoded['schema_version']);
         $this->assertArrayHasKey('petstore-3.0', $decoded['specs']);
     }
 

--- a/tests/fixtures/compatibility/v2-coverage-report.json
+++ b/tests/fixtures/compatibility/v2-coverage-report.json
@@ -1,32 +1,32 @@
 {
     "schema_version": 2,
-    "generated_at": "2026-05-11T12:34:56+00:00",
+    "generated_at": "2026-07-14T00:00:00+00:00",
     "tool": {
         "name": "studio-design/gesso",
-        "version": "dev-main"
+        "version": "<runtime-version>"
     },
     "aggregate": {
         "endpoint_total": 2,
-        "endpoint_fully_covered": 1,
+        "endpoint_fully_covered": 0,
         "endpoint_partial": 1,
         "endpoint_uncovered": 0,
-        "endpoint_request_only": 0,
+        "endpoint_request_only": 1,
         "response_total": 3,
-        "response_covered": 2,
-        "response_skipped": 0,
+        "response_covered": 1,
+        "response_skipped": 1,
         "response_uncovered": 1
     },
     "specs": {
-        "petstore": {
+        "front": {
             "aggregates": {
                 "endpoint_total": 2,
-                "endpoint_fully_covered": 1,
+                "endpoint_fully_covered": 0,
                 "endpoint_partial": 1,
                 "endpoint_uncovered": 0,
-                "endpoint_request_only": 0,
+                "endpoint_request_only": 1,
                 "response_total": 3,
-                "response_covered": 2,
-                "response_skipped": 0,
+                "response_covered": 1,
+                "response_skipped": 1,
                 "response_uncovered": 1
             },
             "endpoints": [
@@ -35,47 +35,26 @@
                     "method": "GET",
                     "path": "/v1/pets",
                     "operation_id": "listPets",
-                    "endpoint_state": "all-covered",
+                    "endpoint_state": "partial",
                     "request_reached": true,
                     "responses": [
                         {
                             "status_key": "200",
                             "content_type_key": "application/json",
                             "response_state": "validated",
-                            "hits": 12,
-                            "skip_reason": null
-                        }
-                    ],
-                    "covered_response_count": 1,
-                    "skipped_response_count": 0,
-                    "total_response_count": 1,
-                    "unexpected_observations": []
-                },
-                {
-                    "endpoint": "POST /v1/pets",
-                    "method": "POST",
-                    "path": "/v1/pets",
-                    "operation_id": "createPet",
-                    "endpoint_state": "partial",
-                    "request_reached": true,
-                    "responses": [
-                        {
-                            "status_key": "201",
-                            "content_type_key": "application/json",
-                            "response_state": "validated",
-                            "hits": 3,
+                            "hits": 2,
                             "skip_reason": null
                         },
                         {
-                            "status_key": "422",
-                            "content_type_key": "application/problem+json",
-                            "response_state": "uncovered",
-                            "hits": 0,
-                            "skip_reason": null
+                            "status_key": "503",
+                            "content_type_key": "*",
+                            "response_state": "skipped",
+                            "hits": 1,
+                            "skip_reason": "status 503 matched skip pattern 5\\d\\d"
                         }
                     ],
                     "covered_response_count": 1,
-                    "skipped_response_count": 0,
+                    "skipped_response_count": 1,
                     "total_response_count": 2,
                     "unexpected_observations": [
                         {
@@ -83,6 +62,27 @@
                             "content_type_key": "application/json"
                         }
                     ]
+                },
+                {
+                    "endpoint": "POST /v1/pets",
+                    "method": "POST",
+                    "path": "/v1/pets",
+                    "operation_id": null,
+                    "endpoint_state": "request-only",
+                    "request_reached": true,
+                    "responses": [
+                        {
+                            "status_key": "201",
+                            "content_type_key": "application/json",
+                            "response_state": "uncovered",
+                            "hits": 0,
+                            "skip_reason": null
+                        }
+                    ],
+                    "covered_response_count": 0,
+                    "skipped_response_count": 0,
+                    "total_response_count": 1,
+                    "unexpected_observations": []
                 }
             ]
         }

--- a/tests/fixtures/compatibility/v2-public-api.json
+++ b/tests/fixtures/compatibility/v2-public-api.json
@@ -911,7 +911,7 @@
         "backing_type": null,
         "cases": [],
         "constants": {
-            "SCHEMA_VERSION": 1
+            "SCHEMA_VERSION": 2
         },
         "properties": [],
         "methods": {


### PR DESCRIPTION
## Summary

- advance coverage JSON to `schema_version: 2`
- emit `studio-design/gesso` as the fixed coverage tool identity
- pin the v2 report with a golden fixture while retaining v1.9 sidecar compatibility
- update the public API baseline, sample output, schema reference, and upgrade guidance

## Compatibility

Doctor JSON and Laravel route parity remain at version 1. The sidecar envelope,
coverage tracker state, and strict-required tracker state also retain their
existing versions and supported reader boundaries.

## Validation

- PHPUnit: 2,079 tests, 5,534 assertions
- PHPStan
- PHP-CS-Fixer (standard and Pest configurations)
- VitePress build and docs base/version verification
- markdownlint-cli2
- `git diff --check`
