### PR TITLE
test(integrations): pin v2 adapter identity parity

### DIFF
--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -221,6 +221,22 @@ Trait methods, explicit-spec precedence, validation defaults, assertion
 behavior, PSR-7 stream handling, and automatic coverage recording require
 consumer-level fixtures rather than namespace-only checks.
 
+Migration status: implemented on the v2 development line. A fixture captured
+from v1.9.0 pins a representative PSR-7 exchange and Symfony request/response
+assertion, including matched operation metadata and automatic coverage. The v2
+consumer test runs the same exchanges through the Gesso adapters and compares
+the normalized result with that fixture. The runnable PSR-7 and Symfony
+examples are separate CI jobs, so their Composer package, imports, PHPUnit
+extension, and real framework objects are exercised from an installed project.
+
+Pest 4 integration tests exercise the Gesso trait wiring, both registered
+expectations, their argument shapes, chaining, and coverage recording. A
+Pest-free subprocess fixture also loads the Composer autoload entrypoint with
+neither Pest symbol and with either symbol present alone, proving that absent
+or partially available optional dependencies remain dormant rather than
+causing a fatal error. The runnable Pest example is installed and executed in
+its own CI job.
+
 ## PHPUnit extension configuration
 
 The extension FQCN and every accepted parameter name are public configuration.
@@ -476,6 +492,12 @@ converter regression suite pins implicit discriminator parity.
 | CLI | old commands plus v1.10 `gesso` aliases and golden output | `gesso` only | flags, exit codes, stdout/stderr parity; legacy binaries absent |
 | Coverage | v1 JSON and sidecar | v2 output | v1 worker payload merged by v2 reader |
 | Doctor/routes | schema v1 consumers | v2 identity | incompatible field change requires version bump |
+
+Migration status: the Pest and PSR-7/Symfony rows are implemented by the
+consumer fixtures described above. Core, Laravel, Symfony, Pest, and PSR-7
+examples all install `studio-design/gesso` from the working tree, register the
+Gesso PHPUnit extension, and run in CI. The remaining matrix rows are covered
+by their surface-specific migration statuses in this inventory.
 
 The PHP row now has an executable
 [namespace compatibility spike](v2-namespace-compatibility-spike.md). It proves

--- a/tests/Integration/FrameworkAdapterIdentityParityTest.php
+++ b/tests/Integration/FrameworkAdapterIdentityParityTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Integration;
+
+use const JSON_THROW_ON_ERROR;
+
+use GuzzleHttp\Psr7\Response as Psr7Response;
+use GuzzleHttp\Psr7\ServerRequest;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Coverage\OpenApiCoverageTracker;
+use Studio\Gesso\Psr7\OpenApiPsr7Validator;
+use Studio\Gesso\Spec\OpenApiSpecLoader;
+use Studio\Gesso\Symfony\OpenApiAssertions;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+use function file_get_contents;
+use function json_decode;
+
+final class FrameworkAdapterIdentityParityTest extends TestCase
+{
+    use OpenApiAssertions;
+
+    /** @var array<string, mixed> */
+    private array $baseline;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs');
+        OpenApiCoverageTracker::reset();
+
+        $contents = file_get_contents(__DIR__ . '/../fixtures/compatibility/v1.9-framework-adapter-parity.json');
+        $this->assertIsString($contents);
+        $baseline = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+        $this->assertIsArray($baseline);
+        $this->baseline = $baseline;
+    }
+
+    protected function tearDown(): void
+    {
+        OpenApiSpecLoader::reset();
+        OpenApiCoverageTracker::reset();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function psr7_exchange_result_and_coverage_match_the_v1_9_consumer_baseline(): void
+    {
+        $request = (new ServerRequest(
+            'POST',
+            'https://example.test/widgets/42?q=blue',
+            ['Content-Type' => 'application/json', 'X-Token' => 'secret'],
+            '{"message":"hello"}',
+        ))
+            ->withQueryParams(['q' => 'blue'])
+            ->withCookieParams(['session' => 'abc']);
+        $response = new Psr7Response(
+            201,
+            ['Content-Type' => 'application/json; charset=utf-8', 'X-Trace' => 'trace-1'],
+            '{"id":42}',
+        );
+
+        $exchange = (new OpenApiPsr7Validator('psr7'))->validateExchange($request, $response);
+
+        $this->assertSame($this->baseline['psr7'], [
+            'request' => [
+                'outcome' => $exchange->requestResult()->outcome()->value,
+                'matched_path' => $exchange->requestResult()->matchedPath(),
+            ],
+            'response' => [
+                'outcome' => $exchange->responseResult()->outcome()->value,
+                'matched_path' => $exchange->responseResult()->matchedPath(),
+                'matched_status_code' => $exchange->responseResult()->matchedStatusCode(),
+                'matched_content_type' => $exchange->responseResult()->matchedContentType(),
+            ],
+            'coverage' => $this->coverageSummary('psr7'),
+        ]);
+    }
+
+    #[Test]
+    public function symfony_assertions_and_coverage_match_the_v1_9_consumer_baseline(): void
+    {
+        $request = Request::create('/v1/pets', 'GET');
+        $response = new JsonResponse(['data' => [['id' => 1, 'name' => 'Fido', 'tag' => null]]]);
+
+        $this->assertRequestMatchesOpenApiSchema($request);
+        $this->assertResponseMatchesOpenApiSchema($request, $response);
+
+        $this->assertSame($this->baseline['symfony'], [
+            'assertions' => ['request' => 'passed', 'response' => 'passed'],
+            'coverage' => $this->coverageSummary('petstore-3.0'),
+        ]);
+    }
+
+    protected function openApiSpec(): string
+    {
+        return 'petstore-3.0';
+    }
+
+    /** @return array{response_covered: int, covered: array<string, true>} */
+    private function coverageSummary(string $spec): array
+    {
+        $coverage = OpenApiCoverageTracker::computeCoverage($spec);
+
+        return [
+            'response_covered' => $coverage['responseCovered'],
+            'covered' => OpenApiCoverageTracker::getCovered()[$spec] ?? [],
+        ];
+    }
+}

--- a/tests/Integration/PestAutoloadBoundaryIntegrationTest.php
+++ b/tests/Integration/PestAutoloadBoundaryIntegrationTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Integration;
+
+use const PHP_BINARY;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function fclose;
+use function file_put_contents;
+use function is_resource;
+use function proc_close;
+use function proc_open;
+use function stream_get_contents;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+final class PestAutoloadBoundaryIntegrationTest extends TestCase
+{
+    /** @var list<string> */
+    private array $temporaryFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->temporaryFiles as $temporaryFile) {
+            unlink($temporaryFile);
+        }
+
+        $this->temporaryFiles = [];
+        parent::tearDown();
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function provideComposer_autoload_entrypoint_stays_dormant_until_pest_is_fully_availableCases(): iterable
+    {
+        yield 'Pest absent' => [<<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            require $argv[1];
+            echo 'loaded';
+            PHP];
+
+        yield 'Expectation class only' => [<<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace Pest {
+                final class Expectation {}
+            }
+
+            namespace {
+                require $argv[1];
+                echo 'loaded';
+            }
+            PHP];
+
+        yield 'expect function only' => [<<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            function expect(): never
+            {
+                throw new RuntimeException('the partial-install guard must return before calling expect()');
+            }
+
+            require $argv[1];
+            echo 'loaded';
+            PHP];
+    }
+
+    #[DataProvider('provideComposer_autoload_entrypoint_stays_dormant_until_pest_is_fully_availableCases')]
+    #[Test]
+    public function composer_autoload_entrypoint_stays_dormant_until_pest_is_fully_available(string $consumer): void
+    {
+        $script = tempnam(sys_get_temp_dir(), 'gesso-pest-autoload-');
+        $this->assertIsString($script);
+        $this->temporaryFiles[] = $script;
+        $this->assertNotFalse(file_put_contents($script, $consumer));
+
+        $process = proc_open(
+            [PHP_BINARY, $script, __DIR__ . '/../../src/Pest/Autoload.php'],
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes,
+            __DIR__ . '/../..',
+        );
+        $this->assertTrue(is_resource($process));
+
+        $stdout = (string) stream_get_contents($pipes[1]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        foreach ($pipes as $pipe) {
+            fclose($pipe);
+        }
+
+        $this->assertSame(0, proc_close($process), $stderr);
+        $this->assertSame('loaded', $stdout);
+        $this->assertSame('', $stderr);
+    }
+}

--- a/tests/fixtures/compatibility/v1.9-framework-adapter-parity.json
+++ b/tests/fixtures/compatibility/v1.9-framework-adapter-parity.json
@@ -1,0 +1,36 @@
+{
+    "baseline": {
+        "release": "v1.9.0",
+        "commit": "57920818e5677835ca681a499a8140ea651ea060"
+    },
+    "psr7": {
+        "request": {
+            "outcome": "success",
+            "matched_path": "/widgets/{id}"
+        },
+        "response": {
+            "outcome": "success",
+            "matched_path": "/widgets/{id}",
+            "matched_status_code": "201",
+            "matched_content_type": "application/json"
+        },
+        "coverage": {
+            "response_covered": 1,
+            "covered": {
+                "POST /widgets/{id}": true
+            }
+        }
+    },
+    "symfony": {
+        "assertions": {
+            "request": "passed",
+            "response": "passed"
+        },
+        "coverage": {
+            "response_covered": 1,
+            "covered": {
+                "GET /v1/pets": true
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- capture a v1.9.0 consumer baseline for representative PSR-7 and Symfony adapter exchanges
- compare Gesso v2 results, matched operation metadata, and automatic coverage against that baseline
- verify the Pest Composer autoload entrypoint remains dormant when Pest is absent or only partially available
- mark the integration and runnable-example rows complete in the v2 compatibility inventory

## Why

The v2 namespace migration already moved the adapters and examples to the Gesso identity, but namespace-only tests did not prove that framework adapter results and coverage remained equivalent to v1.9.0. The optional Pest autoload boundary also needed explicit negative coverage for absent and partial installations.

## Impact

No production behavior changes. This adds consumer-level regression coverage for the final integrations/documentation migration stage.

## Validation

- `vendor/bin/phpunit` — 2,084 tests, 5,553 assertions
- focused integration tests — 5 tests, 26 assertions
- `vendor/bin/phpstan analyse --no-progress --debug --memory-limit=1G`
- both PHP-CS-Fixer configurations
- `composer validate --strict`
- `composer audit --abandoned=fail`
- documentation build, link check, version check, base-path check, and Markdown lint
- Core, Laravel, Symfony, PSR-7, and Pest runnable examples
- `git diff --check`
