### PR TITLE
fix(build): exclude generated files from archives

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -104,6 +104,11 @@
     },
     "archive": {
         "exclude": [
+            "/vendor",
+            "/composer.lock",
+            "/node_modules",
+            "/docs/.vitepress/cache",
+            "/docs/.vitepress/dist",
             "/tests",
             "/examples",
             "/scripts",

--- a/tests/Unit/Build/ComposerArchivePolicyTest.php
+++ b/tests/Unit/Build/ComposerArchivePolicyTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Build;
+
+use const JSON_THROW_ON_ERROR;
+
+use JsonException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function file_get_contents;
+use function json_decode;
+
+final class ComposerArchivePolicyTest extends TestCase
+{
+    /**
+     * @throws JsonException
+     */
+    #[Test]
+    public function generated_development_files_are_excluded_from_archives(): void
+    {
+        $contents = file_get_contents(__DIR__ . '/../../../composer.json');
+
+        $this->assertNotFalse($contents);
+
+        /** @var array{archive?: array{exclude?: list<string>}} $composer */
+        $composer = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        $excluded = $composer['archive']['exclude'] ?? [];
+
+        foreach (
+            [
+                '/vendor',
+                '/composer.lock',
+                '/node_modules',
+                '/docs/.vitepress/cache',
+                '/docs/.vitepress/dist',
+            ] as $generatedPath
+        ) {
+            $this->assertContains($generatedPath, $excluded);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- exclude local Composer and Node dependencies from `composer archive`
- exclude the library lockfile and generated VitePress cache/output
- add an invariant test for the required archive exclusions

## Why

Composer's `archive.exclude` does not automatically reuse `.gitignore`. As a result, a local archive included `vendor`, `node_modules`, `composer.lock`, and generated VitePress files, producing a 198 MB package.

## Impact

The same working tree now produces a 2.9 MB archive while retaining `composer.json`, the CLI, README, LICENSE, and runtime source files. Runtime behavior and Packagist dependency resolution are unchanged.

## Validation

- `vendor/bin/phpunit tests/Unit/Build/ComposerArchivePolicyTest.php`
- full PHPUnit suite: 2,116 tests / 5,684 assertions
- `composer stan -- --debug --no-progress --memory-limit=1G`
- both PHP-CS-Fixer configurations in sequential dry-run mode
- `composer validate --strict`
- `composer audit --abandoned=fail`
- generated and inspected the before/after Composer archives
- `git diff --check`
