### PR TITLE
fix(security): reject malformed requirement shapes

### DIFF
--- a/src/Fuzz/SchemaValueValidator.php
+++ b/src/Fuzz/SchemaValueValidator.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Studio\Gesso\Fuzz;
 
 use Opis\JsonSchema\Validator;
+use stdClass;
 
+use function in_array;
+use function is_array;
 use function json_decode;
 use function json_encode;
 use function sprintf;
@@ -13,12 +16,45 @@ use function sprintf;
 /** @internal */
 final class SchemaValueValidator
 {
+    /** @var list<string> */
+    private const SCHEMA_MAP_KEYWORDS = [
+        'properties',
+        'patternProperties',
+        'dependentSchemas',
+        '$defs',
+        'definitions',
+    ];
+
+    /** @var list<string> */
+    private const SCHEMA_LIST_KEYWORDS = [
+        'allOf',
+        'anyOf',
+        'oneOf',
+        'prefixItems',
+    ];
+
+    /** @var list<string> */
+    private const SCHEMA_VALUE_KEYWORDS = [
+        'items',
+        'additionalItems',
+        'additionalProperties',
+        'contains',
+        'not',
+        'if',
+        'then',
+        'else',
+        'propertyNames',
+        'contentSchema',
+        'unevaluatedProperties',
+        'unevaluatedItems',
+    ];
+
     /** @param array<string, mixed> $schema */
     public static function isValid(mixed $value, array $schema): bool
     {
         $validator = new Validator();
         $instance = json_decode((string) json_encode($value));
-        $jsonSchema = json_decode((string) json_encode($schema));
+        $jsonSchema = json_decode((string) json_encode(self::schemaObject($schema)));
 
         return $validator->validate($instance, $jsonSchema)->isValid();
     }
@@ -34,5 +70,59 @@ final class SchemaValueValidator
             'Internal fuzz generator defect: valid case %d does not satisfy its converted JSON Schema.',
             $iteration,
         ), $iteration);
+    }
+
+    /**
+     * PHP uses `[]` for both an empty mapping and an empty list. Restore JSON
+     * objects at schema-valued keyword positions before handing the converted
+     * schema to opis; opaque values and list-valued keywords remain untouched.
+     *
+     * @param array<string, mixed> $schema
+     */
+    private static function schemaObject(array $schema): stdClass
+    {
+        $object = new stdClass();
+
+        foreach ($schema as $key => $value) {
+            if (in_array($key, self::SCHEMA_MAP_KEYWORDS, true) && is_array($value)) {
+                $object->{$key} = self::schemaMap($value);
+
+                continue;
+            }
+
+            if (in_array($key, self::SCHEMA_LIST_KEYWORDS, true) && is_array($value)) {
+                $items = [];
+                foreach ($value as $item) {
+                    $items[] = is_array($item) ? self::schemaObject($item) : $item;
+                }
+                $object->{$key} = $items;
+
+                continue;
+            }
+
+            if (in_array($key, self::SCHEMA_VALUE_KEYWORDS, true) && is_array($value)) {
+                $object->{$key} = self::schemaObject($value);
+
+                continue;
+            }
+
+            $object->{$key} = $value;
+        }
+
+        return $object;
+    }
+
+    /**
+     * @param array<array-key, mixed> $schemas
+     */
+    private static function schemaMap(array $schemas): stdClass
+    {
+        $object = new stdClass();
+
+        foreach ($schemas as $name => $schema) {
+            $object->{(string) $name} = is_array($schema) ? self::schemaObject($schema) : $schema;
+        }
+
+        return $object;
     }
 }

--- a/src/Internal/OpenApiDocumentShapeNormalizer.php
+++ b/src/Internal/OpenApiDocumentShapeNormalizer.php
@@ -176,6 +176,14 @@ final class OpenApiDocumentShapeNormalizer
 
     private static function normalizeSecurityRequirements(mixed $requirements): mixed
     {
+        // Preserve an empty object at the field boundary. Only an empty object
+        // *inside* a valid security list means anonymous access; `security: {}`
+        // is a malformed container and must reach SecurityValidator as an
+        // object so its list-shape guard can reject it.
+        if (self::isEmptyObject($requirements)) {
+            return $requirements;
+        }
+
         if (!is_array($requirements)) {
             return self::normalizeGeneric($requirements);
         }

--- a/src/Internal/OpenApiDocumentShapeNormalizer.php
+++ b/src/Internal/OpenApiDocumentShapeNormalizer.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Internal;
+
+use stdClass;
+use Studio\Gesso\Spec\OpenApiOperationResolver;
+
+use function get_object_vars;
+use function in_array;
+use function is_array;
+use function is_string;
+
+/**
+ * Restores PHP's historical array representation after parsing object maps,
+ * while retaining the one empty-object distinction required by OpenAPI:
+ * an empty Security Requirement Object means that anonymous access is allowed.
+ *
+ * This must run after reference resolution. An external document may contain
+ * only a Schema Object, so its decoder cannot know whether a key named
+ * `security` is an Operation Object field or a user-defined schema property.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+final class OpenApiDocumentShapeNormalizer
+{
+    private function __construct() {}
+
+    /**
+     * @param array<string, mixed> $document
+     *
+     * @return array<string, mixed>
+     */
+    public static function normalizeResolvedDocument(array $document): array
+    {
+        $normalized = [];
+
+        foreach ($document as $key => $value) {
+            $normalized[$key] = match ($key) {
+                'security' => self::normalizeSecurityRequirements($value),
+                'paths', 'webhooks' => self::normalizePathItemMap($value),
+                'components' => self::normalizeComponents($value),
+                default => self::normalizeGeneric($value),
+            };
+        }
+
+        return $normalized;
+    }
+
+    private static function normalizeComponents(mixed $components): mixed
+    {
+        if (!is_array($components)) {
+            return self::normalizeGeneric($components);
+        }
+
+        $normalized = [];
+        foreach ($components as $key => $value) {
+            $normalized[$key] = match ($key) {
+                'pathItems' => self::normalizePathItemMap($value),
+                'callbacks' => self::normalizeCallbackMap($value),
+                default => self::normalizeGeneric($value),
+            };
+        }
+
+        return $normalized;
+    }
+
+    private static function normalizePathItemMap(mixed $pathItems): mixed
+    {
+        if (!is_array($pathItems)) {
+            return self::normalizeGeneric($pathItems);
+        }
+
+        $normalized = [];
+        foreach ($pathItems as $name => $pathItem) {
+            $normalized[$name] = is_array($pathItem)
+                ? self::normalizePathItem($pathItem)
+                : self::normalizeGeneric($pathItem);
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param array<int|string, mixed> $pathItem
+     *
+     * @return array<int|string, mixed>
+     */
+    private static function normalizePathItem(array $pathItem): array
+    {
+        $normalized = [];
+
+        foreach ($pathItem as $key => $value) {
+            if (is_string($key) && in_array($key, OpenApiOperationResolver::FIXED_OPERATION_FIELDS, true)) {
+                $normalized[$key] = is_array($value)
+                    ? self::normalizeOperation($value)
+                    : self::normalizeGeneric($value);
+
+                continue;
+            }
+
+            $normalized[$key] = $key === 'additionalOperations'
+                ? self::normalizeOperationMap($value)
+                : self::normalizeGeneric($value);
+        }
+
+        return $normalized;
+    }
+
+    private static function normalizeOperationMap(mixed $operations): mixed
+    {
+        if (!is_array($operations)) {
+            return self::normalizeGeneric($operations);
+        }
+
+        $normalized = [];
+        foreach ($operations as $method => $operation) {
+            $normalized[$method] = is_array($operation)
+                ? self::normalizeOperation($operation)
+                : self::normalizeGeneric($operation);
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param array<int|string, mixed> $operation
+     *
+     * @return array<int|string, mixed>
+     */
+    private static function normalizeOperation(array $operation): array
+    {
+        $normalized = [];
+
+        foreach ($operation as $key => $value) {
+            $normalized[$key] = match ($key) {
+                'security' => self::normalizeSecurityRequirements($value),
+                'callbacks' => self::normalizeCallbackMap($value),
+                default => self::normalizeGeneric($value),
+            };
+        }
+
+        return $normalized;
+    }
+
+    private static function normalizeCallbackMap(mixed $callbacks): mixed
+    {
+        if (!is_array($callbacks)) {
+            return self::normalizeGeneric($callbacks);
+        }
+
+        $normalized = [];
+        foreach ($callbacks as $name => $callback) {
+            $normalized[$name] = self::normalizeCallback($callback);
+        }
+
+        return $normalized;
+    }
+
+    private static function normalizeCallback(mixed $callback): mixed
+    {
+        if (!is_array($callback)) {
+            return self::normalizeGeneric($callback);
+        }
+
+        $normalized = [];
+        foreach ($callback as $expression => $pathItem) {
+            $normalized[$expression] = is_array($pathItem)
+                ? self::normalizePathItem($pathItem)
+                : self::normalizeGeneric($pathItem);
+        }
+
+        return $normalized;
+    }
+
+    private static function normalizeSecurityRequirements(mixed $requirements): mixed
+    {
+        if (!is_array($requirements)) {
+            return self::normalizeGeneric($requirements);
+        }
+
+        $normalized = [];
+        foreach ($requirements as $key => $requirement) {
+            $normalized[$key] = self::isEmptyObject($requirement)
+                ? $requirement
+                : self::normalizeGeneric($requirement);
+        }
+
+        return $normalized;
+    }
+
+    private static function normalizeGeneric(mixed $value): mixed
+    {
+        if ($value instanceof stdClass) {
+            $value = get_object_vars($value);
+        }
+
+        if (!is_array($value)) {
+            return $value;
+        }
+
+        $normalized = [];
+        foreach ($value as $key => $child) {
+            $normalized[$key] = self::normalizeGeneric($child);
+        }
+
+        return $normalized;
+    }
+
+    private static function isEmptyObject(mixed $value): bool
+    {
+        return $value instanceof stdClass && get_object_vars($value) === [];
+    }
+}

--- a/src/Internal/SpecDocumentDecoder.php
+++ b/src/Internal/SpecDocumentDecoder.php
@@ -114,31 +114,30 @@ final class SpecDocumentDecoder
     }
 
     /**
-     * Convert parsed object maps back to the array representation used by the
-     * validator while retaining an empty object directly inside a `security`
-     * list. PHP associative decoding otherwise collapses both `{}` and `[]` to
-     * `[]`, making the OpenAPI anonymous-access requirement indistinguishable
-     * from a malformed empty list.
+     * Convert non-empty parsed object maps back to the array representation
+     * used by the validator, while temporarily retaining every nested empty
+     * object. PHP associative decoding otherwise collapses both `{}` and `[]`
+     * to `[]` before the document structure is known.
      *
      * @internal Shared with the root spec loader so root and external `$ref`
      *           documents retain identical collection-shape semantics.
      */
     public static function normalizeObjectMaps(mixed $decoded): mixed
     {
-        return self::normalizeValue($decoded, false);
+        return self::normalizeValue($decoded, true);
     }
 
-    private static function normalizeValue(mixed $value, bool $insideSecurityList): mixed
+    private static function normalizeValue(mixed $value, bool $isRoot): mixed
     {
         if ($value instanceof stdClass) {
             $properties = get_object_vars($value);
-            if ($insideSecurityList && $properties === []) {
+            if (!$isRoot && $properties === []) {
                 return $value;
             }
 
             $normalized = [];
             foreach ($properties as $key => $child) {
-                $normalized[$key] = self::normalizeValue($child, $key === 'security');
+                $normalized[$key] = self::normalizeValue($child, false);
             }
 
             return $normalized;
@@ -150,7 +149,7 @@ final class SpecDocumentDecoder
 
         $normalized = [];
         foreach ($value as $key => $child) {
-            $normalized[$key] = self::normalizeValue($child, $insideSecurityList);
+            $normalized[$key] = self::normalizeValue($child, false);
         }
 
         return $normalized;

--- a/src/Internal/SpecDocumentDecoder.php
+++ b/src/Internal/SpecDocumentDecoder.php
@@ -8,6 +8,7 @@ use const JSON_ERROR_DEPTH;
 use const JSON_THROW_ON_ERROR;
 
 use JsonException;
+use stdClass;
 use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
 use Symfony\Component\Yaml\Exception\ParseException;
@@ -15,6 +16,7 @@ use Symfony\Component\Yaml\Yaml;
 use Throwable;
 
 use function get_debug_type;
+use function get_object_vars;
 use function is_array;
 use function json_decode;
 use function sprintf;
@@ -43,7 +45,7 @@ final class SpecDocumentDecoder
     public static function decodeJson(string $content, string $context): array
     {
         try {
-            $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+            $decoded = json_decode($content, false, 512, JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {
             // The depth-limit case has a different ergonomic story than a
             // syntax error — surface it explicitly so the user knows the
@@ -65,7 +67,7 @@ final class SpecDocumentDecoder
             );
         }
 
-        return self::ensureMappingRoot($decoded, $context);
+        return self::ensureMappingRoot(self::normalizeObjectMaps($decoded), $context);
     }
 
     /**
@@ -85,7 +87,7 @@ final class SpecDocumentDecoder
         }
 
         try {
-            $decoded = Yaml::parse($content);
+            $decoded = Yaml::parse($content, Yaml::PARSE_OBJECT_FOR_MAP);
         } catch (ParseException $e) {
             throw new InvalidOpenApiSpecException(
                 InvalidOpenApiSpecReason::MalformedYaml,
@@ -108,7 +110,50 @@ final class SpecDocumentDecoder
             );
         }
 
-        return self::ensureMappingRoot($decoded, $context);
+        return self::ensureMappingRoot(self::normalizeObjectMaps($decoded), $context);
+    }
+
+    /**
+     * Convert parsed object maps back to the array representation used by the
+     * validator while retaining an empty object directly inside a `security`
+     * list. PHP associative decoding otherwise collapses both `{}` and `[]` to
+     * `[]`, making the OpenAPI anonymous-access requirement indistinguishable
+     * from a malformed empty list.
+     *
+     * @internal Shared with the root spec loader so root and external `$ref`
+     *           documents retain identical collection-shape semantics.
+     */
+    public static function normalizeObjectMaps(mixed $decoded): mixed
+    {
+        return self::normalizeValue($decoded, false);
+    }
+
+    private static function normalizeValue(mixed $value, bool $insideSecurityList): mixed
+    {
+        if ($value instanceof stdClass) {
+            $properties = get_object_vars($value);
+            if ($insideSecurityList && $properties === []) {
+                return $value;
+            }
+
+            $normalized = [];
+            foreach ($properties as $key => $child) {
+                $normalized[$key] = self::normalizeValue($child, $key === 'security');
+            }
+
+            return $normalized;
+        }
+
+        if (!is_array($value)) {
+            return $value;
+        }
+
+        $normalized = [];
+        foreach ($value as $key => $child) {
+            $normalized[$key] = self::normalizeValue($child, $insideSecurityList);
+        }
+
+        return $normalized;
     }
 
     /** @return array<string, mixed> */

--- a/src/Spec/OpenApiRefResolver.php
+++ b/src/Spec/OpenApiRefResolver.php
@@ -6,6 +6,7 @@ namespace Studio\Gesso\Spec;
 
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use stdClass;
 use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
 use Studio\Gesso\Internal\ExternalRefLoader;
@@ -16,6 +17,7 @@ use function array_key_exists;
 use function array_pop;
 use function explode;
 use function get_debug_type;
+use function get_object_vars;
 use function implode;
 use function in_array;
 use function is_array;
@@ -633,6 +635,7 @@ final class OpenApiRefResolver
             );
         }
 
+        $target = self::normalizeEmptyObjectRefTarget($target);
         if (!is_array($target)) {
             throw new InvalidOpenApiSpecException(
                 InvalidOpenApiSpecReason::NonObjectRefTarget,
@@ -831,6 +834,7 @@ final class OpenApiRefResolver
                 );
             }
 
+            $target = self::normalizeEmptyObjectRefTarget($target);
             if (!is_array($target)) {
                 throw new InvalidOpenApiSpecException(
                     InvalidOpenApiSpecReason::NonObjectRefTarget,
@@ -860,6 +864,15 @@ final class OpenApiRefResolver
         $target = $newRoot;
         self::walk($target, $newRoot, [...$chain, $chainKey], false, $context, $documentCache);
         $node = $target;
+    }
+
+    private static function normalizeEmptyObjectRefTarget(mixed $target): mixed
+    {
+        if ($target instanceof stdClass && get_object_vars($target) === []) {
+            return [];
+        }
+
+        return $target;
     }
 
     /**

--- a/src/Spec/OpenApiSpecLoader.php
+++ b/src/Spec/OpenApiSpecLoader.php
@@ -14,6 +14,7 @@ use Psr\Http\Message\RequestFactoryInterface;
 use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
 use Studio\Gesso\Exception\SpecFileNotFoundException;
+use Studio\Gesso\Internal\SpecDocumentDecoder;
 use Studio\Gesso\Internal\YamlAvailability;
 use Studio\Gesso\OpenApiVersion;
 use Symfony\Component\Yaml\Exception\ParseException;
@@ -335,7 +336,9 @@ final class OpenApiSpecLoader
         }
 
         try {
-            $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+            $decoded = SpecDocumentDecoder::normalizeObjectMaps(
+                json_decode($content, false, 512, JSON_THROW_ON_ERROR),
+            );
         } catch (JsonException $e) {
             throw new InvalidOpenApiSpecException(
                 InvalidOpenApiSpecReason::MalformedJson,
@@ -372,7 +375,9 @@ final class OpenApiSpecLoader
         // Yaml::parseFile wraps its own I/O failures in ParseException, so a
         // single catch covers both syntax errors and file-read problems.
         try {
-            $decoded = Yaml::parseFile($path);
+            $decoded = SpecDocumentDecoder::normalizeObjectMaps(
+                Yaml::parseFile($path, Yaml::PARSE_OBJECT_FOR_MAP),
+            );
         } catch (ParseException $e) {
             throw new InvalidOpenApiSpecException(
                 InvalidOpenApiSpecReason::MalformedYaml,

--- a/src/Spec/OpenApiSpecLoader.php
+++ b/src/Spec/OpenApiSpecLoader.php
@@ -14,6 +14,7 @@ use Psr\Http\Message\RequestFactoryInterface;
 use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
 use Studio\Gesso\Exception\SpecFileNotFoundException;
+use Studio\Gesso\Internal\OpenApiDocumentShapeNormalizer;
 use Studio\Gesso\Internal\SpecDocumentDecoder;
 use Studio\Gesso\Internal\YamlAvailability;
 use Studio\Gesso\OpenApiVersion;
@@ -235,12 +236,14 @@ final class OpenApiSpecLoader
         }
 
         try {
-            $resolved = OpenApiRefResolver::resolve(
-                $decoded,
-                $canonicalPath,
-                self::$httpClient,
-                self::$requestFactory,
-                self::$allowRemoteRefs,
+            $resolved = OpenApiDocumentShapeNormalizer::normalizeResolvedDocument(
+                OpenApiRefResolver::resolve(
+                    $decoded,
+                    $canonicalPath,
+                    self::$httpClient,
+                    self::$requestFactory,
+                    self::$allowRemoteRefs,
+                ),
             );
         } catch (InvalidOpenApiSpecException $e) {
             // The resolver is stateless and therefore cannot know which spec

--- a/src/Validation/Request/SecurityValidator.php
+++ b/src/Validation/Request/SecurityValidator.php
@@ -8,12 +8,12 @@ use const E_USER_WARNING;
 
 use Studio\Gesso\Validation\Support\HeaderNormalizer;
 
+use function array_is_list;
 use function array_key_exists;
 use function array_key_first;
 use function get_debug_type;
 use function in_array;
 use function is_array;
-use function is_int;
 use function is_string;
 use function preg_match;
 use function sprintf;
@@ -155,13 +155,15 @@ final class SecurityValidator
             return [];
         }
 
-        if (!is_array($security)) {
+        if (!is_array($security) || !array_is_list($security)) {
             return [
-                sprintf(
-                    '[security] %s %s: operation/root-level `security` must be an array of requirement objects, got %s.',
+                self::formatError(
                     $method,
                     $matchedPath,
-                    get_debug_type($security),
+                    sprintf(
+                        'operation/root-level `security` must be a list of requirement objects, got %s.',
+                        get_debug_type($security),
+                    ),
                 ),
             ];
         }
@@ -198,7 +200,7 @@ final class SecurityValidator
                     '[security] %s %s: security requirement at index %d must be an object mapping scheme names to scope arrays, got %s.',
                     $method,
                     $matchedPath,
-                    is_int($entryIndex) ? $entryIndex : 0,
+                    $entryIndex,
                     get_debug_type($entry),
                 );
 
@@ -210,7 +212,7 @@ final class SecurityValidator
             /** @var array<string, array{kind: SchemeKind, def: array<string, mixed>}> $validatable */
             $validatable = [];
 
-            foreach ($entry as $schemeName => $_scopes) {
+            foreach ($entry as $schemeName => $scopes) {
                 if (!is_string($schemeName)) {
                     $hardErrors[] = sprintf(
                         '[security] %s %s: security scheme name must be a string, got %s.',
@@ -220,6 +222,45 @@ final class SecurityValidator
                     );
                     $entryHasHardError = true;
 
+                    continue;
+                }
+
+                if (!is_array($scopes) || !array_is_list($scopes)) {
+                    $hardErrors[] = self::formatError(
+                        $method,
+                        $matchedPath,
+                        sprintf(
+                            "security requirement '%s' scopes must be a list of strings, got %s.",
+                            $schemeName,
+                            get_debug_type($scopes),
+                        ),
+                    );
+                    $entryHasHardError = true;
+
+                    continue;
+                }
+
+                $scopeHasHardError = false;
+                foreach ($scopes as $scopeIndex => $scope) {
+                    if (is_string($scope)) {
+                        continue;
+                    }
+
+                    $hardErrors[] = self::formatError(
+                        $method,
+                        $matchedPath,
+                        sprintf(
+                            "security requirement '%s' scope at index %d must be a string, got %s.",
+                            $schemeName,
+                            $scopeIndex,
+                            get_debug_type($scope),
+                        ),
+                    );
+                    $entryHasHardError = true;
+                    $scopeHasHardError = true;
+                }
+
+                if ($scopeHasHardError) {
                     continue;
                 }
 
@@ -314,6 +355,11 @@ final class SecurityValidator
         }
 
         return [...$hardErrors, ...$failureErrors];
+    }
+
+    private static function formatError(string $method, string $matchedPath, string $detail): string
+    {
+        return sprintf('[security] %s %s: %s', $method, $matchedPath, $detail);
     }
 
     /**

--- a/src/Validation/Request/SecurityValidator.php
+++ b/src/Validation/Request/SecurityValidator.php
@@ -6,12 +6,14 @@ namespace Studio\Gesso\Validation\Request;
 
 use const E_USER_WARNING;
 
+use stdClass;
 use Studio\Gesso\Validation\Support\HeaderNormalizer;
 
 use function array_is_list;
 use function array_key_exists;
 use function array_key_first;
 use function get_debug_type;
+use function get_object_vars;
 use function in_array;
 use function is_array;
 use function is_string;
@@ -195,7 +197,13 @@ final class SecurityValidator
         $satisfied = false;
 
         foreach ($security as $entryIndex => $entry) {
-            if (!is_array($entry)) {
+            if ($entry instanceof stdClass && get_object_vars($entry) === []) {
+                $satisfied = true;
+
+                break;
+            }
+
+            if (!is_array($entry) || $entry === []) {
                 $hardErrors[] = sprintf(
                     '[security] %s %s: security requirement at index %d must be an object mapping scheme names to scope arrays, got %s.',
                     $method,

--- a/tests/Unit/Fuzz/OpenApiEndpointExplorerTest.php
+++ b/tests/Unit/Fuzz/OpenApiEndpointExplorerTest.php
@@ -129,6 +129,23 @@ class OpenApiEndpointExplorerTest extends TestCase
     }
 
     #[Test]
+    public function generates_required_property_named_security_with_empty_schema(): void
+    {
+        $cases = OpenApiEndpointExplorer::explore(
+            'fuzz-empty-security-property',
+            'POST',
+            '/payload',
+            cases: 1,
+            seed: 1,
+        );
+
+        foreach ($cases as $case) {
+            $this->assertIsArray($case->body);
+            $this->assertArrayHasKey('security', $case->body);
+        }
+    }
+
+    #[Test]
     public function generates_query_parameter_values(): void
     {
         // POST /v1/pets has a `dryRun` boolean query parameter.

--- a/tests/Unit/Internal/OpenApiDocumentShapeNormalizerTest.php
+++ b/tests/Unit/Internal/OpenApiDocumentShapeNormalizerTest.php
@@ -12,6 +12,22 @@ use Studio\Gesso\Internal\OpenApiDocumentShapeNormalizer;
 final class OpenApiDocumentShapeNormalizerTest extends TestCase
 {
     #[Test]
+    public function preserves_empty_object_security_container_for_validation(): void
+    {
+        $document = OpenApiDocumentShapeNormalizer::normalizeResolvedDocument([
+            'security' => new stdClass(),
+            'paths' => [
+                '/pets' => [
+                    'get' => ['security' => new stdClass()],
+                ],
+            ],
+        ]);
+
+        $this->assertInstanceOf(stdClass::class, $document['security']);
+        $this->assertInstanceOf(stdClass::class, $document['paths']['/pets']['get']['security']);
+    }
+
+    #[Test]
     public function preserves_empty_objects_only_in_structural_security_requirement_lists(): void
     {
         $document = OpenApiDocumentShapeNormalizer::normalizeResolvedDocument([

--- a/tests/Unit/Internal/OpenApiDocumentShapeNormalizerTest.php
+++ b/tests/Unit/Internal/OpenApiDocumentShapeNormalizerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Internal;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Studio\Gesso\Internal\OpenApiDocumentShapeNormalizer;
+
+final class OpenApiDocumentShapeNormalizerTest extends TestCase
+{
+    #[Test]
+    public function preserves_empty_objects_only_in_structural_security_requirement_lists(): void
+    {
+        $document = OpenApiDocumentShapeNormalizer::normalizeResolvedDocument([
+            'security' => [new stdClass()],
+            'paths' => [
+                '/pets' => [
+                    'get' => [
+                        'security' => [new stdClass()],
+                        'callbacks' => [
+                            'updated' => [
+                                '{$request.body#/callbackUrl}' => [
+                                    'post' => ['security' => [new stdClass()]],
+                                ],
+                            ],
+                        ],
+                    ],
+                    'additionalOperations' => [
+                        'COPY' => ['security' => [new stdClass()]],
+                    ],
+                ],
+            ],
+            'webhooks' => [
+                'petUpdated' => [
+                    'post' => ['security' => [new stdClass()]],
+                ],
+            ],
+            'components' => [
+                'schemas' => [
+                    'Payload' => [
+                        'type' => 'object',
+                        'required' => ['security'],
+                        'properties' => ['security' => new stdClass()],
+                    ],
+                ],
+                'pathItems' => [
+                    'Pets' => ['get' => ['security' => [new stdClass()]]],
+                ],
+                'callbacks' => [
+                    'Updated' => [
+                        '{$request.body#/callbackUrl}' => [
+                            'post' => ['security' => [new stdClass()]],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertInstanceOf(stdClass::class, $document['security'][0]);
+        $this->assertInstanceOf(stdClass::class, $document['paths']['/pets']['get']['security'][0]);
+        $this->assertInstanceOf(
+            stdClass::class,
+            $document['paths']['/pets']['get']['callbacks']['updated']['{$request.body#/callbackUrl}']['post']['security'][0],
+        );
+        $this->assertInstanceOf(
+            stdClass::class,
+            $document['paths']['/pets']['additionalOperations']['COPY']['security'][0],
+        );
+        $this->assertInstanceOf(stdClass::class, $document['webhooks']['petUpdated']['post']['security'][0]);
+        $this->assertInstanceOf(
+            stdClass::class,
+            $document['components']['pathItems']['Pets']['get']['security'][0],
+        );
+        $this->assertInstanceOf(
+            stdClass::class,
+            $document['components']['callbacks']['Updated']['{$request.body#/callbackUrl}']['post']['security'][0],
+        );
+        $this->assertSame([], $document['components']['schemas']['Payload']['properties']['security']);
+    }
+}

--- a/tests/Unit/Internal/SpecDocumentDecoderTest.php
+++ b/tests/Unit/Internal/SpecDocumentDecoderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Internal;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Studio\Gesso\Internal\SpecDocumentDecoder;
+
+final class SpecDocumentDecoderTest extends TestCase
+{
+    #[Test]
+    public function json_preserves_empty_object_shape_inside_security_list(): void
+    {
+        $decoded = SpecDocumentDecoder::decodeJson(
+            '{"security":[{},[]],"schema":{}}',
+            'inline JSON',
+        );
+
+        $this->assertInstanceOf(stdClass::class, $decoded['security'][0]);
+        $this->assertSame([], $decoded['security'][1]);
+        $this->assertSame([], $decoded['schema']);
+    }
+
+    #[Test]
+    public function yaml_preserves_empty_object_shape_inside_security_list(): void
+    {
+        $decoded = SpecDocumentDecoder::decodeYaml(
+            "security:\n  - {}\n  - []\nschema: {}\n",
+            'inline YAML',
+        );
+
+        $this->assertInstanceOf(stdClass::class, $decoded['security'][0]);
+        $this->assertSame([], $decoded['security'][1]);
+        $this->assertSame([], $decoded['schema']);
+    }
+}

--- a/tests/Unit/Internal/SpecDocumentDecoderTest.php
+++ b/tests/Unit/Internal/SpecDocumentDecoderTest.php
@@ -12,7 +12,7 @@ use Studio\Gesso\Internal\SpecDocumentDecoder;
 final class SpecDocumentDecoderTest extends TestCase
 {
     #[Test]
-    public function json_preserves_empty_object_shape_inside_security_list(): void
+    public function json_temporarily_preserves_nested_empty_object_shapes(): void
     {
         $decoded = SpecDocumentDecoder::decodeJson(
             '{"security":[{},[]],"schema":{}}',
@@ -21,11 +21,11 @@ final class SpecDocumentDecoderTest extends TestCase
 
         $this->assertInstanceOf(stdClass::class, $decoded['security'][0]);
         $this->assertSame([], $decoded['security'][1]);
-        $this->assertSame([], $decoded['schema']);
+        $this->assertInstanceOf(stdClass::class, $decoded['schema']);
     }
 
     #[Test]
-    public function yaml_preserves_empty_object_shape_inside_security_list(): void
+    public function yaml_temporarily_preserves_nested_empty_object_shapes(): void
     {
         $decoded = SpecDocumentDecoder::decodeYaml(
             "security:\n  - {}\n  - []\nschema: {}\n",
@@ -34,6 +34,6 @@ final class SpecDocumentDecoderTest extends TestCase
 
         $this->assertInstanceOf(stdClass::class, $decoded['security'][0]);
         $this->assertSame([], $decoded['security'][1]);
-        $this->assertSame([], $decoded['schema']);
+        $this->assertInstanceOf(stdClass::class, $decoded['schema']);
     }
 }

--- a/tests/Unit/Spec/OpenApiSpecLoaderTest.php
+++ b/tests/Unit/Spec/OpenApiSpecLoaderTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Psr7\HttpFactory;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
 use Studio\Gesso\Exception\SpecFileNotFoundException;
@@ -686,6 +687,40 @@ class OpenApiSpecLoaderTest extends TestCase
         } finally {
             @unlink($scratchDir . '/dual.json');
             @unlink($scratchDir . '/dual.yaml');
+            @rmdir($scratchDir);
+        }
+    }
+
+    #[Test]
+    public function load_preserves_security_empty_object_and_list_shapes_for_json_and_yaml(): void
+    {
+        $scratchDir = sys_get_temp_dir() . '/openapi-spec-loader-test-' . uniqid('', true);
+        mkdir($scratchDir);
+
+        try {
+            file_put_contents(
+                $scratchDir . '/security-shapes-json.json',
+                '{"openapi":"3.2.0","info":{"title":"Shapes","version":"1.0.0"},'
+                . '"paths":{"/anonymous":{"get":{"security":[{}]}},'
+                . '"/malformed":{"get":{"security":[[]]}}}}',
+            );
+            file_put_contents(
+                $scratchDir . '/security-shapes-yaml.yaml',
+                "openapi: 3.2.0\ninfo:\n  title: Shapes\n  version: 1.0.0\npaths:\n"
+                . "  /anonymous:\n    get:\n      security:\n        - {}\n"
+                . "  /malformed:\n    get:\n      security:\n        - []\n",
+            );
+
+            OpenApiSpecLoader::configure($scratchDir);
+            foreach (['security-shapes-json', 'security-shapes-yaml'] as $specName) {
+                $spec = OpenApiSpecLoader::load($specName);
+
+                $this->assertInstanceOf(stdClass::class, $spec['paths']['/anonymous']['get']['security'][0]);
+                $this->assertSame([], $spec['paths']['/malformed']['get']['security'][0]);
+            }
+        } finally {
+            @unlink($scratchDir . '/security-shapes-json.json');
+            @unlink($scratchDir . '/security-shapes-yaml.yaml');
             @rmdir($scratchDir);
         }
     }

--- a/tests/Unit/Spec/OpenApiSpecLoaderTest.php
+++ b/tests/Unit/Spec/OpenApiSpecLoaderTest.php
@@ -15,6 +15,7 @@ use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
 use Studio\Gesso\Exception\SpecFileNotFoundException;
 use Studio\Gesso\Internal\YamlAvailability;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
+use Studio\Gesso\Validation\Request\SecurityValidator;
 use Symfony\Component\Yaml\Yaml;
 
 use function class_exists;
@@ -702,7 +703,8 @@ class OpenApiSpecLoaderTest extends TestCase
                 $scratchDir . '/security-shapes-json.json',
                 '{"openapi":"3.2.0","info":{"title":"Shapes","version":"1.0.0"},'
                 . '"paths":{"/anonymous":{"get":{"security":[{}]}},'
-                . '"/malformed":{"get":{"security":[[]]}}},'
+                . '"/malformed":{"get":{"security":[[]]}},'
+                . '"/malformed-container":{"get":{"security":{}}}},'
                 . '"components":{"schemas":{"Payload":{"type":"object","required":["security"],'
                 . '"properties":{"security":{}}}}}}',
             );
@@ -711,6 +713,7 @@ class OpenApiSpecLoaderTest extends TestCase
                 "openapi: 3.2.0\ninfo:\n  title: Shapes\n  version: 1.0.0\npaths:\n"
                 . "  /anonymous:\n    get:\n      security:\n        - {}\n"
                 . "  /malformed:\n    get:\n      security:\n        - []\n"
+                . "  /malformed-container:\n    get:\n      security: {}\n"
                 . "components:\n  schemas:\n    Payload:\n      type: object\n      required: [security]\n"
                 . "      properties:\n        security: {}\n",
             );
@@ -721,7 +724,20 @@ class OpenApiSpecLoaderTest extends TestCase
 
                 $this->assertInstanceOf(stdClass::class, $spec['paths']['/anonymous']['get']['security'][0]);
                 $this->assertSame([], $spec['paths']['/malformed']['get']['security'][0]);
+                $this->assertInstanceOf(stdClass::class, $spec['paths']['/malformed-container']['get']['security']);
                 $this->assertSame([], $spec['components']['schemas']['Payload']['properties']['security']);
+
+                $errors = (new SecurityValidator())->validate(
+                    'GET',
+                    '/malformed-container',
+                    $spec,
+                    $spec['paths']['/malformed-container']['get'],
+                    [],
+                    [],
+                    [],
+                );
+                $this->assertCount(1, $errors);
+                $this->assertStringContainsString('must be a list of requirement objects', $errors[0]);
             }
         } finally {
             @unlink($scratchDir . '/security-shapes-json.json');

--- a/tests/Unit/Spec/OpenApiSpecLoaderTest.php
+++ b/tests/Unit/Spec/OpenApiSpecLoaderTest.php
@@ -702,13 +702,17 @@ class OpenApiSpecLoaderTest extends TestCase
                 $scratchDir . '/security-shapes-json.json',
                 '{"openapi":"3.2.0","info":{"title":"Shapes","version":"1.0.0"},'
                 . '"paths":{"/anonymous":{"get":{"security":[{}]}},'
-                . '"/malformed":{"get":{"security":[[]]}}}}',
+                . '"/malformed":{"get":{"security":[[]]}}},'
+                . '"components":{"schemas":{"Payload":{"type":"object","required":["security"],'
+                . '"properties":{"security":{}}}}}}',
             );
             file_put_contents(
                 $scratchDir . '/security-shapes-yaml.yaml',
                 "openapi: 3.2.0\ninfo:\n  title: Shapes\n  version: 1.0.0\npaths:\n"
                 . "  /anonymous:\n    get:\n      security:\n        - {}\n"
-                . "  /malformed:\n    get:\n      security:\n        - []\n",
+                . "  /malformed:\n    get:\n      security:\n        - []\n"
+                . "components:\n  schemas:\n    Payload:\n      type: object\n      required: [security]\n"
+                . "      properties:\n        security: {}\n",
             );
 
             OpenApiSpecLoader::configure($scratchDir);
@@ -717,6 +721,7 @@ class OpenApiSpecLoaderTest extends TestCase
 
                 $this->assertInstanceOf(stdClass::class, $spec['paths']['/anonymous']['get']['security'][0]);
                 $this->assertSame([], $spec['paths']['/malformed']['get']['security'][0]);
+                $this->assertSame([], $spec['components']['schemas']['Payload']['properties']['security']);
             }
         } finally {
             @unlink($scratchDir . '/security-shapes-json.json');

--- a/tests/Unit/Validation/Request/SecurityValidatorTest.php
+++ b/tests/Unit/Validation/Request/SecurityValidatorTest.php
@@ -160,6 +160,109 @@ class SecurityValidatorTest extends TestCase
         $this->assertSame([], $errors);
     }
 
+    #[Test]
+    public function validate_rejects_associative_security_container(): void
+    {
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'BearerAuth' => ['type' => 'http', 'scheme' => 'bearer'],
+                ],
+            ],
+        ];
+        $operation = ['security' => ['BearerAuth' => []]];
+
+        $errors = $this->validator->validate('GET', '/pets', $spec, $operation, [], [], []);
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('must be a list of requirement objects', $errors[0]);
+    }
+
+    #[Test]
+    public function validate_accepts_empty_requirement_object_for_anonymous_access(): void
+    {
+        $operation = ['security' => [[]]];
+
+        $errors = $this->validator->validate('GET', '/pets', [], $operation, [], [], []);
+
+        $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function validate_rejects_list_shaped_security_requirement(): void
+    {
+        $operation = ['security' => [[['BearerAuth' => []]]]];
+
+        $errors = $this->validator->validate('GET', '/pets', [], $operation, [], [], []);
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('security scheme name must be a string', $errors[0]);
+    }
+
+    #[Test]
+    public function validate_rejects_non_list_scopes(): void
+    {
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'BearerAuth' => ['type' => 'http', 'scheme' => 'bearer'],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['BearerAuth' => 'not-a-list']]];
+
+        $errors = $this->validator->validate(
+            'GET',
+            '/pets',
+            $spec,
+            $operation,
+            ['Authorization' => 'Bearer token'],
+            [],
+            [],
+        );
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString("requirement 'BearerAuth' scopes must be a list of strings", $errors[0]);
+    }
+
+    #[Test]
+    public function validate_rejects_associative_scopes(): void
+    {
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'OAuth' => ['type' => 'oauth2', 'flows' => []],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['OAuth' => ['scope' => 'read']]]];
+
+        [$errors, $warnings] = $this->validateCapturingWarnings('GET', '/pets', $spec, $operation);
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString("requirement 'OAuth' scopes must be a list of strings", $errors[0]);
+        $this->assertSame([], $warnings);
+    }
+
+    #[Test]
+    public function validate_rejects_non_string_scope_values(): void
+    {
+        $spec = [
+            'components' => [
+                'securitySchemes' => [
+                    'OAuth' => ['type' => 'oauth2', 'flows' => []],
+                ],
+            ],
+        ];
+        $operation = ['security' => [['OAuth' => ['read', 123]]]];
+
+        [$errors, $warnings] = $this->validateCapturingWarnings('GET', '/pets', $spec, $operation);
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString("requirement 'OAuth' scope at index 1 must be a string", $errors[0]);
+        $this->assertSame([], $warnings);
+    }
+
     // ========================================
     // Loud-warning behaviour for unsupported security schemes.
     // ========================================

--- a/tests/Unit/Validation/Request/SecurityValidatorTest.php
+++ b/tests/Unit/Validation/Request/SecurityValidatorTest.php
@@ -8,6 +8,7 @@ use const E_USER_WARNING;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 use Studio\Gesso\Validation\Request\SecurityValidator;
 
 use function restore_error_handler;
@@ -181,11 +182,22 @@ class SecurityValidatorTest extends TestCase
     #[Test]
     public function validate_accepts_empty_requirement_object_for_anonymous_access(): void
     {
-        $operation = ['security' => [[]]];
+        $operation = ['security' => [new stdClass()]];
 
         $errors = $this->validator->validate('GET', '/pets', [], $operation, [], [], []);
 
         $this->assertSame([], $errors);
+    }
+
+    #[Test]
+    public function validate_rejects_empty_list_as_security_requirement(): void
+    {
+        $operation = ['security' => [[]]];
+
+        $errors = $this->validator->validate('GET', '/pets', [], $operation, [], [], []);
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('security requirement at index 0 must be an object', $errors[0]);
     }
 
     #[Test]

--- a/tests/Unit/Validation/Request/SecurityValidatorTest.php
+++ b/tests/Unit/Validation/Request/SecurityValidatorTest.php
@@ -180,6 +180,17 @@ class SecurityValidatorTest extends TestCase
     }
 
     #[Test]
+    public function validate_rejects_empty_object_security_container(): void
+    {
+        $operation = ['security' => new stdClass()];
+
+        $errors = $this->validator->validate('GET', '/pets', [], $operation, [], [], []);
+
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('must be a list of requirement objects', $errors[0]);
+    }
+
+    #[Test]
     public function validate_accepts_empty_requirement_object_for_anonymous_access(): void
     {
         $operation = ['security' => [new stdClass()]];

--- a/tests/fixtures/specs/fuzz-empty-security-property.json
+++ b/tests/fixtures/specs/fuzz-empty-security-property.json
@@ -1,0 +1,34 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Fuzz empty security property schema",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/payload": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "security"
+                ],
+                "properties": {
+                  "security": {}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Accepted"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- require operation/root-level `security` to be a list of Security Requirement Objects
- require every requirement value to be a list of strings
- reject scalar, associative, and non-string scope values as hard spec errors
- preserve `security: []` opt-out and `security: [{}]` anonymous-access semantics
- centralize new structural diagnostics through the existing `[security]` category

## Root cause

The validator checked only that `security` and each requirement were PHP arrays. An associative top-level object could therefore be interpreted as an empty requirement and satisfy authentication without credentials. Scope values were ignored entirely, so malformed values also passed.

## Impact

Malformed security declarations now fail loudly instead of silently disabling authentication validation. Valid bearer/API-key requirements, unsupported-scheme warnings, OR/AND semantics, explicit opt-out, and anonymous access retain their existing behavior.

## Verification

- full PHPUnit suite: 2098 tests, 5595 assertions
- focused security/request suite: 215 tests, 488 assertions
- diagnostic-prefix compatibility: 2 tests, 133 assertions
- PHPStan: no errors
- PHP-CS-Fixer: no changes required
- `git diff --check`
