### PR TITLE
docs: align v2 support policy

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -24,8 +24,10 @@ boots successfully on v2.
 
 Coverage JSON consumers must accept `schema_version: 2` and the fixed
 `tool.name` value `studio-design/gesso`. The remaining coverage fields retain
-their v1 meanings. Doctor JSON, Laravel route parity JSON, sidecar envelopes,
-and tracker-state versions are unchanged; see the
+their v1 meanings. Laravel route parity JSON consumers must also accept
+`schema_version: 2`, including the new `external_operations` result and summary
+count. Doctor JSON remains at `schemaVersion: 1`; sidecar envelope and
+tracker-state versions are unchanged. See the
 [v2 migration guide](docs/migration/v2.md#update-coverage-json-consumers).
 
 Update log routing for the optional-Faker warning and Laravel contradictory-

--- a/docs/adr/0001-gesso-v2-identity.md
+++ b/docs/adr/0001-gesso-v2-identity.md
@@ -198,11 +198,11 @@ fail loudly rather than being interpreted as the nearest known shape.
 
 The implementation must pin the coverage JSON v2 document and Gesso tool
 identity with a golden fixture. It must also retain regression tests proving
-that Doctor and route parity still emit version 1 and that the v2 sidecar reader
-accepts every older payload promised by the versioning policy. JSON Schema
-defines a fixed value as the equivalent of a single-value enum, so changing the
-documented tool name is an incompatible value constraint even though no member
-is added or removed.
+that Doctor still emits version 1, route parity emits version 2, and the v2
+sidecar reader accepts every older payload promised by the versioning policy.
+JSON Schema defines a fixed value as the equivalent of a single-value enum, so
+changing the documented tool name is an incompatible value constraint even
+though no member is added or removed.
 
 ### Resolver provenance extension transition policy
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -78,12 +78,15 @@ See [UPGRADING.md](https://github.com/studio-design/gesso/blob/main/UPGRADING.md
 
 | Component | Supported |
 | --- | --- |
-| PHP runtime | 8.2, 8.3, 8.4 (CI matrix). PHP 8.2 is supported until its security-EOL (2026-12); a SemVer-major bump may drop it after that. |
-| PHPUnit | 11.x, 12.x, 13.x (CI matrix). New stable PHPUnit majors are added to the matrix; older majors are dropped in a SemVer-major bump. |
-| `opis/json-schema` | `^2.6` for v1.x. A jump to `^3` would be a SemVer-major. |
+| PHP runtime | v2.x: 8.3, 8.4, 8.5 (CI matrix). v1.x: `^8.2`, subject to the lifecycle below. |
+| PHPUnit | v2.x: 12.x, 13.x. v1.x: 11.x, 12.x, 13.x. Each line is covered by its branch CI matrix. |
+| `opis/json-schema` | `^2.6` for v1.x and v2.x. A jump to `^3` would be a SemVer-major. |
 | Laravel (optional adapter) | Whatever `orchestra/testbench` `^9 \|\| ^10 \|\| ^11` supports. |
 
-Bug fixes and security updates land on the latest minor of v1.x. There is no LTS branch for older minors — upgrade to the latest minor to receive fixes.
+After v2 stable, v2 bug fixes and security updates land on its latest minor.
+The v1 line follows the maintenance lifecycle below. Neither major maintains
+older minor branches; upgrade to the latest minor of the selected major to
+receive fixes.
 
 ## v1 maintenance lifecycle
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -78,7 +78,7 @@ See [UPGRADING.md](https://github.com/studio-design/gesso/blob/main/UPGRADING.md
 
 | Component | Supported |
 | --- | --- |
-| PHP runtime | v2.x: 8.3, 8.4, 8.5 (CI matrix). v1.x: `^8.2`, subject to the lifecycle below. |
+| PHP runtime | v2.x — CI: 8.3, 8.4, 8.5; Composer: `^8.3`. v1.x — CI: 8.2, 8.3, 8.4; Composer: `^8.2`, subject to the lifecycle below. |
 | PHPUnit | v2.x: 12.x, 13.x. v1.x: 11.x, 12.x, 13.x. Each line is covered by its branch CI matrix. |
 | `opis/json-schema` | `^2.6` for v1.x and v2.x. A jump to `^3` would be a SemVer-major. |
 | Laravel (optional adapter) | Whatever `orchestra/testbench` `^9 \|\| ^10 \|\| ^11` supports. |

--- a/tests/Unit/Build/RuntimeSupportPolicyTest.php
+++ b/tests/Unit/Build/RuntimeSupportPolicyTest.php
@@ -89,6 +89,30 @@ final class RuntimeSupportPolicyTest extends TestCase
         $this->assertStringNotContainsString('composer require --dev "phpunit/phpunit:', $workflow);
     }
 
+    #[Test]
+    public function documentation_distinguishes_v1_and_v2_support_surfaces(): void
+    {
+        $versioning = file_get_contents(__DIR__ . '/../../../docs/versioning.md');
+        $upgrading = file_get_contents(__DIR__ . '/../../../UPGRADING.md');
+
+        $this->assertNotFalse($versioning);
+        $this->assertNotFalse($upgrading);
+        $this->assertStringContainsString('v2.x: 8.3, 8.4, 8.5', $versioning);
+        $this->assertStringContainsString('v1.x: `^8.2`', $versioning);
+        $this->assertStringContainsString('v2.x: 12.x, 13.x', $versioning);
+        $this->assertStringContainsString('v1.x: 11.x, 12.x, 13.x', $versioning);
+        $this->assertStringContainsString(
+            'Laravel route parity JSON consumers must also accept',
+            $upgrading,
+        );
+        $this->assertStringContainsString('`schema_version: 2`', $upgrading);
+        $this->assertStringContainsString('`external_operations`', $upgrading);
+        $this->assertStringNotContainsString(
+            'Doctor JSON, Laravel route parity JSON',
+            $upgrading,
+        );
+    }
+
     /**
      * @return array<string, mixed>
      *

--- a/tests/Unit/Build/RuntimeSupportPolicyTest.php
+++ b/tests/Unit/Build/RuntimeSupportPolicyTest.php
@@ -94,11 +94,19 @@ final class RuntimeSupportPolicyTest extends TestCase
     {
         $versioning = file_get_contents(__DIR__ . '/../../../docs/versioning.md');
         $upgrading = file_get_contents(__DIR__ . '/../../../UPGRADING.md');
+        $identityAdr = file_get_contents(__DIR__ . '/../../../docs/adr/0001-gesso-v2-identity.md');
 
         $this->assertNotFalse($versioning);
         $this->assertNotFalse($upgrading);
-        $this->assertStringContainsString('v2.x: 8.3, 8.4, 8.5', $versioning);
-        $this->assertStringContainsString('v1.x: `^8.2`', $versioning);
+        $this->assertNotFalse($identityAdr);
+        $this->assertStringContainsString(
+            'v2.x — CI: 8.3, 8.4, 8.5; Composer: `^8.3`',
+            $versioning,
+        );
+        $this->assertStringContainsString(
+            'v1.x — CI: 8.2, 8.3, 8.4; Composer: `^8.2`',
+            $versioning,
+        );
         $this->assertStringContainsString('v2.x: 12.x, 13.x', $versioning);
         $this->assertStringContainsString('v1.x: 11.x, 12.x, 13.x', $versioning);
         $this->assertStringContainsString(
@@ -110,6 +118,14 @@ final class RuntimeSupportPolicyTest extends TestCase
         $this->assertStringNotContainsString(
             'Doctor JSON, Laravel route parity JSON',
             $upgrading,
+        );
+        $this->assertStringContainsString(
+            'Doctor still emits version 1, route parity emits version 2',
+            $identityAdr,
+        );
+        $this->assertStringNotContainsString(
+            'Doctor and route parity still emit version 1',
+            $identityAdr,
         );
     }
 


### PR DESCRIPTION
## Summary

- distinguish the v1 and v2 PHP/PHPUnit support matrices
- document the v2 Laravel route-parity JSON schema and `external_operations`
- add an invariant test that prevents the support and upgrade guidance from drifting again

## Why

The support table still described the v1 runtime matrix as the current policy, while `UPGRADING.md` incorrectly stated that Laravel route-parity JSON remained unchanged in v2. This conflicted with `composer.json`, the CI matrix, and the v2 route-parity output contract.

## Impact

Documentation now accurately separates v1 maintenance from v2 support and warns JSON consumers about the v2 route-parity format. Runtime behavior is unchanged.

## Validation

- `vendor/bin/phpunit tests/Unit/Build/RuntimeSupportPolicyTest.php`
- `HOME=/tmp/gesso-audit-home NPM_CONFIG_CACHE=/tmp/gesso-audit-npm XDG_STATE_HOME=/tmp/gesso-audit-state vendor/bin/phpunit`
- `vendor/bin/phpstan analyse --debug --no-progress --memory-limit=1G`
- `vendor/bin/php-cs-fixer fix --dry-run --diff --using-cache=no --sequential`
- `npm run docs:build`
- `npm run docs:links`
- `git diff --check`
