### PR TITLE
feat(laravel)!: classify external route parity operations

### DIFF
--- a/docs/adr/0001-gesso-v2-identity.md
+++ b/docs/adr/0001-gesso-v2-identity.md
@@ -177,13 +177,14 @@ consumer may validate or route reports by it. Schema version 2 otherwise keeps
 the version 1 fields, types, and meanings. The v2 writer emits only the Gesso
 identity rather than a second legacy identity field.
 
-The identity migration does not change the other versioned formats:
+The identity migration does not require the other versioned formats to change.
+Route parity advances independently because v2 adds a new result category:
 
 | Format | Gesso v2 writer | Gesso v2 reader responsibility | Reason |
 | --- | ---: | --- | --- |
 | Coverage JSON report | `schema_version: 2` | N/A (output contract) | The documented fixed `tool.name` value changes |
 | Doctor JSON | `schemaVersion: 1` | N/A (output contract) | It contains no package or namespace identity and its shape is unchanged |
-| Laravel route parity JSON | `schema_version: 1` | N/A (output contract) | It contains no package or namespace identity and its shape is unchanged |
+| Laravel route parity JSON | `schema_version: 2` | N/A (output contract) | `external_operations` is added to the result and summary |
 | Sidecar envelope | `envelopeVersion: 2` | Continue accepting the documented v1.9 envelope and legacy bare coverage state | No persisted field changes for the rename |
 | Coverage tracker state | `version: 1` | Continue accepting version 1 | No persisted field changes for the rename |
 | Strict-required tracker state | `version: 2` | Continue accepting version 2 inside supported envelopes | No persisted field changes for the rename |

--- a/docs/laravel-route-parity.md
+++ b/docs/laravel-route-parity.md
@@ -25,6 +25,10 @@ return [
     'default_spec' => 'front',
     'spec_base_path' => base_path('openapi/bundled'),
     'strip_prefixes' => ['/api'],
+    'route_parity' => [
+        'external_operation_ids' => ['forms.*'],
+        'external_openapi_paths' => ['/v2/proxy/*'],
+    ],
 ];
 ```
 
@@ -50,7 +54,9 @@ php artisan openapi:routes \
   --prefix=api/v2 \
   --middleware=api \
   --domain=api.example.com \
-  --exclude-route='internal.*'
+  --exclude-route='internal.*' \
+  --exclude-operation='forms.*' \
+  --exclude-openapi-path='/v2/proxy/*'
 ```
 
 Filters are combined with AND semantics:
@@ -60,6 +66,15 @@ Filters are combined with AND semantics:
 - Repeat `--domain` to allow any listed exact route domain.
 - Repeat `--exclude-route` to exclude named routes; `*` wildcards are
   supported. Unnamed routes are not excluded by this option.
+
+Documented-side exclusions classify operations implemented by another service
+in a gateway topology. Repeat `--exclude-operation` to match `operationId`, or
+`--exclude-openapi-path` to match the OpenAPI path template. Both support `*`
+wildcards and are merged with `route_parity.external_operation_ids` and
+`route_parity.external_openapi_paths` from the Laravel config. An exclusion is
+applied only when the operation has no matching Laravel route: implemented
+operations remain in `matched`. External operations are reported separately
+instead of being silently removed.
 
 Laravel parameter names do not need to equal OpenAPI parameter names:
 `/pets/{pet}` matches `/pets/{petId}`. A trailing optional Laravel parameter
@@ -86,7 +101,7 @@ php artisan openapi:routes --fail-on-unimplemented
 - `--fail-on-undocumented` exits `1` for registered-but-undocumented routes or
   unsupported route methods.
 - `--fail-on-unimplemented` exits `1` for documented-but-not-registered
-  operations.
+  operations, excluding those classified under `external_operations`.
 - Invalid command options exit `2`; load/configuration failures exit `1`.
 
 ## JSON output
@@ -111,11 +126,13 @@ of relying only on the job log:
     path: route-parity.json
 ```
 
-The top-level `schema_version` is currently `1`. The payload contains the
+The top-level `schema_version` is currently `2`. Version 2 adds the
+`external_operations` result and summary count. The payload contains the
 selected `specs`, a `summary`, and these result arrays:
 
 - `matched`
 - `documented_but_not_registered`
+- `external_operations`
 - `registered_but_undocumented`
 - `ambiguous`
 - `unsupported`

--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -312,7 +312,8 @@ same string.
 | `skip_request_validation_response_codes` | `['422', '400']` |
 
 The `openapi:routes` command accepts `--spec`, `--prefix`, `--middleware`,
-`--domain`, `--exclude-route`, `--format=text|json`,
+`--domain`, `--exclude-route`, `--exclude-operation`,
+`--exclude-openapi-path`, `--format=text|json`,
 `--fail-on-undocumented`, and `--fail-on-unimplemented`. It uses Laravel's
 standard success (`0`), failure (`1`), and invalid usage (`2`) exit codes.
 
@@ -397,7 +398,7 @@ channel.
 | Coverage tracker state | `version: 1` | V2 retains version 1 and accepts supported v1 payloads |
 | Strict-required tracker state | `version: 2` | V2 retains version 2 and preserves the documented import boundary |
 | Sidecar envelope | `envelopeVersion: 2` | V2 retains version 2 and continues accepting legacy bare coverage v1 payloads |
-| Laravel route parity JSON | `schema_version: 1` | V2 retains version 1 because neither identity nor shape changes |
+| Laravel route parity JSON | `schema_version: 1` | V2 emits schema 2 because `external_operations` is added to the result and summary |
 | Doctor JSON | `schemaVersion: 1` | V2 retains version 1 because neither identity nor shape changes |
 | Sidecar filenames | `part-*.json`, failure marker `failed-*` | Keep reader compatibility during mixed runs |
 
@@ -405,7 +406,8 @@ Coverage JSON v1 documents `generated_at`, `tool`, `aggregate`, and `specs`.
 The per-spec contract includes aggregate counts and endpoint rows with response
 states and unexpected observations. Laravel route parity JSON includes `specs`,
 `summary`, `matched`, `documented_but_not_registered`,
-`registered_but_undocumented`, `ambiguous`, and `unsupported`.
+`external_operations`, `registered_but_undocumented`, `ambiguous`, and
+`unsupported`.
 
 The sidecar compatibility boundary is now explicit in the
 [versioning policy](../versioning.md#versioned-sidecar-compatibility): the PHP
@@ -420,12 +422,12 @@ identity. The sidecar fixture pins coverage tracker state v1 and strict-required
 tracker state v2, and consumer-style tests verify both the envelope reader and
 the legacy bare-coverage reader path.
 
-V2 decision: only coverage JSON advances its schema version. Its documented
-`tool.name` behaves as a fixed value, so changing it to `studio-design/gesso` is
-an incompatible contract change even though the surrounding object shape stays
-the same. Format versions are otherwise independent of the Composer major:
-Doctor JSON, route parity JSON, the sidecar envelope, and both tracker states do
-not carry the legacy identity and therefore retain their existing versions.
+V2 decision: coverage JSON advances because its documented `tool.name` changes
+to `studio-design/gesso`. Route parity JSON advances independently because its
+shape gains the `external_operations` category. Format versions remain
+independent of the Composer major: Doctor JSON, the sidecar envelope, and both
+tracker states retain their existing versions because their contracts do not
+change.
 
 ## Diagnostic categories and embedded identifiers
 

--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -312,18 +312,26 @@ same string.
 | `skip_request_validation_response_codes` | `['422', '400']` |
 
 The `openapi:routes` command accepts `--spec`, `--prefix`, `--middleware`,
-`--domain`, `--exclude-route`, `--exclude-operation`,
-`--exclude-openapi-path`, `--format=text|json`,
+`--domain`, `--exclude-route`, `--format=text|json`,
 `--fail-on-undocumented`, and `--fail-on-unimplemented`. It uses Laravel's
 standard success (`0`), failure (`1`), and invalid usage (`2`) exit codes.
 
-Migration status: implemented on the v2 development line. The complete v1.9
-configuration defaults remain unchanged, while `GessoServiceProvider` owns only
-the `gesso` key, publish tag, and `config/gesso.php` destination. Consumer-level
-tests cover defaults, application overrides, discovery metadata, publishing,
-and rejection of legacy-only and dual-key configurations. Versioned route-parity
-JSON remains unchanged. Text output remains covered semantically because Laravel
-owns its cross-version console table rendering.
+Migration status: implemented on the v2 development line.
+`GessoServiceProvider` owns only the `gesso` key, publish tag, and
+`config/gesso.php` destination. V2 adds the empty-by-default
+`route_parity.external_operation_ids` and
+`route_parity.external_openapi_paths` configuration lists, plus the matching
+`--exclude-operation` and `--exclude-openapi-path` repeatable command flags.
+These wildcard-aware exclusions classify unmatched documented operations as
+external instead of removing them from the report. They are omitted from the
+`--fail-on-unimplemented` gate.
+
+Route-parity JSON advances from `schema_version: 1` to `schema_version: 2` and
+adds `external_operations` to both the summary and top-level result arrays.
+Consumer-level tests and v2 golden fixtures cover the new defaults, application
+overrides, discovery metadata, publishing, exclusion sources, JSON shape, and
+rejection of malformed or legacy configuration. Text output remains covered
+semantically because Laravel owns its cross-version console table rendering.
 
 V1.10 intentionally does not register a `gesso` configuration alias. At the v2
 package boundary, consumers rename the published file and direct configuration
@@ -406,8 +414,9 @@ Coverage JSON v1 documents `generated_at`, `tool`, `aggregate`, and `specs`.
 The per-spec contract includes aggregate counts and endpoint rows with response
 states and unexpected observations. Laravel route parity JSON includes `specs`,
 `summary`, `matched`, `documented_but_not_registered`,
-`external_operations`, `registered_but_undocumented`, `ambiguous`, and
-`unsupported`.
+`registered_but_undocumented`, `ambiguous`, and `unsupported` in schema version
+1. Schema version 2 additionally includes `external_operations` in the summary
+and top-level result arrays.
 
 The sidecar compatibility boundary is now explicit in the
 [versioning policy](../versioning.md#versioned-sidecar-compatibility): the PHP
@@ -415,12 +424,13 @@ import/export methods are internal, but versioned payloads accepted by the
 released merge CLI are compatibility inputs. A newer reader preserves the
 documented older inputs, while unknown or lossy formats fail loudly.
 
-Migration status: the exact v1.9 coverage JSON report and sidecar envelope, plus
-the v2 coverage JSON report, are captured under
-`tests/fixtures/compatibility/`. The v2 report pins schema 2 and the Gesso tool
-identity. The sidecar fixture pins coverage tracker state v1 and strict-required
-tracker state v2, and consumer-style tests verify both the envelope reader and
-the legacy bare-coverage reader path.
+Migration status: the exact v1.9 coverage JSON report, route-parity JSON, and
+sidecar envelope, plus the v2 coverage and route-parity JSON reports, are
+captured under `tests/fixtures/compatibility/`. The v2 coverage report pins
+schema 2 and the Gesso tool identity; the v2 route-parity report pins schema 2
+and the external-operation category. The sidecar fixture pins coverage tracker
+state v1 and strict-required tracker state v2, and consumer-style tests verify
+both the envelope reader and the legacy bare-coverage reader path.
 
 V2 decision: coverage JSON advances because its documented `tool.name` changes
 to `studio-design/gesso`. Route parity JSON advances independently because its

--- a/docs/migration/v2.md
+++ b/docs/migration/v2.md
@@ -194,11 +194,11 @@ coverage fields and meanings stay compatible with schema version 1; the version
 bump makes the documented fixed identity change visible instead of silently
 passing it through existing consumers.
 
-Do not update unrelated format checks solely because the Composer major
-changes. Doctor JSON remains at `schemaVersion: 1`, Laravel route parity JSON
-remains at `schema_version: 1`, and the sidecar envelope and tracker-state
-versions remain unchanged. Gesso v2's merge reader continues to accept the
-older sidecar payloads documented in the
+Laravel route parity JSON also advances to `schema_version: 2` because it adds
+the `external_operations` result and summary count. Doctor JSON remains at
+`schemaVersion: 1`, and the sidecar envelope and tracker-state versions remain
+unchanged. Gesso v2's merge reader continues to accept the older sidecar
+payloads documented in the
 [versioning policy](../versioning.md#versioned-sidecar-compatibility), so a
 branding-only migration does not make supported worker data unreadable.
 

--- a/src/Laravel/Commands/OpenApiRoutesCommand.php
+++ b/src/Laravel/Commands/OpenApiRoutesCommand.php
@@ -20,6 +20,8 @@ use Throwable;
 
 use function array_filter;
 use function array_map;
+use function array_merge;
+use function array_unique;
 use function array_values;
 use function count;
 use function implode;
@@ -39,6 +41,8 @@ final class OpenApiRoutesCommand extends Command
         {--middleware=* : Only include routes using all of these middleware names}
         {--domain=* : Only include routes registered for these exact domains}
         {--exclude-route=* : Exclude route names; * wildcards are supported}
+        {--exclude-operation=* : Classify unmatched operationIds as external; * wildcards are supported}
+        {--exclude-openapi-path=* : Classify unmatched OpenAPI paths as external; * wildcards are supported}
         {--format=text : Output format: text or json}
         {--fail-on-undocumented : Fail when a Laravel route is absent from OpenAPI}
         {--fail-on-unimplemented : Fail when an OpenAPI operation has no Laravel route}';
@@ -75,6 +79,14 @@ final class OpenApiRoutesCommand extends Command
                     'middleware' => $this->stringListOption('middleware'),
                     'domains' => $this->stringListOption('domain'),
                     'excluded_route_names' => $this->stringListOption('exclude-route'),
+                    'excluded_operation_ids' => $this->documentedSideExclusions(
+                        'exclude-operation',
+                        'gesso.route_parity.external_operation_ids',
+                    ),
+                    'excluded_openapi_paths' => $this->documentedSideExclusions(
+                        'exclude-openapi-path',
+                        'gesso.route_parity.external_openapi_paths',
+                    ),
                 ],
             );
         } catch (Throwable $e) {
@@ -192,16 +204,39 @@ final class OpenApiRoutesCommand extends Command
         ), static fn(string $entry): bool => $entry !== ''));
     }
 
+    /** @return list<string> */
+    private function documentedSideExclusions(string $option, string $configKey): array
+    {
+        $configured = config($configKey, []);
+        if (!is_array($configured)) {
+            throw new InvalidArgumentException("{$configKey} must be an array of strings.");
+        }
+
+        $normalized = [];
+        foreach ($configured as $entry) {
+            if (!is_string($entry) || trim($entry) === '') {
+                throw new InvalidArgumentException("{$configKey} must contain only non-empty strings.");
+            }
+            $normalized[] = trim($entry);
+        }
+
+        return array_values(array_unique(array_merge(
+            $normalized,
+            $this->stringListOption($option),
+        )));
+    }
+
     private function renderText(RouteParityResult $result): void
     {
         $this->components->info('OpenAPI route parity');
         $this->line('Specs: ' . implode(', ', $result->specs));
         $this->newLine();
         $this->table(
-            ['Matched', 'OpenAPI only', 'Laravel only', 'Ambiguous', 'Unsupported'],
+            ['Matched', 'OpenAPI only', 'External', 'Laravel only', 'Ambiguous', 'Unsupported'],
             [[
                 count($result->matched),
                 count($result->documentedButNotRegistered),
+                count($result->externalOperations),
                 count($result->registeredButUndocumented),
                 count($result->ambiguous),
                 count($result->unsupported),
@@ -218,6 +253,19 @@ final class OpenApiRoutesCommand extends Command
                     $entry['operation_id'] ?? '',
                 ],
                 $result->documentedButNotRegistered,
+            ));
+        }
+
+        if ($result->externalOperations !== []) {
+            $this->components->info('External operations');
+            $this->table(['Spec', 'Method', 'OpenAPI path', 'operationId'], array_map(
+                static fn(array $entry): array => [
+                    $entry['spec'],
+                    $entry['method'],
+                    $entry['openapi_path'],
+                    $entry['operation_id'] ?? '',
+                ],
+                $result->externalOperations,
             ));
         }
 

--- a/src/Laravel/RouteParity/LaravelRouteParityAnalyzer.php
+++ b/src/Laravel/RouteParity/LaravelRouteParityAnalyzer.php
@@ -35,7 +35,7 @@ use function trim;
  *
  * @internal Not part of the package's public API.
  *
- * @phpstan-type Filters array{prefix?: ?string, middleware?: list<string>, domains?: list<string>, excluded_route_names?: list<string>}
+ * @phpstan-type Filters array{prefix?: ?string, middleware?: list<string>, domains?: list<string>, excluded_route_names?: list<string>, excluded_operation_ids?: list<string>, excluded_openapi_paths?: list<string>}
  * @phpstan-type Operation array{spec: string, method: string, openapi_path: string, normalized_path: string, operation_id: ?string}
  * @phpstan-type RegisteredRoute array{method: string, route_uri: string, normalized_path: string, route_name: ?string, domain: ?string}
  */
@@ -177,27 +177,64 @@ final class LaravelRouteParityAnalyzer
         }
 
         $openApiOnly = [];
+        $externalOperations = [];
         foreach ($operations as $index => $operation) {
             if (isset($matchedOperationIndexes[$index])) {
                 continue;
             }
 
-            $openApiOnly[] = [
+            $entry = [
                 'spec' => $operation['spec'],
                 'method' => $operation['method'],
                 'openapi_path' => $operation['openapi_path'],
                 'operation_id' => $operation['operation_id'],
             ];
+
+            if ($this->isExcludedOperation($operation, $filters)) {
+                $externalOperations[] = $entry;
+
+                continue;
+            }
+
+            $openApiOnly[] = $entry;
         }
 
         return new RouteParityResult(
             specs: array_keys($specs),
             matched: $matched,
             documentedButNotRegistered: $openApiOnly,
+            externalOperations: $externalOperations,
             registeredButUndocumented: $routeOnly,
             ambiguous: $ambiguous,
             unsupported: $unsupported,
         );
+    }
+
+    /**
+     * Documented-side exclusions only classify unmatched operations. A route
+     * that implements an excluded operation is still reported as matched.
+     *
+     * @param Operation $operation
+     * @param Filters $filters
+     */
+    private function isExcludedOperation(array $operation, array $filters): bool
+    {
+        $operationId = $operation['operation_id'];
+        if ($operationId !== null) {
+            foreach ($filters['excluded_operation_ids'] ?? [] as $pattern) {
+                if (Str::is($pattern, $operationId)) {
+                    return true;
+                }
+            }
+        }
+
+        foreach ($filters['excluded_openapi_paths'] ?? [] as $pattern) {
+            if (Str::is($pattern, $operation['openapi_path'])) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Laravel/RouteParity/RouteParityResult.php
+++ b/src/Laravel/RouteParity/RouteParityResult.php
@@ -26,6 +26,7 @@ final readonly class RouteParityResult implements JsonSerializable
      * @param list<string> $specs
      * @param list<MatchedEntry> $matched
      * @param list<OpenApiOnlyEntry> $documentedButNotRegistered
+     * @param list<OpenApiOnlyEntry> $externalOperations
      * @param list<RouteOnlyEntry> $registeredButUndocumented
      * @param list<AmbiguousEntry> $ambiguous
      * @param list<UnsupportedEntry> $unsupported
@@ -34,6 +35,7 @@ final readonly class RouteParityResult implements JsonSerializable
         public array $specs,
         public array $matched,
         public array $documentedButNotRegistered,
+        public array $externalOperations,
         public array $registeredButUndocumented,
         public array $ambiguous,
         public array $unsupported,
@@ -43,17 +45,19 @@ final readonly class RouteParityResult implements JsonSerializable
     public function jsonSerialize(): array
     {
         return [
-            'schema_version' => 1,
+            'schema_version' => 2,
             'specs' => $this->specs,
             'summary' => [
                 'matched' => count($this->matched),
                 'documented_but_not_registered' => count($this->documentedButNotRegistered),
+                'external_operations' => count($this->externalOperations),
                 'registered_but_undocumented' => count($this->registeredButUndocumented),
                 'ambiguous' => count($this->ambiguous),
                 'unsupported' => count($this->unsupported),
             ],
             'matched' => $this->matched,
             'documented_but_not_registered' => $this->documentedButNotRegistered,
+            'external_operations' => $this->externalOperations,
             'registered_but_undocumented' => $this->registeredButUndocumented,
             'ambiguous' => $this->ambiguous,
             'unsupported' => $this->unsupported,

--- a/src/Laravel/config.php
+++ b/src/Laravel/config.php
@@ -17,6 +17,15 @@ return [
     // `strip_prefixes` parameter so static parity and runtime validation agree.
     'strip_prefixes' => [],
 
+    // Documented operations implemented by another service in a gateway
+    // topology. Patterns use Laravel's `Str::is` wildcard matching. These
+    // operations remain visible in route-parity output under
+    // `external_operations`, but do not fail `--fail-on-unimplemented`.
+    'route_parity' => [
+        'external_operation_ids' => [],
+        'external_openapi_paths' => [],
+    ],
+
     // Maximum number of validation errors to report per response.
     // 0 = unlimited (reports all errors).
     'max_errors' => 20,

--- a/tests/Integration/Laravel/GessoServiceProviderIntegrationTest.php
+++ b/tests/Integration/Laravel/GessoServiceProviderIntegrationTest.php
@@ -23,12 +23,12 @@ use function json_encode;
 final class GessoServiceProviderIntegrationTest extends TestCase
 {
     #[Test]
-    public function provider_merges_unchanged_defaults_under_the_gesso_key(): void
+    public function provider_merges_v2_defaults_under_the_gesso_key(): void
     {
         /** @var array<string, mixed> $configuration */
         $configuration = require dirname(__DIR__, 3) . '/src/Laravel/config.php';
         $expected = file_get_contents(
-            dirname(__DIR__, 2) . '/fixtures/compatibility/v1.9-laravel-config.json',
+            dirname(__DIR__, 2) . '/fixtures/compatibility/v2-laravel-config.json',
         );
 
         $this->assertIsString($expected);

--- a/tests/Integration/Laravel/OpenApiRoutesCommandIntegrationTest.php
+++ b/tests/Integration/Laravel/OpenApiRoutesCommandIntegrationTest.php
@@ -32,6 +32,8 @@ final class OpenApiRoutesCommandIntegrationTest extends TestCase
         config()->set('gesso.default_spec', 'route-parity');
         config()->set('gesso.spec_base_path', dirname(__DIR__, 2) . '/fixtures/specs');
         config()->set('gesso.strip_prefixes', ['/api']);
+        config()->set('gesso.route_parity.external_operation_ids', []);
+        config()->set('gesso.route_parity.external_openapi_paths', []);
     }
 
     protected function tearDown(): void
@@ -73,16 +75,17 @@ final class OpenApiRoutesCommandIntegrationTest extends TestCase
 
         $this->assertSame(0, $exitCode);
         $decoded = json_decode(trim(Artisan::output()), true, flags: JSON_THROW_ON_ERROR);
-        $this->assertSame(1, $decoded['schema_version']);
+        $this->assertSame(2, $decoded['schema_version']);
         $this->assertSame(['route-parity', 'route-parity-admin'], $decoded['specs']);
         $this->assertSame(6, $decoded['summary']['matched']);
         $this->assertSame(1, $decoded['summary']['documented_but_not_registered']);
+        $this->assertSame(0, $decoded['summary']['external_operations']);
         $this->assertSame(1, $decoded['summary']['registered_but_undocumented']);
         $this->assertSame(0, $decoded['summary']['ambiguous']);
     }
 
     #[Test]
-    public function json_output_matches_the_v1_9_compatibility_fixture(): void
+    public function json_output_matches_the_v2_compatibility_fixture(): void
     {
         $exitCode = Artisan::call('openapi:routes', [
             '--spec' => ['route-parity', 'route-parity-admin'],
@@ -94,7 +97,7 @@ final class OpenApiRoutesCommandIntegrationTest extends TestCase
         ]);
 
         $expected = file_get_contents(
-            dirname(__DIR__, 2) . '/fixtures/compatibility/v1.9-laravel-route-parity.json',
+            dirname(__DIR__, 2) . '/fixtures/compatibility/v2-laravel-route-parity.json',
         );
 
         $this->assertIsString($expected);
@@ -119,7 +122,7 @@ final class OpenApiRoutesCommandIntegrationTest extends TestCase
         $decoded = json_decode($output, true, flags: JSON_THROW_ON_ERROR);
         $lines = explode("\n", $output);
 
-        $this->assertSame(1, $decoded['schema_version']);
+        $this->assertSame(2, $decoded['schema_version']);
         $this->assertGreaterThan(1_000, count($lines));
         $this->assertLessThan(1_000, max(array_map(strlen(...), $lines)));
     }
@@ -143,6 +146,61 @@ final class OpenApiRoutesCommandIntegrationTest extends TestCase
             ...$options,
             '--fail-on-unimplemented' => true,
         ]));
+    }
+
+    #[Test]
+    public function documented_side_exclusions_are_reported_and_ignored_by_the_strict_gate(): void
+    {
+        $exitCode = Artisan::call('openapi:routes', [
+            '--prefix' => 'api',
+            '--middleware' => ['api'],
+            '--domain' => ['api.example.test'],
+            '--exclude-route' => ['internal.*', 'undocumented'],
+            '--exclude-operation' => ['delete*'],
+            '--format' => 'json',
+            '--fail-on-unimplemented' => true,
+        ]);
+
+        $decoded = json_decode(trim(Artisan::output()), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame(0, $decoded['summary']['documented_but_not_registered']);
+        $this->assertSame(1, $decoded['summary']['external_operations']);
+        $this->assertSame('deleteMissing', $decoded['external_operations'][0]['operation_id']);
+    }
+
+    #[Test]
+    public function documented_side_exclusions_are_loaded_from_config_and_merged_with_options(): void
+    {
+        config()->set('gesso.route_parity.external_operation_ids', ['does-not-match']);
+        config()->set('gesso.route_parity.external_openapi_paths', ['/v1/miss*']);
+
+        $exitCode = Artisan::call('openapi:routes', [
+            '--prefix' => 'api',
+            '--middleware' => ['api'],
+            '--domain' => ['api.example.test'],
+            '--exclude-route' => ['internal.*'],
+            '--exclude-operation' => ['also-does-not-match'],
+            '--format' => 'json',
+        ]);
+
+        $decoded = json_decode(trim(Artisan::output()), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame(1, $decoded['summary']['external_operations']);
+        $this->assertSame('/v1/missing', $decoded['external_operations'][0]['openapi_path']);
+    }
+
+    #[Test]
+    public function invalid_documented_side_exclusion_config_fails_loudly(): void
+    {
+        config()->set('gesso.route_parity.external_operation_ids', 'forms.*');
+
+        $this->assertSame(1, Artisan::call('openapi:routes'));
+        $this->assertStringContainsString(
+            'gesso.route_parity.external_operation_ids must be an array of strings',
+            Artisan::output(),
+        );
     }
 
     #[Test]

--- a/tests/Unit/Laravel/LaravelRouteParityAnalyzerTest.php
+++ b/tests/Unit/Laravel/LaravelRouteParityAnalyzerTest.php
@@ -120,6 +120,53 @@ final class LaravelRouteParityAnalyzerTest extends TestCase
     }
 
     #[Test]
+    public function classifies_unmatched_operation_id_and_path_patterns_as_external(): void
+    {
+        $result = (new LaravelRouteParityAnalyzer())->analyze(
+            ['front' => $this->spec([
+                '/gateway/forms/{formId}' => ['get' => ['operationId' => 'forms.show']],
+                '/gateway/proxy/chat' => ['post' => ['operationId' => 'proxyChat']],
+                '/local/missing' => ['delete' => ['operationId' => 'deleteMissing']],
+            ])],
+            [],
+            filters: [
+                'excluded_operation_ids' => ['forms.*'],
+                'excluded_openapi_paths' => ['/gateway/proxy/*'],
+            ],
+        );
+
+        $this->assertSame(
+            ['forms.show', 'proxyChat'],
+            array_column($result->externalOperations, 'operation_id'),
+        );
+        $this->assertSame(
+            ['deleteMissing'],
+            array_column($result->documentedButNotRegistered, 'operation_id'),
+        );
+    }
+
+    #[Test]
+    public function documented_side_exclusions_do_not_hide_matched_operations(): void
+    {
+        $route = new Route(['GET'], 'gateway/forms/{form}', static fn() => null);
+
+        $result = (new LaravelRouteParityAnalyzer())->analyze(
+            ['front' => $this->spec([
+                '/gateway/forms/{formId}' => ['get' => ['operationId' => 'forms.show']],
+            ])],
+            [$route],
+            filters: [
+                'excluded_operation_ids' => ['forms.*'],
+                'excluded_openapi_paths' => ['/gateway/*'],
+            ],
+        );
+
+        $this->assertCount(1, $result->matched);
+        $this->assertSame([], $result->externalOperations);
+        $this->assertSame([], $result->documentedButNotRegistered);
+    }
+
+    #[Test]
     public function reports_fallback_and_custom_method_without_openapi_declaration(): void
     {
         $fallback = new Route(['GET'], '{fallbackPlaceholder}', static fn() => null);

--- a/tests/fixtures/compatibility/v2-laravel-config.json
+++ b/tests/fixtures/compatibility/v2-laravel-config.json
@@ -1,0 +1,22 @@
+{
+    "default_spec": "",
+    "spec_base_path": "openapi",
+    "strip_prefixes": [],
+    "route_parity": {
+        "external_operation_ids": [],
+        "external_openapi_paths": []
+    },
+    "max_errors": 20,
+    "enforce_discriminator": true,
+    "auto_assert": false,
+    "auto_validate_request": false,
+    "auto_inject_dummy_credentials": false,
+    "auto_inject_dummy_bearer": false,
+    "skip_response_codes": [
+        "5\\d\\d"
+    ],
+    "skip_request_validation_response_codes": [
+        "422",
+        "400"
+    ]
+}

--- a/tests/fixtures/compatibility/v2-laravel-route-parity.json
+++ b/tests/fixtures/compatibility/v2-laravel-route-parity.json
@@ -1,0 +1,90 @@
+{
+    "schema_version": 2,
+    "specs": [
+        "route-parity",
+        "route-parity-admin"
+    ],
+    "summary": {
+        "matched": 6,
+        "documented_but_not_registered": 1,
+        "external_operations": 0,
+        "registered_but_undocumented": 1,
+        "ambiguous": 0,
+        "unsupported": 0
+    },
+    "matched": [
+        {
+            "spec": "route-parity",
+            "method": "GET",
+            "openapi_path": "/v1/pets",
+            "operation_id": "listPets",
+            "route_uri": "/api/v1/pets",
+            "route_name": "pets.index",
+            "domain": "api.example.test"
+        },
+        {
+            "spec": "route-parity-admin",
+            "method": "GET",
+            "openapi_path": "/v1/pets",
+            "operation_id": "adminListPets",
+            "route_uri": "/api/v1/pets",
+            "route_name": "pets.index",
+            "domain": "api.example.test"
+        },
+        {
+            "spec": "route-parity",
+            "method": "POST",
+            "openapi_path": "/v1/pets",
+            "operation_id": "createPet",
+            "route_uri": "/api/v1/pets",
+            "route_name": "pets.index",
+            "domain": "api.example.test"
+        },
+        {
+            "spec": "route-parity",
+            "method": "GET",
+            "openapi_path": "/v1/pets/{petId}",
+            "operation_id": "showPet",
+            "route_uri": "/api/v1/pets/{pet}",
+            "route_name": "pets.show",
+            "domain": "api.example.test"
+        },
+        {
+            "spec": "route-parity",
+            "method": "GET",
+            "openapi_path": "/v1/optional",
+            "operation_id": "listOptional",
+            "route_uri": "/api/v1/optional",
+            "route_name": "optional.show",
+            "domain": "api.example.test"
+        },
+        {
+            "spec": "route-parity",
+            "method": "GET",
+            "openapi_path": "/v1/optional/{optionalId}",
+            "operation_id": "showOptional",
+            "route_uri": "/api/v1/optional/{optional?}",
+            "route_name": "optional.show",
+            "domain": "api.example.test"
+        }
+    ],
+    "documented_but_not_registered": [
+        {
+            "spec": "route-parity",
+            "method": "DELETE",
+            "openapi_path": "/v1/missing",
+            "operation_id": "deleteMissing"
+        }
+    ],
+    "external_operations": [],
+    "registered_but_undocumented": [
+        {
+            "method": "GET",
+            "route_uri": "/api/v1/undocumented",
+            "route_name": "undocumented",
+            "domain": "api.example.test"
+        }
+    ],
+    "ambiguous": [],
+    "unsupported": []
+}


### PR DESCRIPTION
## Summary

- add wildcard-aware documented-side exclusions by operationId and OpenAPI path
- merge CLI exclusions with persistent Laravel route-parity configuration
- report excluded operations separately and keep them out of the `--fail-on-unimplemented` gate
- advance route-parity JSON to `schema_version: 2` with an `external_operations` category
- update v2 compatibility fixtures, migration guidance, and route-parity documentation

## Why

Gateway-backed applications can share one public OpenAPI document while only implementing part of it locally. Previously, expected external operations remained in `documented_but_not_registered`, so `--fail-on-unimplemented` could never become a useful CI gate.

## Breaking change

The versioned route-parity JSON output advances from schema version 1 to 2. Version 2 adds `external_operations` to both the summary and top-level result arrays.

## Verification

- `vendor/bin/phpunit tests/Unit/Laravel/LaravelRouteParityAnalyzerTest.php tests/Integration/Laravel/OpenApiRoutesCommandIntegrationTest.php tests/Integration/Laravel/GessoServiceProviderIntegrationTest.php` — 23 tests, 75 assertions
- `NPM_CONFIG_CACHE=/tmp/gesso-npm-cache vendor/bin/phpunit` — 2113 tests, 5686 assertions
- `vendor/bin/phpstan analyse --no-progress --debug --memory-limit=512M` — no errors
- PHP-CS-Fixer default and Pest configurations in sequential dry-run mode — clean
- VitePress build plus version/base verification — passed
- `git diff --check` — clean

Closes #319
