### PR TITLE
test(compatibility): lock trait composition surfaces

### DIFF
--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -43,7 +43,11 @@ php scripts/export-public-api.php --write
 The snapshot includes type kind/modifiers, parent and directly introduced
 interfaces/traits, attributes, enum backing types and cases, public constants,
 public properties, and declared public method signatures. Declarations or
-members marked `@internal` are excluded.
+members marked `@internal` are excluded. The v2 snapshot additionally records
+the complete composition surface of each public trait: methods, properties,
+and constants of every visibility. The historical v1.9 fixture predates that
+inventory capability, so the v1-to-v2 parity assertion projects this additional
+metadata out while the v2 baseline protects it directly.
 
 ## Composer and autoload identity
 
@@ -221,9 +225,11 @@ Studio\OpenApiContractTesting\Psr7\OpenApiPsr7Validator
 Studio\OpenApiContractTesting\Symfony\OpenApiAssertions
 ```
 
-Trait methods, explicit-spec precedence, validation defaults, assertion
-behavior, PSR-7 stream handling, and automatic coverage recording require
-consumer-level fixtures rather than namespace-only checks.
+Trait composition members, explicit-spec precedence, validation defaults,
+assertion behavior, PSR-7 stream handling, and automatic coverage recording
+require consumer-level fixtures rather than namespace-only checks. The PHP API
+snapshot also protects non-`@internal` protected/private trait members because
+they are copied into the consuming class and can conflict with consumer code.
 
 Migration status: implemented on the v2 development line. A fixture captured
 from v1.9.0 pins a representative PSR-7 exchange and Symfony request/response

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -13,6 +13,8 @@ This library follows [Semantic Versioning 2.0](https://semver.org/). v1.0.0 is t
 - Public class names and namespaces (anything not marked `@internal`)
 - Public method signatures (parameters, return types, visibility)
 - Public constants and their values
+- Every non-`@internal` member composed by a public trait, including protected
+  and private methods, properties, and constants
 - Enum cases (additions are minor; removals or renames are major)
 - The `OpenApiValidationResult` shape (`outcome()`, `errors()`, `matchedPath()`, `skipReason()`, `isValid()`, `isSkipped()`)
 - CLI surfaces by major (commands, flags, exit codes, and versioned inputs and

--- a/tests/Helpers/PublicApiInventory.php
+++ b/tests/Helpers/PublicApiInventory.php
@@ -132,12 +132,7 @@ final class PublicApiInventory
                 continue;
             }
 
-            $properties[$property->getName()] = [
-                'type' => $property->hasType() ? (string) $property->getType() : null,
-                'static' => $property->isStatic(),
-                'readonly' => $property->isReadOnly(),
-                'default' => $property->hasDefaultValue() ? self::normaliseValue($property->getDefaultValue()) : ['unavailable' => true],
-            ];
+            $properties[$property->getName()] = self::describeProperty($property);
         }
         ksort($properties);
 
@@ -165,7 +160,7 @@ final class PublicApiInventory
             }
         }
 
-        return [
+        $description = [
             'kind' => $reflection->isTrait() ? 'trait' : ($reflection->isInterface() ? 'interface' : ($reflection->isEnum() ? 'enum' : 'class')),
             'final' => $reflection->isFinal(),
             'abstract' => $reflection->isAbstract(),
@@ -178,6 +173,76 @@ final class PublicApiInventory
             'attributes' => self::describeAttributes($reflection->getAttributes()),
             'backing_type' => $backingType,
             'cases' => $cases,
+            'constants' => $constants,
+            'properties' => $properties,
+            'methods' => $methods,
+        ];
+
+        if ($reflection->isTrait()) {
+            $description['trait_composition'] = self::describeTraitComposition($reflection);
+        }
+
+        return $description;
+    }
+
+    /**
+     * Trait members of every visibility are copied into the consuming class.
+     * Their names and declarations can therefore conflict with consumer code
+     * even when they are protected or private.
+     *
+     * @param ReflectionClass<object> $reflection
+     *
+     * @return array<string, array<string, array<string, mixed>>>
+     */
+    private static function describeTraitComposition(ReflectionClass $reflection): array
+    {
+        $methods = [];
+        foreach ($reflection->getMethods() as $method) {
+            if ($method->getDeclaringClass()->getName() !== $reflection->getName() ||
+                self::isInternal($method->getDocComment())) {
+                continue;
+            }
+
+            $methods[$method->getName()] = [
+                'visibility' => self::visibility($method),
+                ...self::describeMethod($method),
+            ];
+        }
+        ksort($methods);
+
+        $properties = [];
+        foreach ($reflection->getProperties() as $property) {
+            if ($property->getDeclaringClass()->getName() !== $reflection->getName() ||
+                self::isInternal($property->getDocComment())) {
+                continue;
+            }
+
+            $properties[$property->getName()] = [
+                'visibility' => self::visibility($property),
+                ...self::describeProperty($property),
+                'attributes' => self::describeAttributes($property->getAttributes()),
+            ];
+        }
+        ksort($properties);
+
+        $constants = [];
+        foreach ($reflection->getReflectionConstants() as $constant) {
+            if ($constant->getDeclaringClass()->getName() !== $reflection->getName() ||
+                $constant->isEnumCase() ||
+                self::isInternal($constant->getDocComment())) {
+                continue;
+            }
+
+            $constants[$constant->getName()] = [
+                'visibility' => self::visibility($constant),
+                'final' => $constant->isFinal(),
+                'value' => self::normaliseValue($constant->getValue()),
+                'attributes' => self::describeAttributes($constant->getAttributes()),
+            ];
+        }
+        ksort($constants);
+
+        return [
             'constants' => $constants,
             'properties' => $properties,
             'methods' => $methods,
@@ -221,6 +286,23 @@ final class PublicApiInventory
             'attributes' => self::describeAttributes($method->getAttributes()),
             'parameters' => array_map(self::describeParameter(...), $method->getParameters()),
         ];
+    }
+
+    /** @return array<string, mixed> */
+    private static function describeProperty(ReflectionProperty $property): array
+    {
+        return [
+            'type' => $property->hasType() ? (string) $property->getType() : null,
+            'static' => $property->isStatic(),
+            'readonly' => $property->isReadOnly(),
+            'default' => $property->hasDefaultValue() ? self::normaliseValue($property->getDefaultValue()) : ['unavailable' => true],
+        ];
+    }
+
+    private static function visibility(
+        ReflectionClassConstant|ReflectionMethod|ReflectionProperty $member,
+    ): string {
+        return $member->isPublic() ? 'public' : ($member->isProtected() ? 'protected' : 'private');
     }
 
     private static function describeReturnType(ReflectionMethod $method): ?string

--- a/tests/Unit/Compatibility/Fixture/PublicApiTraitSurfaceConsumerFixture.php
+++ b/tests/Unit/Compatibility/Fixture/PublicApiTraitSurfaceConsumerFixture.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Compatibility\Fixture;
+
+final class PublicApiTraitSurfaceConsumerFixture
+{
+    use PublicApiTraitSurfaceFixture;
+}

--- a/tests/Unit/Compatibility/Fixture/PublicApiTraitSurfaceFixture.php
+++ b/tests/Unit/Compatibility/Fixture/PublicApiTraitSurfaceFixture.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Compatibility\Fixture;
+
+trait PublicApiTraitSurfaceFixture
+{
+    public const PUBLIC_CONSTANT = 'public';
+    protected const PROTECTED_CONSTANT = 'protected';
+    private const PRIVATE_CONSTANT = 'private';
+
+    /** @internal Test member that must remain outside the compatibility surface. */
+    private const INTERNAL_CONSTANT = 'internal';
+    protected static ?int $protectedProperty = null;
+    public string $publicProperty = 'public';
+    private bool $privateProperty = false;
+
+    /** @internal Test member that must remain outside the compatibility surface. */
+    private string $internalProperty = 'internal';
+
+    public function publicMethod(): void {}
+
+    protected static function protectedMethod(int $value): string
+    {
+        return (string) $value;
+    }
+
+    private function privateMethod(): string
+    {
+        return self::PRIVATE_CONSTANT . ($this->privateProperty ? '-true' : '-false');
+    }
+
+    /** @internal Test member that must remain outside the compatibility surface. */
+    private function internalMethod(): string
+    {
+        return self::INTERNAL_CONSTANT;
+    }
+}

--- a/tests/Unit/Compatibility/PublicApiBaselineTest.php
+++ b/tests/Unit/Compatibility/PublicApiBaselineTest.php
@@ -32,8 +32,11 @@ use Studio\Gesso\Tests\Helpers\PublicApiInventory;
 use Studio\Gesso\Tests\Unit\Compatibility\Fixture\PublicApiImplicitConstructorFixture;
 use Studio\Gesso\Tests\Unit\Compatibility\Fixture\PublicApiPrivateConstructorFixture;
 use Studio\Gesso\Tests\Unit\Compatibility\Fixture\PublicApiReturnTypeFixture;
+use Studio\Gesso\Tests\Unit\Compatibility\Fixture\PublicApiTraitSurfaceConsumerFixture;
+use Studio\Gesso\Tests\Unit\Compatibility\Fixture\PublicApiTraitSurfaceFixture;
 use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
 
+use function array_keys;
 use function dirname;
 use function file_get_contents;
 use function json_decode;
@@ -77,6 +80,43 @@ final class PublicApiBaselineTest extends TestCase
         $this->assertFalse($privateConstructor['instantiable']);
         $this->assertSame('declared', $privateConstructor['constructor']['kind']);
         $this->assertSame('private', $privateConstructor['constructor']['visibility']);
+    }
+
+    #[Test]
+    public function inventory_records_the_complete_trait_composition_surface(): void
+    {
+        $consumer = new PublicApiTraitSurfaceConsumerFixture();
+        $this->assertSame('public', $consumer->publicProperty);
+
+        $inventory = PublicApiInventory::capture(
+            __DIR__ . '/Fixture',
+            'Studio\\Gesso\\Tests\\Unit\\Compatibility\\Fixture\\',
+        );
+        $surface = $inventory[PublicApiTraitSurfaceFixture::class]['trait_composition'];
+
+        $this->assertSame(
+            ['PRIVATE_CONSTANT', 'PROTECTED_CONSTANT', 'PUBLIC_CONSTANT'],
+            array_keys($surface['constants']),
+        );
+        $this->assertSame('private', $surface['constants']['PRIVATE_CONSTANT']['visibility']);
+        $this->assertSame('protected', $surface['constants']['PROTECTED_CONSTANT']['visibility']);
+        $this->assertSame('public', $surface['constants']['PUBLIC_CONSTANT']['visibility']);
+
+        $this->assertSame(
+            ['privateProperty', 'protectedProperty', 'publicProperty'],
+            array_keys($surface['properties']),
+        );
+        $this->assertSame('private', $surface['properties']['privateProperty']['visibility']);
+        $this->assertSame('protected', $surface['properties']['protectedProperty']['visibility']);
+        $this->assertSame('public', $surface['properties']['publicProperty']['visibility']);
+
+        $this->assertSame(
+            ['privateMethod', 'protectedMethod', 'publicMethod'],
+            array_keys($surface['methods']),
+        );
+        $this->assertSame('private', $surface['methods']['privateMethod']['visibility']);
+        $this->assertSame('protected', $surface['methods']['protectedMethod']['visibility']);
+        $this->assertSame('public', $surface['methods']['publicMethod']['visibility']);
     }
 
     #[Test]
@@ -201,6 +241,11 @@ final class PublicApiBaselineTest extends TestCase
 
         /** @var array<string, array<string, mixed>> $actual */
         $actual = json_decode($v2Json, true, flags: JSON_THROW_ON_ERROR);
+
+        foreach ($actual as &$type) {
+            unset($type['trait_composition']);
+        }
+        unset($type);
 
         $this->assertSame($expected, $actual);
     }

--- a/tests/fixtures/compatibility/v2-public-api.json
+++ b/tests/fixtures/compatibility/v2-public-api.json
@@ -3541,6 +3541,215 @@
                     }
                 ]
             }
+        },
+        "trait_composition": {
+            "constants": [],
+            "properties": {
+                "explicitOpenApiSpec": {
+                    "visibility": "private",
+                    "type": "?string",
+                    "static": false,
+                    "readonly": false,
+                    "default": null,
+                    "attributes": []
+                }
+            },
+            "methods": {
+                "exploreEndpoint": {
+                    "visibility": "public",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "Studio\\Gesso\\Fuzz\\ExplorationCases",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "method",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "path",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "cases",
+                            "type": "int",
+                            "optional": true,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": 30,
+                            "attributes": []
+                        },
+                        {
+                            "name": "seed",
+                            "type": "?int",
+                            "optional": true,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": null,
+                            "attributes": []
+                        }
+                    ]
+                },
+                "exploreInvalidEndpoint": {
+                    "visibility": "public",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "Studio\\Gesso\\Fuzz\\ExplorationCases",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "method",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "path",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "expectedStatusClasses",
+                            "type": "array",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "cases",
+                            "type": "int",
+                            "optional": true,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": 30,
+                            "attributes": []
+                        },
+                        {
+                            "name": "seed",
+                            "type": "?int",
+                            "optional": true,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": null,
+                            "attributes": []
+                        }
+                    ]
+                },
+                "exploreSpec": {
+                    "visibility": "public",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "Studio\\Gesso\\Fuzz\\OpenApiSpecExploration",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "casesPerOperation",
+                            "type": "int",
+                            "optional": true,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": 30,
+                            "attributes": []
+                        },
+                        {
+                            "name": "seed",
+                            "type": "int",
+                            "optional": true,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": 1,
+                            "attributes": []
+                        }
+                    ]
+                },
+                "failExplore": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "never",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "message",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "openApiSpec": {
+                    "visibility": "protected",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "string",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "openApiSpecFallback": {
+                    "visibility": "protected",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "string",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "resolveOpenApiSpec": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "string",
+                    "attributes": [],
+                    "parameters": []
+                }
+            }
         }
     },
     "Studio\\Gesso\\Laravel\\GessoServiceProvider": {
@@ -3648,6 +3857,1025 @@
                 "return_type": "static",
                 "attributes": [],
                 "parameters": []
+            }
+        },
+        "trait_composition": {
+            "constants": {
+                "DUMMY_API_KEY_VALUE": {
+                    "visibility": "private",
+                    "final": false,
+                    "value": "test-api-key",
+                    "attributes": []
+                },
+                "DUMMY_BEARER_TOKEN": {
+                    "visibility": "private",
+                    "final": false,
+                    "value": "test-token",
+                    "attributes": []
+                }
+            },
+            "properties": {
+                "cachedMaxErrors": {
+                    "visibility": "private",
+                    "type": "?int",
+                    "static": true,
+                    "readonly": false,
+                    "default": null,
+                    "attributes": []
+                },
+                "cachedRequestMaxErrors": {
+                    "visibility": "private",
+                    "type": "?int",
+                    "static": true,
+                    "readonly": false,
+                    "default": null,
+                    "attributes": []
+                },
+                "cachedRequestValidator": {
+                    "visibility": "private",
+                    "type": "?Studio\\Gesso\\OpenApiRequestValidator",
+                    "static": true,
+                    "readonly": false,
+                    "default": null,
+                    "attributes": []
+                },
+                "cachedSecuritySchemeIntrospector": {
+                    "visibility": "private",
+                    "type": "?Studio\\Gesso\\Validation\\Request\\SecuritySchemeIntrospector",
+                    "static": true,
+                    "readonly": false,
+                    "default": null,
+                    "attributes": []
+                },
+                "cachedSkipRequestValidationResponseCodes": {
+                    "visibility": "private",
+                    "type": "?array",
+                    "static": true,
+                    "readonly": false,
+                    "default": null,
+                    "attributes": []
+                },
+                "cachedSkipResponseCodes": {
+                    "visibility": "private",
+                    "type": "?array",
+                    "static": true,
+                    "readonly": false,
+                    "default": null,
+                    "attributes": []
+                },
+                "cachedValidator": {
+                    "visibility": "private",
+                    "type": "?Studio\\Gesso\\OpenApiResponseValidator",
+                    "static": true,
+                    "readonly": false,
+                    "default": null,
+                    "attributes": []
+                },
+                "explicitOpenApiSpec": {
+                    "visibility": "private",
+                    "type": "?string",
+                    "static": false,
+                    "readonly": false,
+                    "default": null,
+                    "attributes": []
+                },
+                "skipNextRequestValidation": {
+                    "visibility": "private",
+                    "type": "bool",
+                    "static": false,
+                    "readonly": false,
+                    "default": false,
+                    "attributes": []
+                },
+                "skipNextResponseCodes": {
+                    "visibility": "private",
+                    "type": "array",
+                    "static": false,
+                    "readonly": false,
+                    "default": [],
+                    "attributes": []
+                },
+                "skipNextResponseValidation": {
+                    "visibility": "private",
+                    "type": "bool",
+                    "static": false,
+                    "readonly": false,
+                    "default": false,
+                    "attributes": []
+                },
+                "skipWarningHandler": {
+                    "visibility": "private",
+                    "type": null,
+                    "static": true,
+                    "readonly": false,
+                    "default": null,
+                    "attributes": []
+                },
+                "validatedResponses": {
+                    "visibility": "private",
+                    "type": "?WeakMap",
+                    "static": true,
+                    "readonly": false,
+                    "default": null,
+                    "attributes": []
+                }
+            },
+            "methods": {
+                "applyDiscriminatorEnforcementConfig": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "void",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "assertOpenApi": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "void",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "condition",
+                            "type": "bool",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "message",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "assertResponseMatchesOpenApiSchema": {
+                    "visibility": "protected",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "void",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "response",
+                            "type": "Illuminate\\Testing\\TestResponse",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "method",
+                            "type": "?Studio\\Gesso\\HttpMethod",
+                            "optional": true,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": null,
+                            "attributes": []
+                        },
+                        {
+                            "name": "path",
+                            "type": "?string",
+                            "optional": true,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": null,
+                            "attributes": []
+                        },
+                        {
+                            "name": "extraSkipResponseCodes",
+                            "type": "array",
+                            "optional": true,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": [],
+                            "attributes": []
+                        }
+                    ]
+                },
+                "buildOneOffValidator": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "Studio\\Gesso\\OpenApiResponseValidator",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "extraSkipResponseCodes",
+                            "type": "array",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "createTestResponse": {
+                    "visibility": "protected",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "Illuminate\\Testing\\TestResponse",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "response",
+                            "type": null,
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "request",
+                            "type": null,
+                            "optional": true,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": null,
+                            "attributes": []
+                        }
+                    ]
+                },
+                "dispatchSkipWarning": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "void",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "message",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "emitSkipOpenApiWarning": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "void",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "attribute",
+                            "type": "Studio\\Gesso\\Attribute\\SkipOpenApi",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "emitSkipResponseCodeWarning": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "void",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "extractJsonBody": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "Studio\\Gesso\\DecodedBody",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "content",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "contentType",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "extractRequestBody": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "Studio\\Gesso\\DecodedBody",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "request",
+                            "type": "Symfony\\Component\\HttpFoundation\\Request",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "contentType",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "failOpenApi": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "never",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "message",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "findOperationForRequest": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "?array",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "paths",
+                            "type": "array",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "method",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "path",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "findSkipOpenApiAttribute": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "?Studio\\Gesso\\Attribute\\SkipOpenApi",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "getOrCreateRequestValidator": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "Studio\\Gesso\\OpenApiRequestValidator",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "getOrCreateValidator": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "Studio\\Gesso\\OpenApiResponseValidator",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "getSecuritySchemeIntrospector": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "Studio\\Gesso\\Validation\\Request\\SecuritySchemeIntrospector",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "isAlreadyValidated": {
+                    "visibility": "private",
+                    "static": true,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "bool",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "response",
+                            "type": "Illuminate\\Testing\\TestResponse",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "signature",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "isAutoAssertEnabled": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "bool",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "isAutoInjectDummyBearerEnabled": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "bool",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "isAutoInjectDummyCredentialsEnabled": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "bool",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "isAutoValidateRequestEnabled": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "bool",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "markValidated": {
+                    "visibility": "private",
+                    "static": true,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "void",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "response",
+                            "type": "Illuminate\\Testing\\TestResponse",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "signature",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "maybeAutoAssertOpenApiSchema": {
+                    "visibility": "protected",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "void",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "response",
+                            "type": "Illuminate\\Testing\\TestResponse",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "method",
+                            "type": "?Studio\\Gesso\\HttpMethod",
+                            "optional": true,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": null,
+                            "attributes": []
+                        },
+                        {
+                            "name": "path",
+                            "type": "?string",
+                            "optional": true,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": null,
+                            "attributes": []
+                        }
+                    ]
+                },
+                "maybeAutoValidateOpenApiRequest": {
+                    "visibility": "protected",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "void",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "request",
+                            "type": "?Symfony\\Component\\HttpFoundation\\Request",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "method",
+                            "type": "?Studio\\Gesso\\HttpMethod",
+                            "optional": true,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": null,
+                            "attributes": []
+                        },
+                        {
+                            "name": "path",
+                            "type": "?string",
+                            "optional": true,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": null,
+                            "attributes": []
+                        },
+                        {
+                            "name": "responseStatusCode",
+                            "type": "?int",
+                            "optional": true,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": null,
+                            "attributes": []
+                        }
+                    ]
+                },
+                "normalizeSkipCode": {
+                    "visibility": "private",
+                    "static": true,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "string",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "code",
+                            "type": "string|int",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "openApiSpec": {
+                    "visibility": "protected",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "string",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "openApiSpecFallback": {
+                    "visibility": "protected",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "string",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "resolveAutoInjectCredentials": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "array",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "specName",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "method",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "path",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "headers",
+                            "type": "array",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "cookies",
+                            "type": "array",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "queryParams",
+                            "type": "array",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "resolveBoolConfig": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "bool",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "key",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "default",
+                            "type": "bool",
+                            "optional": true,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": false,
+                            "attributes": []
+                        }
+                    ]
+                },
+                "resolveMaxErrors": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "int",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "resolveOpenApiSpec": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "string",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "resolveSkipRequestValidationResponseCodes": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "array",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "resolveSkipResponseCodes": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "array",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "runRequestAssertion": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "void",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "request",
+                            "type": "Symfony\\Component\\HttpFoundation\\Request",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "method",
+                            "type": "Studio\\Gesso\\HttpMethod",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "path",
+                            "type": "?string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "responseStatusCode",
+                            "type": "?int",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "shouldSkipOpenApi": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "bool",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "skipResponseCode": {
+                    "visibility": "public",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "static",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "codes",
+                            "type": "array|string|int",
+                            "optional": true,
+                            "variadic": true,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "slotIsAlreadyPopulated": {
+                    "visibility": "private",
+                    "static": true,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "bool",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "value",
+                            "type": "mixed",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "withoutRequestValidation": {
+                    "visibility": "public",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "static",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "withoutResponseValidation": {
+                    "visibility": "public",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "static",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "withoutValidation": {
+                    "visibility": "public",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "static",
+                    "attributes": [],
+                    "parameters": []
+                }
             }
         }
     },
@@ -4437,6 +5665,34 @@
                     }
                 ]
             }
+        },
+        "trait_composition": {
+            "constants": [],
+            "properties": [],
+            "methods": {
+                "assertNoEnumDrift": {
+                    "visibility": "public",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "void",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "enumFqcns",
+                            "type": "array",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                }
+            }
         }
     },
     "Studio\\Gesso\\PHPUnit\\OpenApiCoverageExtension": {
@@ -4670,6 +5926,336 @@
                         "attributes": []
                     }
                 ]
+            }
+        },
+        "trait_composition": {
+            "constants": [],
+            "properties": {
+                "cachedPsr7SpecName": {
+                    "visibility": "private",
+                    "type": "?string",
+                    "static": false,
+                    "readonly": false,
+                    "default": null,
+                    "attributes": []
+                },
+                "cachedPsr7Validator": {
+                    "visibility": "private",
+                    "type": "?Studio\\Gesso\\Psr7\\OpenApiPsr7Validator",
+                    "static": false,
+                    "readonly": false,
+                    "default": null,
+                    "attributes": []
+                },
+                "explicitOpenApiSpec": {
+                    "visibility": "private",
+                    "type": "?string",
+                    "static": false,
+                    "readonly": false,
+                    "default": null,
+                    "attributes": []
+                }
+            },
+            "methods": {
+                "assertPsr7": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "void",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "condition",
+                            "type": "bool",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "message",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "assertPsr7ExchangeMatchesOpenApiSchema": {
+                    "visibility": "public",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "void",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "request",
+                            "type": "Psr\\Http\\Message\\RequestInterface",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "response",
+                            "type": "Psr\\Http\\Message\\ResponseInterface",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "assertPsr7RequestMatchesOpenApiSchema": {
+                    "visibility": "public",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "void",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "request",
+                            "type": "Psr\\Http\\Message\\RequestInterface",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "responseStatusCode",
+                            "type": "?int",
+                            "optional": true,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": null,
+                            "attributes": []
+                        }
+                    ]
+                },
+                "assertPsr7ResponseForOperationMatchesOpenApiSchema": {
+                    "visibility": "public",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "void",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "method",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "requestPath",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "response",
+                            "type": "Psr\\Http\\Message\\ResponseInterface",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "assertPsr7ResponseMatchesOpenApiSchema": {
+                    "visibility": "public",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "void",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "request",
+                            "type": "Psr\\Http\\Message\\RequestInterface",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "response",
+                            "type": "Psr\\Http\\Message\\ResponseInterface",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "assertPsr7Result": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "void",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "result",
+                            "type": "Studio\\Gesso\\OpenApiValidationResult",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "prefix",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "failPsr7": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "never",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "message",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "openApiMaxErrors": {
+                    "visibility": "protected",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "int",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "openApiSkipRequestValidationResponseCodes": {
+                    "visibility": "protected",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "array",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "openApiSkipResponseCodes": {
+                    "visibility": "protected",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "array",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "openApiSpec": {
+                    "visibility": "protected",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "string",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "openApiSpecFallback": {
+                    "visibility": "protected",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "string",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "psr7Validator": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "Studio\\Gesso\\Psr7\\OpenApiPsr7Validator",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "resolveOpenApiSpec": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "string",
+                    "attributes": [],
+                    "parameters": []
+                }
             }
         }
     },
@@ -5327,7 +6913,42 @@
         "cases": [],
         "constants": [],
         "properties": [],
-        "methods": []
+        "methods": [],
+        "trait_composition": {
+            "constants": [],
+            "properties": {
+                "explicitOpenApiSpec": {
+                    "visibility": "private",
+                    "type": "?string",
+                    "static": false,
+                    "readonly": false,
+                    "default": null,
+                    "attributes": []
+                }
+            },
+            "methods": {
+                "openApiSpecFallback": {
+                    "visibility": "protected",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "string",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "resolveOpenApiSpec": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "string",
+                    "attributes": [],
+                    "parameters": []
+                }
+            }
+        }
     },
     "Studio\\Gesso\\Symfony\\OpenApiAssertions": {
         "kind": "trait",
@@ -5447,6 +7068,332 @@
                         "attributes": []
                     }
                 ]
+            }
+        },
+        "trait_composition": {
+            "constants": [],
+            "properties": {
+                "cachedSymfonyRequestValidator": {
+                    "visibility": "private",
+                    "type": "?Studio\\Gesso\\OpenApiRequestValidator",
+                    "static": false,
+                    "readonly": false,
+                    "default": null,
+                    "attributes": []
+                },
+                "cachedSymfonyResponseValidator": {
+                    "visibility": "private",
+                    "type": "?Studio\\Gesso\\OpenApiResponseValidator",
+                    "static": false,
+                    "readonly": false,
+                    "default": null,
+                    "attributes": []
+                },
+                "explicitOpenApiSpec": {
+                    "visibility": "private",
+                    "type": "?string",
+                    "static": false,
+                    "readonly": false,
+                    "default": null,
+                    "attributes": []
+                }
+            },
+            "methods": {
+                "assertClientMatchesOpenApiSchema": {
+                    "visibility": "public",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "void",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "client",
+                            "type": "Symfony\\Component\\HttpKernel\\HttpKernelBrowser",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "extraSkipResponseCodes",
+                            "type": "array",
+                            "optional": true,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": [],
+                            "attributes": []
+                        }
+                    ]
+                },
+                "assertOpenApi": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "void",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "condition",
+                            "type": "bool",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "message",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "assertRequestMatchesOpenApiSchema": {
+                    "visibility": "public",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "void",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "request",
+                            "type": "Symfony\\Component\\HttpFoundation\\Request",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "responseStatusCode",
+                            "type": "?int",
+                            "optional": true,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": null,
+                            "attributes": []
+                        }
+                    ]
+                },
+                "assertResponseMatchesOpenApiSchema": {
+                    "visibility": "public",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "void",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "request",
+                            "type": "Symfony\\Component\\HttpFoundation\\Request",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "response",
+                            "type": "Symfony\\Component\\HttpFoundation\\Response",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "extraSkipResponseCodes",
+                            "type": "array",
+                            "optional": true,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": [],
+                            "attributes": []
+                        }
+                    ]
+                },
+                "extractSymfonyJsonBody": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "Studio\\Gesso\\DecodedBody",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "content",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "contentType",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "subject",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "failOpenApi": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "never",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "message",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "openApiMaxErrors": {
+                    "visibility": "protected",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "int",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "openApiSpec": {
+                    "visibility": "protected",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "string",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "openApiSpecFallback": {
+                    "visibility": "protected",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "string",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "resolveOpenApiSpec": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "string",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "resolveSymfonyHttpMethod": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "Studio\\Gesso\\HttpMethod",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "request",
+                            "type": "Symfony\\Component\\HttpFoundation\\Request",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
+                "resolveSymfonyOpenApiSpec": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "string",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "symfonyRequestValidator": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "Studio\\Gesso\\OpenApiRequestValidator",
+                    "attributes": [],
+                    "parameters": []
+                },
+                "symfonyResponseValidator": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "Studio\\Gesso\\OpenApiResponseValidator",
+                    "attributes": [],
+                    "parameters": []
+                }
             }
         }
     },


### PR DESCRIPTION
## Summary

- extend the public API inventory with a dedicated `trait_composition` surface
- snapshot non-`@internal` trait methods, properties, and constants across public, protected, and private visibility
- add focused fixtures covering visibility and `@internal` exclusions
- document the v2 trait compatibility policy while preserving the historical v1.9 comparison projection

## Why

Trait members are copied into the consuming class. Protected and private method names, property declarations, and constants can therefore conflict with consumer code even though they were absent from the existing public-only reflection snapshot.

The previous baseline could miss breaking changes such as renaming a protected extension hook, changing a composed property type, or introducing an incompatible private member.

## Impact

This does not change runtime behavior. It strengthens future compatibility checks for the six public Gesso traits. Regular classes continue to snapshot only their public API, and members marked `@internal` remain excluded.

## Verification

- `vendor/bin/phpunit` — 2,114 tests, 5,665 assertions
- `vendor/bin/phpunit tests/Unit/Compatibility` — 16 tests, 276 assertions
- `vendor/bin/phpstan analyse --debug --no-progress --memory-limit=1G`
- `vendor/bin/php-cs-fixer fix --dry-run --diff --using-cache=no --sequential`
- `npm run docs:build`
- `npm run docs:links`
- regenerated public API output matches `v2-public-api.json`
- `git diff --check`
