### PR TITLE
fix(coverage): secure sidecar file writes

### DIFF
--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -58,6 +58,12 @@ trivial CI step has no extra config to keep in sync. Set `sidecar_dir` (in
 `phpunit.xml`) and `--sidecar-dir=` (on the merge CLI) to the same custom
 path if `sys_get_temp_dir()` is unavailable in your runner.
 
+Gesso creates a missing sidecar directory with mode `0700` and publishes
+sidecars and worker-failure markers with mode `0600`. For local-user safety,
+the writer rejects a `sidecar_dir` that is itself a symbolic link or is
+writable by group or other users. Use a dedicated directory rather than `/tmp`
+itself; the default already does this.
+
 ## Sidecar compatibility
 
 Sidecars are a versioned worker-to-merge protocol, separate from the coverage

--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -58,11 +58,12 @@ trivial CI step has no extra config to keep in sync. Set `sidecar_dir` (in
 `phpunit.xml`) and `--sidecar-dir=` (on the merge CLI) to the same custom
 path if `sys_get_temp_dir()` is unavailable in your runner.
 
-Gesso creates a missing sidecar directory with mode `0700` and publishes
-sidecars and worker-failure markers with mode `0600`. For local-user safety,
-the writer rejects a `sidecar_dir` that is itself a symbolic link or is
-writable by group or other users. Use a dedicated directory rather than `/tmp`
-itself; the default already does this.
+On POSIX systems, Gesso creates a missing sidecar directory with mode `0700`
+and publishes sidecars and worker-failure markers with mode `0600`. For
+local-user safety, the writer rejects a `sidecar_dir` that is itself a symbolic
+link or is writable by group or other users. The permission-bit check is not
+applied on Windows, whose ACL model is not represented by POSIX mode bits. Use
+a dedicated directory rather than `/tmp` itself; the default already does this.
 
 ## Sidecar compatibility
 

--- a/src/Coverage/CoverageSidecarWriter.php
+++ b/src/Coverage/CoverageSidecarWriter.php
@@ -9,17 +9,29 @@ use const JSON_THROW_ON_ERROR;
 use const JSON_UNESCAPED_SLASHES;
 
 use JsonException;
+use Random\RandomException;
 use RuntimeException;
 
-use function file_put_contents;
+use function bin2hex;
+use function chmod;
+use function fclose;
+use function fflush;
+use function fileperms;
+use function fopen;
+use function fwrite;
 use function getmypid;
 use function is_dir;
+use function is_link;
+use function is_resource;
 use function json_encode;
 use function mkdir;
 use function preg_replace;
+use function random_bytes;
 use function rename;
 use function rtrim;
 use function sprintf;
+use function strlen;
+use function substr;
 use function unlink;
 
 /**
@@ -31,13 +43,13 @@ use function unlink;
  * accepted and sanitised); `<pid>` is appended so a leftover sidecar from
  * a crashed previous run cannot be mistaken for the current one.
  *
- * Atomicity: written to a sibling `*.tmp` first, then `rename()`d into place
- * so a partial file is never observable by the reader. POSIX `rename()` is
- * atomic when source and destination live on the same filesystem; on
- * Windows or across filesystem boundaries the underlying `MoveFileEx` /
- * copy+unlink fallback may not provide the same guarantee. Configure
- * `sidecar_dir` to live alongside the merge target (same FS) to keep the
- * atomic guarantee.
+ * Atomicity and local-user safety: payloads are written to a cryptographically
+ * random sibling file opened with exclusive-create semantics, chmodded to
+ * `0600`, and then `rename()`d into place. Keeping the temporary file in the
+ * sidecar directory prevents cross-filesystem moves and avoids predictable
+ * `*.tmp` names that could be replaced with symlinks. POSIX `rename()` is
+ * atomic; Windows may not provide the same replacement guarantee when the
+ * destination already exists, in which case the write fails loudly.
  *
  * @internal PHPUnit extension implementation detail. Do not use from user code.
  */
@@ -46,6 +58,8 @@ final class CoverageSidecarWriter
     public const FAILURE_MARKER_PREFIX = 'failed-';
     public const FILENAME_PREFIX = 'part-';
     public const FILENAME_SUFFIX = '.json';
+    private const TEMP_FILE_ATTEMPTS = 10;
+    private const TEMP_FILE_PREFIX = '.gesso-sidecar-';
 
     private function __construct() {}
 
@@ -58,7 +72,6 @@ final class CoverageSidecarWriter
     {
         $dir = self::ensureDir($sidecarDir);
         $finalPath = self::pathFor($dir, self::FILENAME_PREFIX, $testToken);
-        $tmpPath = $finalPath . '.tmp';
 
         try {
             $payload = json_encode($state, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
@@ -66,17 +79,7 @@ final class CoverageSidecarWriter
             throw new RuntimeException(sprintf('failed to encode coverage state: %s', $e->getMessage()), 0, $e);
         }
 
-        $written = @file_put_contents($tmpPath, $payload);
-        if ($written === false) {
-            throw new RuntimeException(sprintf('failed to write sidecar tmp file "%s"', $tmpPath));
-        }
-
-        if (!@rename($tmpPath, $finalPath)) {
-            // Best-effort cleanup; the rename failure is the primary error.
-            @unlink($tmpPath);
-
-            throw new RuntimeException(sprintf('failed to rename sidecar "%s" -> "%s"', $tmpPath, $finalPath));
-        }
+        self::writeAtomically($dir, $finalPath, $payload);
 
         return $finalPath;
     }
@@ -101,7 +104,13 @@ final class CoverageSidecarWriter
         }
         $path = self::pathFor($dir, self::FAILURE_MARKER_PREFIX, $testToken);
         $body = json_encode(['testToken' => $testToken, 'reason' => $reason]);
-        if ($body === false || @file_put_contents($path, $body) === false) {
+        if ($body === false) {
+            return null;
+        }
+
+        try {
+            self::writeAtomically($dir, $path, $body);
+        } catch (RuntimeException) {
             return null;
         }
 
@@ -114,11 +123,94 @@ final class CoverageSidecarWriter
     private static function ensureDir(string $sidecarDir): string
     {
         $dir = rtrim($sidecarDir, '/' . DIRECTORY_SEPARATOR);
-        if (!is_dir($dir) && !@mkdir($dir, 0o755, recursive: true) && !is_dir($dir)) {
+        if (is_link($dir)) {
+            throw new RuntimeException(sprintf('sidecar dir must not be a symbolic link: "%s"', $dir));
+        }
+
+        if (!is_dir($dir) && !@mkdir($dir, 0o700, recursive: true) && !is_dir($dir)) {
             throw new RuntimeException(sprintf('failed to create sidecar dir "%s"', $dir));
         }
 
+        $permissions = @fileperms($dir);
+        if ($permissions !== false && ($permissions & 0o022) !== 0) {
+            throw new RuntimeException(sprintf('sidecar dir must not be writable by group or other users: "%s"', $dir));
+        }
+
         return $dir;
+    }
+
+    /**
+     * Persist a payload without ever opening a caller-predictable temporary
+     * path. The exclusive handle prevents a pre-existing symlink from being
+     * followed; rename replaces the final directory entry rather than writing
+     * through a symlink at that path.
+     *
+     * @throws RuntimeException
+     */
+    private static function writeAtomically(string $dir, string $finalPath, string $payload): void
+    {
+        [$handle, $tmpPath] = self::openExclusiveTempFile($dir);
+        $published = false;
+
+        try {
+            if (!@chmod($tmpPath, 0o600)) {
+                throw new RuntimeException(sprintf('failed to restrict sidecar tmp file permissions: "%s"', $tmpPath));
+            }
+
+            $length = strlen($payload);
+            $offset = 0;
+            while ($offset < $length) {
+                $written = @fwrite($handle, substr($payload, $offset));
+                if ($written === false || $written === 0) {
+                    throw new RuntimeException(sprintf('failed to write sidecar tmp file "%s"', $tmpPath));
+                }
+                $offset += $written;
+            }
+
+            if (!@fflush($handle)) {
+                throw new RuntimeException(sprintf('failed to flush sidecar tmp file "%s"', $tmpPath));
+            }
+            if (!@fclose($handle)) {
+                throw new RuntimeException(sprintf('failed to close sidecar tmp file "%s"', $tmpPath));
+            }
+            $handle = null;
+
+            if (!@rename($tmpPath, $finalPath)) {
+                throw new RuntimeException(sprintf('failed to rename sidecar "%s" -> "%s"', $tmpPath, $finalPath));
+            }
+            $published = true;
+        } finally {
+            if (is_resource($handle)) {
+                @fclose($handle);
+            }
+            if (!$published) {
+                @unlink($tmpPath);
+            }
+        }
+    }
+
+    /**
+     * @return array{0: resource, 1: string}
+     *
+     * @throws RuntimeException
+     */
+    private static function openExclusiveTempFile(string $dir): array
+    {
+        for ($attempt = 0; $attempt < self::TEMP_FILE_ATTEMPTS; $attempt++) {
+            try {
+                $random = bin2hex(random_bytes(16));
+            } catch (RandomException $e) {
+                throw new RuntimeException('failed to generate a secure sidecar temporary filename', 0, $e);
+            }
+
+            $tmpPath = sprintf('%s/%s%s.tmp', $dir, self::TEMP_FILE_PREFIX, $random);
+            $handle = @fopen($tmpPath, 'xb');
+            if ($handle !== false) {
+                return [$handle, $tmpPath];
+            }
+        }
+
+        throw new RuntimeException(sprintf('failed to create an exclusive sidecar tmp file in "%s"', $dir));
     }
 
     /**

--- a/src/Coverage/CoverageSidecarWriter.php
+++ b/src/Coverage/CoverageSidecarWriter.php
@@ -131,9 +131,11 @@ final class CoverageSidecarWriter
             throw new RuntimeException(sprintf('failed to create sidecar dir "%s"', $dir));
         }
 
-        $permissions = @fileperms($dir);
-        if ($permissions !== false && ($permissions & 0o022) !== 0) {
-            throw new RuntimeException(sprintf('sidecar dir must not be writable by group or other users: "%s"', $dir));
+        if (DIRECTORY_SEPARATOR !== '\\') {
+            $permissions = @fileperms($dir);
+            if ($permissions !== false && ($permissions & 0o022) !== 0) {
+                throw new RuntimeException(sprintf('sidecar dir must not be writable by group or other users: "%s"', $dir));
+            }
         }
 
         return $dir;

--- a/tests/Unit/Coverage/CoverageSidecarTest.php
+++ b/tests/Unit/Coverage/CoverageSidecarTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Studio\Gesso\Tests\Unit\Coverage;
 
+use const DIRECTORY_SEPARATOR;
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
@@ -14,13 +17,19 @@ use Studio\Gesso\Coverage\OpenApiCoverageTracker;
 use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
 
 use function array_map;
+use function chmod;
+use function file_get_contents;
 use function file_put_contents;
+use function fileperms;
 use function getmypid;
 use function glob;
 use function is_dir;
+use function is_link;
 use function mkdir;
 use function rmdir;
 use function sort;
+use function sprintf;
+use function symlink;
 use function sys_get_temp_dir;
 use function uniqid;
 use function unlink;
@@ -55,6 +64,13 @@ class CoverageSidecarTest extends TestCase
             @rmdir($this->tmpDir);
         }
         parent::tearDown();
+    }
+
+    /** @return iterable<string, array{int}> */
+    public static function provideWriter_rejects_a_group_or_world_writable_sidecar_directoryCases(): iterable
+    {
+        yield 'group writable' => [0o770];
+        yield 'world writable' => [0o707];
     }
 
     #[Test]
@@ -95,9 +111,104 @@ class CoverageSidecarTest extends TestCase
 
         $this->assertDirectoryExists($nested);
         $this->assertStringStartsWith($nested . '/', $path);
+        if (DIRECTORY_SEPARATOR !== '\\') {
+            $permissions = fileperms($nested);
+            $this->assertNotFalse($permissions);
+            $this->assertSame(0o700, $permissions & 0o777);
+        }
 
         @unlink($path);
         @rmdir($nested);
+    }
+
+    #[Test]
+    public function writer_does_not_follow_a_predictable_legacy_tmp_symlink(): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('symlink semantics differ on Windows');
+        }
+
+        $target = $this->tmpDir . '/sensitive-target';
+        file_put_contents($target, 'unchanged');
+        $legacyTmp = sprintf('%s/part-slot-%s.json.tmp', $this->tmpDir, (string) getmypid());
+        if (!@symlink($target, $legacyTmp)) {
+            $this->markTestSkipped('symlink creation is not available');
+        }
+
+        $path = CoverageSidecarWriter::write(
+            $this->tmpDir,
+            'slot',
+            ['version' => 1, 'specs' => []],
+        );
+
+        $this->assertSame('unchanged', file_get_contents($target));
+        $this->assertTrue(is_link($legacyTmp));
+        $this->assertFileExists($path);
+        $permissions = fileperms($path);
+        $this->assertNotFalse($permissions);
+        $this->assertSame(0o600, $permissions & 0o777);
+    }
+
+    #[Test]
+    public function failure_marker_replaces_a_symlink_without_writing_through_it(): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('symlink semantics differ on Windows');
+        }
+
+        $target = $this->tmpDir . '/marker-target';
+        file_put_contents($target, 'unchanged');
+        $marker = sprintf('%s/failed-slot-%s.json', $this->tmpDir, (string) getmypid());
+        if (!@symlink($target, $marker)) {
+            $this->markTestSkipped('symlink creation is not available');
+        }
+
+        $path = CoverageSidecarWriter::writeFailureMarker($this->tmpDir, 'slot', 'worker failed');
+
+        $this->assertSame($marker, $path);
+        $this->assertSame('unchanged', file_get_contents($target));
+        $this->assertFalse(is_link($marker));
+        $this->assertJson((string) file_get_contents($marker));
+    }
+
+    #[Test]
+    #[DataProvider('provideWriter_rejects_a_group_or_world_writable_sidecar_directoryCases')]
+    public function writer_rejects_a_group_or_world_writable_sidecar_directory(int $mode): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('POSIX permission bits are not portable to Windows');
+        }
+
+        $this->assertTrue(chmod($this->tmpDir, $mode));
+
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('must not be writable by group or other users');
+            CoverageSidecarWriter::write($this->tmpDir, 'slot', ['version' => 1, 'specs' => []]);
+        } finally {
+            chmod($this->tmpDir, 0o755);
+        }
+    }
+
+    #[Test]
+    public function writer_rejects_a_symlink_sidecar_directory(): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('symlink semantics differ on Windows');
+        }
+
+        $link = $this->tmpDir . '-link';
+        if (!@symlink($this->tmpDir, $link)) {
+            $this->markTestSkipped('symlink creation is not available');
+        }
+
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('must not be a symbolic link');
+            CoverageSidecarWriter::write($link, 'slot', ['version' => 1, 'specs' => []]);
+        } finally {
+            @unlink($link);
+        }
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- publish coverage sidecars and failure markers through cryptographically random, exclusively created sibling files
- restrict generated directories to `0700` and published files to `0600`
- reject symlinked or group/other-writable sidecar directories
- document the local filesystem trust boundary and add regression coverage

## Root cause

The writer used a predictable `<final>.tmp` path with a normal write operation. A pre-created symlink at that path could therefore redirect the write to another file ([CWE-59](https://cwe.mitre.org/data/definitions/59.html)). Failure markers were also written directly to their final predictable path.

The new writer opens a random sibling path with exclusive-create semantics, applies `0600` before writing any payload, flushes and closes it, then publishes it with `rename()`. The public final filename and sidecar JSON protocol remain unchanged.

## Impact

Custom `sidecar_dir` locations must now be real directories that are not writable by group or other users. Missing directories are created securely. Existing dedicated runner-owned directories continue to work; shared locations such as `/tmp` itself must not be configured directly.

## Verification

- `vendor/bin/phpunit` — 2125 tests, 5862 assertions
- `vendor/bin/phpunit tests/Unit/Coverage/CoverageSidecarTest.php` — 15 tests, 47 assertions
- `vendor/bin/phpstan analyse --debug --no-progress --memory-limit=1G`
- both PHP-CS-Fixer configurations in sequential dry-run mode
- `git diff --check`

The aggregate `composer ci` wrapper could not use its parallel local TCP worker inside the sandbox; its PHP-CS-Fixer, PHPStan, and PHPUnit stages were run separately in sequential/debug mode.
