### PR TITLE
fix(request): reject absent required bodies without schemas

### DIFF
--- a/src/Validation/Request/RequestBodyValidator.php
+++ b/src/Validation/Request/RequestBodyValidator.php
@@ -37,8 +37,8 @@ final class RequestBodyValidator
      *
      * Returns a {@see RequestBodyValidationResult} with an empty `errors`
      * list when the body is acceptable (including when the spec defines no
-     * body, no content, no JSON content type, or no schema). Hard spec-level
-     * errors (malformed `requestBody` / `content`) are reported as error
+     * body, or an optional body has no content, JSON content type, or schema).
+     * Hard spec-level errors (malformed `requestBody` / `content`) are reported as error
      * entries so the orchestrator can accumulate them alongside other
      * validators' errors. A non-JSON Content-Type that matched a spec
      * media-type key declaring a `schema` this engine cannot evaluate yields
@@ -87,6 +87,10 @@ final class RequestBodyValidator
         $required = ($requestBodySpec['required'] ?? false) === true;
 
         if (!isset($requestBodySpec['content'])) {
+            if ($required && !$requestBody->present) {
+                return self::missingRequiredBodyResult($specName, $method, $matchedPath);
+            }
+
             return new RequestBodyValidationResult([]);
         }
 
@@ -166,6 +170,10 @@ final class RequestBodyValidator
             if (!ContentTypeMatcher::isJsonContentType($normalizedType)) {
                 $matchedKey = ContentTypeMatcher::findContentTypeKey($normalizedType, $content);
                 if ($matchedKey !== null) {
+                    if ($required && !$requestBody->present) {
+                        return self::missingRequiredBodyResult($specName, $method, $matchedPath);
+                    }
+
                     if (isset($content[$matchedKey]['itemSchema'])) {
                         return self::unsupportedItemSchemaResult($normalizedType);
                     }
@@ -213,6 +221,15 @@ final class RequestBodyValidator
 
         $jsonContentType = ContentTypeMatcher::findJsonContentType($content);
 
+        // `requestBody.required` constrains whether a body is present on the
+        // wire; it does not depend on the selected media-type entry declaring
+        // a schema this validator can evaluate. Run this after content-type
+        // matching so an unknown actual Content-Type remains the primary
+        // diagnostic, but before the no-JSON/no-schema early returns below.
+        if ($required && !$requestBody->present) {
+            return self::missingRequiredBodyResult($specName, $method, $matchedPath);
+        }
+
         // If no JSON-compatible content type is defined, skip body validation.
         // This validator only handles JSON schemas; non-JSON types (e.g. application/xml,
         // application/octet-stream) are outside its scope.
@@ -234,18 +251,13 @@ final class RequestBodyValidator
             return new RequestBodyValidationResult([]);
         }
 
-        // An absent body is acceptable unless the spec marks the requestBody
-        // `required`. A literal JSON `null` body is distinct — `->present` is
-        // true with a `null` value (issues #246 / #248), so it falls through
-        // to schema type-checking below instead of taking this branch.
+        // Required absence was rejected before content negotiation. An absent
+        // optional body remains acceptable. A literal JSON `null` body is
+        // distinct — `->present` is true with a `null` value (issues #246 /
+        // #248), so it falls through to schema type-checking below instead of
+        // taking this branch.
         if (!$requestBody->present) {
-            if (!$required) {
-                return new RequestBodyValidationResult([]);
-            }
-
-            return new RequestBodyValidationResult([
-                "Request body is empty but {$method} {$matchedPath} defines a required JSON request body schema in '{$specName}' spec.",
-            ]);
+            return new RequestBodyValidationResult([]);
         }
 
         $bodyValue = $requestBody->value;
@@ -280,6 +292,16 @@ final class RequestBodyValidator
         }
 
         return new RequestBodyValidationResult($errors);
+    }
+
+    private static function missingRequiredBodyResult(
+        string $specName,
+        string $method,
+        string $matchedPath,
+    ): RequestBodyValidationResult {
+        return new RequestBodyValidationResult([
+            "Request body is empty but {$method} {$matchedPath} defines a required request body in '{$specName}' spec.",
+        ]);
     }
 
     private static function unsupportedItemSchemaResult(string $mediaType): RequestBodyValidationResult

--- a/tests/Unit/Validation/Request/RequestBodyValidatorTest.php
+++ b/tests/Unit/Validation/Request/RequestBodyValidatorTest.php
@@ -66,6 +66,55 @@ class RequestBodyValidatorTest extends TestCase
     }
 
     #[Test]
+    public function validate_flags_missing_required_body_when_content_is_absent(): void
+    {
+        $operation = [
+            'requestBody' => [
+                'required' => true,
+            ],
+        ];
+
+        $result = $this->validator->validate(
+            'spec',
+            'POST',
+            '/pets',
+            $operation,
+            DecodedBody::absent(),
+            null,
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertCount(1, $result->errors);
+        $this->assertStringContainsString('Request body is empty', $result->errors[0]);
+    }
+
+    #[Test]
+    public function validate_flags_missing_required_body_when_media_type_has_no_schema(): void
+    {
+        $operation = [
+            'requestBody' => [
+                'required' => true,
+                'content' => [
+                    'application/json' => [],
+                ],
+            ],
+        ];
+
+        $result = $this->validator->validate(
+            'spec',
+            'POST',
+            '/pets',
+            $operation,
+            DecodedBody::absent(),
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertCount(1, $result->errors);
+        $this->assertStringContainsString('Request body is empty', $result->errors[0]);
+    }
+
+    #[Test]
     public function validate_flags_present_literal_null_body_against_object_schema_when_optional(): void
     {
         // Issue #246 — the core silent-pass bug. A request body of the literal


### PR DESCRIPTION
## Summary

- reject an absent request body whenever `requestBody.required` is true, even when `content` is missing or the selected media type has no `schema`
- preserve malformed-spec and unknown Content-Type diagnostics as the higher-priority failures
- add regression coverage for both silent-pass paths

## Root cause

The required-body presence check ran only after selecting a JSON media type with a schema. Earlier returns for missing `content`, missing JSON media types, and missing schemas therefore treated an absent required body as valid.

## Impact

Specs with `requestBody.required: true` can no longer silently accept a request with no body merely because schema validation is unavailable. Optional absent bodies and present JSON `null` bodies keep their existing behavior.

## Verification

- `vendor/bin/phpunit`: 2092 tests, 5582 assertions
- focused request validation suite: 212 tests, 462 assertions
- PHPStan: no errors
- PHP-CS-Fixer: no changes required
- `git diff --check`
