### PR TITLE
fix(refs): redact credentials from remote errors

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -598,6 +598,10 @@ OpenApiSpecLoader::configure(
 
 The library does not bundle an HTTP client — pick whichever your project already uses. (Guzzle 7+ implements PSR-18 directly; Guzzle 6 needs an adapter.)
 
+Remote-reference diagnostics remove URL userinfo and query values before they
+reach exception messages or CI logs. Configure authentication on the HTTP
+client instead of embedding credentials in a `$ref` URL.
+
 Misconfiguration is caught early:
 
 | Setup | Result |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -600,7 +600,9 @@ The library does not bundle an HTTP client — pick whichever your project alrea
 
 Remote-reference diagnostics remove URL userinfo and query values before they
 reach exception messages or CI logs. Configure authentication on the HTTP
-client instead of embedding credentials in a `$ref` URL.
+client instead of embedding credentials in a `$ref` URL. Raw PSR-18 transport
+exceptions are not chained into the public exception because a nested cause may
+contain unsanitized request data; the sanitized top-level message is retained.
 
 Misconfiguration is caught early:
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -603,6 +603,9 @@ reach exception messages or CI logs. Configure authentication on the HTTP
 client instead of embedding credentials in a `$ref` URL. Raw PSR-18 transport
 exceptions are not chained into the public exception because a nested cause may
 contain unsanitized request data; the sanitized top-level message is retained.
+The original `$ref` argument is also replaced with its diagnostic-safe form
+before network operations, so exception traces remain redacted even when
+`zend.exception_ignore_args=Off`.
 
 Misconfiguration is caught early:
 

--- a/src/Internal/HttpRefLoader.php
+++ b/src/Internal/HttpRefLoader.php
@@ -71,17 +71,21 @@ final class HttpRefLoader
             return new LoadedDocument($canonicalUri, $documentCache[$canonicalUri]);
         }
 
-        $safeUrl = self::redactUserInfo($url);
+        $safeUrl = self::redactSensitiveUrlData($url);
         $request = $requestFactory->createRequest('GET', $canonicalUri);
 
         try {
             $response = $client->sendRequest($request);
         } catch (ClientExceptionInterface $e) {
+            $safeTransportMessage = self::redactSensitiveUrlData($e->getMessage());
+
             throw new InvalidOpenApiSpecException(
                 InvalidOpenApiSpecReason::RemoteRefFetchFailed,
-                sprintf('HTTP $ref fetch failed: %s (%s)', $safeUrl, $e->getMessage()),
+                sprintf('HTTP $ref fetch failed: %s (%s)', $safeUrl, $safeTransportMessage),
                 ref: $safeUrl,
-                previous: $e,
+                // Exception stringification includes the entire previous chain.
+                // Do not reattach an exception whose message required redaction.
+                previous: $safeTransportMessage === $e->getMessage() ? $e : null,
             );
         }
 
@@ -92,7 +96,7 @@ final class HttpRefLoader
             // to not). A bare 3xx is almost always "user's client has
             // redirect-following disabled", not a server bug. Including
             // the Location target makes the next step obvious.
-            $location = $response->getHeaderLine('Location');
+            $location = self::redactSensitiveUrlData($response->getHeaderLine('Location'));
 
             throw new InvalidOpenApiSpecException(
                 InvalidOpenApiSpecReason::RemoteRefFetchFailed,
@@ -158,15 +162,25 @@ final class HttpRefLoader
     }
 
     /**
-     * Strip `user:pass@` from a URL before it lands in error messages or
-     * logs. Spec authors occasionally embed credentials in `$ref` URLs
-     * for testing, and we don't want them leaking into stderr / CI logs.
+     * Remove URL userinfo and query values before diagnostics reach stderr or
+     * CI logs. This also accepts surrounding transport-error prose because
+     * PSR-18 exception messages commonly embed the request URL.
      */
-    private static function redactUserInfo(string $url): string
+    private static function redactSensitiveUrlData(string $value): string
     {
-        $redacted = preg_replace('#(://)[^/@\s]+@#', '$1', $url);
+        // Cover both absolute (`https://user:pass@host`) and network-path
+        // (`//user:pass@host`) references. HTTP client exception messages may
+        // contain either form rather than only the original URL string.
+        $redacted = preg_replace('#((?:[a-z][a-z0-9+.-]*:)?//)[^/@\s]+@#i', '$1', $value);
+        if ($redacted === null) {
+            return $value;
+        }
 
-        return $redacted ?? $url;
+        // Query values frequently carry signed-URL tokens and API keys. Keep
+        // parameter names for diagnostics without exposing their values.
+        $withoutQueryValues = preg_replace('~([?&][^=\s&#]+)=([^&#\s]*)~', '$1=[redacted]', $redacted);
+
+        return $withoutQueryValues ?? $redacted;
     }
 
     private static function canonicalizeUri(string $url): string

--- a/src/Internal/HttpRefLoader.php
+++ b/src/Internal/HttpRefLoader.php
@@ -72,6 +72,12 @@ final class HttpRefLoader
         }
 
         $safeUrl = self::redactSensitiveUrlData($url);
+
+        // PHP may include live function arguments when stringifying an
+        // exception with zend.exception_ignore_args=Off. The raw URI is
+        // already captured for the request and cache key, so replace the
+        // parameter slot before any downstream operation can throw.
+        $url = $safeUrl;
         $request = $requestFactory->createRequest('GET', $canonicalUri);
 
         try {
@@ -166,8 +172,10 @@ final class HttpRefLoader
      * Remove URL userinfo and query values before diagnostics reach stderr or
      * CI logs. This also accepts surrounding transport-error prose because
      * PSR-18 exception messages commonly embed the request URL.
+     *
+     * @internal Shared with the ref resolver's exception-trace boundary.
      */
-    private static function redactSensitiveUrlData(string $value): string
+    public static function redactSensitiveUrlData(string $value): string
     {
         // Cover both absolute (`https://user:pass@host`) and network-path
         // (`//user:pass@host`) references. HTTP client exception messages may

--- a/src/Internal/HttpRefLoader.php
+++ b/src/Internal/HttpRefLoader.php
@@ -83,9 +83,10 @@ final class HttpRefLoader
                 InvalidOpenApiSpecReason::RemoteRefFetchFailed,
                 sprintf('HTTP $ref fetch failed: %s (%s)', $safeUrl, $safeTransportMessage),
                 ref: $safeUrl,
-                // Exception stringification includes the entire previous chain.
-                // Do not reattach an exception whose message required redaction.
-                previous: $safeTransportMessage === $e->getMessage() ? $e : null,
+                // Exception stringification includes every nested previous
+                // message. A PSR-18 client may wrap a credential-bearing
+                // exception below a harmless top-level message, so the raw
+                // transport chain cannot be safely reattached here.
             );
         }
 

--- a/src/Spec/OpenApiRefResolver.php
+++ b/src/Spec/OpenApiRefResolver.php
@@ -475,7 +475,9 @@ final class OpenApiRefResolver
         }
 
         if (str_starts_with($ref, 'http://') || str_starts_with($ref, 'https://')) {
-            self::resolveHttpRef($node, $ref, $chain, $context, $documentCache);
+            $rawRef = $ref;
+            $ref = HttpRefLoader::redactSensitiveUrlData($ref);
+            self::resolveHttpRef($node, $rawRef, $chain, $context, $documentCache);
 
             return;
         }
@@ -716,6 +718,9 @@ final class OpenApiRefResolver
         RefResolutionContext $context,
         array &$documentCache,
     ): void {
+        $rawRef = $ref;
+        $ref = HttpRefLoader::redactSensitiveUrlData($ref);
+
         if (!$context->allowRemoteRefs) {
             throw new InvalidOpenApiSpecException(
                 InvalidOpenApiSpecReason::RemoteRefDisallowed,
@@ -740,7 +745,7 @@ final class OpenApiRefResolver
             );
         }
 
-        [$urlPart, $fragment, $hadHash] = self::splitRef($ref);
+        [$urlPart, $fragment, $hadHash] = self::splitRef($rawRef);
 
         if ($urlPart === '') {
             throw new InvalidOpenApiSpecException(
@@ -772,7 +777,7 @@ final class OpenApiRefResolver
             if ($e->reason === InvalidOpenApiSpecReason::RemoteRefFetchFailed && $chain !== []) {
                 throw new InvalidOpenApiSpecException(
                     $e->reason,
-                    sprintf('%s (via $ref chain: %s)', $e->getMessage(), implode(' -> ', $chain)),
+                    sprintf('%s (via $ref chain: %s)', $e->getMessage(), self::diagnosticRefChain($chain)),
                     ref: $e->ref,
                     previous: $e,
                 );
@@ -783,7 +788,7 @@ final class OpenApiRefResolver
 
         self::descendIntoLoadedDocument(
             $node,
-            $ref,
+            $rawRef,
             $fragment,
             $chain,
             $document->canonicalIdentifier,
@@ -791,6 +796,17 @@ final class OpenApiRefResolver
             $context->withSourceFile($document->canonicalIdentifier),
             $documentCache,
         );
+    }
+
+    /** @param list<string> $chain */
+    private static function diagnosticRefChain(array $chain): string
+    {
+        $safeChain = [];
+        foreach ($chain as $ref) {
+            $safeChain[] = HttpRefLoader::redactSensitiveUrlData($ref);
+        }
+
+        return implode(' -> ', $safeChain);
     }
 
     /**

--- a/tests/Unit/Internal/HttpRefLoaderTest.php
+++ b/tests/Unit/Internal/HttpRefLoaderTest.php
@@ -255,6 +255,27 @@ class HttpRefLoaderTest extends TestCase
     }
 
     #[Test]
+    public function redacts_credentials_from_redirect_location(): void
+    {
+        $url = 'https://example.com/redirect.json';
+        $client = new FakeHttpClient([
+            $url => new Response(302, [
+                'Location' => 'https://alice:secret@example.com/canonical.json?token=redirect-secret',
+            ]),
+        ]);
+
+        try {
+            $cache = [];
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertStringNotContainsString('alice', $e->getMessage());
+            $this->assertStringNotContainsString('secret', $e->getMessage());
+            $this->assertStringContainsString('https://example.com/canonical.json?token=[redacted]', $e->getMessage());
+        }
+    }
+
+    #[Test]
     public function url_extension_takes_precedence_over_conflicting_content_type(): void
     {
         // Pin the documented priority: extension wins, even if the
@@ -329,6 +350,29 @@ class HttpRefLoaderTest extends TestCase
             $this->assertStringNotContainsString('secret', $e->getMessage());
             $this->assertStringNotContainsString('alice', $e->getMessage());
             $this->assertStringContainsString('example.com', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function redacts_credentials_from_transport_exception_chain(): void
+    {
+        $url = 'https://alice:secret@example.com/private/pet.json?token=query-secret';
+        $client = new FakeHttpClient([
+            $url => static function () use ($url): Response {
+                throw new FakeHttpClientUnexpectedRequest('request failed for ' . $url);
+            },
+        ]);
+
+        try {
+            $cache = [];
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertStringNotContainsString('alice', $e->getMessage());
+            $this->assertStringNotContainsString('secret', $e->getMessage());
+            $this->assertStringContainsString('https://example.com/private/pet.json?token=[redacted]', $e->getMessage());
+            $this->assertSame('https://example.com/private/pet.json?token=[redacted]', $e->ref);
+            $this->assertNull($e->getPrevious());
         }
     }
 

--- a/tests/Unit/Internal/HttpRefLoaderTest.php
+++ b/tests/Unit/Internal/HttpRefLoaderTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
+use RuntimeException;
 use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
 use Studio\Gesso\Internal\HttpRefLoader;
@@ -173,7 +174,7 @@ class HttpRefLoaderTest extends TestCase
         } catch (InvalidOpenApiSpecException $e) {
             $this->assertSame(InvalidOpenApiSpecReason::RemoteRefFetchFailed, $e->reason);
             $this->assertStringContainsString('connection refused', $e->getMessage());
-            $this->assertNotNull($e->getPrevious());
+            $this->assertNull($e->getPrevious());
         }
     }
 
@@ -372,6 +373,34 @@ class HttpRefLoaderTest extends TestCase
             $this->assertStringNotContainsString('secret', $e->getMessage());
             $this->assertStringContainsString('https://example.com/private/pet.json?token=[redacted]', $e->getMessage());
             $this->assertSame('https://example.com/private/pet.json?token=[redacted]', $e->ref);
+            $this->assertNull($e->getPrevious());
+        }
+    }
+
+    #[Test]
+    public function does_not_reconnect_a_sensitive_nested_transport_exception(): void
+    {
+        $url = 'https://example.com/pet.json';
+        $client = new FakeHttpClient([
+            $url => static function (): Response {
+                $cause = new RuntimeException(
+                    'request failed for https://alice:secret@example.com/private.json?token=query-secret',
+                );
+
+                throw new FakeHttpClientUnexpectedRequest('transport failed', 0, $cause);
+            },
+        ]);
+
+        try {
+            $cache = [];
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $rendered = (string) $e;
+
+            $this->assertStringContainsString('transport failed', $rendered);
+            $this->assertStringNotContainsString('alice', $rendered);
+            $this->assertStringNotContainsString('secret', $rendered);
             $this->assertNull($e->getPrevious());
         }
     }

--- a/tests/Unit/Internal/HttpRefLoaderTest.php
+++ b/tests/Unit/Internal/HttpRefLoaderTest.php
@@ -16,6 +16,8 @@ use Studio\Gesso\Internal\HttpRefLoader;
 use Studio\Gesso\Tests\Helpers\FakeHttpClient;
 use Studio\Gesso\Tests\Helpers\FakeHttpClientUnexpectedRequest;
 
+use function ini_set;
+
 class HttpRefLoaderTest extends TestCase
 {
     private HttpFactory $factory;
@@ -380,28 +382,45 @@ class HttpRefLoaderTest extends TestCase
     #[Test]
     public function does_not_reconnect_a_sensitive_nested_transport_exception(): void
     {
-        $url = 'https://example.com/pet.json';
+        $url = 'https://alice:secret@example.com/pet.json?token=query-secret';
         $client = new FakeHttpClient([
             $url => static function (): Response {
                 $cause = new RuntimeException(
-                    'request failed for https://alice:secret@example.com/private.json?token=query-secret',
+                    'request failed for https://nested:nested-secret@example.com/private.json?token=nested-query-secret',
                 );
 
                 throw new FakeHttpClientUnexpectedRequest('transport failed', 0, $cause);
             },
         ]);
 
-        try {
-            $cache = [];
-            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
-            $this->fail('expected InvalidOpenApiSpecException');
-        } catch (InvalidOpenApiSpecException $e) {
-            $rendered = (string) $e;
+        $previousIgnoreArgs = ini_set('zend.exception_ignore_args', '0');
+        if ($previousIgnoreArgs === false) {
+            $this->markTestSkipped('zend.exception_ignore_args cannot be changed at runtime');
+        }
+        $previousMaxLength = ini_set('zend.exception_string_param_max_len', '1024');
+        if ($previousMaxLength === false) {
+            ini_set('zend.exception_ignore_args', $previousIgnoreArgs);
+            $this->markTestSkipped('zend.exception_string_param_max_len cannot be changed at runtime');
+        }
 
-            $this->assertStringContainsString('transport failed', $rendered);
-            $this->assertStringNotContainsString('alice', $rendered);
-            $this->assertStringNotContainsString('secret', $rendered);
-            $this->assertNull($e->getPrevious());
+        try {
+            try {
+                $cache = [];
+                HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+                $this->fail('expected InvalidOpenApiSpecException');
+            } catch (InvalidOpenApiSpecException $e) {
+                $rendered = (string) $e;
+
+                $this->assertStringContainsString('transport failed', $rendered);
+                $this->assertStringNotContainsString('alice:secret', $rendered);
+                $this->assertStringNotContainsString('query-secret', $rendered);
+                $this->assertStringNotContainsString('nested:nested-secret', $rendered);
+                $this->assertStringNotContainsString('nested-query-secret', $rendered);
+                $this->assertNull($e->getPrevious());
+            }
+        } finally {
+            ini_set('zend.exception_ignore_args', $previousIgnoreArgs);
+            ini_set('zend.exception_string_param_max_len', $previousMaxLength);
         }
     }
 

--- a/tests/Unit/Spec/OpenApiRefResolverHttpRefsTest.php
+++ b/tests/Unit/Spec/OpenApiRefResolverHttpRefsTest.php
@@ -15,6 +15,7 @@ use Studio\Gesso\Spec\OpenApiRefResolver;
 use Studio\Gesso\Tests\Helpers\FakeHttpClient;
 
 use function file_put_contents;
+use function ini_set;
 use function is_dir;
 use function mkdir;
 use function rmdir;
@@ -446,6 +447,45 @@ class OpenApiRefResolverHttpRefsTest extends TestCase
             $this->assertSame(InvalidOpenApiSpecReason::RemoteRefFetchFailed, $e->reason);
             $this->assertStringContainsString('via $ref chain', $e->getMessage());
             $this->assertStringContainsString($a, $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function fetch_failure_trace_redacts_the_original_remote_ref_argument(): void
+    {
+        $url = 'https://alice:secret@example.com/missing.json?token=query-secret';
+        $client = new FakeHttpClient([$url => new Response(404)]);
+        $spec = ['components' => ['schemas' => ['Leaf' => ['$ref' => $url]]]];
+
+        $previousIgnoreArgs = ini_set('zend.exception_ignore_args', '0');
+        if ($previousIgnoreArgs === false) {
+            $this->markTestSkipped('zend.exception_ignore_args cannot be changed at runtime');
+        }
+        $previousMaxLength = ini_set('zend.exception_string_param_max_len', '1024');
+        if ($previousMaxLength === false) {
+            ini_set('zend.exception_ignore_args', $previousIgnoreArgs);
+            $this->markTestSkipped('zend.exception_string_param_max_len cannot be changed at runtime');
+        }
+
+        try {
+            try {
+                OpenApiRefResolver::resolve(
+                    $spec,
+                    httpClient: $client,
+                    requestFactory: $this->factory,
+                    allowRemoteRefs: true,
+                );
+                $this->fail('expected InvalidOpenApiSpecException');
+            } catch (InvalidOpenApiSpecException $e) {
+                $rendered = (string) $e;
+
+                $this->assertStringContainsString('https://example.com/missing.json?token=[redacted]', $rendered);
+                $this->assertStringNotContainsString('alice:secret', $rendered);
+                $this->assertStringNotContainsString('query-secret', $rendered);
+            }
+        } finally {
+            ini_set('zend.exception_ignore_args', $previousIgnoreArgs);
+            ini_set('zend.exception_string_param_max_len', $previousMaxLength);
         }
     }
 


### PR DESCRIPTION
## Summary

- redact URL userinfo and query values from HTTP `$ref` diagnostics
- sanitize PSR-18 transport exception messages and redirect `Location` values
- never attach raw PSR-18 exception chains to the public exception
- replace live remote-ref arguments with diagnostic-safe values before failures can be captured in stack traces
- document that HTTP client authentication should be used instead of URL-embedded credentials

## Root cause

`HttpRefLoader` sanitized the original `$ref` URL, but appended the raw PSR-18 exception message and exposed its previous-exception chain. HTTP clients commonly include the request URL in those messages or nested causes. With `zend.exception_ignore_args=Off`, PHP could also render the unsanitized live `$ref` argument in the stack trace. Redirect `Location` headers were likewise rendered without sanitization.

This is a sensitive-information-in-logs risk consistent with [CWE-532](https://cwe.mitre.org/data/definitions/532.html).

## Impact

Remote-reference failures still report the host, path, query parameter names, and sanitized top-level transport message needed for diagnosis. Userinfo is removed and query values are replaced with `[redacted]`. Raw PSR-18 exception chains are not attached because a harmless outer message cannot prove that nested causes contain no credentials. Resolver and loader argument slots are replaced with diagnostic-safe values after the raw request URI is captured, protecting exception stringification even when `zend.exception_ignore_args=Off`.

## Verification

- `vendor/bin/phpunit` — 2129 tests, 5879 assertions
- HTTP ref focused suites — 39 tests, 73 assertions
- full PHPStan analysis
- both PHP-CS-Fixer configurations in sequential dry-run mode
- `git diff --check`
