### PR TITLE
fix(ci): enforce least-privilege workflow tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main, 1.x]
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: PHP ${{ matrix.php }} / PHPUnit ${{ matrix.phpunit }}${{ matrix.deps == 'lowest' && ' / lowest deps' || '' }}
@@ -36,6 +39,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
@@ -72,6 +77,8 @@ jobs:
         php: ['8.3', '8.4', '8.5']
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
@@ -99,6 +106,8 @@ jobs:
     # cover the matrix.
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
@@ -119,6 +128,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
@@ -149,6 +160,8 @@ jobs:
             php: '8.3'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
@@ -169,6 +182,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -203,6 +218,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
@@ -221,6 +238,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
@@ -239,6 +258,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
@@ -257,6 +278,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
@@ -278,6 +301,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pages: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,10 +6,7 @@ on:
     tags: ['v*']
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: pages
@@ -18,9 +15,12 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup Node
@@ -49,6 +49,9 @@ jobs:
           path: docs/.vitepress/dist
 
   deploy:
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/tag-guard.yml
+++ b/.github/workflows/tag-guard.yml
@@ -13,6 +13,8 @@ on:
     tags:
       - 'v*'
 
+permissions: {}
+
 jobs:
   guard:
     name: Reject non-bot v* tag

--- a/tests/Unit/Build/GitHubActionsSecurityPolicyTest.php
+++ b/tests/Unit/Build/GitHubActionsSecurityPolicyTest.php
@@ -6,12 +6,12 @@ namespace Studio\Gesso\Tests\Unit\Build;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
 
-use function file_get_contents;
+use function array_key_exists;
 use function glob;
-use function preg_match_all;
-use function str_contains;
-use function substr_count;
+use function is_string;
+use function str_starts_with;
 
 final class GitHubActionsSecurityPolicyTest extends TestCase
 {
@@ -25,9 +25,9 @@ final class GitHubActionsSecurityPolicyTest extends TestCase
         $this->assertNotEmpty($workflows);
 
         foreach ($workflows as $path) {
-            $workflow = $this->read($path);
-            $this->assertMatchesRegularExpression(
-                '/^permissions:(?: \{\}|\n)/m',
+            $workflow = $this->parse($path);
+            $this->assertArrayHasKey(
+                'permissions',
                 $workflow,
                 "{$path} must not inherit the repository's default GITHUB_TOKEN permissions.",
             );
@@ -35,65 +35,141 @@ final class GitHubActionsSecurityPolicyTest extends TestCase
     }
 
     #[Test]
-    public function ci_is_read_only_and_does_not_persist_checkout_credentials(): void
+    public function ci_is_read_only_at_workflow_and_job_level(): void
     {
-        $workflow = $this->read(self::WORKFLOW_DIR . '/ci.yml');
+        $workflow = $this->parse(self::WORKFLOW_DIR . '/ci.yml');
 
-        $this->assertMatchesRegularExpression('/^permissions:\n  contents: read\n/m', $workflow);
-        $this->assertStringNotContainsString('contents: write', $workflow);
-        $this->assertStringNotContainsString('pull-requests: write', $workflow);
-        $this->assertStringNotContainsString('id-token: write', $workflow);
+        $this->assertSame(['contents' => 'read'], $workflow['permissions'] ?? null);
+        foreach ($this->jobs($workflow) as $jobName => $job) {
+            $this->assertIsArray($job, "CI job {$jobName} must be a mapping.");
+            if (!array_key_exists('permissions', $job)) {
+                continue;
+            }
+
+            $this->assertContainsNoWritePermission($job['permissions'], "CI job {$jobName}");
+        }
+
         $this->assertCheckoutCredentialsAreNotPersisted($workflow);
     }
 
     #[Test]
-    public function tag_guard_has_no_token_permissions(): void
+    public function tag_guard_has_no_workflow_or_job_token_permissions(): void
     {
-        $workflow = $this->read(self::WORKFLOW_DIR . '/tag-guard.yml');
+        $workflow = $this->parse(self::WORKFLOW_DIR . '/tag-guard.yml');
 
-        $this->assertMatchesRegularExpression('/^permissions: \{\}\n/m', $workflow);
-        $this->assertStringNotContainsString('contents:', $workflow);
-        $this->assertStringNotContainsString('pull-requests:', $workflow);
+        $this->assertSame([], $workflow['permissions'] ?? null);
+        foreach ($this->jobs($workflow) as $jobName => $job) {
+            $this->assertIsArray($job, "tag-guard job {$jobName} must be a mapping.");
+            $this->assertArrayNotHasKey(
+                'permissions',
+                $job,
+                "tag-guard job {$jobName} must not override the empty workflow token policy.",
+            );
+        }
     }
 
     #[Test]
-    public function pages_write_and_oidc_are_confined_to_the_deploy_job(): void
+    public function pages_permissions_are_confined_to_the_jobs_that_need_them(): void
     {
-        $workflow = $this->read(self::WORKFLOW_DIR . '/docs.yml');
+        $workflow = $this->parse(self::WORKFLOW_DIR . '/docs.yml');
+        $jobs = $this->jobs($workflow);
 
-        $this->assertMatchesRegularExpression('/^permissions: \{\}\n/m', $workflow);
-        $this->assertMatchesRegularExpression(
-            '/^  build:\n    runs-on: ubuntu-latest\n    permissions:\n      contents: read\n/m',
-            $workflow,
+        $this->assertSame([], $workflow['permissions'] ?? null);
+        $this->assertSame(
+            ['contents' => 'read', 'pages' => 'read'],
+            $this->jobPermissions($jobs, 'build'),
         );
-        $this->assertMatchesRegularExpression(
-            '/^  deploy:\n    permissions:\n      pages: write\n      id-token: write\n/m',
-            $workflow,
+        $this->assertSame(
+            ['pages' => 'write', 'id-token' => 'write'],
+            $this->jobPermissions($jobs, 'deploy'),
         );
-        $this->assertSame(1, substr_count($workflow, 'pages: write'));
-        $this->assertSame(1, substr_count($workflow, 'id-token: write'));
         $this->assertCheckoutCredentialsAreNotPersisted($workflow);
     }
 
-    private function assertCheckoutCredentialsAreNotPersisted(string $workflow): void
+    /**
+     * @param array<string, mixed> $workflow
+     */
+    private function assertCheckoutCredentialsAreNotPersisted(array $workflow): void
     {
-        $checkoutCount = substr_count($workflow, 'uses: actions/checkout@');
+        $checkoutCount = 0;
+        foreach ($this->jobs($workflow) as $jobName => $job) {
+            $this->assertIsArray($job, "job {$jobName} must be a mapping.");
+            $steps = $job['steps'] ?? [];
+            $this->assertIsArray($steps, "steps for job {$jobName} must be a list.");
+
+            foreach ($steps as $step) {
+                $this->assertIsArray($step, "each step in job {$jobName} must be a mapping.");
+                $uses = $step['uses'] ?? null;
+                if (!is_string($uses) || !str_starts_with($uses, 'actions/checkout@')) {
+                    continue;
+                }
+
+                $checkoutCount++;
+                $with = $step['with'] ?? null;
+                $this->assertIsArray($with, "checkout in job {$jobName} must declare with options.");
+                $this->assertSame(
+                    false,
+                    $with['persist-credentials'] ?? null,
+                    "checkout in job {$jobName} must disable credential persistence.",
+                );
+            }
+        }
+
         $this->assertGreaterThan(0, $checkoutCount);
-
-        $matched = preg_match_all(
-            '/uses: actions\/checkout@[^\n]+\n\s+with:\n(?:\s+[^\n]+\n)*?\s+persist-credentials: false(?:\n|$)/',
-            $workflow,
-        );
-        $this->assertNotFalse($matched);
-        $this->assertSame($checkoutCount, $matched, 'Every checkout step must disable credential persistence.');
     }
 
-    private function read(string $path): string
+    private function assertContainsNoWritePermission(mixed $permissions, string $context): void
     {
-        $contents = file_get_contents($path);
-        $this->assertNotFalse($contents);
-        $this->assertTrue(str_contains($contents, 'jobs:'), "{$path} must contain jobs.");
+        $this->assertIsArray($permissions, "{$context} permissions must be a mapping.");
+        foreach ($permissions as $permission => $access) {
+            $this->assertNotSame(
+                'write',
+                $access,
+                "{$context} must not grant {$permission}: write.",
+            );
+        }
+    }
 
-        return $contents;
+    /**
+     * @param array<string, mixed> $workflow
+     *
+     * @return array<string, mixed>
+     */
+    private function jobs(array $workflow): array
+    {
+        $jobs = $workflow['jobs'] ?? null;
+        $this->assertIsArray($jobs);
+
+        return $jobs;
+    }
+
+    /**
+     * @param array<string, mixed> $jobs
+     *
+     * @return array<string, string>
+     */
+    private function jobPermissions(array $jobs, string $jobName): array
+    {
+        $job = $jobs[$jobName] ?? null;
+        $this->assertIsArray($job, "{$jobName} job must be a mapping.");
+        $permissions = $job['permissions'] ?? null;
+        $this->assertIsArray($permissions, "{$jobName} permissions must be a mapping.");
+
+        foreach ($permissions as $permission => $access) {
+            $this->assertIsString($permission);
+            $this->assertIsString($access);
+        }
+
+        /** @var array<string, string> $permissions */
+        return $permissions;
+    }
+
+    /** @return array<string, mixed> */
+    private function parse(string $path): array
+    {
+        $workflow = Yaml::parseFile($path);
+        $this->assertIsArray($workflow, "{$path} must parse to a mapping.");
+
+        return $workflow;
     }
 }

--- a/tests/Unit/Build/GitHubActionsSecurityPolicyTest.php
+++ b/tests/Unit/Build/GitHubActionsSecurityPolicyTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Build;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function file_get_contents;
+use function glob;
+use function preg_match_all;
+use function str_contains;
+use function substr_count;
+
+final class GitHubActionsSecurityPolicyTest extends TestCase
+{
+    private const WORKFLOW_DIR = __DIR__ . '/../../../.github/workflows';
+
+    #[Test]
+    public function every_workflow_declares_an_explicit_token_policy(): void
+    {
+        $workflows = glob(self::WORKFLOW_DIR . '/*.yml');
+        $this->assertNotFalse($workflows);
+        $this->assertNotEmpty($workflows);
+
+        foreach ($workflows as $path) {
+            $workflow = $this->read($path);
+            $this->assertMatchesRegularExpression(
+                '/^permissions:(?: \{\}|\n)/m',
+                $workflow,
+                "{$path} must not inherit the repository's default GITHUB_TOKEN permissions.",
+            );
+        }
+    }
+
+    #[Test]
+    public function ci_is_read_only_and_does_not_persist_checkout_credentials(): void
+    {
+        $workflow = $this->read(self::WORKFLOW_DIR . '/ci.yml');
+
+        $this->assertMatchesRegularExpression('/^permissions:\n  contents: read\n/m', $workflow);
+        $this->assertStringNotContainsString('contents: write', $workflow);
+        $this->assertStringNotContainsString('pull-requests: write', $workflow);
+        $this->assertStringNotContainsString('id-token: write', $workflow);
+        $this->assertCheckoutCredentialsAreNotPersisted($workflow);
+    }
+
+    #[Test]
+    public function tag_guard_has_no_token_permissions(): void
+    {
+        $workflow = $this->read(self::WORKFLOW_DIR . '/tag-guard.yml');
+
+        $this->assertMatchesRegularExpression('/^permissions: \{\}\n/m', $workflow);
+        $this->assertStringNotContainsString('contents:', $workflow);
+        $this->assertStringNotContainsString('pull-requests:', $workflow);
+    }
+
+    #[Test]
+    public function pages_write_and_oidc_are_confined_to_the_deploy_job(): void
+    {
+        $workflow = $this->read(self::WORKFLOW_DIR . '/docs.yml');
+
+        $this->assertMatchesRegularExpression('/^permissions: \{\}\n/m', $workflow);
+        $this->assertMatchesRegularExpression(
+            '/^  build:\n    runs-on: ubuntu-latest\n    permissions:\n      contents: read\n/m',
+            $workflow,
+        );
+        $this->assertMatchesRegularExpression(
+            '/^  deploy:\n    permissions:\n      pages: write\n      id-token: write\n/m',
+            $workflow,
+        );
+        $this->assertSame(1, substr_count($workflow, 'pages: write'));
+        $this->assertSame(1, substr_count($workflow, 'id-token: write'));
+        $this->assertCheckoutCredentialsAreNotPersisted($workflow);
+    }
+
+    private function assertCheckoutCredentialsAreNotPersisted(string $workflow): void
+    {
+        $checkoutCount = substr_count($workflow, 'uses: actions/checkout@');
+        $this->assertGreaterThan(0, $checkoutCount);
+
+        $matched = preg_match_all(
+            '/uses: actions\/checkout@[^\n]+\n\s+with:\n(?:\s+[^\n]+\n)*?\s+persist-credentials: false(?:\n|$)/',
+            $workflow,
+        );
+        $this->assertNotFalse($matched);
+        $this->assertSame($checkoutCount, $matched, 'Every checkout step must disable credential persistence.');
+    }
+
+    private function read(string $path): string
+    {
+        $contents = file_get_contents($path);
+        $this->assertNotFalse($contents);
+        $this->assertTrue(str_contains($contents, 'jobs:'), "{$path} must contain jobs.");
+
+        return $contents;
+    }
+}


### PR DESCRIPTION
## Summary

- make CI read-only and disable persisted checkout credentials
- remove all token permissions from tag guard
- confine Pages and OIDC write permissions to the deploy job
- add repository-level invariant tests for workflow token policies

## Why

The repository previously defaulted `GITHUB_TOKEN` to write access. Workflows
without an explicit `permissions` block inherited that setting, and the Pages
build job received deployment permissions it did not need. Persisted checkout
credentials also remained available to later test and build steps.

The repository settings were hardened alongside this PR:

- default workflow permissions: `read`
- workflow PR approval: disabled
- full-SHA action pinning: required

## Impact

CI and documentation builds retain the permissions they need. Only the Pages
deploy job receives `pages: write` and `id-token: write`; release-please keeps
its existing explicit release permissions.

## Verification

- `vendor/bin/phpunit tests/Unit/Build` — 18 tests, 244 assertions
- `vendor/bin/phpstan analyse --debug --no-progress --memory-limit=1G tests/Unit/Build/GitHubActionsSecurityPolicyTest.php`
- `vendor/bin/php-cs-fixer fix --dry-run --diff --sequential tests/Unit/Build/GitHubActionsSecurityPolicyTest.php`
- `npm_config_cache=/tmp/gesso-npm-cache vendor/bin/phpunit` — 2120 tests, 5725 assertions
- parsed every `.github/workflows/*.yml` file structurally with Symfony YAML
- parsed every `.github/workflows/*.yml` file with Ruby Psych as an independent syntax check
