### PR TITLE
refactor(response)!: require strict tracker dependency

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -39,6 +39,20 @@ OpenAPI Description after upgrading. V2 replaces the resolver-owned
 with `x-studio-gesso-implicit-schema-name`; it deliberately does not trust or
 dual-read either marker when authored in input.
 
+Direct `OpenApiResponseValidator` construction now requires a
+`StrictRequiredTracker` as its first argument. Create one tracker per test run
+and reuse it across validators; framework adapters inject their run-level
+tracker automatically:
+
+```php
+$tracker = new StrictRequiredTracker();
+$validator = new OpenApiResponseValidator($tracker, maxErrors: 20);
+```
+
+This removes the validator's fallback to the process-global tracker. Named
+`maxErrors` and `skipResponseCodes` arguments remain unchanged after the new
+required first argument.
+
 ## Within v1.x
 
 The v1.x line is covered end-to-end by SemVer (see "v0.x → v1.0.0"

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -10,12 +10,17 @@
 
 Main validator class. Validates a response body against the spec.
 
-The constructor accepts a `maxErrors` parameter (default: `20`) that limits how many validation errors the underlying JSON Schema validator collects. Use `0` for unlimited, `1` to stop at the first error.
+The constructor requires a `StrictRequiredTracker` that receives successful
+response-body observations. Reuse one tracker for validators that belong to the
+same test run. The optional `maxErrors` parameter (default: `20`) limits how many
+validation errors the underlying JSON Schema validator collects. Use `0` for
+unlimited, `1` to stop at the first error.
 
 The optional `responseContentType` parameter enables content negotiation: when provided, non-JSON content types (e.g., `text/html`) are checked for spec presence only, while JSON-compatible types proceed to full schema validation. When a non-JSON content type matches a spec media-type key that declares a `schema`, the body cannot be evaluated by the JSON Schema engine — the result is reported as `Skipped` (with a `skipReason`) rather than a clean success, so the unvalidated body is not miscounted.
 
 ```php
-$validator = new OpenApiResponseValidator(maxErrors: 20);
+$tracker = new StrictRequiredTracker();
+$validator = new OpenApiResponseValidator($tracker, maxErrors: 20);
 $result = $validator->validate(
     specName: 'front',
     method: 'GET',

--- a/docs/migration/v2.md
+++ b/docs/migration/v2.md
@@ -98,6 +98,22 @@ supports PHP 8.2 or PHPUnit 11. The supported combinations are PHPUnit 12 on PHP
 but resolving them before the package switch keeps dependency failures separate
 from source and configuration migration failures.
 
+### Inject the response observation tracker
+
+Direct construction of `OpenApiResponseValidator` requires a
+`StrictRequiredTracker` as the first argument in v2. Create one instance for a
+test run and reuse it across validators:
+
+```diff
+-$validator = new OpenApiResponseValidator(maxErrors: 20);
++$tracker = new StrictRequiredTracker();
++$validator = new OpenApiResponseValidator($tracker, maxErrors: 20);
+```
+
+Laravel, Symfony, and PSR-7 adapters resolve and inject the run-level tracker
+automatically. This change removes the direct validator's service-locator
+fallback; `maxErrors` and `skipResponseCodes` remain optional named arguments.
+
 ### Migrate Laravel configuration before changing packages
 
 Laravel applications must rename the published configuration file while v1.10

--- a/docs/quickstarts/core.md
+++ b/docs/quickstarts/core.md
@@ -7,7 +7,7 @@ composer require --dev studio-design/gesso
 Copy the minimal [`examples/core`](https://github.com/studio-design/gesso/tree/main/examples/core) project. Its test validates a JSON response without a framework adapter:
 
 ```php
-$result = (new OpenApiResponseValidator())->validate(
+$result = (new OpenApiResponseValidator(new StrictRequiredTracker()))->validate(
     'petstore', 'GET', '/pets', 200,
     [['id' => 1, 'name' => 'Fido']],
     'application/json',

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -262,6 +262,7 @@ You can use the `#[OpenApiSpec]` attribute with the `OpenApiSpecResolver` trait 
 use Studio\Gesso\Attribute\OpenApiSpec;
 use Studio\Gesso\Spec\OpenApiSpecResolver;
 use Studio\Gesso\OpenApiResponseValidator;
+use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
 
 #[OpenApiSpec('front')]
 class GetPetsTest extends TestCase
@@ -271,7 +272,7 @@ class GetPetsTest extends TestCase
     public function test_list_pets(): void
     {
         $specName = $this->resolveOpenApiSpec(); // 'front'
-        $validator = new OpenApiResponseValidator();
+        $validator = new OpenApiResponseValidator(new StrictRequiredTracker());
         $result = $validator->validate(
             specName: $specName,
             method: 'GET',
@@ -291,12 +292,13 @@ Or without the attribute, pass the spec name directly:
 ```php
 use Studio\Gesso\OpenApiResponseValidator;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
+use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
 
 // Configure once (e.g., in bootstrap)
 OpenApiSpecLoader::configure(__DIR__ . '/openapi/bundled', ['/api']);
 
 // In your test
-$validator = new OpenApiResponseValidator();
+$validator = new OpenApiResponseValidator(new StrictRequiredTracker());
 $result = $validator->validate(
     specName: 'front',
     method: 'GET',
@@ -314,14 +316,16 @@ $this->assertTrue($result->isValid(), $result->errorMessage());
 By default, up to **20** validation errors are reported per response. You can change this via the constructor:
 
 ```php
+$tracker = new StrictRequiredTracker();
+
 // Report up to 5 errors
-$validator = new OpenApiResponseValidator(maxErrors: 5);
+$validator = new OpenApiResponseValidator($tracker, maxErrors: 5);
 
 // Report all errors (unlimited)
-$validator = new OpenApiResponseValidator(maxErrors: 0);
+$validator = new OpenApiResponseValidator($tracker, maxErrors: 0);
 
 // Stop at first error
-$validator = new OpenApiResponseValidator(maxErrors: 1);
+$validator = new OpenApiResponseValidator($tracker, maxErrors: 1);
 ```
 
 For Laravel, set the `max_errors` key in `config/gesso.php`.
@@ -348,7 +352,10 @@ return [
 Or pass directly to `OpenApiResponseValidator`:
 
 ```php
-$validator = new OpenApiResponseValidator(skipResponseCodes: ['5\d\d']);
+$validator = new OpenApiResponseValidator(
+    new StrictRequiredTracker(),
+    skipResponseCodes: ['5\d\d'],
+);
 ```
 
 Notes:

--- a/examples/core/tests/PetContractTest.php
+++ b/examples/core/tests/PetContractTest.php
@@ -8,13 +8,14 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\Gesso\Coverage\OpenApiCoverageTracker;
 use Studio\Gesso\OpenApiResponseValidator;
+use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
 
 final class PetContractTest extends TestCase
 {
     #[Test]
     public function validates_a_response_without_a_framework_adapter(): void
     {
-        $result = (new OpenApiResponseValidator())->validate(
+        $result = (new OpenApiResponseValidator(new StrictRequiredTracker()))->validate(
             'petstore',
             'GET',
             '/pets',

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -28,6 +28,7 @@ use Studio\Gesso\Spec\OpenApiOperationResolver;
 use Studio\Gesso\Spec\OpenApiPathMatcher;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 use Studio\Gesso\Validation\Request\SecuritySchemeIntrospector;
+use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
 use Studio\Gesso\Validation\Support\ContentTypeMatcher;
 use Studio\Gesso\Validation\Support\DiscriminatorEnforcement;
 use Studio\Gesso\Validation\Support\HeaderNormalizer;
@@ -891,6 +892,7 @@ trait ValidatesOpenApiSchema
             self::$cachedSkipResponseCodes !== $resolvedSkipCodes
         ) {
             self::$cachedValidator = new OpenApiResponseValidator(
+                strictRequiredTracker: StrictRequiredTracker::current(),
                 maxErrors: $resolvedMaxErrors,
                 skipResponseCodes: $resolvedSkipCodes,
             );
@@ -909,6 +911,7 @@ trait ValidatesOpenApiSchema
         $this->applyDiscriminatorEnforcementConfig();
 
         return new OpenApiResponseValidator(
+            strictRequiredTracker: StrictRequiredTracker::current(),
             maxErrors: $this->resolveMaxErrors(),
             skipResponseCodes: array_merge(
                 $this->resolveSkipResponseCodes(),

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -48,7 +48,7 @@ final class OpenApiResponseValidator
     private readonly ResponseBodyValidator $bodyValidator;
     private readonly ResponseHeaderValidator $headerValidator;
     private readonly StatusCodePatternSet $skipPatterns;
-    private readonly ?StrictRequiredTracker $strictRequiredTracker;
+    private readonly StrictRequiredTracker $strictRequiredTracker;
 
     /**
      * @param string[] $skipResponseCodes Regex patterns (without delimiters or
@@ -56,22 +56,15 @@ final class OpenApiResponseValidator
      *                                    short-circuits validation and returns an `OpenApiValidationResult::skipped()`
      *                                    — isValid() stays true, isSkipped() becomes true, and the matched
      *                                    path is still reported so coverage is recorded.
-     * @param null|StrictRequiredTracker $strictRequiredTracker Optional injected tracker (Issue #229). When
-     *                                                          omitted, recording falls back to
-     *                                                          {@see StrictRequiredTracker::current()}, which
-     *                                                          the PHPUnit extension installs at bootstrap.
-     *                                                          The Laravel `ValidatesOpenApiSchema` trait
-     *                                                          caches one validator per config without
-     *                                                          injecting anything, so the fallback is the
-     *                                                          common production path; tests or framework
-     *                                                          adapters can pass an instance directly to
-     *                                                          assert against without touching the
-     *                                                          process-global locator.
+     * @param StrictRequiredTracker $strictRequiredTracker Tracker receiving successful response-body
+     *                                                     observations. Framework adapters resolve their
+     *                                                     run-level tracker at the integration boundary;
+     *                                                     direct callers must choose the tracker explicitly.
      */
     public function __construct(
+        StrictRequiredTracker $strictRequiredTracker,
         int $maxErrors = 20,
         array $skipResponseCodes = self::DEFAULT_SKIP_RESPONSE_CODES,
-        ?StrictRequiredTracker $strictRequiredTracker = null,
     ) {
         $this->skipPatterns = new StatusCodePatternSet($skipResponseCodes, 'skipResponseCodes');
         $runner = new SchemaValidatorRunner($maxErrors);
@@ -466,10 +459,9 @@ final class OpenApiResponseValidator
             return;
         }
         $contentTypeKey = $matchedContentType ?? StrictRequiredTracker::ANY_CONTENT_TYPE;
-        $tracker = $this->strictRequiredTracker ?? StrictRequiredTracker::current();
 
         try {
-            $tracker->recordOn(
+            $this->strictRequiredTracker->recordOn(
                 $specName,
                 $method,
                 $matchedPath,

--- a/src/Psr7/OpenApiPsr7Validator.php
+++ b/src/Psr7/OpenApiPsr7Validator.php
@@ -17,6 +17,7 @@ use Studio\Gesso\DecodedBody;
 use Studio\Gesso\OpenApiRequestValidator;
 use Studio\Gesso\OpenApiResponseValidator;
 use Studio\Gesso\OpenApiValidationResult;
+use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
 use Studio\Gesso\Validation\Support\ContentTypeMatcher;
 
 use function array_key_exists;
@@ -59,6 +60,7 @@ final class OpenApiPsr7Validator
             skipRequestValidationResponseCodes: $skipRequestValidationResponseCodes,
         );
         $this->responseValidator = new OpenApiResponseValidator(
+            strictRequiredTracker: StrictRequiredTracker::current(),
             maxErrors: $maxErrors,
             skipResponseCodes: $skipResponseCodes,
         );

--- a/src/Symfony/OpenApiAssertions.php
+++ b/src/Symfony/OpenApiAssertions.php
@@ -17,6 +17,7 @@ use Studio\Gesso\OpenApiRequestValidator;
 use Studio\Gesso\OpenApiResponseValidator;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 use Studio\Gesso\Spec\OpenApiSpecResolver;
+use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
 use Studio\Gesso\Validation\Support\ContentTypeMatcher;
 use Symfony\Component\BrowserKit\Exception\BadMethodCallException;
 use Symfony\Component\HttpFoundation\Request;
@@ -122,6 +123,7 @@ trait OpenApiAssertions
         $validator = $extraSkipResponseCodes === []
             ? $this->symfonyResponseValidator()
             : new OpenApiResponseValidator(
+                strictRequiredTracker: StrictRequiredTracker::current(),
                 maxErrors: $this->openApiMaxErrors(),
                 skipResponseCodes: array_merge(
                     OpenApiResponseValidator::DEFAULT_SKIP_RESPONSE_CODES,
@@ -313,6 +315,7 @@ trait OpenApiAssertions
     private function symfonyResponseValidator(): OpenApiResponseValidator
     {
         return $this->cachedSymfonyResponseValidator ??= new OpenApiResponseValidator(
+            strictRequiredTracker: StrictRequiredTracker::current(),
             maxErrors: $this->openApiMaxErrors(),
         );
     }

--- a/src/Validation/Strict/StrictRequiredTracker.php
+++ b/src/Validation/Strict/StrictRequiredTracker.php
@@ -30,11 +30,10 @@ use function trigger_error;
  * Tracker that accumulates response body object-node observations per
  * `(spec, METHOD path, statusKey, contentTypeKey)` across a test run.
  * Exposed through a static facade (see {@see self::current()} /
- * {@see self::setCurrent()}) so the Laravel `ValidatesOpenApiSchema` trait
- * can still reach it without DI — the trait has no constructor and cannot
- * receive an instance through injection. Production callers (the PHPUnit
- * extension, the merge CLI, the validator) construct and use instances
- * directly.
+ * {@see self::setCurrent()}) so framework adapters without constructor
+ * injection can resolve the run-level instance at their integration boundary.
+ * The validator itself requires an instance explicitly; the PHPUnit extension
+ * and merge CLI construct and use their owned instances directly.
  *
  * Each observation feeds a JSON-Pointer-like map `pointer => list<string>`
  * (see {@see StrictRequiredBodyWalker}) describing the keys present at every
@@ -84,11 +83,11 @@ final class StrictRequiredTracker
     public const STATE_FORMAT_VERSION = 2;
 
     /**
-     * Service-locator slot for the static facade (Issue #229). Symmetric with
-     * {@see OpenApiCoverageTracker::$current}: the Laravel trait and the
-     * {@see OpenApiResponseValidator} reach for the tracker via static call,
-     * and we route those to whichever instance the host installed via
-     * {@see self::setCurrent()}.
+     * Service-locator slot for the framework-adapter facade (Issue #229).
+     * Symmetric with {@see OpenApiCoverageTracker::$current}: adapters resolve
+     * whichever run-level instance the host installed via
+     * {@see self::setCurrent()}, then inject it into
+     * {@see OpenApiResponseValidator}.
      */
     private static ?self $current = null;
 

--- a/tests/Integration/FixtureCoverageTest.php
+++ b/tests/Integration/FixtureCoverageTest.php
@@ -13,6 +13,7 @@ use Studio\Gesso\OpenApiRequestValidator;
 use Studio\Gesso\OpenApiResponseValidator;
 use Studio\Gesso\Spec\OpenApiSchemaConverter;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
+use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
 use Studio\Gesso\Validation\Support\DiscriminatorEnforcement;
 
 use function implode;
@@ -53,7 +54,7 @@ class FixtureCoverageTest extends TestCase
         // a prior test that toggled the process-global gate (#262).
         DiscriminatorEnforcement::reset();
         OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs');
-        $this->responseValidator = new OpenApiResponseValidator();
+        $this->responseValidator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker());
         $this->requestValidator = new OpenApiRequestValidator();
     }
 

--- a/tests/Integration/ResponseValidationTest.php
+++ b/tests/Integration/ResponseValidationTest.php
@@ -13,6 +13,7 @@ use Studio\Gesso\Laravel\ValidatesOpenApiSchema;
 use Studio\Gesso\OpenApiResponseValidator;
 use Studio\Gesso\OpenApiValidationResult;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
+use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
 
 class ResponseValidationTest extends TestCase
 {
@@ -24,7 +25,7 @@ class ResponseValidationTest extends TestCase
         OpenApiSpecLoader::reset();
         OpenApiCoverageTracker::reset();
         OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs');
-        $this->validator = new OpenApiResponseValidator();
+        $this->validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker());
     }
 
     protected function tearDown(): void

--- a/tests/Unit/Compatibility/PublicApiBaselineTest.php
+++ b/tests/Unit/Compatibility/PublicApiBaselineTest.php
@@ -12,8 +12,10 @@ use Studio\Gesso\Coverage\ConsoleCoverageRenderer;
 use Studio\Gesso\Coverage\HtmlCoverageRenderer;
 use Studio\Gesso\Coverage\JsonCoverageRenderer;
 use Studio\Gesso\Fuzz\ExploredCase;
+use Studio\Gesso\OpenApiResponseValidator;
 use Studio\Gesso\Tests\Helpers\PublicApiInventory;
 use Studio\Gesso\Tests\Unit\Compatibility\Fixture\PublicApiReturnTypeFixture;
+use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
 
 use function dirname;
 use function file_get_contents;
@@ -137,6 +139,24 @@ final class PublicApiBaselineTest extends TestCase
             ]],
         ];
         ksort($expected[ExploredCase::class]['methods']);
+
+        $responseValidatorConstructor = $expected[OpenApiResponseValidator::class]['methods']['__construct'];
+        $maxErrors = $responseValidatorConstructor['parameters'][0];
+        $skipResponseCodes = $responseValidatorConstructor['parameters'][1];
+        $expected[OpenApiResponseValidator::class]['methods']['__construct']['parameters'] = [
+            [
+                'name' => 'strictRequiredTracker',
+                'type' => StrictRequiredTracker::class,
+                'optional' => false,
+                'variadic' => false,
+                'by_reference' => false,
+                'default' => ['unavailable' => true],
+                'attributes' => [],
+            ],
+            $maxErrors,
+            $skipResponseCodes,
+        ];
+
         /** @var array<string, array<string, mixed>> $actual */
         $actual = json_decode($v2Json, true, flags: JSON_THROW_ON_ERROR);
 

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -13,6 +13,7 @@ use Studio\Gesso\DecodedBody;
 use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\OpenApiResponseValidator;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
+use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
 
 use function array_map;
 use function count;
@@ -30,7 +31,7 @@ class OpenApiResponseValidatorTest extends TestCase
         parent::setUp();
         OpenApiSpecLoader::reset();
         OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs');
-        $this->validator = new OpenApiResponseValidator();
+        $this->validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker());
     }
 
     protected function tearDown(): void
@@ -451,7 +452,7 @@ class OpenApiResponseValidatorTest extends TestCase
     {
         // Opting out of the default skip list means 5xx behaves like any
         // other status code again — a 503 not in the spec becomes a failure.
-        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+        $validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), skipResponseCodes: []);
 
         $result = $validator->validate(
             'petstore-3.0',
@@ -470,7 +471,7 @@ class OpenApiResponseValidatorTest extends TestCase
     public function custom_skip_response_codes_pattern(): void
     {
         // Users can widen the skip set to cover 4xx or a specific code.
-        $validator = new OpenApiResponseValidator(skipResponseCodes: ['4\d\d', '5\d\d']);
+        $validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), skipResponseCodes: ['4\d\d', '5\d\d']);
 
         $result = $validator->validate(
             'petstore-3.0',
@@ -489,7 +490,7 @@ class OpenApiResponseValidatorTest extends TestCase
     {
         // Anchoring matters: "20" must not match "201". Without anchors, a
         // pattern like "20" would accidentally skip any code starting with 20.
-        $validator = new OpenApiResponseValidator(skipResponseCodes: ['20']);
+        $validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), skipResponseCodes: ['20']);
 
         $result = $validator->validate(
             'content-without-schema',
@@ -542,7 +543,7 @@ class OpenApiResponseValidatorTest extends TestCase
     {
         // Regression guard: the foreach in matchingSkipPattern must try every
         // configured pattern, not short-circuit on the first.
-        $validator = new OpenApiResponseValidator(skipResponseCodes: ['4\d\d', '5\d\d']);
+        $validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), skipResponseCodes: ['4\d\d', '5\d\d']);
 
         $result404 = $validator->validate('petstore-3.0', 'GET', '/v1/pets', 404, null);
         $result500 = $validator->validate('petstore-3.0', 'GET', '/v1/pets', 500, null);
@@ -557,7 +558,7 @@ class OpenApiResponseValidatorTest extends TestCase
         // skipReason() carries enough detail to audit which configured pattern
         // fired, not just which status code triggered — useful when running
         // with multiple distinct patterns.
-        $validator = new OpenApiResponseValidator(skipResponseCodes: ['4\d\d', '5\d\d']);
+        $validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), skipResponseCodes: ['4\d\d', '5\d\d']);
 
         $result = $validator->validate('petstore-3.0', 'GET', '/v1/pets', 503, null);
 
@@ -579,7 +580,7 @@ class OpenApiResponseValidatorTest extends TestCase
         // shape to compileSkipPatterns(). Pin the round-trip so a future
         // refactor that drops the (string) cast fails here, not at the
         // caller site where the root cause is less obvious.
-        $validator = new OpenApiResponseValidator(skipResponseCodes: ['503']);
+        $validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), skipResponseCodes: ['503']);
 
         $result = $validator->validate('petstore-3.0', 'GET', '/v1/pets', 503, null);
 
@@ -594,14 +595,14 @@ class OpenApiResponseValidatorTest extends TestCase
         $this->expectExceptionMessage('skipResponseCodes');
         $this->expectExceptionMessage('(unclosed');
 
-        new OpenApiResponseValidator(skipResponseCodes: ['(unclosed']);
+        new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), skipResponseCodes: ['(unclosed']);
     }
 
     #[Test]
     public function invalid_skip_pattern_error_includes_preg_detail(): void
     {
         try {
-            new OpenApiResponseValidator(skipResponseCodes: ['(unclosed']);
+            new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), skipResponseCodes: ['(unclosed']);
             $this->fail('Expected InvalidArgumentException was not thrown.');
         } catch (InvalidArgumentException $e) {
             // The message carries both the offending raw pattern and a
@@ -623,7 +624,7 @@ class OpenApiResponseValidatorTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('must not be an empty string');
 
-        new OpenApiResponseValidator(skipResponseCodes: ['']);
+        new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), skipResponseCodes: ['']);
     }
 
     // ========================================
@@ -1179,7 +1180,7 @@ class OpenApiResponseValidatorTest extends TestCase
             range(1, 50),
         );
 
-        $capped = new OpenApiResponseValidator(maxErrors: 5);
+        $capped = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), maxErrors: 5);
         $cappedResult = $capped->validate(
             'petstore-3.0',
             'GET',
@@ -1188,7 +1189,7 @@ class OpenApiResponseValidatorTest extends TestCase
             ['data' => $items],
         );
 
-        $unlimited = new OpenApiResponseValidator(maxErrors: 0);
+        $unlimited = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), maxErrors: 0);
         $unlimitedResult = $unlimited->validate(
             'petstore-3.0',
             'GET',
@@ -1208,7 +1209,7 @@ class OpenApiResponseValidatorTest extends TestCase
     #[Test]
     public function max_errors_one_limits_to_single_error(): void
     {
-        $validator = new OpenApiResponseValidator(maxErrors: 1);
+        $validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), maxErrors: 1);
         $result = $validator->validate(
             'petstore-3.0',
             'GET',
@@ -1234,7 +1235,7 @@ class OpenApiResponseValidatorTest extends TestCase
             range(1, 50),
         );
 
-        $validator = new OpenApiResponseValidator(maxErrors: 2);
+        $validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), maxErrors: 2);
         $result = $validator->validate(
             'petstore-3.0',
             'GET',
@@ -1255,7 +1256,7 @@ class OpenApiResponseValidatorTest extends TestCase
             range(1, 50),
         );
 
-        $validator = new OpenApiResponseValidator(maxErrors: 0);
+        $validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), maxErrors: 0);
         $result = $validator->validate(
             'petstore-3.0',
             'GET',
@@ -1274,7 +1275,7 @@ class OpenApiResponseValidatorTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('maxErrors must be 0 (unlimited) or a positive integer, got -1.');
 
-        new OpenApiResponseValidator(maxErrors: -1);
+        new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), maxErrors: -1);
     }
 
     // ========================================
@@ -1700,7 +1701,7 @@ class OpenApiResponseValidatorTest extends TestCase
         // Spec declares only `200` and `default`. A 418 response should
         // validate against the `default` schema rather than failing with
         // "Status code 418 not defined".
-        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+        $validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), skipResponseCodes: []);
 
         $result = $validator->validate(
             'spec-fallback',
@@ -1721,7 +1722,7 @@ class OpenApiResponseValidatorTest extends TestCase
     {
         // Falling back to `default` does not bypass schema validation —
         // a body that doesn't match `default`'s schema still fails.
-        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+        $validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), skipResponseCodes: []);
 
         $result = $validator->validate(
             'spec-fallback',
@@ -1739,7 +1740,7 @@ class OpenApiResponseValidatorTest extends TestCase
     #[Test]
     public function range_key_5xx_validates_503_response(): void
     {
-        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+        $validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), skipResponseCodes: []);
 
         $result = $validator->validate(
             'spec-fallback',
@@ -1761,7 +1762,7 @@ class OpenApiResponseValidatorTest extends TestCase
         // Spec declares both `503` (specific) and `5XX` (range). 503 must
         // match the specific key — and the test pins it via the unique
         // `specific: true` field that only the 503 schema requires.
-        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+        $validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), skipResponseCodes: []);
 
         $result = $validator->validate(
             'spec-fallback',
@@ -1780,7 +1781,7 @@ class OpenApiResponseValidatorTest extends TestCase
     public function range_key_falls_through_to_5_x_x_for_other_5xx_codes(): void
     {
         // 599 isn't declared explicitly, so the 5XX range key matches.
-        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+        $validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), skipResponseCodes: []);
 
         $result = $validator->validate(
             'spec-fallback',
@@ -1801,7 +1802,7 @@ class OpenApiResponseValidatorTest extends TestCase
         // OpenAPI permits both upper and lower case for the X in range keys
         // (`5XX` and `5xx` are both legal). The matched key preserves the
         // spec author's casing so coverage reports show what they wrote.
-        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+        $validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), skipResponseCodes: []);
 
         $result = $validator->validate(
             'spec-fallback',
@@ -1821,7 +1822,7 @@ class OpenApiResponseValidatorTest extends TestCase
     {
         // A 4xx response against a spec that only declares 5XX should still
         // fail (assuming default is not declared and skip patterns are off).
-        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+        $validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), skipResponseCodes: []);
 
         $result = $validator->validate(
             'spec-fallback',
@@ -1842,7 +1843,7 @@ class OpenApiResponseValidatorTest extends TestCase
         // /with-default-only declares both 200 and default. The exact
         // match must win — verified via a unique required field that
         // exists ONLY on the 200 schema.
-        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+        $validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), skipResponseCodes: []);
 
         $result = $validator->validate(
             'spec-fallback',
@@ -1863,7 +1864,7 @@ class OpenApiResponseValidatorTest extends TestCase
         // /with-range-and-default declares both 5XX and default. A 503
         // response must hit 5XX (range > default), verified via the
         // `from5xx` required field that only the 5XX schema requires.
-        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+        $validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), skipResponseCodes: []);
 
         $result = $validator->validate(
             'spec-fallback',
@@ -1883,7 +1884,7 @@ class OpenApiResponseValidatorTest extends TestCase
     {
         // Same fixture, but a 418 (non-5xx). 5XX doesn't match → falls
         // through to default. Verified via `fromDefault` required field.
-        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+        $validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), skipResponseCodes: []);
 
         $result = $validator->validate(
             'spec-fallback',
@@ -1905,7 +1906,7 @@ class OpenApiResponseValidatorTest extends TestCase
         // resolveResponseKey. A spec declaring only `default` + a 503
         // response with the default 5\d\d skip pattern enabled must yield
         // isSkipped() — NOT validated against `default`.
-        $validator = new OpenApiResponseValidator(); // default skip = ['5\d\d']
+        $validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker()); // default skip = ['5\d\d']
 
         $result = $validator->validate(
             'spec-fallback',
@@ -1931,7 +1932,7 @@ class OpenApiResponseValidatorTest extends TestCase
         // by other tests; this provider covers 1XX-4XX. Skip patterns are
         // off so the lookup actually runs (default 5\d\d skip wouldn't fire
         // on these classes anyway).
-        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+        $validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), skipResponseCodes: []);
 
         $result = $validator->validate(
             'spec-fallback',
@@ -1953,7 +1954,7 @@ class OpenApiResponseValidatorTest extends TestCase
         // truncated 404). When the literal status doesn't match exact or
         // range, and we're about to fall back to `default`, emit a warning
         // so the spec author notices the typo.
-        $validator = new OpenApiResponseValidator(skipResponseCodes: []);
+        $validator = new OpenApiResponseValidator(strictRequiredTracker: new StrictRequiredTracker(), skipResponseCodes: []);
 
         $captured = [];
         $previous = set_error_handler(static function (int $errno, string $message) use (&$captured): bool {

--- a/tests/Unit/Validation/Strict/StrictRequiredValidatorIntegrationTest.php
+++ b/tests/Unit/Validation/Strict/StrictRequiredValidatorIntegrationTest.php
@@ -33,7 +33,7 @@ final class StrictRequiredValidatorIntegrationTest extends TestCase
         OpenApiSpecLoader::configure(__DIR__ . '/../../../fixtures/specs');
         StrictRequiredTracker::reset();
         StrictRequiredPerCallChecker::reset();
-        $this->validator = new OpenApiResponseValidator();
+        $this->validator = new OpenApiResponseValidator(StrictRequiredTracker::current());
     }
 
     protected function tearDown(): void
@@ -47,8 +47,8 @@ final class StrictRequiredValidatorIntegrationTest extends TestCase
     #[Test]
     public function injected_tracker_receives_observations_instead_of_current_locator(): void
     {
-        // Issue #229: the validator accepts an optional StrictRequiredTracker
-        // via ctor. When one is injected, observations must go to the
+        // Issue #234: the validator requires a StrictRequiredTracker via its
+        // constructor. Observations must go to the
         // injected instance, NOT the process-global current() locator. A
         // regression that drops the field would silently route to current()
         // and the suite-level intersection would absorb the test traffic.

--- a/tests/fixtures/compatibility/v2-public-api.json
+++ b/tests/fixtures/compatibility/v2-public-api.json
@@ -4630,6 +4630,17 @@
                 "attributes": [],
                 "parameters": [
                     {
+                        "name": "strictRequiredTracker",
+                        "type": "Studio\\Gesso\\Validation\\Strict\\StrictRequiredTracker",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
                         "name": "maxErrors",
                         "type": "int",
                         "optional": true,
@@ -4650,15 +4661,6 @@
                                 "5\\d\\d"
                             ]
                         },
-                        "attributes": []
-                    },
-                    {
-                        "name": "strictRequiredTracker",
-                        "type": "?Studio\\Gesso\\Validation\\Strict\\StrictRequiredTracker",
-                        "optional": true,
-                        "variadic": false,
-                        "by_reference": false,
-                        "default": null,
                         "attributes": []
                     }
                 ]


### PR DESCRIPTION
## Summary

- require `StrictRequiredTracker` as the first `OpenApiResponseValidator` constructor argument
- remove the validator's process-global tracker fallback and inject the run-level tracker at Laravel, Symfony, and PSR-7 adapter boundaries
- update direct-use examples, v2 migration guidance, and the public API compatibility baseline

## Why

`OpenApiResponseValidator` previously accepted a nullable tracker and silently resolved `StrictRequiredTracker::current()` while recording successful responses. That hid a service-locator dependency inside a constructor-built object and made tracker ownership implicit. The v2 pre-stable window is the appropriate point to make this dependency explicit.

## Impact

Direct callers must create and pass a tracker:

```php
$tracker = new StrictRequiredTracker();
$validator = new OpenApiResponseValidator($tracker, maxErrors: 20);
```

Laravel, Symfony, and PSR-7 adapter users do not need to change adapter calls; those integrations inject the run-level tracker automatically.

## Verification

- `NPM_CONFIG_CACHE=/tmp/gesso-npm-cache vendor/bin/phpunit` — 2106 tests, 5630 assertions
- `vendor/bin/phpstan analyse --no-progress --debug --memory-limit=512M` — no errors
- both PHP-CS-Fixer configurations in sequential dry-run mode — clean
- core example — 1 test, 1 assertion
- `git diff --check` — clean

Closes #234
