### PR TITLE
fix(fuzz): make Laravel exploration examples executable

### DIFF
--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -7,6 +7,7 @@ contract; this package does not claim feature parity.
 
 ```php
 use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Fuzz\ExploredCase;
 use Studio\Gesso\Laravel\ExploresOpenApiEndpoint;
 use Studio\Gesso\Laravel\ValidatesOpenApiSchema;
 use Studio\Gesso\Attribute\OpenApiSpec;
@@ -20,7 +21,7 @@ class CreatePetTest extends TestCase
     public function test_create_pet_contract(): void
     {
         $this->exploreEndpoint('POST', '/v1/pets', cases: 50, seed: 1)
-            ->each(fn ($input) => $this->postJson('/api/v1/pets', $input->body)
+            ->each(fn (ExploredCase $case) => $this->postJson('/api/v1/pets', $case->bodyAsArray() ?? [])
                 ->assertSuccessful());
     }
 }
@@ -40,6 +41,13 @@ What you get per case (`Studio\Gesso\Fuzz\ExploredCase`):
 | `seed`, `caseIndex` | Stable replay identity |
 
 The collection is `Countable` and `IteratorAggregate`, so `foreach ($cases as $case)` works too if you prefer it over the fluent `each()` helper.
+
+Use `bodyAsArray()` with Laravel and other HTTP helpers that require an array
+payload. It recursively converts generated JSON objects, but an empty JSON
+object becomes an empty PHP array; encode `body` directly when the `{}` versus
+`[]` distinction matters. `uri($prefix)` substitutes and URL-encodes path
+parameters, prepends an optional application prefix, and appends the generated
+query string.
 
 ## Explore a whole spec
 
@@ -68,8 +76,8 @@ class ApiContractTest extends TestCase
             ->excludeOperations(['admin.users.destroy'])
             ->authenticateUsing(fn (ExploredOperation $operation) => $this->actingAs($this->userFor($operation)))
             ->dispatchUsing(fn (ExploredCase $case) => match ($case->method) {
-                HttpMethod::GET => $this->get($this->uriFor($case), $case->headers),
-                HttpMethod::POST => $this->postJson($this->uriFor($case), $case->body, $case->headers),
+                HttpMethod::GET => $this->get($case->uri('/api'), $case->headers),
+                HttpMethod::POST => $this->postJson($case->uri('/api'), $case->bodyAsArray() ?? [], $case->headers),
                 default => throw new LogicException('Add the method to the test dispatcher.'),
             })
             ->assertResponses(); // ValidatesOpenApiSchema auto_assert validates each response
@@ -187,7 +195,7 @@ $this->exploreInvalidEndpoint(
     cases: 20,
     seed: 7,
 )->each(function (ExploredCase $case): void {
-    $response = $this->postJson('/api/v1/pets', $case->body);
+    $response = $this->postJson('/api/v1/pets', $case->bodyAsArray() ?? []);
     self::assertContains(intdiv($response->getStatusCode(), 100), $case->expectedStatusClasses);
 });
 ```

--- a/src/Fuzz/ExploredCase.php
+++ b/src/Fuzz/ExploredCase.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace Studio\Gesso\Fuzz;
 
+use const JSON_THROW_ON_ERROR;
+
 use InvalidArgumentException;
+use JsonException;
+use LogicException;
 use Studio\Gesso\HttpMethod;
 
 use function base64_encode;
 use function escapeshellarg;
 use function http_build_query;
 use function implode;
+use function is_array;
+use function json_decode;
 use function json_encode;
 use function rawurlencode;
 use function sprintf;
@@ -24,8 +30,7 @@ use function str_replace;
  * `query`, `headers`, and `pathParams` are name → value maps, where the
  * `pathParams` keys are the placeholder *names* extracted from `matchedPath`
  * (e.g. `petId`), not positional. `matchedPath` is the spec template with
- * `{placeholders}` unsubstituted — callers needing a concrete URI substitute
- * `pathParams` into it themselves.
+ * `{placeholders}` unsubstituted. Use {@see self::uri()} for a concrete URI.
  */
 final readonly class ExploredCase
 {
@@ -85,6 +90,45 @@ final readonly class ExploredCase
         return $this->copy($this->body, $this->query, $this->headers, $pathParams);
     }
 
+    /**
+     * Convert a generated JSON object or array for array-typed HTTP helpers.
+     *
+     * Empty JSON objects become empty PHP arrays, so callers that must preserve
+     * the distinction between `{}` and `[]` should encode {@see self::$body}
+     * directly instead.
+     *
+     * @return null|array<array-key, mixed>
+     *
+     * @throws JsonException when the generated body cannot be encoded or decoded
+     * @throws LogicException when the generated JSON body is a scalar
+     */
+    public function bodyAsArray(): ?array
+    {
+        if ($this->body === null) {
+            return null;
+        }
+
+        $body = json_decode(json_encode($this->body, JSON_THROW_ON_ERROR), true, flags: JSON_THROW_ON_ERROR);
+        if (!is_array($body)) {
+            throw new LogicException(
+                'ExploredCase::bodyAsArray() requires a JSON object or array body; encode the scalar body directly.',
+            );
+        }
+
+        return $body;
+    }
+
+    public function uri(string $prefix = ''): string
+    {
+        $path = $this->matchedPath;
+        foreach ($this->pathParams as $name => $value) {
+            $path = str_replace('{' . $name . '}', rawurlencode((string) $value), $path);
+        }
+        $query = $this->query !== [] ? '?' . http_build_query($this->query) : '';
+
+        return $prefix . $path . $query;
+    }
+
     public function replayToken(): string
     {
         return base64_encode((string) json_encode([
@@ -124,12 +168,7 @@ final readonly class ExploredCase
 
     public function curlSnippet(string $baseUrl = ''): string
     {
-        $path = $this->matchedPath;
-        foreach ($this->pathParams as $name => $value) {
-            $path = str_replace('{' . $name . '}', rawurlencode((string) $value), $path);
-        }
-        $query = $this->query !== [] ? '?' . http_build_query($this->query) : '';
-        $command = sprintf('curl -X %s %s', $this->method->value, escapeshellarg($baseUrl . $path . $query));
+        $command = sprintf('curl -X %s %s', $this->method->value, escapeshellarg($this->uri($baseUrl)));
         foreach ($this->headers as $name => $value) {
             $command .= ' -H ' . escapeshellarg($name . ': ' . (string) $value);
         }

--- a/src/Fuzz/ExploredCase.php
+++ b/src/Fuzz/ExploredCase.php
@@ -11,11 +11,13 @@ use JsonException;
 use LogicException;
 use Studio\Gesso\HttpMethod;
 
+use function array_map;
 use function base64_encode;
 use function escapeshellarg;
 use function http_build_query;
 use function implode;
 use function is_array;
+use function is_bool;
 use function json_decode;
 use function json_encode;
 use function rawurlencode;
@@ -124,7 +126,9 @@ final readonly class ExploredCase
         foreach ($this->pathParams as $name => $value) {
             $path = str_replace('{' . $name . '}', rawurlencode((string) $value), $path);
         }
-        $query = $this->query !== [] ? '?' . http_build_query($this->query) : '';
+        $query = $this->query !== []
+            ? '?' . http_build_query(array_map(self::serialiseQueryValue(...), $this->query))
+            : '';
 
         return $prefix . $path . $query;
     }
@@ -177,6 +181,17 @@ final readonly class ExploredCase
         }
 
         return $command;
+    }
+
+    private static function serialiseQueryValue(mixed $value): mixed
+    {
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        return is_array($value)
+            ? array_map(self::serialiseQueryValue(...), $value)
+            : $value;
     }
 
     /**

--- a/src/Fuzz/ExploredCase.php
+++ b/src/Fuzz/ExploredCase.php
@@ -124,10 +124,14 @@ final readonly class ExploredCase
     {
         $path = $this->matchedPath;
         foreach ($this->pathParams as $name => $value) {
-            $path = str_replace('{' . $name . '}', rawurlencode((string) $value), $path);
+            $path = str_replace(
+                '{' . $name . '}',
+                rawurlencode((string) self::serialiseParameterValue($value)),
+                $path,
+            );
         }
         $query = $this->query !== []
-            ? '?' . http_build_query(array_map(self::serialiseQueryValue(...), $this->query))
+            ? '?' . http_build_query(array_map(self::serialiseParameterValue(...), $this->query))
             : '';
 
         return $prefix . $path . $query;
@@ -183,14 +187,14 @@ final readonly class ExploredCase
         return $command;
     }
 
-    private static function serialiseQueryValue(mixed $value): mixed
+    private static function serialiseParameterValue(mixed $value): mixed
     {
         if (is_bool($value)) {
             return $value ? 'true' : 'false';
         }
 
         return is_array($value)
-            ? array_map(self::serialiseQueryValue(...), $value)
+            ? array_map(self::serialiseParameterValue(...), $value)
             : $value;
     }
 

--- a/tests/Integration/Laravel/WholeSpecExplorationIntegrationTest.php
+++ b/tests/Integration/Laravel/WholeSpecExplorationIntegrationTest.php
@@ -11,7 +11,6 @@ use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 use Studio\Gesso\Coverage\OpenApiCoverageTracker;
 use Studio\Gesso\Fuzz\ExploredCase;
-use Studio\Gesso\Fuzz\ExploredOperation;
 use Studio\Gesso\HttpMethod;
 use Studio\Gesso\Laravel\ExploresOpenApiEndpoint;
 use Studio\Gesso\Laravel\GessoServiceProvider;
@@ -48,10 +47,10 @@ class WholeSpecExplorationIntegrationTest extends TestCase
     {
         $summary = $this->exploreSpec(casesPerOperation: 2, seed: 5)
             ->includeOperations(['listPets', 'createPet'])
-            ->dispatchUsing(function (ExploredCase $case, ExploredOperation $operation): TestResponse {
+            ->dispatchUsing(function (ExploredCase $case): TestResponse {
                 return match ($case->method) {
-                    HttpMethod::GET => $this->get($operation->path, $case->headers),
-                    HttpMethod::POST => $this->postJson($operation->path, $case->body, $case->headers),
+                    HttpMethod::GET => $this->get($case->uri(), $case->headers),
+                    HttpMethod::POST => $this->postJson($case->uri(), $case->bodyAsArray() ?? [], $case->headers),
                     default => throw new LogicException('Unexpected method in Laravel exploration example.'),
                 };
             })

--- a/tests/Unit/Compatibility/PublicApiBaselineTest.php
+++ b/tests/Unit/Compatibility/PublicApiBaselineTest.php
@@ -11,12 +11,14 @@ use PHPUnit\Framework\TestCase;
 use Studio\Gesso\Coverage\ConsoleCoverageRenderer;
 use Studio\Gesso\Coverage\HtmlCoverageRenderer;
 use Studio\Gesso\Coverage\JsonCoverageRenderer;
+use Studio\Gesso\Fuzz\ExploredCase;
 use Studio\Gesso\Tests\Helpers\PublicApiInventory;
 use Studio\Gesso\Tests\Unit\Compatibility\Fixture\PublicApiReturnTypeFixture;
 
 use function dirname;
 use function file_get_contents;
 use function json_decode;
+use function ksort;
 use function str_replace;
 
 final class PublicApiBaselineTest extends TestCase
@@ -108,6 +110,33 @@ final class PublicApiBaselineTest extends TestCase
         /** @var array<string, array<string, mixed>> $expected */
         $expected = json_decode($mappedV1Json, true, flags: JSON_THROW_ON_ERROR);
         $expected[JsonCoverageRenderer::class]['constants']['SCHEMA_VERSION'] = 2;
+        $expected[ExploredCase::class]['methods']['bodyAsArray'] = [
+            'static' => false,
+            'final' => false,
+            'abstract' => false,
+            'returns_reference' => false,
+            'return_type' => '?array',
+            'attributes' => [],
+            'parameters' => [],
+        ];
+        $expected[ExploredCase::class]['methods']['uri'] = [
+            'static' => false,
+            'final' => false,
+            'abstract' => false,
+            'returns_reference' => false,
+            'return_type' => 'string',
+            'attributes' => [],
+            'parameters' => [[
+                'name' => 'prefix',
+                'type' => 'string',
+                'optional' => true,
+                'variadic' => false,
+                'by_reference' => false,
+                'default' => '',
+                'attributes' => [],
+            ]],
+        ];
+        ksort($expected[ExploredCase::class]['methods']);
         /** @var array<string, array<string, mixed>> $actual */
         $actual = json_decode($v2Json, true, flags: JSON_THROW_ON_ERROR);
 

--- a/tests/Unit/Fuzz/ExploredCaseTest.php
+++ b/tests/Unit/Fuzz/ExploredCaseTest.php
@@ -75,16 +75,23 @@ class ExploredCaseTest extends TestCase
     {
         $case = new ExploredCase(
             body: null,
-            query: ['search' => 'snowy owl', 'page' => 2],
+            query: [
+                'search' => 'snowy owl',
+                'page' => 2,
+                'active' => true,
+                'filters' => ['archived' => false],
+            ],
             headers: [],
             pathParams: ['petId' => 'pet/7'],
             method: HttpMethod::GET,
             matchedPath: '/v1/pets/{petId}',
         );
 
-        $this->assertSame('/api/v1/pets/pet%2F7?search=snowy+owl&page=2', $case->uri('/api'));
+        $expectedQuery = 'search=snowy+owl&page=2&active=true&filters%5Barchived%5D=false';
+
+        $this->assertSame('/api/v1/pets/pet%2F7?' . $expectedQuery, $case->uri('/api'));
         $this->assertStringContainsString(
-            "'https://api.example.test/v1/pets/pet%2F7?search=snowy+owl&page=2'",
+            "'https://api.example.test/v1/pets/pet%2F7?{$expectedQuery}'",
             $case->curlSnippet('https://api.example.test'),
         );
     }

--- a/tests/Unit/Fuzz/ExploredCaseTest.php
+++ b/tests/Unit/Fuzz/ExploredCaseTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Studio\Gesso\Tests\Unit\Fuzz;
 
 use InvalidArgumentException;
+use LogicException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 use Studio\Gesso\Fuzz\ExploredCase;
 use Studio\Gesso\Fuzz\FailureReducer;
 use Studio\Gesso\HttpMethod;
@@ -69,6 +71,50 @@ class ExploredCaseTest extends TestCase
     }
 
     #[Test]
+    public function builds_a_concrete_uri_with_encoded_path_and_query_values(): void
+    {
+        $case = new ExploredCase(
+            body: null,
+            query: ['search' => 'snowy owl', 'page' => 2],
+            headers: [],
+            pathParams: ['petId' => 'pet/7'],
+            method: HttpMethod::GET,
+            matchedPath: '/v1/pets/{petId}',
+        );
+
+        $this->assertSame('/api/v1/pets/pet%2F7?search=snowy+owl&page=2', $case->uri('/api'));
+        $this->assertStringContainsString(
+            "'https://api.example.test/v1/pets/pet%2F7?search=snowy+owl&page=2'",
+            $case->curlSnippet('https://api.example.test'),
+        );
+    }
+
+    #[Test]
+    public function converts_json_object_and_array_bodies_for_array_typed_http_helpers(): void
+    {
+        $object = new stdClass();
+        $object->name = 'Snowy';
+        $object->details = (object) ['age' => 3];
+
+        $objectCase = $this->caseWithBody($object);
+        $arrayCase = $this->caseWithBody(['name' => 'Snowy']);
+
+        $this->assertSame(['name' => 'Snowy', 'details' => ['age' => 3]], $objectCase->bodyAsArray());
+        $this->assertSame(['name' => 'Snowy'], $arrayCase->bodyAsArray());
+        $this->assertNull($this->caseWithBody(null)->bodyAsArray());
+        $this->assertSame([], $this->caseWithBody(new stdClass())->bodyAsArray());
+    }
+
+    #[Test]
+    public function rejects_scalar_bodies_for_array_typed_http_helpers(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('requires a JSON object or array body');
+
+        $this->caseWithBody('scalar')->bodyAsArray();
+    }
+
+    #[Test]
     public function reducer_preserves_the_original_failure_classification(): void
     {
         $case = new ExploredCase(
@@ -86,5 +132,17 @@ class ExploredCaseTest extends TestCase
         );
 
         $this->assertSame(['trigger' => true], $reduced->body);
+    }
+
+    private function caseWithBody(mixed $body): ExploredCase
+    {
+        return new ExploredCase(
+            body: $body,
+            query: [],
+            headers: [],
+            pathParams: [],
+            method: HttpMethod::POST,
+            matchedPath: '/v1/pets',
+        );
     }
 }

--- a/tests/Unit/Fuzz/OpenApiEndpointExplorerTest.php
+++ b/tests/Unit/Fuzz/OpenApiEndpointExplorerTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Studio\Gesso\Tests\Unit\Fuzz;
 
+use const PHP_URL_PATH;
+use const PHP_URL_QUERY;
+
 use InvalidArgumentException;
 use Opis\JsonSchema\Validator;
 use PHPUnit\Framework\Attributes\Test;
@@ -14,10 +17,13 @@ use Studio\Gesso\Fuzz\ExplorationCases;
 use Studio\Gesso\Fuzz\ExploredCase;
 use Studio\Gesso\Fuzz\OpenApiEndpointExplorer;
 use Studio\Gesso\HttpMethod;
+use Studio\Gesso\OpenApiRequestValidator;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 
 use function json_decode;
 use function json_encode;
+use function parse_str;
+use function parse_url;
 use function str_repeat;
 
 class OpenApiEndpointExplorerTest extends TestCase
@@ -136,6 +142,40 @@ class OpenApiEndpointExplorerTest extends TestCase
             }
         }
         $this->assertTrue($sawValue, 'at least one case should generate the dryRun query param');
+    }
+
+    #[Test]
+    public function generated_boolean_query_round_trips_through_uri_and_request_validation(): void
+    {
+        $cases = OpenApiEndpointExplorer::explore('petstore-3.0', 'POST', '/v1/pets', cases: 2, seed: 1);
+        $validator = new OpenApiRequestValidator();
+        $serialisedValues = [];
+
+        foreach ($cases as $case) {
+            $uri = $case->uri();
+            $path = parse_url($uri, PHP_URL_PATH);
+            $queryString = parse_url($uri, PHP_URL_QUERY);
+            $this->assertIsString($path);
+            $this->assertIsString($queryString);
+
+            $query = [];
+            parse_str($queryString, $query);
+            $serialisedValues[] = $query['dryRun'] ?? null;
+
+            $result = $validator->validate(
+                'petstore-3.0',
+                'POST',
+                $path,
+                $query,
+                [],
+                $case->body,
+                'application/json',
+            );
+
+            $this->assertTrue($result->isValid(), $result->errorMessage());
+        }
+
+        $this->assertSame(['false', 'true'], $serialisedValues);
     }
 
     #[Test]

--- a/tests/Unit/Fuzz/OpenApiEndpointExplorerTest.php
+++ b/tests/Unit/Fuzz/OpenApiEndpointExplorerTest.php
@@ -207,6 +207,30 @@ class OpenApiEndpointExplorerTest extends TestCase
     }
 
     #[Test]
+    public function generated_boolean_path_round_trips_through_uri_and_request_validation(): void
+    {
+        $cases = OpenApiEndpointExplorer::explore(
+            'fuzz-boolean-path',
+            'GET',
+            '/flags/{enabled}',
+            cases: 2,
+            seed: 1,
+        );
+        $validator = new OpenApiRequestValidator();
+        $uris = [];
+
+        foreach ($cases as $case) {
+            $uri = $case->uri();
+            $uris[] = $uri;
+            $result = $validator->validate('fuzz-boolean-path', 'GET', $uri, [], [], null);
+
+            $this->assertTrue($result->isValid(), $result->errorMessage());
+        }
+
+        $this->assertSame(['/flags/false', '/flags/true'], $uris);
+    }
+
+    #[Test]
     public function resolves_concrete_uri_to_spec_template(): void
     {
         $cases = OpenApiEndpointExplorer::explore('petstore-3.0', 'GET', '/v1/pets/123', cases: 1, seed: 1);

--- a/tests/fixtures/compatibility/v2-public-api.json
+++ b/tests/fixtures/compatibility/v2-public-api.json
@@ -2833,6 +2833,15 @@
                     }
                 ]
             },
+            "bodyAsArray": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "?array",
+                "attributes": [],
+                "parameters": []
+            },
             "curlSnippet": {
                 "static": false,
                 "final": false,
@@ -2881,6 +2890,25 @@
                 "return_type": "string",
                 "attributes": [],
                 "parameters": []
+            },
+            "uri": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "string",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "prefix",
+                        "type": "string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": "",
+                        "attributes": []
+                    }
+                ]
             },
             "withBody": {
                 "static": false,

--- a/tests/fixtures/specs/fuzz-boolean-path.json
+++ b/tests/fixtures/specs/fuzz-boolean-path.json
@@ -1,0 +1,28 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Boolean path fuzzing fixture",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/flags/{enabled}": {
+            "get": {
+                "parameters": [
+                    {
+                        "name": "enabled",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add `ExploredCase::bodyAsArray()` for Laravel and other array-typed JSON helpers
- add `ExploredCase::uri()` for path-parameter substitution, query encoding, and optional prefixes
- update the Laravel fuzzing examples and integration coverage to use the executable APIs
- record the two additive methods in the v2 public API baseline

## Why

The documented Laravel examples passed generated request bodies directly to `postJson()` and called an undefined `uriFor()` helper. Generated JSON objects can be represented as `stdClass`, while Laravel requires an array payload, so the examples could fail before dispatch. Consumers also had to duplicate the URI construction already embedded in `curlSnippet()`.

`bodyAsArray()` now provides an explicit conversion boundary and documents the empty-object fidelity caveat. `uri()` centralizes the existing path and query construction, and `curlSnippet()` reuses it.

Closes #318.

## Validation

- targeted PHPUnit: 12 tests, 48 assertions
- full PHPUnit: 2088 tests, 5567 assertions
- full PHPStan
- PHP-CS-Fixer with both repository configurations
- VitePress build, version/base checks, and documentation link check
- `git diff --check`
