### PR TITLE
fix(fuzz): diversify pattern-generated strings

### DIFF
--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -151,7 +151,7 @@ fuzz generator defect` diagnostic instead of sending invalid data to the API.
 | Strategy | Valid generation | Targeted invalid mutation |
 |---|---|---|
 | Scalars | `type`, `const`, `enum`, nullable branches | wrong type, const/enum miss |
-| Strings | min/max length, common regex patterns (including anchored character classes with fixed quantifiers, FQDN labels with a fixed domain suffix, and phone-number alternations), Unicode code points, Faker-backed email/UUID/date/time/URI/host/IP formats | below/above length, pattern miss, invalid recognized format |
+| Strings | min/max length, common regex patterns (including anchored character classes with fixed or `+` quantifiers, FQDN labels with a fixed domain suffix, and phone-number alternations), Unicode code points, Faker-backed email/UUID/date/time/URI/host/IP formats | below/above length, pattern miss, invalid recognized format |
 | Numbers | inclusive/exclusive bounds and `multipleOf`, including OAS 3.0 boolean-exclusive lowering | outside/equal-exclusive bound, non-multiple |
 | Arrays | `items`, `prefixItems`, min/max items, `uniqueItems` | too few/many or duplicate items |
 | Objects | properties, required, min/max properties, schema-valued/default additional properties | missing required, extra forbidden, too few/many properties, nested property constraint |
@@ -172,6 +172,8 @@ diagnostic or is an explicit whole-spec skip carrying that reason.
 When [`fakerphp/faker`][faker] is installed, generation uses Faker's
 locale-aware primitives and is deterministic for a given `seed:`. Without it,
 ordinary strings and scalar boundaries use deterministic counter-based values.
+Supported character-class patterns sample multiple class members after the
+first boundary case, so increasing `cases:` also increases their input variety.
 Recognized formats such as email and UUID cannot be synthesized reliably by
 that fallback: the existing one-shot warning is followed by the valid-case
 self-check, so the operation fails locally rather than dispatching a value that

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -410,7 +410,7 @@ final class SchemaDataGenerator
             : 16;
 
         if (isset($schema['pattern']) && is_string($schema['pattern'])) {
-            $patternValue = self::generateCommonPattern($schema['pattern'], $schema, $iteration);
+            $patternValue = self::generateCommonPattern($schema['pattern'], $schema, $faker, $iteration);
             if ($patternValue !== null) {
                 return $patternValue;
             }
@@ -832,9 +832,13 @@ final class SchemaDataGenerator
     }
 
     /** @param array<string, mixed> $schema */
-    private static function generateCommonPattern(string $pattern, array $schema, int $iteration): ?string
-    {
-        $fixedQuantifierValue = self::generateFixedQuantifierPattern($pattern, $schema);
+    private static function generateCommonPattern(
+        string $pattern,
+        array $schema,
+        ?Generator $faker,
+        int $iteration,
+    ): ?string {
+        $fixedQuantifierValue = self::generateCharacterClassPattern($pattern, $schema, $faker, $iteration);
         if ($fixedQuantifierValue !== null) {
             return $fixedQuantifierValue;
         }
@@ -970,15 +974,25 @@ final class SchemaDataGenerator
     }
 
     /** @param array<string, mixed> $schema */
-    private static function generateFixedQuantifierPattern(string $pattern, array $schema): ?string
-    {
-        if (preg_match('/^\^(\[[^]]+]|\\\\d)\{([0-9]+)\}\$$/D', $pattern, $matches) !== 1) {
+    private static function generateCharacterClassPattern(
+        string $pattern,
+        array $schema,
+        ?Generator $faker,
+        int $iteration,
+    ): ?string {
+        if (preg_match('/^\^(\[[^]]+]|\\\\d)(?:\{([0-9]+)\}|(\+))\$$/D', $pattern, $matches) !== 1) {
             return null;
         }
 
-        $length = (int) $matches[2];
         $minimum = isset($schema['minLength']) && is_int($schema['minLength']) ? max(0, $schema['minLength']) : null;
         $maximum = isset($schema['maxLength']) && is_int($schema['maxLength']) ? max(0, $schema['maxLength']) : null;
+        $length = $matches[2] !== ''
+            ? (int) $matches[2]
+            : match ($iteration % 3) {
+                0 => max(1, $minimum ?? 1),
+                1 => max(1, $maximum ?? 16),
+                default => max(1, $minimum ?? 1, min($maximum ?? 16, 8)),
+            };
         if ($length > self::MAX_SYNTHESIZED_PATTERN_LENGTH ||
             ($minimum !== null && $length < $minimum) ||
             ($maximum !== null && $length > $maximum)) {
@@ -986,34 +1000,64 @@ final class SchemaDataGenerator
         }
 
         $atom = $matches[1];
-        $character = $atom === '\\d' ? '0' : self::characterMatchingClass($atom);
-        if ($character === null) {
+        $characters = $atom === '\\d'
+            ? self::unicodeCharacters('0123456789')
+            : self::charactersMatchingClass($atom);
+        if ($characters === []) {
             return null;
         }
 
-        $value = str_repeat($character, $length);
+        $value = self::samplePatternCharacters($characters, $length, $faker, $iteration);
         $delimiter = '~';
         $escaped = str_replace($delimiter, '\\' . $delimiter, $pattern);
 
         return @preg_match($delimiter . $escaped . $delimiter . 'u', $value) === 1 ? $value : null;
     }
 
-    private static function characterMatchingClass(string $characterClass): ?string
+    /** @return list<string> */
+    private static function charactersMatchingClass(string $characterClass): array
     {
         $delimiter = '~';
         $escaped = str_replace($delimiter, '\\' . $delimiter, $characterClass);
         $expression = $delimiter . '^' . $escaped . '$' . $delimiter . 'u';
-        $candidates = self::unicodeCharacters(
+        $candidates = array_values(array_unique(self::unicodeCharacters(
             'aA0abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_- ',
-        );
+        )));
+        $matches = [];
 
         foreach ($candidates as $candidate) {
             if (@preg_match($expression, $candidate) === 1) {
-                return $candidate;
+                $matches[] = $candidate;
             }
         }
 
-        return null;
+        return $matches;
+    }
+
+    /** @param non-empty-list<string> $characters */
+    private static function samplePatternCharacters(
+        array $characters,
+        int $length,
+        ?Generator $faker,
+        int $iteration,
+    ): string {
+        if ($iteration === 0 || count($characters) === 1) {
+            return str_repeat($characters[0], $length);
+        }
+
+        $sampled = [];
+        for ($position = 0; $position < $length; $position++) {
+            $index = $faker !== null
+                ? $faker->numberBetween(0, count($characters) - 1)
+                : ($iteration + $position) % count($characters);
+            $sampled[] = $characters[$index];
+        }
+
+        if ($length > 1 && count(array_unique($sampled)) === 1) {
+            $sampled[$length - 1] = $sampled[0] === $characters[0] ? $characters[1] : $characters[0];
+        }
+
+        return implode('', $sampled);
     }
 
     private static function repeatToLength(string $value, int $length): string

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -1050,6 +1050,11 @@ final class SchemaDataGenerator
             $index = $faker !== null
                 ? $faker->numberBetween(0, count($characters) - 1)
                 : ($iteration + $position) % count($characters);
+            // Reserve the first candidate for iteration zero so even a
+            // one-character value differs after the boundary case.
+            if ($position === 0 && $index === 0) {
+                $index = 1 + (($iteration - 1) % (count($characters) - 1));
+            }
             $sampled[] = $characters[$index];
         }
 

--- a/tests/Unit/Fuzz/OpenApiEndpointExplorerTest.php
+++ b/tests/Unit/Fuzz/OpenApiEndpointExplorerTest.php
@@ -20,11 +20,13 @@ use Studio\Gesso\HttpMethod;
 use Studio\Gesso\OpenApiRequestValidator;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 
+use function array_unique;
+use function count;
 use function json_decode;
 use function json_encode;
 use function parse_str;
 use function parse_url;
-use function str_repeat;
+use function str_split;
 
 class OpenApiEndpointExplorerTest extends TestCase
 {
@@ -198,17 +200,52 @@ class OpenApiEndpointExplorerTest extends TestCase
     #[Test]
     public function generates_fixed_quantifier_pattern_for_query_parameter(): void
     {
-        $cases = OpenApiEndpointExplorer::explore(
+        $first = OpenApiEndpointExplorer::explore(
             'fuzz-fixed-quantifier-query',
             'GET',
             '/oauth/callback',
-            cases: 1,
-            seed: 1,
+            cases: 3,
+            seed: 42,
+        );
+        $replayed = OpenApiEndpointExplorer::explore(
+            'fuzz-fixed-quantifier-query',
+            'GET',
+            '/oauth/callback',
+            cases: 3,
+            seed: 42,
         );
 
-        foreach ($cases as $case) {
-            $this->assertSame(str_repeat('a', 64), $case->query['state']);
+        $states = [];
+        $validator = new OpenApiRequestValidator();
+        foreach ($first as $case) {
+            $states[] = $case->query['state'];
+            $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $case->query['state']);
+            $uri = $case->uri();
+            $path = parse_url($uri, PHP_URL_PATH);
+            $queryString = parse_url($uri, PHP_URL_QUERY);
+            $this->assertIsString($path);
+            $this->assertIsString($queryString);
+            $query = [];
+            parse_str($queryString, $query);
+            $result = $validator->validate(
+                'fuzz-fixed-quantifier-query',
+                'GET',
+                $path,
+                $query,
+                [],
+                null,
+            );
+            $this->assertTrue($result->isValid(), $result->errorMessage());
         }
+
+        $replayedStates = [];
+        foreach ($replayed as $case) {
+            $replayedStates[] = $case->query['state'];
+        }
+
+        $this->assertSame($states, $replayedStates);
+        $this->assertCount(3, array_unique($states));
+        $this->assertGreaterThan(1, count(array_unique(str_split($states[1]))));
     }
 
     #[Test]

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -21,6 +21,7 @@ use Studio\Gesso\Validation\Support\DiscriminatorContext;
 
 use function array_filter;
 use function array_map;
+use function array_unique;
 use function array_values;
 use function count;
 use function fmod;
@@ -30,6 +31,7 @@ use function preg_match;
 use function restore_error_handler;
 use function set_error_handler;
 use function str_repeat;
+use function str_split;
 use function strlen;
 
 class SchemaDataGeneratorTest extends TestCase
@@ -487,6 +489,37 @@ class SchemaDataGeneratorTest extends TestCase
         $this->assertSame(str_repeat('a', 64), SchemaDataGenerator::generate($schemas[0], 1, seed: 1)[0]);
         $this->assertSame('AA', SchemaDataGenerator::generate($schemas[1], 1, seed: 1)[0]);
         $this->assertSame('000000', SchemaDataGenerator::generate($schemas[2], 1, seed: 1)[0]);
+    }
+
+    #[Test]
+    public function samples_anchored_character_classes_deterministically_across_cases(): void
+    {
+        $fixed = ['type' => 'string', 'pattern' => '^[a-f0-9]{64}$'];
+        $variable = ['type' => 'string', 'pattern' => '^[a-zA-Z0-9_]+$', 'maxLength' => 40];
+
+        $fixedValues = SchemaDataGenerator::generate($fixed, 3, seed: 42);
+        $replayedFixedValues = SchemaDataGenerator::generate($fixed, 3, seed: 42);
+        $differentSeedValues = SchemaDataGenerator::generate($fixed, 3, seed: 43);
+        $variableValues = SchemaDataGenerator::generate($variable, 3, seed: 42);
+        $fallbackValues = [
+            SchemaDataGenerator::generateOne($fixed, null, 1),
+            SchemaDataGenerator::generateOne($fixed, null, 2),
+        ];
+
+        $this->assertSame($fixedValues, $replayedFixedValues);
+        $this->assertNotSame($fixedValues, $differentSeedValues);
+        $this->assertCount(3, array_unique($fixedValues));
+        $this->assertGreaterThan(1, count(array_unique(str_split($fixedValues[1]))));
+        $this->assertCount(3, array_unique($variableValues));
+        $this->assertNotSame($fallbackValues[0], $fallbackValues[1]);
+        $this->assertGreaterThan(1, count(array_unique(str_split($fallbackValues[0]))));
+        foreach ($fixedValues as $value) {
+            $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $value);
+        }
+        foreach ($variableValues as $value) {
+            $this->assertMatchesRegularExpression('/^[a-zA-Z0-9_]+$/', $value);
+            $this->assertLessThanOrEqual(40, strlen($value));
+        }
     }
 
     #[Test]

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -523,6 +523,28 @@ class SchemaDataGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function varies_single_character_patterns_after_the_boundary_case(): void
+    {
+        $fixedValues = SchemaDataGenerator::generate(
+            ['type' => 'string', 'pattern' => '^[ab]{1}$'],
+            3,
+            seed: 3,
+        );
+        $plusValues = SchemaDataGenerator::generate(
+            ['type' => 'string', 'pattern' => '^[ab]+$', 'maxLength' => 1],
+            3,
+            seed: 3,
+        );
+
+        foreach ([$fixedValues, $plusValues] as $values) {
+            $this->assertSame('a', $values[0]);
+            $this->assertNotSame($values[0], $values[1]);
+            $this->assertNotSame($values[0], $values[2]);
+            $this->assertCount(2, array_unique($values));
+        }
+    }
+
+    #[Test]
     public function generates_common_hostname_patterns_with_a_fixed_domain_suffix(): void
     {
         $schema = [


### PR DESCRIPTION
## Summary

- sample supported anchored character classes across fuzz cases instead of repeating one constant witness
- preserve deterministic output for a fixed seed and provide counter-based diversity when Faker is unavailable
- support the same strategy for fixed (`{N}`) and `+` quantifiers while retaining the first boundary case
- document the behavior and cover the full `explore() -> uri() -> parse -> request validator` path

## Root cause

The fixed-quantifier synthesis path selected the first matching character and repeated it for every case. Generic `+` patterns also returned the first matching repeated candidate, so increasing `cases:` did not increase the effective input corpus.

## Impact

Pattern-constrained fields now exercise mixed character-class members after the first boundary case. Runs remain reproducible for the same seed, and every generated value still passes the converted JSON Schema self-check before dispatch.

## Verification

- focused PHPUnit: `77 tests, 771 assertions`
- full PHPUnit: `2107 tests, 5663 assertions`
- PHPStan: no errors
- PHP-CS-Fixer: clean
- `git diff --check`: clean

Closes #320
