### PR TITLE
feat(identity)!: rename diagnostic and resolver identifiers

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -28,6 +28,17 @@ their v1 meanings. Doctor JSON, Laravel route parity JSON, sidecar envelopes,
 and tracker-state versions are unchanged; see the
 [v2 migration guide](docs/migration/v2.md#update-coverage-json-consumers).
 
+Update log routing for the optional-Faker warning and Laravel contradictory-
+intent deprecation from `[openapi-contract-testing]` to `[Gesso]`. Feature-
+oriented prefixes such as `[OpenAPI Coverage]` and `[OpenAPI Schema]` are
+unchanged.
+
+If tooling persists arrays returned by the spec loader, reload the original
+OpenAPI Description after upgrading. V2 replaces the resolver-owned
+`x-studio-openapi-contract-testing-implicit-schema-name` provenance extension
+with `x-studio-gesso-implicit-schema-name`; it deliberately does not trust or
+dual-read either marker when authored in input.
+
 ## Within v1.x
 
 The v1.x line is covered end-to-end by SemVer (see "v0.x → v1.0.0"

--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -441,9 +441,10 @@ V2 decision: feature-oriented prefixes remain unchanged because they are
 identity-neutral log-routing categories. Both `[openapi-contract-testing]`
 occurrences change to `[Gesso]` together. V2 does not dual-emit warnings; log
 consumers update the branded routing rule as part of the major-version
-migration. A source-level regression test must prove that the legacy branded
-prefix is absent from v2 while parity tests retain every identity-neutral
-category.
+migration. Migration status: the complete v2 inventory is pinned in
+`tests/fixtures/compatibility/v2-diagnostic-prefixes.json`; it records zero
+legacy branded occurrences, both `[Gesso]` channels, and exact file-level
+parity for every identity-neutral category.
 
 The OpenAPI vendor extension
 `x-studio-openapi-contract-testing-implicit-schema-name` is embedded in spec
@@ -458,8 +459,9 @@ input, and consumes only the newly generated Gesso marker. There is no
 dual-read period because a legacy input field cannot be authenticated as
 resolver output. Consumers must carry the original OpenAPI Description across
 the upgrade rather than persist and reload a resolved array. The validation
-semantics remain unchanged; v2 tests must cover direct-reference generation,
-both spoofed input names, and implicit discriminator parity.
+semantics remain unchanged. Migration status: the v2 resolver fixture covers
+direct-reference generation and both spoofed input names, while the schema
+converter regression suite pins implicit discriminator parity.
 
 ## v2 migration verification matrix
 

--- a/docs/migration/v2.md
+++ b/docs/migration/v2.md
@@ -180,6 +180,22 @@ Feature-oriented categories such as `[OpenAPI Coverage]`, `[OpenAPI Doctor]`,
 those categories. V2 emits only the Gesso-branded form rather than duplicating
 each warning under both names.
 
+### Reload persisted resolved specifications
+
+The eager resolver's internal discriminator provenance extension changes from
+`x-studio-openapi-contract-testing-implicit-schema-name` to
+`x-studio-gesso-implicit-schema-name`. If a tool persists the array returned by
+the spec loader, discard that derived data and reload the original OpenAPI
+Description after installing v2.
+
+Do not rename the field in persisted resolved arrays. The resolver removes
+both marker names from authored input to prevent a specification extension
+from spoofing an implicit discriminator mapping, and it creates the Gesso
+marker only after successfully resolving a direct local component-schema
+reference. There is intentionally no legacy-marker read path or configuration
+switch. Validation behavior for genuine implicit discriminator mappings is
+otherwise unchanged.
+
 See [ADR 0001](../adr/0001-gesso-v2-identity.md) for the complete identity
 decision and [the namespace compatibility spike](v2-namespace-compatibility-spike.md)
 for the tested behavior and identity limits of `class_alias()`.

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -493,7 +493,7 @@ final class SchemaDataGenerator
 
         trigger_error(
             sprintf(
-                '[openapi-contract-testing] fakerphp/faker is not installed; '
+                '[Gesso] fakerphp/faker is not installed; '
                 . "string format '%s' will be generated as a deterministic primitive "
                 . 'and is unlikely to satisfy the spec constraint. '
                 . 'Install via: composer require --dev fakerphp/faker',

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -1047,7 +1047,7 @@ trait ValidatesOpenApiSchema
         // PHPUnit's `displayDetailsOnTestsThatTriggerDeprecations` setting —
         // without it, the default config would only show a "1 deprecation"
         // tally and hide the actual contradictory-intent message.
-        fwrite(STDERR, sprintf("\n[openapi-contract-testing] %s\n", $message));
+        fwrite(STDERR, sprintf("\n[Gesso] %s\n", $message));
         // trigger_error still fires so PHPUnit counts the deprecation and
         // surfaces it in the run summary for downstream tools to detect.
         trigger_error($message, E_USER_DEPRECATED);

--- a/src/Spec/OpenApiRefResolver.php
+++ b/src/Spec/OpenApiRefResolver.php
@@ -41,7 +41,9 @@ final class OpenApiRefResolver
      * `oneOf` / `anyOf`. Eager reference resolution otherwise erases the
      * component name needed for OpenAPI discriminator implicit mappings.
      */
-    public const IMPLICIT_SCHEMA_NAME_EXTENSION = 'x-studio-openapi-contract-testing-implicit-schema-name';
+    public const IMPLICIT_SCHEMA_NAME_EXTENSION = 'x-studio-gesso-implicit-schema-name';
+
+    private const LEGACY_IMPLICIT_SCHEMA_NAME_EXTENSION = 'x-studio-openapi-contract-testing-implicit-schema-name';
 
     /**
      * Keys whose value is opaque user data per OpenAPI 3.x and JSON Schema —
@@ -231,10 +233,13 @@ final class OpenApiRefResolver
         array &$documentCache,
         bool $captureImplicitSchemaName = false,
     ): void {
-        // Reserve the provenance key for resolver-generated data. Removing a
-        // user-authored value before descent prevents an inline schema from
-        // spoofing an implicit discriminator mapping.
-        unset($node[self::IMPLICIT_SCHEMA_NAME_EXTENSION]);
+        // Reserve both provenance keys for resolver-generated data. Removing
+        // user-authored values before descent prevents an inline schema from
+        // spoofing an implicit discriminator mapping across the v1/v2 rename.
+        unset(
+            $node[self::LEGACY_IMPLICIT_SCHEMA_NAME_EXTENSION],
+            $node[self::IMPLICIT_SCHEMA_NAME_EXTENSION],
+        );
 
         if (!$insideUserNamedMap && array_key_exists('$ref', $node)) {
             $ref = self::assertStringRef($node['$ref']);

--- a/src/Spec/OpenApiRefResolver.php
+++ b/src/Spec/OpenApiRefResolver.php
@@ -233,13 +233,16 @@ final class OpenApiRefResolver
         array &$documentCache,
         bool $captureImplicitSchemaName = false,
     ): void {
-        // Reserve both provenance keys for resolver-generated data. Removing
-        // user-authored values before descent prevents an inline schema from
-        // spoofing an implicit discriminator mapping across the v1/v2 rename.
-        unset(
-            $node[self::LEGACY_IMPLICIT_SCHEMA_NAME_EXTENSION],
-            $node[self::IMPLICIT_SCHEMA_NAME_EXTENSION],
-        );
+        // Reserve both provenance fields for resolver-generated data. Keys at
+        // the current level of a user-named map are property/component names,
+        // not Schema Object fields, so preserve them and scrub the provenance
+        // only after descending into each named child.
+        if (!$insideUserNamedMap) {
+            unset(
+                $node[self::LEGACY_IMPLICIT_SCHEMA_NAME_EXTENSION],
+                $node[self::IMPLICIT_SCHEMA_NAME_EXTENSION],
+            );
+        }
 
         if (!$insideUserNamedMap && array_key_exists('$ref', $node)) {
             $ref = self::assertStringRef($node['$ref']);

--- a/tests/Unit/Compatibility/DiagnosticPrefixesBaselineTest.php
+++ b/tests/Unit/Compatibility/DiagnosticPrefixesBaselineTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Studio\Gesso\Tests\Unit\Compatibility;
 
+use const ARRAY_FILTER_USE_KEY;
 use const JSON_THROW_ON_ERROR;
 use const T_CONSTANT_ENCAPSED_STRING;
 use const T_ENCAPSED_AND_WHITESPACE;
@@ -15,6 +16,7 @@ use RecursiveIteratorIterator;
 use SplFileInfo;
 
 use function array_fill_keys;
+use function array_filter;
 use function array_keys;
 use function dirname;
 use function file_get_contents;
@@ -29,15 +31,10 @@ use function token_get_all;
 final class DiagnosticPrefixesBaselineTest extends TestCase
 {
     #[Test]
-    public function diagnostic_prefixes_match_the_v1_9_inventory(): void
+    public function diagnostic_prefixes_match_the_v2_inventory(): void
     {
-        /** @var array<string, array<string, positive-int>> $fixture */
-        $fixture = json_decode(
-            $this->fixture(),
-            true,
-            flags: JSON_THROW_ON_ERROR,
-        );
-        /** @var array<string, array<string, positive-int>> $actual */
+        $fixture = $this->fixture('v2-diagnostic-prefixes.json');
+        /** @var array<string, array<string, positive-int>|array{}> $actual */
         $actual = array_fill_keys(array_keys($fixture), []);
 
         foreach ($this->sourceFiles() as $file => $contents) {
@@ -78,6 +75,24 @@ final class DiagnosticPrefixesBaselineTest extends TestCase
         $this->assertSame($fixture, $actual);
     }
 
+    #[Test]
+    public function identity_neutral_prefixes_retain_v1_9_parity(): void
+    {
+        $brandedPrefixes = ['[openapi-contract-testing]', '[Gesso]'];
+        $v1 = array_filter(
+            $this->fixture('v1.9-diagnostic-prefixes.json'),
+            static fn(string $prefix): bool => !in_array($prefix, $brandedPrefixes, true),
+            ARRAY_FILTER_USE_KEY,
+        );
+        $v2 = array_filter(
+            $this->fixture('v2-diagnostic-prefixes.json'),
+            static fn(string $prefix): bool => !in_array($prefix, $brandedPrefixes, true),
+            ARRAY_FILTER_USE_KEY,
+        );
+
+        $this->assertSame($v1, $v2);
+    }
+
     /** @return array<string, string> */
     private function sourceFiles(): array
     {
@@ -102,13 +117,15 @@ final class DiagnosticPrefixesBaselineTest extends TestCase
         return $sources;
     }
 
-    private function fixture(): string
+    /** @return array<string, array<string, positive-int>|array{}> */
+    private function fixture(string $filename): array
     {
         $contents = file_get_contents(
-            dirname(__DIR__, 2) . '/fixtures/compatibility/v1.9-diagnostic-prefixes.json',
+            dirname(__DIR__, 2) . '/fixtures/compatibility/' . $filename,
         );
         $this->assertIsString($contents);
 
-        return $contents;
+        /** @var array<string, array<string, positive-int>|array{}> */
+        return json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
     }
 }

--- a/tests/Unit/Compatibility/ResolverProvenanceBaselineTest.php
+++ b/tests/Unit/Compatibility/ResolverProvenanceBaselineTest.php
@@ -16,28 +16,39 @@ use Studio\Gesso\Spec\OpenApiRefResolver;
 use function dirname;
 use function file_get_contents;
 use function json_encode;
+use function str_replace;
 
 final class ResolverProvenanceBaselineTest extends TestCase
 {
     #[Test]
-    public function resolved_composition_matches_the_v1_9_provenance_fixture(): void
+    public function resolved_composition_matches_the_v2_provenance_fixture(): void
     {
         $legacyMarker = 'x-studio-openapi-contract-testing-implicit-schema-name';
+        $gessoMarker = 'x-studio-gesso-implicit-schema-name';
         $resolved = OpenApiRefResolver::resolve([
             'components' => ['schemas' => [
-                'Cat' => ['type' => 'object', 'required' => ['meow']],
+                'Cat' => [
+                    'type' => 'object',
+                    'required' => ['meow'],
+                    $legacyMarker => 'Legacy component spoof',
+                    $gessoMarker => 'Gesso component spoof',
+                ],
             ]],
             'schema' => [
                 'oneOf' => [
                     ['$ref' => '#/components/schemas/Cat'],
-                    ['type' => 'object', $legacyMarker => 'Spoofed'],
+                    [
+                        'type' => 'object',
+                        $legacyMarker => 'Legacy inline spoof',
+                        $gessoMarker => 'Gesso inline spoof',
+                    ],
                 ],
             ],
         ]);
 
-        $this->assertSame($legacyMarker, OpenApiRefResolver::IMPLICIT_SCHEMA_NAME_EXTENSION);
+        $this->assertSame($gessoMarker, OpenApiRefResolver::IMPLICIT_SCHEMA_NAME_EXTENSION);
         $this->assertSame(
-            $this->fixture(),
+            $this->fixture('v2-resolver-provenance.json'),
             json_encode(
                 $resolved,
                 JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
@@ -45,10 +56,22 @@ final class ResolverProvenanceBaselineTest extends TestCase
         );
     }
 
-    private function fixture(): string
+    #[Test]
+    public function v2_provenance_differs_from_v1_9_only_by_marker_name(): void
+    {
+        $normalizedV1 = str_replace(
+            'x-studio-openapi-contract-testing-implicit-schema-name',
+            'x-studio-gesso-implicit-schema-name',
+            $this->fixture('v1.9-resolver-provenance.json'),
+        );
+
+        $this->assertSame($normalizedV1, $this->fixture('v2-resolver-provenance.json'));
+    }
+
+    private function fixture(string $filename): string
     {
         $contents = file_get_contents(
-            dirname(__DIR__, 2) . '/fixtures/compatibility/v1.9-resolver-provenance.json',
+            dirname(__DIR__, 2) . '/fixtures/compatibility/' . $filename,
         );
         $this->assertIsString($contents);
 

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -429,6 +429,7 @@ class SchemaDataGeneratorTest extends TestCase
         }
 
         $this->assertCount(1, $captured, 'warning should fire exactly once per format per process');
+        $this->assertStringStartsWith('[Gesso] ', $captured[0]);
         $this->assertStringContainsString("'email'", $captured[0]);
         $this->assertStringContainsString('fakerphp/faker', $captured[0]);
     }

--- a/tests/Unit/Spec/OpenApiRefResolverTest.php
+++ b/tests/Unit/Spec/OpenApiRefResolverTest.php
@@ -65,6 +65,37 @@ class OpenApiRefResolverTest extends TestCase
     }
 
     #[Test]
+    public function preserves_provenance_names_as_component_and_property_names(): void
+    {
+        $names = [
+            'x-studio-openapi-contract-testing-implicit-schema-name',
+            OpenApiRefResolver::IMPLICIT_SCHEMA_NAME_EXTENSION,
+        ];
+        $schemas = [];
+        $properties = [];
+        foreach ($names as $name) {
+            $schemas[$name] = ['type' => 'string'];
+            $properties[$name] = ['$ref' => '#/components/schemas/' . $name];
+        }
+        $schemas['Holder'] = [
+            'type' => 'object',
+            'properties' => $properties,
+        ];
+
+        $resolved = OpenApiRefResolver::resolve([
+            'components' => ['schemas' => $schemas],
+        ]);
+
+        foreach ($names as $name) {
+            $this->assertSame(['type' => 'string'], $resolved['components']['schemas'][$name]);
+            $this->assertSame(
+                ['type' => 'string'],
+                $resolved['components']['schemas']['Holder']['properties'][$name],
+            );
+        }
+    }
+
+    #[Test]
     public function resolves_nested_refs(): void
     {
         $spec = [

--- a/tests/fixtures/compatibility/v2-diagnostic-prefixes.json
+++ b/tests/fixtures/compatibility/v2-diagnostic-prefixes.json
@@ -1,0 +1,49 @@
+{
+    "[Gesso]": {
+        "src/Fuzz/SchemaDataGenerator.php": 1,
+        "src/Laravel/ValidatesOpenApiSchema.php": 1
+    },
+    "[OpenAPI 3.2 $self]": {
+        "src/Spec/OpenApiSpecLoader.php": 1
+    },
+    "[OpenAPI 3.2 discriminator]": {
+        "src/Spec/OpenApiSchemaConverter.php": 1
+    },
+    "[OpenAPI 3.2 querystring]": {
+        "src/Validation/Request/QueryParameterValidator.php": 1
+    },
+    "[OpenAPI Coverage]": {
+        "src/Coverage/CoverageMergeCommand.php": 15,
+        "src/Coverage/CoverageThresholdEvaluator.php": 1,
+        "src/Coverage/OpenApiCoverageTracker.php": 2,
+        "src/PHPUnit/ConsoleOutput.php": 2,
+        "src/PHPUnit/CoverageReportSubscriber.php": 9,
+        "src/PHPUnit/OpenApiCoverageExtension.php": 8
+    },
+    "[OpenAPI Doctor]": {
+        "src/Cli/DoctorCommand.php": 1
+    },
+    "[OpenAPI Enum Drift]": {
+        "src/PHPUnit/OpenApiCoverageExtension.php": 7,
+        "src/Schema/EnumDriftAsserter.php": 1
+    },
+    "[OpenAPI Schema]": {
+        "src/Spec/OpenApiSchemaConverter.php": 4
+    },
+    "[OpenAPI Strict Required per-call]": {
+        "src/PHPUnit/OpenApiCoverageExtension.php": 1,
+        "src/Validation/Strict/StrictRequiredPerCallChecker.php": 4
+    },
+    "[OpenAPI Strict Required]": {
+        "src/Coverage/CoverageMergeCommand.php": 3,
+        "src/OpenApiResponseValidator.php": 1,
+        "src/PHPUnit/CoverageReportSubscriber.php": 3,
+        "src/PHPUnit/OpenApiCoverageExtension.php": 2,
+        "src/Validation/Strict/StrictRequiredAsserter.php": 1,
+        "src/Validation/Strict/StrictRequiredTracker.php": 1
+    },
+    "[openapi-contract-testing]": {},
+    "[security]": {
+        "src/Validation/Request/SecurityValidator.php": 8
+    }
+}

--- a/tests/fixtures/compatibility/v2-resolver-provenance.json
+++ b/tests/fixtures/compatibility/v2-resolver-provenance.json
@@ -1,0 +1,26 @@
+{
+    "components": {
+        "schemas": {
+            "Cat": {
+                "type": "object",
+                "required": [
+                    "meow"
+                ]
+            }
+        }
+    },
+    "schema": {
+        "oneOf": [
+            {
+                "type": "object",
+                "required": [
+                    "meow"
+                ],
+                "x-studio-gesso-implicit-schema-name": "Cat"
+            },
+            {
+                "type": "object"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Summary

- rename the two branded diagnostic prefixes from `[openapi-contract-testing]` to `[Gesso]`
- rename resolver-owned implicit discriminator provenance to `x-studio-gesso-implicit-schema-name`
- strip both legacy and Gesso provenance from authored input before resolution, while generating only the Gesso marker for successfully resolved direct component references
- add complete v2 diagnostic and resolver fixtures, retain identity-neutral prefix parity, and document the required consumer migration

## Why

Gesso v2 should expose Gesso-owned identifiers consistently without weakening the resolver provenance integrity boundary. The exact fixtures ensure the rename does not alter implicit discriminator behavior or unrelated diagnostic routing categories.

## Breaking changes

- log routing and assertions for the optional-Faker warning and Laravel contradictory-intent deprecation must use `[Gesso]`
- consumers that persist resolved spec arrays must reload the original OpenAPI Description; the legacy resolver provenance marker is not dual-read

## Validation

- `NPM_CONFIG_CACHE=/tmp/gesso-npm-cache vendor/bin/phpunit` — 2,081 tests, 5,541 assertions
- `vendor/bin/phpstan analyse --no-progress --debug --memory-limit=1G`
- PHP-CS-Fixer default and Pest configurations in dry-run sequential mode
- `npm run docs:build`
- `npm run docs:verify-base`
- `npm run docs:verify-version`
- markdownlint-cli2 v0.23.0 on changed documentation
- `git diff --check`
