### PR TITLE
chore(release): remove first beta override

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,6 @@
   "versioning": "prerelease",
   "prerelease-type": "beta",
   "prerelease": true,
-  "release-as": "2.0.0-beta.1",
   "changelog-path": "CHANGELOG.md",
   "packages": {
     ".": {

--- a/tests/Unit/Build/ReleasePleaseConfigTest.php
+++ b/tests/Unit/Build/ReleasePleaseConfigTest.php
@@ -136,6 +136,14 @@ class ReleasePleaseConfigTest extends TestCase
             $this->config,
             'release-as MUST be absent after v2.0.0-beta.1 so later beta releases can increment normally.',
         );
+
+        $rootPackage = $this->config['packages']['.'] ?? null;
+        $this->assertIsArray($rootPackage);
+        $this->assertArrayNotHasKey(
+            'release-as',
+            $rootPackage,
+            'Package-level release-as MUST be absent after v2.0.0-beta.1 so it cannot override the root configuration.',
+        );
     }
 
     #[Test]

--- a/tests/Unit/Build/ReleasePleaseConfigTest.php
+++ b/tests/Unit/Build/ReleasePleaseConfigTest.php
@@ -131,11 +131,10 @@ class ReleasePleaseConfigTest extends TestCase
             $this->config['prerelease'] ?? null,
             'The v2 beta must be tagged as a GitHub prerelease. Set this to false only in the stable-promotion PR.',
         );
-        $this->assertSame(
-            '2.0.0-beta.1',
-            $this->config['release-as'] ?? null,
-            'The first beta version MUST be fixed in configuration because squash merge commit bodies are blank. '
-                . 'Remove release-as immediately after v2.0.0-beta.1 is published.',
+        $this->assertArrayNotHasKey(
+            'release-as',
+            $this->config,
+            'release-as MUST be absent after v2.0.0-beta.1 so later beta releases can increment normally.',
         );
     }
 


### PR DESCRIPTION
## Summary

- remove the one-shot `release-as: 2.0.0-beta.1` override after the first beta was published
- keep release-please in beta prerelease mode
- update the invariant test so the published beta version cannot be forced again accidentally

## Why

`v2.0.0-beta.1` is now published. Leaving `release-as` in the configuration would continue forcing an already-published version instead of allowing the next releasable change to advance to `v2.0.0-beta.2`.

## Verification

- `vendor/bin/phpunit tests/Unit/Build/ReleasePleaseConfigTest.php`
- `NPM_CONFIG_CACHE=/tmp/gesso-npm-cache vendor/bin/phpunit` (2085 tests, 5557 assertions)
- `vendor/bin/phpstan analyse --no-progress --debug --memory-limit=1G`
- both PHP-CS-Fixer dry-run configurations
- `composer validate --strict`
- `composer audit --abandoned=fail`
- `git diff --check`
