### PR TITLE
chore(release): promote v2 stable

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,8 +8,61 @@
   "draft": false,
   "versioning": "prerelease",
   "prerelease-type": "beta",
-  "prerelease": true,
+  "prerelease": false,
+  "release-as": "2.0.0",
   "changelog-path": "CHANGELOG.md",
+  "changelog-sections": [
+    {
+      "type": "feat",
+      "section": "Features"
+    },
+    {
+      "type": "fix",
+      "section": "Bug Fixes"
+    },
+    {
+      "type": "perf",
+      "section": "Performance Improvements"
+    },
+    {
+      "type": "revert",
+      "section": "Reverts"
+    },
+    {
+      "type": "chore",
+      "section": "Miscellaneous Chores"
+    },
+    {
+      "type": "docs",
+      "section": "Documentation",
+      "hidden": true
+    },
+    {
+      "type": "style",
+      "section": "Styles",
+      "hidden": true
+    },
+    {
+      "type": "refactor",
+      "section": "Code Refactoring",
+      "hidden": true
+    },
+    {
+      "type": "test",
+      "section": "Tests",
+      "hidden": true
+    },
+    {
+      "type": "build",
+      "section": "Build System",
+      "hidden": true
+    },
+    {
+      "type": "ci",
+      "section": "Continuous Integration",
+      "hidden": true
+    }
+  ],
   "packages": {
     ".": {
       "package-name": "gesso"

--- a/tests/Unit/Build/ReleasePleaseConfigTest.php
+++ b/tests/Unit/Build/ReleasePleaseConfigTest.php
@@ -114,7 +114,7 @@ class ReleasePleaseConfigTest extends TestCase
     }
 
     #[Test]
-    public function main_is_configured_for_the_v2_beta_line(): void
+    public function main_is_configured_for_v2_stable_promotion(): void
     {
         $this->assertSame(
             'prerelease',
@@ -127,14 +127,31 @@ class ReleasePleaseConfigTest extends TestCase
             'The v2 prerelease line MUST use the documented beta identifier.',
         );
         $this->assertSame(
-            true,
+            false,
             $this->config['prerelease'] ?? null,
-            'The v2 beta must be tagged as a GitHub prerelease. Set this to false only in the stable-promotion PR.',
+            'The stable v2 release MUST not be tagged as a GitHub prerelease.',
         );
-        $this->assertArrayNotHasKey(
-            'release-as',
-            $this->config,
-            'release-as MUST be absent after v2.0.0-beta.1 so later beta releases can increment normally.',
+        $this->assertSame(
+            '2.0.0',
+            $this->config['release-as'] ?? null,
+            'The stable-promotion PR MUST temporarily force exactly v2.0.0.',
+        );
+        $this->assertSame(
+            [
+                ['type' => 'feat', 'section' => 'Features'],
+                ['type' => 'fix', 'section' => 'Bug Fixes'],
+                ['type' => 'perf', 'section' => 'Performance Improvements'],
+                ['type' => 'revert', 'section' => 'Reverts'],
+                ['type' => 'chore', 'section' => 'Miscellaneous Chores'],
+                ['type' => 'docs', 'section' => 'Documentation', 'hidden' => true],
+                ['type' => 'style', 'section' => 'Styles', 'hidden' => true],
+                ['type' => 'refactor', 'section' => 'Code Refactoring', 'hidden' => true],
+                ['type' => 'test', 'section' => 'Tests', 'hidden' => true],
+                ['type' => 'build', 'section' => 'Build System', 'hidden' => true],
+                ['type' => 'ci', 'section' => 'Continuous Integration', 'hidden' => true],
+            ],
+            $this->config['changelog-sections'] ?? null,
+            'The stable-promotion chore MUST be visible so release-please does not skip an empty changelog.',
         );
 
         $rootPackage = $this->config['packages']['.'] ?? null;
@@ -142,7 +159,7 @@ class ReleasePleaseConfigTest extends TestCase
         $this->assertArrayNotHasKey(
             'release-as',
             $rootPackage,
-            'Package-level release-as MUST be absent after v2.0.0-beta.1 so it cannot override the root configuration.',
+            'Package-level release-as MUST stay absent so it cannot override the stable-promotion version.',
         );
     }
 


### PR DESCRIPTION
## Summary

- switch release-please from GitHub prerelease publication to stable publication
- temporarily force the promotion target to exactly `2.0.0`
- temporarily expose `chore` release notes so the promotion commit cannot be skipped as an empty changelog
- pin both invariants in the repository test while rejecting a package-level `release-as` override

## Why

`v2.0.0-beta.2` has been published and verified from Packagist in a clean project. The public package installed at the release commit, the Gesso doctor accepted a representative contract, and the beta.2 boolean parameter fix round-tripped through exploration, URI generation, and request validation.

After this PR merges, release-please should open the separate generated release PR for `v2.0.0`. Both the temporary `release-as` and visible-chore changelog override must be removed in a follow-up after the stable release is published.

## Verification

- release-please v17.6.0 `Simple::buildReleasePullRequest()` simulation from `v2.0.0-beta.2`, producing `chore(main): release 2.0.0`
- `vendor/bin/phpunit tests/Unit/Build/ReleasePleaseConfigTest.php` (7 tests, 19 assertions)
- PHP-CS-Fixer main and Pest configurations in sequential dry-run mode
- `vendor/bin/phpstan analyse --debug --no-progress --memory-limit=1G`
- `NPM_CONFIG_CACHE=/tmp/gesso-stable-promotion-npm-cache composer test` (2090 tests, 5578 assertions)
- clean Packagist install of `studio-design/gesso:2.0.0-beta.2`
- published beta smoke test: boolean path exploration -> URI generation -> request validation
- `vendor/bin/gesso doctor --spec=specs/boolean-path.json`

## Release sequence

1. Merge this configuration PR.
2. Review and merge the generated `chore(main): release 2.0.0` PR.
3. Verify the GitHub release and Packagist stable package.
4. Remove the temporary stable-promotion override in a follow-up PR.
