### PR TITLE
refactor(exception)!: remove deprecated ref reasons

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -53,6 +53,15 @@ This removes the validator's fallback to the process-global tracker. Named
 `maxErrors` and `skipResponseCodes` arguments remain unchanged after the new
 required first argument.
 
+`InvalidOpenApiSpecReason::ExternalRef` and
+`InvalidOpenApiSpecReason::RemoteRefNotImplemented` have been removed. Neither
+case was emitted by production code by the end of v1. Use the specific resolver
+reason instead: local-reference failures use `LocalRefNotFound`,
+`LocalRefUnreadable`, or `LocalRefRequiresSourceFile`; remote-reference failures
+use `RemoteRefDisallowed`, `HttpClientNotConfigured`, or
+`RemoteRefFetchFailed`; unsupported `file:` references use
+`FileSchemeNotSupported`.
+
 ## Within v1.x
 
 The v1.x line is covered end-to-end by SemVer (see "v0.x → v1.0.0"

--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -114,8 +114,12 @@ Studio\OpenApiContractTesting\Exception\SpecFileNotFoundException
 Studio\OpenApiContractTesting\Exception\StrictRequiredDriftException
 ```
 
-The cases of `EnumBindingReason` and `InvalidOpenApiSpecReason`, including
-deprecated cases, must be included in the PHP API snapshot.
+The v1 PHP API snapshot includes every case of `EnumBindingReason` and
+`InvalidOpenApiSpecReason`, including deprecated cases. V2 removes the
+production-unused `InvalidOpenApiSpecReason::ExternalRef` and
+`InvalidOpenApiSpecReason::RemoteRefNotImplemented` cases. Consumers must use
+the specific local, remote, HTTP-client, fetch, or file-scheme reason described
+in the repository's `UPGRADING.md`.
 
 ### Spec loading
 

--- a/src/Exception/InvalidOpenApiSpecReason.php
+++ b/src/Exception/InvalidOpenApiSpecReason.php
@@ -11,28 +11,9 @@ namespace Studio\Gesso\Exception;
  */
 enum InvalidOpenApiSpecReason
 {
-    /**
-     * @deprecated Use the more specific external-ref reasons instead:
-     *             `LocalRefNotFound`, `LocalRefUnreadable`, `LocalRefRequiresSourceFile`,
-     *             `RemoteRefDisallowed`, `HttpClientNotConfigured`,
-     *             `RemoteRefFetchFailed`, or `FileSchemeNotSupported`. Kept for
-     *             backwards compatibility with consumers that branched on this case
-     *             before the resolver learned to follow external `$ref` targets.
-     *             No production code throws this reason any more.
-     */
-    case ExternalRef;
     case LocalRefNotFound;
     case LocalRefUnreadable;
     case LocalRefRequiresSourceFile;
-    /**
-     * @deprecated Use `RemoteRefDisallowed` (when `allowRemoteRefs` is false)
-     *             or `HttpClientNotConfigured` (when the flag is on but no
-     *             PSR-18 client + PSR-17 factory have been provided). Kept
-     *             for backwards compatibility with consumers that branched
-     *             on this case before HTTP `$ref` resolution shipped.
-     *             No production code throws this reason any more.
-     */
-    case RemoteRefNotImplemented;
     case RemoteRefDisallowed;
     case RemoteRefFetchFailed;
     case HttpClientNotConfigured;

--- a/tests/Unit/Compatibility/PublicApiBaselineTest.php
+++ b/tests/Unit/Compatibility/PublicApiBaselineTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 use Studio\Gesso\Coverage\ConsoleCoverageRenderer;
 use Studio\Gesso\Coverage\HtmlCoverageRenderer;
 use Studio\Gesso\Coverage\JsonCoverageRenderer;
+use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
 use Studio\Gesso\Fuzz\ExploredCase;
 use Studio\Gesso\OpenApiResponseValidator;
 use Studio\Gesso\Tests\Helpers\PublicApiInventory;
@@ -111,6 +112,10 @@ final class PublicApiBaselineTest extends TestCase
 
         /** @var array<string, array<string, mixed>> $expected */
         $expected = json_decode($mappedV1Json, true, flags: JSON_THROW_ON_ERROR);
+        unset(
+            $expected[InvalidOpenApiSpecReason::class]['cases']['ExternalRef'],
+            $expected[InvalidOpenApiSpecReason::class]['cases']['RemoteRefNotImplemented'],
+        );
         $expected[JsonCoverageRenderer::class]['constants']['SCHEMA_VERSION'] = 2;
         $expected[ExploredCase::class]['methods']['bodyAsArray'] = [
             'static' => false,

--- a/tests/fixtures/compatibility/v2-public-api.json
+++ b/tests/fixtures/compatibility/v2-public-api.json
@@ -2125,11 +2125,9 @@
         "attributes": [],
         "backing_type": null,
         "cases": {
-            "ExternalRef": null,
             "LocalRefNotFound": null,
             "LocalRefUnreadable": null,
             "LocalRefRequiresSourceFile": null,
-            "RemoteRefNotImplemented": null,
             "RemoteRefDisallowed": null,
             "RemoteRefFetchFailed": null,
             "HttpClientNotConfigured": null,


### PR DESCRIPTION
## Summary

- remove the production-unused `InvalidOpenApiSpecReason::ExternalRef` case
- remove the production-unused `InvalidOpenApiSpecReason::RemoteRefNotImplemented` case
- record the intentional v2 public API delta and document replacement reasons for consumers

## Why

Both cases were retained only for v1 compatibility and are no longer emitted by production code. Removing them before the v2 stable release keeps the public exception taxonomy focused on actionable resolver failures.

## Breaking change

Consumers branching on either removed enum case must switch to the specific local-reference, remote-reference, HTTP-client, fetch, or file-scheme reason documented in `UPGRADING.md`.

## Verification

- `vendor/bin/phpunit` — 2,113 tests, 5,686 assertions
- `vendor/bin/phpunit tests/Unit/Compatibility` — 15 tests, 297 assertions
- `vendor/bin/phpstan analyse --debug --no-progress --memory-limit=1G`
- `vendor/bin/php-cs-fixer fix --dry-run --diff --using-cache=no --sequential`
- `npm run docs:build`
- `npm run docs:links`
- `git diff --check`
