### PR TITLE
chore(release): prepare v2 beta

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,60 @@ version per package path on each target branch; this repo is single-package so
 it stays `{ ".": "X.Y.Z" }`. The value may differ between `main` and `1.x`.
 The `.` key is the bot's package-root identifier; do not rename or duplicate it.
 
+### Gesso 2.0 beta and stable promotion
+
+The first release of the new `studio-design/gesso` package uses a beta stage so
+the published artifact can be tested before the stable compatibility promise.
+This is a temporary `main`-branch procedure; the `1.x` branch continues its
+normal stable patch flow from its own release configuration.
+
+1. Close any open stable v2 release PR as obsolete. Changing the release
+   component from the legacy package name to `gesso` changes release-please's
+   bot branch, so it cannot safely update that old PR in place. Never merge or
+   manually edit the obsolete release PR.
+2. Register `studio-design/gesso` on Packagist from this GitHub repository.
+   Confirm that its `dev-main` metadata reports the new package name and source
+   repository. Do not mark the old package abandoned yet.
+3. Merge the beta-readiness PR with this footer in an actual commit message:
+
+   ```text
+   Release-As: 2.0.0-beta.1
+   ```
+
+   The `main` configuration must use `versioning: prerelease`,
+   `prerelease-type: beta`, and `prerelease: true`. The footer fixes the first
+   release at `2.0.0-beta.1`; later beta fixes increment the prerelease number.
+4. Wait for the bot-managed release PR to refresh. Before merging it, verify
+   that it proposes `2.0.0-beta.1`, changes only release-please-owned files,
+   and has a green supported matrix.
+5. Merge that release PR. Verify all four records agree: the `v2.0.0-beta.1`
+   git tag, the GitHub Release marked **Pre-release**, the manifest value, and
+   the Packagist version/source reference.
+6. Test the Packagist artifact in a clean project with
+   `composer require --dev "studio-design/gesso:^2.0@beta"`. Run the repository
+   examples and at least one representative downstream migration against the
+   published package rather than a path repository. Ship any corrections as
+   normal PRs and publish another beta through release-please when necessary.
+7. To promote the accepted beta, open a normal PR that changes only
+   `prerelease` to `false` (keep `versioning: prerelease`) and updates the
+   corresponding invariant test. Its actual commit message must contain:
+
+   ```text
+   Release-As: 2.0.0
+   ```
+
+   After merge, verify that the refreshed release PR proposes stable `2.0.0`
+   and repeat the tag, GitHub Release, manifest, Packagist, clean-install, and
+   example checks before announcing general availability.
+8. Only after the stable package is installable and verified, mark
+   `studio-design/openapi-contract-testing` abandoned on Packagist with
+   `studio-design/gesso` as its suggested replacement. Do not delete its tags
+   or releases; v1 remains supported through its documented lifecycle.
+
+Do not merge a stable `2.0.0` release PR while `prerelease` is `true`, while the
+new Packagist package is unregistered, or before the published beta artifact
+has passed the clean-consumer checks.
+
 ### Maintenance branches and backports
 
 After v1.10.0 is released, `main` is the v2 development branch and `1.x` is the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,37 +124,33 @@ normal stable patch flow from its own release configuration.
 2. Register `studio-design/gesso` on Packagist from this GitHub repository.
    Confirm that its `dev-main` metadata reports the new package name and source
    repository. Do not mark the old package abandoned yet.
-3. Merge the beta-readiness PR with this footer in an actual commit message:
-
-   ```text
-   Release-As: 2.0.0-beta.1
-   ```
-
-   The `main` configuration must use `versioning: prerelease`,
-   `prerelease-type: beta`, and `prerelease: true`. The footer fixes the first
-   release at `2.0.0-beta.1`; later beta fixes increment the prerelease number.
+3. Merge the beta-readiness PR. The `main` configuration must use
+   `versioning: prerelease`, `prerelease-type: beta`, `prerelease: true`, and
+   the temporary `release-as: 2.0.0-beta.1`. The repository discards commit
+   bodies when squash-merging, so a `Release-As` commit footer is not a safe
+   source for the first beta version.
 4. Wait for the bot-managed release PR to refresh. Before merging it, verify
    that it proposes `2.0.0-beta.1`, changes only release-please-owned files,
    and has a green supported matrix.
 5. Merge that release PR. Verify all four records agree: the `v2.0.0-beta.1`
    git tag, the GitHub Release marked **Pre-release**, the manifest value, and
-   the Packagist version/source reference.
+   the Packagist version/source reference. Immediately remove `release-as`
+   from the configuration through a normal PR before merging another
+   releasable change; otherwise release-please will keep forcing the already
+   published beta version.
 6. Test the Packagist artifact in a clean project with
    `composer require --dev "studio-design/gesso:^2.0@beta"`. Run the repository
    examples and at least one representative downstream migration against the
    published package rather than a path repository. Ship any corrections as
    normal PRs and publish another beta through release-please when necessary.
-7. To promote the accepted beta, open a normal PR that changes only
-   `prerelease` to `false` (keep `versioning: prerelease`) and updates the
-   corresponding invariant test. Its actual commit message must contain:
-
-   ```text
-   Release-As: 2.0.0
-   ```
-
-   After merge, verify that the refreshed release PR proposes stable `2.0.0`
-   and repeat the tag, GitHub Release, manifest, Packagist, clean-install, and
-   example checks before announcing general availability.
+7. To promote the accepted beta, open a normal PR that changes `prerelease` to
+   `false`, temporarily sets `release-as: 2.0.0`, and updates the corresponding
+   invariant test. Keep `versioning: prerelease` so release-please promotes the
+   beta line instead of calculating an unrelated bump. After merge, verify that
+   the refreshed release PR proposes stable `2.0.0` and repeat the tag, GitHub
+   Release, manifest, Packagist, clean-install, and example checks before
+   announcing general availability. Remove `release-as` through a normal PR
+   immediately after the stable release is published.
 8. Only after the stable package is installable and verified, mark
    `studio-design/openapi-contract-testing` abandoned on Packagist with
    `studio-design/gesso` as its suggested replacement. Do not delete its tags

--- a/docs/migration/v2.md
+++ b/docs/migration/v2.md
@@ -66,9 +66,29 @@ namespace.
 ## Stage 2: install v2
 
 After `studio-design/gesso` v2 is published, replace the root Composer
-requirement instead of treating the package as an in-place update. The exact
-pre-release and stable commands will be added here after the new package is
-registered and verified.
+requirement instead of treating the package as an in-place update.
+
+To test a published beta, explicitly opt in to beta stability for this package:
+
+```bash
+composer remove --dev studio-design/openapi-contract-testing --no-update
+composer require --dev "studio-design/gesso:^2.0@beta"
+```
+
+After v2.0.0 stable is published, use the normal stable constraint:
+
+```bash
+composer remove --dev studio-design/openapi-contract-testing --no-update
+composer require --dev "studio-design/gesso:^2.0"
+```
+
+The `--no-update` step edits only the root requirement; the following
+`composer require` resolves and installs the complete package switch. Do not
+run them in separate deployed revisions. Commit the resulting `composer.json`
+and `composer.lock` changes together with the namespace and integration changes
+described below. Composer does not select beta versions under its default
+`stable` policy unless the requirement opts in with a stability flag such as
+`@beta`.
 
 Before switching packages, upgrade the test environment to PHP 8.3 or later.
 Gesso v2 requires PHP `^8.3` and supports PHPUnit `^12.0 || ^13.0`; it no longer

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -149,4 +149,10 @@ Before publishing a release:
 
 - [ ] Run the supported PHP / PHPUnit / framework matrix in CI.
 - [ ] Review `UPGRADING.md` and the generated release notes for SemVer accuracy.
+- [ ] For a v2 beta or stable promotion, complete the tag, GitHub Release,
+  release manifest, Packagist metadata, clean-install, and published-artifact
+  checks in the
+  [Gesso 2.0 release procedure][v2-release-procedure].
 - [ ] If the README feature comparison was last checked three or more months ago, verify every competitor version and linked capability against its tagged official README and `composer.json`, update the checked date, and keep competitor strengths as well as gaps.
+
+[v2-release-procedure]: https://github.com/studio-design/gesso/blob/main/CONTRIBUTING.md#gesso-20-beta-and-stable-promotion

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,7 @@
   "versioning": "prerelease",
   "prerelease-type": "beta",
   "prerelease": true,
+  "release-as": "2.0.0-beta.1",
   "changelog-path": "CHANGELOG.md",
   "packages": {
     ".": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,11 +6,13 @@
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "draft": false,
-  "prerelease": false,
+  "versioning": "prerelease",
+  "prerelease-type": "beta",
+  "prerelease": true,
   "changelog-path": "CHANGELOG.md",
   "packages": {
     ".": {
-      "package-name": "openapi-contract-testing"
+      "package-name": "gesso"
     }
   }
 }

--- a/tests/Unit/Build/ReleasePleaseConfigTest.php
+++ b/tests/Unit/Build/ReleasePleaseConfigTest.php
@@ -108,8 +108,28 @@ class ReleasePleaseConfigTest extends TestCase
         $rootPackage = $packages['.'] ?? null;
         $this->assertIsArray($rootPackage);
         $this->assertSame(
-            'openapi-contract-testing',
+            'gesso',
             $rootPackage['package-name'] ?? null,
+        );
+    }
+
+    #[Test]
+    public function main_is_configured_for_the_v2_beta_line(): void
+    {
+        $this->assertSame(
+            'prerelease',
+            $this->config['versioning'] ?? null,
+            'The prerelease versioning strategy is required to produce and later promote v2 beta versions.',
+        );
+        $this->assertSame(
+            'beta',
+            $this->config['prerelease-type'] ?? null,
+            'The v2 prerelease line MUST use the documented beta identifier.',
+        );
+        $this->assertSame(
+            true,
+            $this->config['prerelease'] ?? null,
+            'The v2 beta must be tagged as a GitHub prerelease. Set this to false only in the stable-promotion PR.',
         );
     }
 

--- a/tests/Unit/Build/ReleasePleaseConfigTest.php
+++ b/tests/Unit/Build/ReleasePleaseConfigTest.php
@@ -131,6 +131,12 @@ class ReleasePleaseConfigTest extends TestCase
             $this->config['prerelease'] ?? null,
             'The v2 beta must be tagged as a GitHub prerelease. Set this to false only in the stable-promotion PR.',
         );
+        $this->assertSame(
+            '2.0.0-beta.1',
+            $this->config['release-as'] ?? null,
+            'The first beta version MUST be fixed in configuration because squash merge commit bodies are blank. '
+                . 'Remove release-as immediately after v2.0.0-beta.1 is published.',
+        );
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- configure release-please to produce the Gesso 2.0 beta line
- rename the release component from the legacy package identity to `gesso`
- pin the prerelease settings with a repository invariant test
- document Packagist registration, beta verification, stable promotion, and Composer migration commands

## Why

The current release PR proposes stable `2.0.0`, while ADR 0001 requires
published prerelease testing before general availability. release-please also
still uses the legacy package component name. This PR makes the release path
explicit and forces the first proposal to `2.0.0-beta.1` through temporary
`release-as` configuration. This avoids relying on commit bodies, which this
repository discards during squash merge.

## Merge prerequisites

- [ ] Close #339 as obsolete; its bot branch uses the legacy component name and will not be updated in place
- [ ] Register `studio-design/gesso` on Packagist from this repository
- [ ] Verify Packagist `dev-main` metadata reports the new package name and correct source repository
- [ ] Keep `studio-design/openapi-contract-testing` un-abandoned until stable v2 is installable and verified

## Validation

- PHPUnit: 2,085 tests / 5,556 assertions
- PHPStan
- PHP-CS-Fixer (normal and Pest configurations)
- Composer validate and audit
- VitePress build, version, base-path, and link checks
- Markdown renderer lint tests
- `git diff --check`
