### PR TITLE
fix(refs): require a remote ref host allowlist

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -60,9 +60,16 @@ required first argument.
 case was emitted by production code by the end of v1. Use the specific resolver
 reason instead: local-reference failures use `LocalRefNotFound`,
 `LocalRefUnreadable`, or `LocalRefRequiresSourceFile`; remote-reference failures
-use `RemoteRefDisallowed`, `HttpClientNotConfigured`, or
-`RemoteRefFetchFailed`; unsupported `file:` references use
+use `RemoteRefDisallowed`, `HttpClientNotConfigured`,
+`RemoteRefHostDisallowed`, or `RemoteRefFetchFailed`; unsupported `file:` references use
 `FileSchemeNotSupported`.
+
+HTTP(S) `$ref` resolution now requires an explicit destination allowlist.
+Pass `allowedRemoteRefHosts: ['specs.example.com']` together with
+`allowRemoteRefs: true`; list every trusted host used by nested references.
+The Doctor equivalent is repeatable `--remote-ref-host=<host>`. Unlisted hosts
+are rejected before a request is sent. Keep PSR-18 redirect following disabled
+and use canonical URLs so a redirect cannot move below this policy boundary.
 
 Several orchestration types that were unintentionally part of the v1 PHP API
 are marked `@internal` in v2. Do not call coverage renderer, sidecar I/O,

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -36,10 +36,11 @@ Remote references remain opt-in because diagnostics must not access the network 
 ```bash
 vendor/bin/gesso doctor \
   --spec=openapi/root.yaml \
-  --allow-remote-refs
+  --allow-remote-refs \
+  --remote-ref-host=specs.example.com
 ```
 
-The command automatically uses an installed Guzzle (`guzzlehttp/guzzle` plus `guzzlehttp/psr7`) or Symfony HttpClient PSR-18 implementation. Without `--allow-remote-refs`, an HTTP(S) `$ref` is reported as a reference error with an actionable hint. Network failures, malformed remote documents, content-type mismatches, and reference cycles also exit non-zero.
+The command automatically uses an installed Guzzle (`guzzlehttp/guzzle` plus `guzzlehttp/psr7`) or Symfony HttpClient PSR-18 implementation. Every permitted host must be listed with `--remote-ref-host`; repeat the option when a trusted contract intentionally spans hosts. A nested `$ref` that switches to an unlisted host is rejected before any request is sent. Without `--allow-remote-refs`, an HTTP(S) `$ref` is reported as a reference error with an actionable hint. Network failures, malformed remote documents, content-type mismatches, and reference cycles also exit non-zero.
 
 ## Machine-readable output
 

--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -123,7 +123,9 @@ The v1 PHP API snapshot includes every case of `EnumBindingReason` and
 production-unused `InvalidOpenApiSpecReason::ExternalRef` and
 `InvalidOpenApiSpecReason::RemoteRefNotImplemented` cases. Consumers must use
 the specific local, remote, HTTP-client, fetch, or file-scheme reason described
-in the repository's `UPGRADING.md`.
+in the repository's `UPGRADING.md`. V2 also adds
+`InvalidOpenApiSpecReason::RemoteRefHostDisallowed` for the destination
+allowlist enforced before HTTP requests.
 
 ### Spec loading
 
@@ -134,7 +136,8 @@ Studio\OpenApiContractTesting\Spec\OpenApiSpecResolver
 
 The loader's static configuration, base paths, strip prefixes, local/remote
 reference inputs, cache behavior exposed through non-internal methods, and
-exception taxonomy are observable contracts.
+exception taxonomy are observable contracts. Remote resolution in v2 requires
+the new `allowedRemoteRefHosts` argument whenever `allowRemoteRefs` is enabled.
 
 ### Coverage
 
@@ -385,6 +388,7 @@ Accepted options:
 - repeated `--strip-prefix=<prefix>`;
 - `--format=text|json`;
 - `--allow-remote-refs`;
+- repeatable `--remote-ref-host=<host>` (required with `--allow-remote-refs`);
 - `--phpunit-snippet`;
 - `--help` / `-h`.
 

--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -119,5 +119,6 @@ changing a sidecar shape or filename pattern.
   `OpenApiSpecLoader::configure()` with only `spec_base_path` and
   `strip_prefixes` — `allowRemoteRefs` cannot be set via CLI flags. If your
   spec uses HTTP(S) `$ref`, run the merge step from a process that calls
-  `OpenApiSpecLoader::configure(..., allowRemoteRefs: true, ...)` first
+  `OpenApiSpecLoader::configure(..., allowRemoteRefs: true,
+  allowedRemoteRefHosts: ['specs.example.com'], ...)` first
   (e.g. a Composer script), or pre-bundle remote refs offline.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -593,6 +593,7 @@ OpenApiSpecLoader::configure(
     httpClient: new Client(),       // PSR-18 ClientInterface
     requestFactory: new HttpFactory(), // PSR-17 RequestFactoryInterface
     allowRemoteRefs: true,
+    allowedRemoteRefHosts: ['specs.example.com'],
 );
 ```
 
@@ -607,14 +608,29 @@ The original `$ref` argument is also replaced with its diagnostic-safe form
 before network operations, so exception traces remain redacted even when
 `zend.exception_ignore_args=Off`.
 
+Remote access requires a non-empty `allowedRemoteRefHosts` list. Matching is
+case-insensitive against the URL's exact host; schemes, ports, paths, and
+userinfo do not belong in the list. Every nested remote `$ref` is checked, so
+a document served by an allowed host cannot redirect resolution to another
+host through an absolute `$ref`. Configure the injected PSR-18 client not to
+follow redirects and use the canonical URL instead: a client-side redirect
+would otherwise happen below Gesso's host-policy boundary.
+
+This follows OWASP's SSRF guidance to prefer an allowlist and disable redirect
+following. DNS and network-layer controls remain the application's
+responsibility because PSR-18 does not expose connection-level address policy.
+[See the OWASP SSRF Prevention Cheat Sheet.](https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html)
+
 Misconfiguration is caught early:
 
 | Setup | Result |
 | --- | --- |
 | `allowRemoteRefs: true` without `$httpClient` / `$requestFactory` | `InvalidArgumentException` at `configure()` |
+| `allowRemoteRefs: true` without `allowedRemoteRefHosts` | `InvalidArgumentException` at `configure()` |
+| HTTP(S) `$ref` targets an unlisted host | `InvalidOpenApiSpecException` with reason `RemoteRefHostDisallowed`; no request is sent |
 | `$httpClient` set but `allowRemoteRefs: false` | `InvalidArgumentException` at `configure()` (silent misuse impossible) |
 | `allowRemoteRefs: true` + client + ref to URL that 4xx/5xx | `InvalidOpenApiSpecException` with reason `RemoteRefFetchFailed` |
-| `allowRemoteRefs: true` + client + ref to URL that 3xx | `RemoteRefFetchFailed` with redirect target — configure your PSR-18 client to follow redirects, or use the canonical URL |
+| `allowRemoteRefs: true` + client + ref to URL that 3xx | `RemoteRefFetchFailed` with redirect target — keep redirects disabled and use the canonical URL |
 | `allowRemoteRefs: true` + client + ref to URL with no detectable format | reason `UnsupportedExtension` (URL extension or `Content-Type` header is required) |
 
 Format detection prefers the URL's filename extension (`.json` / `.yaml` / `.yml`) and falls back to the response's `Content-Type` (`application/json`, `application/*+json`, `application/yaml`, `text/yaml`, etc.). URLs without a recognisable extension still work as long as the server sets a usable `Content-Type`.

--- a/src/Cli/DoctorCommand.php
+++ b/src/Cli/DoctorCommand.php
@@ -69,7 +69,7 @@ use function substr;
 /**
  * Pre-test compatibility diagnostics for one or more OpenAPI documents.
  *
- * @phpstan-type DoctorOptions array{specs?: list<string>, strip_prefixes?: list<string>, format?: string, allow_remote_refs?: bool, phpunit_snippet?: bool, help?: bool, invalid_options?: list<string>}
+ * @phpstan-type DoctorOptions array{specs?: list<string>, strip_prefixes?: list<string>, remote_ref_hosts?: list<string>, format?: string, allow_remote_refs?: bool, phpunit_snippet?: bool, help?: bool, invalid_options?: list<string>}
  * @phpstan-type DoctorIssue array{severity: 'error'|'warning'|'skipped', category: string, spec: ?string, message: string, suggestion: ?string}
  * @phpstan-type SpecResult array{path: string, name: string, openapi: string, dialect: string, operations: int, responses: int}
  *
@@ -97,7 +97,7 @@ final class DoctorCommand
      */
     public static function parseArgv(array $argv): array
     {
-        $options = ['specs' => [], 'strip_prefixes' => [], 'invalid_options' => []];
+        $options = ['specs' => [], 'strip_prefixes' => [], 'remote_ref_hosts' => [], 'invalid_options' => []];
 
         foreach ($argv as $arg) {
             if ($arg === 'doctor') {
@@ -141,6 +141,13 @@ final class DoctorCommand
                     $options['allow_remote_refs'] = !in_array($value, ['0', 'false', 'no'], true);
 
                     break;
+                case 'remote_ref_host':
+                    $options['remote_ref_hosts'] = [
+                        ...$options['remote_ref_hosts'],
+                        ...array_values(array_filter(array_map('trim', explode(',', $value)), static fn(string $item): bool => $item !== '')),
+                    ];
+
+                    break;
                 case 'phpunit_snippet':
                     $options['phpunit_snippet'] = !in_array($value, ['0', 'false', 'no'], true);
 
@@ -167,6 +174,8 @@ final class DoctorCommand
               --format=text|json         Output format (default: text).
               --allow-remote-refs        Resolve HTTP(S) refs with an installed Guzzle or
                                          Symfony PSR-18 implementation.
+              --remote-ref-host=<host>   Exact host allowed for HTTP(S) refs. Required with
+                                         --allow-remote-refs; repeat as needed.
               --phpunit-snippet          Include the equivalent PHPUnit extension XML.
               --help                     Show this message.
 
@@ -193,12 +202,22 @@ final class DoctorCommand
             $message = $invalid !== []
                 ? 'Unknown argument(s): ' . implode(', ', $invalid)
                 : (($options['specs'] ?? []) === [] ? 'At least one --spec is required.' : "Unsupported --format={$format}.");
-            $this->writeStderr("[OpenAPI Doctor] {$message}\n\n" . self::usage($this->invocation));
+            $this->writeUsageError($message);
 
             return self::EXIT_USAGE;
         }
 
         $allowRemoteRefs = $options['allow_remote_refs'] ?? false;
+        $remoteRefHosts = $options['remote_ref_hosts'] ?? [];
+        if (($allowRemoteRefs && $remoteRefHosts === []) || (!$allowRemoteRefs && $remoteRefHosts !== [])) {
+            $message = $allowRemoteRefs
+                ? '--allow-remote-refs requires at least one --remote-ref-host.'
+                : '--remote-ref-host requires --allow-remote-refs.';
+            $this->writeUsageError($message);
+
+            return self::EXIT_USAGE;
+        }
+
         $transport = $allowRemoteRefs ? $this->remoteTransport() : null;
         if ($allowRemoteRefs && $transport === null) {
             $report = $this->report([], [[
@@ -216,7 +235,7 @@ final class DoctorCommand
         $specResults = [];
         $issues = [];
         foreach ($options['specs'] as $path) {
-            $this->diagnoseSpec($path, $options['strip_prefixes'] ?? [], $allowRemoteRefs, $transport, $specResults, $issues);
+            $this->diagnoseSpec($path, $options['strip_prefixes'] ?? [], $allowRemoteRefs, $remoteRefHosts, $transport, $specResults, $issues);
         }
 
         $report = $this->report($specResults, $issues, $options);
@@ -233,6 +252,7 @@ final class DoctorCommand
 
     /**
      * @param list<string> $stripPrefixes
+     * @param list<string> $remoteRefHosts
      * @param null|array{0: ClientInterface, 1: RequestFactoryInterface} $transport
      * @param list<SpecResult> $specResults
      * @param list<DoctorIssue> $issues
@@ -241,6 +261,7 @@ final class DoctorCommand
         string $inputPath,
         array $stripPrefixes,
         bool $allowRemoteRefs,
+        array $remoteRefHosts,
         ?array $transport,
         array &$specResults,
         array &$issues,
@@ -300,6 +321,7 @@ final class DoctorCommand
                 $transport[0] ?? null,
                 $transport[1] ?? null,
                 $allowRemoteRefs,
+                allowedRemoteRefHosts: $remoteRefHosts,
             );
             $spec = OpenApiSpecLoader::load($name);
             $version = OpenApiVersion::fromSpec($spec);
@@ -688,11 +710,17 @@ final class DoctorCommand
         return 'spec';
     }
 
+    private function writeUsageError(string $message): void
+    {
+        $this->writeStderr("[OpenAPI Doctor] {$message}\n\n" . self::usage($this->invocation));
+    }
+
     private function suggestionForException(InvalidOpenApiSpecException $e): ?string
     {
         return match ($e->reason->name) {
             'YamlLibraryMissing' => 'Run: composer require --dev symfony/yaml',
             'RemoteRefDisallowed' => 'Re-run with --allow-remote-refs and install a supported PSR-18 implementation, or bundle the spec.',
+            'RemoteRefHostDisallowed' => 'Add the exact trusted host with --remote-ref-host, or bundle the spec.',
             'HttpClientNotConfigured' => 'Install Guzzle or Symfony HttpClient and re-run with --allow-remote-refs.',
             default => null,
         };

--- a/src/Exception/InvalidOpenApiSpecReason.php
+++ b/src/Exception/InvalidOpenApiSpecReason.php
@@ -15,6 +15,7 @@ enum InvalidOpenApiSpecReason
     case LocalRefUnreadable;
     case LocalRefRequiresSourceFile;
     case RemoteRefDisallowed;
+    case RemoteRefHostDisallowed;
     case RemoteRefFetchFailed;
     case HttpClientNotConfigured;
     case FileSchemeNotSupported;

--- a/src/Internal/HttpRefLoader.php
+++ b/src/Internal/HttpRefLoader.php
@@ -100,19 +100,17 @@ final class HttpRefLoader
 
         $status = $response->getStatusCode();
         if ($status >= 300 && $status < 400) {
-            // Surface the redirect explicitly: PSR-18 clients diverge on
-            // whether they auto-follow (Guzzle defaults to follow, Symfony
-            // to not). A bare 3xx is almost always "user's client has
-            // redirect-following disabled", not a server bug. Including
-            // the Location target makes the next step obvious.
+            // Redirects must remain disabled because following one happens
+            // below Gesso's host allowlist boundary and could reach an
+            // unapproved host. The Location is diagnostic only, so callers
+            // can configure the canonical URL directly.
             $location = self::redactSensitiveUrlData($response->getHeaderLine('Location'));
 
             throw new InvalidOpenApiSpecException(
                 InvalidOpenApiSpecReason::RemoteRefFetchFailed,
                 sprintf(
                     'HTTP $ref fetch returned redirect status %d: %s%s. '
-                    . 'Configure your PSR-18 client to follow redirects, '
-                    . 'or pin the spec to the canonical URL.',
+                    . 'Keep redirects disabled and use the canonical URL directly.',
                     $status,
                     $safeUrl,
                     $location !== '' ? sprintf(' (Location: %s)', $location) : '',

--- a/src/Internal/HttpRefLoader.php
+++ b/src/Internal/HttpRefLoader.php
@@ -56,6 +56,7 @@ final class HttpRefLoader
      * `UnsupportedExtension`.
      *
      * @param array<string, array<string, mixed>> $documentCache by-ref cache keyed by canonical URL
+     * @param list<string> $allowedRemoteRefHosts exact normalized or user-provided host allowlist
      *
      * @throws InvalidOpenApiSpecException when the URL cannot be fetched, decoded, or has no detectable format
      */
@@ -64,13 +65,9 @@ final class HttpRefLoader
         ClientInterface $client,
         RequestFactoryInterface $requestFactory,
         array &$documentCache,
+        array $allowedRemoteRefHosts,
     ): LoadedDocument {
         $canonicalUri = self::canonicalizeUri($url);
-
-        if (isset($documentCache[$canonicalUri])) {
-            return new LoadedDocument($canonicalUri, $documentCache[$canonicalUri]);
-        }
-
         $safeUrl = self::redactSensitiveUrlData($url);
 
         // PHP may include live function arguments when stringifying an
@@ -79,6 +76,11 @@ final class HttpRefLoader
         // parameter slot before any downstream operation can throw.
         $url = $safeUrl;
         $request = $requestFactory->createRequest('GET', $canonicalUri);
+        self::assertHostAllowed($safeUrl, $request->getUri()->getHost(), $allowedRemoteRefHosts);
+
+        if (isset($documentCache[$canonicalUri])) {
+            return new LoadedDocument($canonicalUri, $documentCache[$canonicalUri]);
+        }
 
         try {
             $response = $client->sendRequest($request);
@@ -168,6 +170,12 @@ final class HttpRefLoader
         return new LoadedDocument($canonicalUri, $decoded);
     }
 
+    /** @internal Shared with remote-ref configuration validation. */
+    public static function normalizeHost(string $host): string
+    {
+        return strtolower(rtrim(trim($host), '.'));
+    }
+
     /**
      * Remove URL userinfo and query values before diagnostics reach stderr or
      * CI logs. This also accepts surrounding transport-error prose because
@@ -190,6 +198,28 @@ final class HttpRefLoader
         $withoutQueryValues = preg_replace('~([?&][^=\s&#]+)=([^&#\s]*)~', '$1=[redacted]', $redacted);
 
         return $withoutQueryValues ?? $redacted;
+    }
+
+    /** @param list<string> $allowedRemoteRefHosts */
+    private static function assertHostAllowed(string $safeUrl, string $host, array $allowedRemoteRefHosts): void
+    {
+        $normalizedHost = self::normalizeHost($host);
+        if ($normalizedHost !== '') {
+            foreach ($allowedRemoteRefHosts as $allowedHost) {
+                if ($normalizedHost === self::normalizeHost($allowedHost)) {
+                    return;
+                }
+            }
+        }
+
+        throw new InvalidOpenApiSpecException(
+            InvalidOpenApiSpecReason::RemoteRefHostDisallowed,
+            sprintf(
+                'HTTP(S) $ref host is not allowed: %s. Add the exact host to $allowedRemoteRefHosts.',
+                $safeUrl,
+            ),
+            ref: $safeUrl,
+        );
     }
 
     private static function canonicalizeUri(string $url): string

--- a/src/Spec/OpenApiRefResolver.php
+++ b/src/Spec/OpenApiRefResolver.php
@@ -125,14 +125,16 @@ final class OpenApiRefResolver
      * any **filesystem-relative** `$ref` triggers `LocalRefRequiresSourceFile`.
      * HTTP(S) refs are dispatched via `$httpClient` regardless of `$sourceFile`.
      *
-     * Pass `$httpClient` + `$requestFactory` (PSR-18 / PSR-17) AND
-     * `$allowRemoteRefs: true` to permit HTTP(S) `$ref` resolution.
+     * Pass `$httpClient` + `$requestFactory` (PSR-18 / PSR-17),
+     * `$allowRemoteRefs: true`, and at least one exact host in
+     * `$allowedRemoteRefHosts` to permit HTTP(S) `$ref` resolution.
      * Without both, HTTP refs throw `RemoteRefDisallowed` (flag off) or
      * `HttpClientNotConfigured` (flag on but client/factory missing).
      * `file://` URLs are always rejected to keep path-resolution rules
      * predictable.
      *
      * @param array<string, mixed> $spec
+     * @param list<string> $allowedRemoteRefHosts exact hosts allowed for HTTP(S) refs
      *
      * @return array<string, mixed>
      *
@@ -144,6 +146,7 @@ final class OpenApiRefResolver
         ?ClientInterface $httpClient = null,
         ?RequestFactoryInterface $requestFactory = null,
         bool $allowRemoteRefs = false,
+        array $allowedRemoteRefHosts = [],
     ): array {
         // OpenApiSpecLoader::configure() catches this earlier with an
         // InvalidArgumentException; this guard is for callers that
@@ -158,10 +161,18 @@ final class OpenApiRefResolver
             );
         }
 
+        if ($allowRemoteRefs && $allowedRemoteRefHosts === []) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::RemoteRefHostDisallowed,
+                'OpenApiRefResolver::resolve(): allowRemoteRefs requires at least one exact host '
+                . 'in $allowedRemoteRefHosts.',
+            );
+        }
+
         // After the guard above, allowRemoteRefs:true implies non-null
         // client + factory.
         $context = $allowRemoteRefs
-            ? RefResolutionContext::withRemoteRefs($httpClient, $requestFactory, $sourceFile)
+            ? RefResolutionContext::withRemoteRefs($httpClient, $requestFactory, $allowedRemoteRefHosts, $sourceFile)
             : RefResolutionContext::filesystemOnly($sourceFile);
 
         // $root is a frozen snapshot used for pointer lookups. PHP array
@@ -769,6 +780,7 @@ final class OpenApiRefResolver
                 $context->httpClient,
                 $context->requestFactory,
                 $documentCache,
+                $context->allowedRemoteRefHosts,
             );
         } catch (InvalidOpenApiSpecException $e) {
             // Re-wrap remote-fetch failures with the resolution chain so

--- a/src/Spec/OpenApiSpecLoader.php
+++ b/src/Spec/OpenApiSpecLoader.php
@@ -14,6 +14,7 @@ use Psr\Http\Message\RequestFactoryInterface;
 use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
 use Studio\Gesso\Exception\SpecFileNotFoundException;
+use Studio\Gesso\Internal\HttpRefLoader;
 use Studio\Gesso\Internal\OpenApiDocumentShapeNormalizer;
 use Studio\Gesso\Internal\SpecDocumentDecoder;
 use Studio\Gesso\Internal\YamlAvailability;
@@ -22,15 +23,21 @@ use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
 use function array_key_exists;
+use function array_values;
 use function file_exists;
 use function file_get_contents;
 use function get_debug_type;
 use function implode;
+use function in_array;
 use function is_array;
+use function is_string;
 use function json_decode;
 use function realpath;
 use function rtrim;
 use function sprintf;
+use function str_contains;
+use function str_ends_with;
+use function str_starts_with;
 use function trigger_error;
 use function trim;
 
@@ -62,6 +69,9 @@ final class OpenApiSpecLoader
     private static ?RequestFactoryInterface $requestFactory = null;
     private static bool $allowRemoteRefs = false;
 
+    /** @var list<string> */
+    private static array $allowedRemoteRefHosts = [];
+
     /**
      * Configure the spec loader.
      *
@@ -86,6 +96,9 @@ final class OpenApiSpecLoader
      *                                  `openapi/_shared/...`). When `null` the asserter falls
      *                                  back to `$basePath`, keeping single-root setups
      *                                  bit-for-bit identical to the pre-issue-#170 behavior.
+     * @param list<string> $allowedRemoteRefHosts Exact hostnames or IP literals permitted when
+     *                                            `$allowRemoteRefs` is true. Ports and URL paths
+     *                                            are not accepted. Matching is case-insensitive.
      *
      * @throws InvalidArgumentException for any misconfigured pair: `$allowRemoteRefs` true
      *                                  without client/factory, OR client provided without
@@ -99,6 +112,7 @@ final class OpenApiSpecLoader
         ?RequestFactoryInterface $requestFactory = null,
         bool $allowRemoteRefs = false,
         ?string $enumBasePath = null,
+        array $allowedRemoteRefHosts = [],
     ): void {
         if ($allowRemoteRefs && ($httpClient === null || $requestFactory === null)) {
             throw new InvalidArgumentException(
@@ -121,6 +135,22 @@ final class OpenApiSpecLoader
             );
         }
 
+        if ($allowRemoteRefs && $allowedRemoteRefHosts === []) {
+            throw new InvalidArgumentException(
+                'OpenApiSpecLoader::configure(): allowRemoteRefs requires at least one exact host '
+                . 'in $allowedRemoteRefHosts.',
+            );
+        }
+
+        if (!$allowRemoteRefs && $allowedRemoteRefHosts !== []) {
+            throw new InvalidArgumentException(
+                'OpenApiSpecLoader::configure(): $allowedRemoteRefHosts was provided but '
+                . 'allowRemoteRefs is false.',
+            );
+        }
+
+        $allowedRemoteRefHosts = self::normalizeAllowedRemoteRefHosts($allowedRemoteRefHosts);
+
         if ($enumBasePath !== null && trim($enumBasePath) === '') {
             // Empty / whitespace-only `enumBasePath` would otherwise survive
             // rtrim() as the empty string and surface later as
@@ -141,6 +171,7 @@ final class OpenApiSpecLoader
         self::$httpClient = $httpClient;
         self::$requestFactory = $requestFactory;
         self::$allowRemoteRefs = $allowRemoteRefs;
+        self::$allowedRemoteRefHosts = $allowedRemoteRefHosts;
         // A previous configure() call may have cached specs under a
         // different remote-refs policy. Evict so the next load() runs
         // with the new client/flag combination.
@@ -243,6 +274,7 @@ final class OpenApiSpecLoader
                     self::$httpClient,
                     self::$requestFactory,
                     self::$allowRemoteRefs,
+                    self::$allowedRemoteRefHosts,
                 ),
             );
         } catch (InvalidOpenApiSpecException $e) {
@@ -294,7 +326,49 @@ final class OpenApiSpecLoader
         self::$httpClient = null;
         self::$requestFactory = null;
         self::$allowRemoteRefs = false;
+        self::$allowedRemoteRefHosts = [];
         YamlAvailability::reset();
+    }
+
+    /**
+     * @param list<string> $hosts
+     *
+     * @return list<string>
+     */
+    private static function normalizeAllowedRemoteRefHosts(array $hosts): array
+    {
+        $normalized = [];
+        foreach ($hosts as $host) {
+            if (!is_string($host)) {
+                throw new InvalidArgumentException(
+                    'OpenApiSpecLoader::configure(): every $allowedRemoteRefHosts entry must be a string.',
+                );
+            }
+
+            $candidate = HttpRefLoader::normalizeHost($host);
+            $isBracketedIpv6 = str_starts_with($candidate, '[') && str_ends_with($candidate, ']');
+            if ($candidate === '' ||
+                str_contains($candidate, '://') ||
+                str_contains($candidate, '/') ||
+                str_contains($candidate, '@') ||
+                str_contains($candidate, '?') ||
+                str_contains($candidate, '#') ||
+                (str_contains($candidate, ':') && !$isBracketedIpv6)
+            ) {
+                throw new InvalidArgumentException(
+                    sprintf(
+                        'OpenApiSpecLoader::configure(): invalid remote-ref host `%s`; pass a host only, without scheme, port, path, or userinfo.',
+                        $host,
+                    ),
+                );
+            }
+
+            if (!in_array($candidate, $normalized, true)) {
+                $normalized[] = $candidate;
+            }
+        }
+
+        return array_values($normalized);
     }
 
     /** @return array{path: string, extension: string} */

--- a/src/Spec/OpenApiSpecLoader.php
+++ b/src/Spec/OpenApiSpecLoader.php
@@ -23,14 +23,12 @@ use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
 use function array_key_exists;
-use function array_values;
 use function file_exists;
 use function file_get_contents;
 use function get_debug_type;
 use function implode;
 use function in_array;
 use function is_array;
-use function is_string;
 use function json_decode;
 use function realpath;
 use function rtrim;
@@ -339,12 +337,6 @@ final class OpenApiSpecLoader
     {
         $normalized = [];
         foreach ($hosts as $host) {
-            if (!is_string($host)) {
-                throw new InvalidArgumentException(
-                    'OpenApiSpecLoader::configure(): every $allowedRemoteRefHosts entry must be a string.',
-                );
-            }
-
             $candidate = HttpRefLoader::normalizeHost($host);
             $isBracketedIpv6 = str_starts_with($candidate, '[') && str_ends_with($candidate, ']');
             if ($candidate === '' ||
@@ -368,7 +360,7 @@ final class OpenApiSpecLoader
             }
         }
 
-        return array_values($normalized);
+        return $normalized;
     }
 
     /** @return array{path: string, extension: string} */

--- a/src/Spec/RefResolutionContext.php
+++ b/src/Spec/RefResolutionContext.php
@@ -52,6 +52,8 @@ final class RefResolutionContext
      * A context with HTTP `$ref` resolution enabled. The `$client` /
      * `$factory` pair is required — passing `null` for either is
      * structurally impossible via this factory.
+     *
+     * @param list<string> $allowedRemoteRefHosts
      */
     public static function withRemoteRefs(
         ClientInterface $client,

--- a/src/Spec/RefResolutionContext.php
+++ b/src/Spec/RefResolutionContext.php
@@ -35,6 +35,8 @@ final class RefResolutionContext
         public readonly ?ClientInterface $httpClient,
         public readonly ?RequestFactoryInterface $requestFactory,
         public readonly bool $allowRemoteRefs,
+        /** @var list<string> */
+        public readonly array $allowedRemoteRefHosts,
     ) {}
 
     /**
@@ -43,7 +45,7 @@ final class RefResolutionContext
      */
     public static function filesystemOnly(?string $sourceFile = null): self
     {
-        return new self($sourceFile, null, null, false);
+        return new self($sourceFile, null, null, false, []);
     }
 
     /**
@@ -54,9 +56,10 @@ final class RefResolutionContext
     public static function withRemoteRefs(
         ClientInterface $client,
         RequestFactoryInterface $factory,
+        array $allowedRemoteRefHosts,
         ?string $sourceFile = null,
     ): self {
-        return new self($sourceFile, $client, $factory, true);
+        return new self($sourceFile, $client, $factory, true, $allowedRemoteRefHosts);
     }
 
     /**
@@ -73,6 +76,7 @@ final class RefResolutionContext
             $this->httpClient,
             $this->requestFactory,
             $this->allowRemoteRefs,
+            $this->allowedRemoteRefHosts,
         );
     }
 }

--- a/tests/Integration/DoctorCliIntegrationTest.php
+++ b/tests/Integration/DoctorCliIntegrationTest.php
@@ -19,7 +19,6 @@ use function proc_close;
 use function proc_open;
 use function realpath;
 use function sprintf;
-use function str_replace;
 use function stream_get_contents;
 
 class DoctorCliIntegrationTest extends TestCase
@@ -95,11 +94,7 @@ class DoctorCliIntegrationTest extends TestCase
         $this->assertSame(0, $exit);
         $this->assertSame('', $stderr);
         $this->assertSame(
-            str_replace(
-                'openapi-contract doctor',
-                'gesso doctor',
-                (string) file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v1.9-openapi-contract-help.txt'),
-            ),
+            file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v2-gesso-doctor-help.txt'),
             $stdout,
         );
     }
@@ -112,11 +107,7 @@ class DoctorCliIntegrationTest extends TestCase
         $this->assertSame(2, $exit);
         $this->assertSame('', $stdout);
         $this->assertSame(
-            str_replace(
-                'openapi-contract doctor',
-                'gesso doctor',
-                (string) file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v1.9-openapi-contract-usage-error.txt'),
-            ),
+            file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v2-gesso-doctor-usage-error.txt'),
             $stderr,
         );
     }

--- a/tests/Integration/GessoCliIntegrationTest.php
+++ b/tests/Integration/GessoCliIntegrationTest.php
@@ -63,21 +63,13 @@ final class GessoCliIntegrationTest extends TestCase
         $this->assertSame(0, $helpExit);
         $this->assertSame('', $helpStderr);
         $this->assertSame(
-            str_replace(
-                'openapi-contract doctor',
-                'gesso doctor',
-                (string) file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v1.9-openapi-contract-help.txt'),
-            ),
+            file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v2-gesso-doctor-help.txt'),
             $helpStdout,
         );
         $this->assertSame(2, $errorExit);
         $this->assertSame('', $errorStdout);
         $this->assertSame(
-            str_replace(
-                'openapi-contract doctor',
-                'gesso doctor',
-                (string) file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v1.9-openapi-contract-usage-error.txt'),
-            ),
+            file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v2-gesso-doctor-usage-error.txt'),
             $errorStderr,
         );
     }

--- a/tests/Unit/Cli/DoctorCommandTest.php
+++ b/tests/Unit/Cli/DoctorCommandTest.php
@@ -50,6 +50,7 @@ class DoctorCommandTest extends TestCase
             [
                 'specs' => ['front.json', 'admin.yaml'],
                 'strip_prefixes' => ['/api', '/internal'],
+                'remote_ref_hosts' => ['specs.example.com', 'schemas.example.com'],
                 'invalid_options' => [],
                 'format' => 'json',
                 'allow_remote_refs' => true,
@@ -62,6 +63,8 @@ class DoctorCommandTest extends TestCase
                 '--strip-prefix=/internal',
                 '--format=json',
                 '--allow-remote-refs',
+                '--remote-ref-host=specs.example.com',
+                '--remote-ref-host=schemas.example.com',
                 '--phpunit-snippet',
             ]),
         );
@@ -141,12 +144,35 @@ class DoctorCommandTest extends TestCase
             remoteTransportFactory: static fn(): array => [$client, new HttpFactory()],
         );
 
-        $exit = $command->run(['specs' => [$root], 'format' => 'json', 'allow_remote_refs' => true]);
+        $exit = $command->run([
+            'specs' => [$root],
+            'format' => 'json',
+            'allow_remote_refs' => true,
+            'remote_ref_hosts' => ['example.com'],
+        ]);
         $report = json_decode($output, true, flags: JSON_THROW_ON_ERROR);
 
         $this->assertSame(DoctorCommand::EXIT_OK, $exit);
         $this->assertSame('ok', $report['status']);
         $this->assertSame([$url], $client->sentUrls());
+    }
+
+    #[Test]
+    public function remote_refs_require_an_explicit_host_allowlist(): void
+    {
+        $spec = $this->writeSpec('root.json', $this->validSpec('/pets'));
+        $stderr = '';
+        $command = new DoctorCommand(stderrWriter: static function (string $message) use (&$stderr): void {
+            $stderr .= $message;
+        });
+
+        $exit = $command->run([
+            'specs' => [$spec],
+            'allow_remote_refs' => true,
+        ]);
+
+        $this->assertSame(DoctorCommand::EXIT_USAGE, $exit);
+        $this->assertStringContainsString('--remote-ref-host', $stderr);
     }
 
     #[Test]

--- a/tests/Unit/Compatibility/PublicApiBaselineTest.php
+++ b/tests/Unit/Compatibility/PublicApiBaselineTest.php
@@ -28,6 +28,7 @@ use Studio\Gesso\PHPUnit\ConsoleOutput;
 use Studio\Gesso\PHPUnit\InvalidStrictRequiredConfigurationException;
 use Studio\Gesso\SchemaContext;
 use Studio\Gesso\SkipOpenApiResolver;
+use Studio\Gesso\Spec\OpenApiSpecLoader;
 use Studio\Gesso\Tests\Helpers\PublicApiInventory;
 use Studio\Gesso\Tests\Unit\Compatibility\Fixture\PublicApiImplicitConstructorFixture;
 use Studio\Gesso\Tests\Unit\Compatibility\Fixture\PublicApiPrivateConstructorFixture;
@@ -171,6 +172,23 @@ final class PublicApiBaselineTest extends TestCase
             $expected[InvalidOpenApiSpecReason::class]['cases']['ExternalRef'],
             $expected[InvalidOpenApiSpecReason::class]['cases']['RemoteRefNotImplemented'],
         );
+        $reasonCases = [];
+        foreach ($expected[InvalidOpenApiSpecReason::class]['cases'] as $name => $value) {
+            $reasonCases[$name] = $value;
+            if ($name === 'RemoteRefDisallowed') {
+                $reasonCases['RemoteRefHostDisallowed'] = null;
+            }
+        }
+        $expected[InvalidOpenApiSpecReason::class]['cases'] = $reasonCases;
+        $expected[OpenApiSpecLoader::class]['methods']['configure']['parameters'][] = [
+            'name' => 'allowedRemoteRefHosts',
+            'type' => 'array',
+            'optional' => true,
+            'variadic' => false,
+            'by_reference' => false,
+            'default' => [],
+            'attributes' => [],
+        ];
         $expected[JsonCoverageRenderer::class]['constants']['SCHEMA_VERSION'] = 2;
         $expected[ExploredCase::class]['methods']['bodyAsArray'] = [
             'static' => false,

--- a/tests/Unit/Internal/HttpRefLoaderTest.php
+++ b/tests/Unit/Internal/HttpRefLoaderTest.php
@@ -37,7 +37,7 @@ class HttpRefLoaderTest extends TestCase
         ]);
 
         $cache = [];
-        $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+        $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
 
         $this->assertSame($url, $result->canonicalIdentifier);
         $this->assertSame(['type' => 'object', 'required' => ['id']], $result->decoded);
@@ -52,7 +52,7 @@ class HttpRefLoaderTest extends TestCase
         ]);
 
         $cache = [];
-        $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+        $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
 
         $this->assertSame(['type' => 'object', 'required' => ['id']], $result->decoded);
     }
@@ -69,7 +69,7 @@ class HttpRefLoaderTest extends TestCase
         ]);
 
         $cache = [];
-        $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+        $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['registry.example.com']);
 
         $this->assertSame(['type' => 'string'], $result->decoded);
     }
@@ -83,7 +83,7 @@ class HttpRefLoaderTest extends TestCase
         ]);
 
         $cache = [];
-        $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+        $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
 
         $this->assertSame(['type' => 'object'], $result->decoded);
     }
@@ -97,7 +97,7 @@ class HttpRefLoaderTest extends TestCase
         ]);
 
         $cache = [];
-        $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+        $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
 
         $this->assertSame(['type' => 'integer'], $result->decoded);
     }
@@ -116,8 +116,8 @@ class HttpRefLoaderTest extends TestCase
         ]);
 
         $cache = [];
-        HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
-        HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+        HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
+        HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
 
         $this->assertSame(1, $callCount);
     }
@@ -132,7 +132,7 @@ class HttpRefLoaderTest extends TestCase
 
         try {
             $cache = [];
-            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
             $this->assertSame(InvalidOpenApiSpecReason::RemoteRefFetchFailed, $e->reason);
@@ -151,7 +151,7 @@ class HttpRefLoaderTest extends TestCase
 
         try {
             $cache = [];
-            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
             $this->assertSame(InvalidOpenApiSpecReason::RemoteRefFetchFailed, $e->reason);
@@ -171,7 +171,7 @@ class HttpRefLoaderTest extends TestCase
 
         try {
             $cache = [];
-            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
             $this->assertSame(InvalidOpenApiSpecReason::RemoteRefFetchFailed, $e->reason);
@@ -190,7 +190,7 @@ class HttpRefLoaderTest extends TestCase
 
         try {
             $cache = [];
-            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
             $this->assertSame(InvalidOpenApiSpecReason::UnsupportedExtension, $e->reason);
@@ -208,7 +208,7 @@ class HttpRefLoaderTest extends TestCase
 
         try {
             $cache = [];
-            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
             $this->assertSame(InvalidOpenApiSpecReason::MalformedJson, $e->reason);
@@ -226,7 +226,7 @@ class HttpRefLoaderTest extends TestCase
 
         try {
             $cache = [];
-            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
             $this->assertSame(InvalidOpenApiSpecReason::MalformedYaml, $e->reason);
@@ -247,7 +247,7 @@ class HttpRefLoaderTest extends TestCase
 
         try {
             $cache = [];
-            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
             $this->assertSame(InvalidOpenApiSpecReason::RemoteRefFetchFailed, $e->reason);
@@ -269,7 +269,7 @@ class HttpRefLoaderTest extends TestCase
 
         try {
             $cache = [];
-            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
             $this->assertStringNotContainsString('alice', $e->getMessage());
@@ -290,7 +290,7 @@ class HttpRefLoaderTest extends TestCase
         ]);
 
         $cache = [];
-        $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+        $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
 
         $this->assertSame(['type' => 'object'], $result->decoded);
     }
@@ -305,7 +305,7 @@ class HttpRefLoaderTest extends TestCase
 
         try {
             $cache = [];
-            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
             $this->assertSame(InvalidOpenApiSpecReason::UnsupportedExtension, $e->reason);
@@ -329,7 +329,7 @@ class HttpRefLoaderTest extends TestCase
         ]);
 
         $cache = [];
-        $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+        $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
 
         $this->assertSame(['type' => 'object'], $result->decoded);
     }
@@ -347,7 +347,7 @@ class HttpRefLoaderTest extends TestCase
 
         try {
             $cache = [];
-            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
             $this->assertStringNotContainsString('secret', $e->getMessage());
@@ -368,7 +368,7 @@ class HttpRefLoaderTest extends TestCase
 
         try {
             $cache = [];
-            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
             $this->assertStringNotContainsString('alice', $e->getMessage());
@@ -406,7 +406,7 @@ class HttpRefLoaderTest extends TestCase
         try {
             try {
                 $cache = [];
-                HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+                HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
                 $this->fail('expected InvalidOpenApiSpecException');
             } catch (InvalidOpenApiSpecException $e) {
                 $rendered = (string) $e;
@@ -434,7 +434,7 @@ class HttpRefLoaderTest extends TestCase
 
         try {
             $cache = [];
-            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache);
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
             $this->assertSame(InvalidOpenApiSpecReason::NonMappingRoot, $e->reason);

--- a/tests/Unit/Internal/HttpRefLoaderTest.php
+++ b/tests/Unit/Internal/HttpRefLoaderTest.php
@@ -236,10 +236,9 @@ class HttpRefLoaderTest extends TestCase
     #[Test]
     public function rejects_3xx_redirect_with_hint_pointing_at_location(): void
     {
-        // Surface the redirect explicitly: PSR-18 clients vary on whether
-        // they auto-follow (Guzzle does, Symfony does not). A bare 302
-        // landing here is almost always "user's client has redirect-following
-        // disabled", and the error message must point at the next step.
+        // Redirect following would happen below Gesso's allowlist boundary,
+        // so the diagnostic must keep it disabled and point users at the
+        // canonical URL instead of recommending an SSRF bypass.
         $url = 'https://example.com/redirect.json';
         $client = new FakeHttpClient([
             $url => new Response(302, ['Location' => 'https://example.com/canonical.json']),
@@ -253,7 +252,9 @@ class HttpRefLoaderTest extends TestCase
             $this->assertSame(InvalidOpenApiSpecReason::RemoteRefFetchFailed, $e->reason);
             $this->assertStringContainsString('302', $e->getMessage());
             $this->assertStringContainsString('https://example.com/canonical.json', $e->getMessage());
-            $this->assertStringContainsString('redirect', $e->getMessage());
+            $this->assertStringContainsString('Keep redirects disabled', $e->getMessage());
+            $this->assertStringContainsString('canonical URL', $e->getMessage());
+            $this->assertStringNotContainsString('follow redirects', $e->getMessage());
         }
     }
 

--- a/tests/Unit/Spec/OpenApiRefResolverHttpRefsTest.php
+++ b/tests/Unit/Spec/OpenApiRefResolverHttpRefsTest.php
@@ -59,12 +59,64 @@ class OpenApiRefResolverHttpRefsTest extends TestCase
             httpClient: $client,
             requestFactory: $this->factory,
             allowRemoteRefs: true,
+            allowedRemoteRefHosts: ['example.com'],
         );
 
         $this->assertSame(
             ['type' => 'object', 'required' => ['id']],
             $resolved['components']['schemas']['Pet'],
         );
+    }
+
+    #[Test]
+    public function rejects_unlisted_host_before_sending_a_request(): void
+    {
+        $url = 'http://169.254.169.254/latest/meta-data.json';
+        $client = new FakeHttpClient([
+            $url => FakeHttpClient::jsonResponse('{"type":"string"}'),
+        ]);
+        $spec = ['components' => ['schemas' => ['Metadata' => ['$ref' => $url]]]];
+
+        try {
+            OpenApiRefResolver::resolve(
+                $spec,
+                httpClient: $client,
+                requestFactory: $this->factory,
+                allowRemoteRefs: true,
+                allowedRemoteRefHosts: ['specs.example.com'],
+            );
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::RemoteRefHostDisallowed, $e->reason);
+            $this->assertStringContainsString('169.254.169.254', $e->getMessage());
+            $this->assertSame([], $client->sentUrls());
+        }
+    }
+
+    #[Test]
+    public function rechecks_the_allowlist_for_nested_cross_host_refs(): void
+    {
+        $entry = 'https://specs.example.com/root.json';
+        $nested = 'http://169.254.169.254/latest/meta-data.json';
+        $client = new FakeHttpClient([
+            $entry => FakeHttpClient::jsonResponse('{"$ref":"' . $nested . '"}'),
+            $nested => FakeHttpClient::jsonResponse('{"type":"string"}'),
+        ]);
+        $spec = ['components' => ['schemas' => ['Metadata' => ['$ref' => $entry]]]];
+
+        try {
+            OpenApiRefResolver::resolve(
+                $spec,
+                httpClient: $client,
+                requestFactory: $this->factory,
+                allowRemoteRefs: true,
+                allowedRemoteRefHosts: ['SPECS.EXAMPLE.COM.'],
+            );
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::RemoteRefHostDisallowed, $e->reason);
+            $this->assertSame([$entry], $client->sentUrls());
+        }
     }
 
     #[Test]
@@ -84,6 +136,7 @@ class OpenApiRefResolverHttpRefsTest extends TestCase
             httpClient: $client,
             requestFactory: $this->factory,
             allowRemoteRefs: true,
+            allowedRemoteRefHosts: ['example.com'],
         );
 
         $this->assertSame(['type' => 'object'], $resolved['components']['schemas']['Pet']);
@@ -108,6 +161,7 @@ class OpenApiRefResolverHttpRefsTest extends TestCase
             httpClient: $client,
             requestFactory: $this->factory,
             allowRemoteRefs: true,
+            allowedRemoteRefHosts: ['example.com'],
         );
 
         $this->assertSame(['type' => 'string'], $resolved['components']['schemas']['Leaf']);
@@ -131,6 +185,7 @@ class OpenApiRefResolverHttpRefsTest extends TestCase
                 httpClient: $client,
                 requestFactory: $this->factory,
                 allowRemoteRefs: true,
+                allowedRemoteRefHosts: ['example.com'],
             );
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
@@ -163,6 +218,7 @@ class OpenApiRefResolverHttpRefsTest extends TestCase
             httpClient: $client,
             requestFactory: $this->factory,
             allowRemoteRefs: true,
+            allowedRemoteRefHosts: ['example.com'],
         );
 
         $this->assertSame(['type' => 'integer'], $resolved['components']['schemas']['Final']);
@@ -199,6 +255,7 @@ class OpenApiRefResolverHttpRefsTest extends TestCase
             httpClient: $client,
             requestFactory: $this->factory,
             allowRemoteRefs: true,
+            allowedRemoteRefHosts: ['example.com'],
         );
 
         $this->assertSame(1, $callCount, 'duplicate URLs should hit the per-resolution cache');
@@ -257,6 +314,7 @@ class OpenApiRefResolverHttpRefsTest extends TestCase
                 httpClient: $client,
                 requestFactory: null,
                 allowRemoteRefs: true,
+                allowedRemoteRefHosts: ['example.com'],
             );
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
@@ -279,6 +337,7 @@ class OpenApiRefResolverHttpRefsTest extends TestCase
             httpClient: $client,
             requestFactory: $this->factory,
             allowRemoteRefs: true,
+            allowedRemoteRefHosts: ['example.com'],
         );
 
         $this->assertSame(['type' => 'object'], $resolved['components']['schemas']['Slash']);
@@ -300,6 +359,7 @@ class OpenApiRefResolverHttpRefsTest extends TestCase
                 httpClient: $client,
                 requestFactory: $this->factory,
                 allowRemoteRefs: true,
+                allowedRemoteRefHosts: ['example.com'],
             );
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
@@ -330,6 +390,7 @@ class OpenApiRefResolverHttpRefsTest extends TestCase
             httpClient: $client,
             requestFactory: $this->factory,
             allowRemoteRefs: true,
+            allowedRemoteRefHosts: ['example.com'],
         );
         $this->assertSame(['v' => 1], $first['components']['schemas']['Pet']);
 
@@ -339,6 +400,7 @@ class OpenApiRefResolverHttpRefsTest extends TestCase
             httpClient: $client,
             requestFactory: $this->factory,
             allowRemoteRefs: true,
+            allowedRemoteRefHosts: ['example.com'],
         );
         $this->assertSame(['v' => 2], $second['components']['schemas']['Pet']);
         $this->assertSame(2, $callCount);
@@ -366,6 +428,7 @@ class OpenApiRefResolverHttpRefsTest extends TestCase
             httpClient: $client,
             requestFactory: $this->factory,
             allowRemoteRefs: true,
+            allowedRemoteRefHosts: ['example.com'],
         );
 
         $this->assertSame(
@@ -391,6 +454,7 @@ class OpenApiRefResolverHttpRefsTest extends TestCase
             httpClient: $client,
             requestFactory: $this->factory,
             allowRemoteRefs: true,
+            allowedRemoteRefHosts: ['example.com'],
         );
 
         $this->assertSame(['type' => 'string'], $resolved['components']['schemas']['X']);
@@ -413,6 +477,7 @@ class OpenApiRefResolverHttpRefsTest extends TestCase
             httpClient: $client,
             requestFactory: $this->factory,
             allowRemoteRefs: true,
+            allowedRemoteRefHosts: ['example.com'],
         );
 
         $this->assertSame(['type' => 'integer'], $resolved['components']['schemas']['X']);
@@ -441,6 +506,7 @@ class OpenApiRefResolverHttpRefsTest extends TestCase
                 httpClient: $client,
                 requestFactory: $this->factory,
                 allowRemoteRefs: true,
+                allowedRemoteRefHosts: ['example.com'],
             );
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {
@@ -474,6 +540,7 @@ class OpenApiRefResolverHttpRefsTest extends TestCase
                     httpClient: $client,
                     requestFactory: $this->factory,
                     allowRemoteRefs: true,
+                    allowedRemoteRefHosts: ['example.com'],
                 );
                 $this->fail('expected InvalidOpenApiSpecException');
             } catch (InvalidOpenApiSpecException $e) {
@@ -503,6 +570,7 @@ class OpenApiRefResolverHttpRefsTest extends TestCase
                 httpClient: $client,
                 requestFactory: $this->factory,
                 allowRemoteRefs: true,
+                allowedRemoteRefHosts: ['example.com'],
             );
             $this->fail('expected InvalidOpenApiSpecException');
         } catch (InvalidOpenApiSpecException $e) {

--- a/tests/Unit/Spec/OpenApiSpecLoaderTest.php
+++ b/tests/Unit/Spec/OpenApiSpecLoaderTest.php
@@ -418,6 +418,7 @@ class OpenApiSpecLoaderTest extends TestCase
             OpenApiSpecLoader::configure(
                 '/path/to/specs',
                 allowRemoteRefs: true,
+                allowedRemoteRefHosts: ['example.com'],
             );
             $this->fail('expected InvalidArgumentException');
         } catch (InvalidArgumentException $e) {
@@ -457,9 +458,51 @@ class OpenApiSpecLoaderTest extends TestCase
             httpClient: $client,
             requestFactory: $factory,
             allowRemoteRefs: true,
+            allowedRemoteRefHosts: ['example.com'],
         );
 
         $this->assertSame('/path/to/specs', OpenApiSpecLoader::getBasePath());
+    }
+
+    #[Test]
+    public function configure_rejects_remote_refs_without_an_allowed_host(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('allowedRemoteRefHosts');
+
+        OpenApiSpecLoader::configure(
+            '/path/to/specs',
+            httpClient: new Client(),
+            requestFactory: new HttpFactory(),
+            allowRemoteRefs: true,
+        );
+    }
+
+    #[Test]
+    public function configure_rejects_allowed_hosts_when_remote_refs_are_disabled(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('allowRemoteRefs is false');
+
+        OpenApiSpecLoader::configure(
+            '/path/to/specs',
+            allowedRemoteRefHosts: ['example.com'],
+        );
+    }
+
+    #[Test]
+    public function configure_rejects_urls_in_the_host_allowlist(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('pass a host only');
+
+        OpenApiSpecLoader::configure(
+            '/path/to/specs',
+            httpClient: new Client(),
+            requestFactory: new HttpFactory(),
+            allowRemoteRefs: true,
+            allowedRemoteRefHosts: ['https://example.com/specs'],
+        );
     }
 
     #[Test]
@@ -478,6 +521,7 @@ class OpenApiSpecLoaderTest extends TestCase
             httpClient: new Client(),
             requestFactory: new HttpFactory(),
             allowRemoteRefs: true,
+            allowedRemoteRefHosts: ['example.com'],
         );
 
         // Reload — by-value-equal but not the cached array from before.
@@ -493,6 +537,7 @@ class OpenApiSpecLoaderTest extends TestCase
             httpClient: new Client(),
             requestFactory: new HttpFactory(),
             allowRemoteRefs: true,
+            allowedRemoteRefHosts: ['example.com'],
         );
 
         OpenApiSpecLoader::reset();

--- a/tests/fixtures/compatibility/v2-gesso-doctor-help.txt
+++ b/tests/fixtures/compatibility/v2-gesso-doctor-help.txt
@@ -1,0 +1,20 @@
+gesso doctor — check whether this package can load and enforce your contract.
+
+Usage:
+  gesso doctor --spec=<path> [--spec=<path> ...] [options]
+
+Options:
+  --spec=<path[,path]>       JSON/YAML entry document. Repeat for multiple specs.
+  --strip-prefix=<prefix>    Request-path prefix used by PHPUnit. Repeat as needed.
+  --format=text|json         Output format (default: text).
+  --allow-remote-refs        Resolve HTTP(S) refs with an installed Guzzle or
+                             Symfony PSR-18 implementation.
+  --remote-ref-host=<host>   Exact host allowed for HTTP(S) refs. Required with
+                             --allow-remote-refs; repeat as needed.
+  --phpunit-snippet          Include the equivalent PHPUnit extension XML.
+  --help                     Show this message.
+
+Exit codes:
+  0  All specs are compatible (warnings/skipped features may be present).
+  1  A spec cannot be loaded or enforced.
+  2  Command-line usage is invalid.

--- a/tests/fixtures/compatibility/v2-gesso-doctor-usage-error.txt
+++ b/tests/fixtures/compatibility/v2-gesso-doctor-usage-error.txt
@@ -1,0 +1,22 @@
+[OpenAPI Doctor] At least one --spec is required.
+
+gesso doctor — check whether this package can load and enforce your contract.
+
+Usage:
+  gesso doctor --spec=<path> [--spec=<path> ...] [options]
+
+Options:
+  --spec=<path[,path]>       JSON/YAML entry document. Repeat for multiple specs.
+  --strip-prefix=<prefix>    Request-path prefix used by PHPUnit. Repeat as needed.
+  --format=text|json         Output format (default: text).
+  --allow-remote-refs        Resolve HTTP(S) refs with an installed Guzzle or
+                             Symfony PSR-18 implementation.
+  --remote-ref-host=<host>   Exact host allowed for HTTP(S) refs. Required with
+                             --allow-remote-refs; repeat as needed.
+  --phpunit-snippet          Include the equivalent PHPUnit extension XML.
+  --help                     Show this message.
+
+Exit codes:
+  0  All specs are compatible (warnings/skipped features may be present).
+  1  A spec cannot be loaded or enforced.
+  2  Command-line usage is invalid.

--- a/tests/fixtures/compatibility/v2-public-api.json
+++ b/tests/fixtures/compatibility/v2-public-api.json
@@ -1405,6 +1405,7 @@
             "LocalRefUnreadable": null,
             "LocalRefRequiresSourceFile": null,
             "RemoteRefDisallowed": null,
+            "RemoteRefHostDisallowed": null,
             "RemoteRefFetchFailed": null,
             "HttpClientNotConfigured": null,
             "FileSchemeNotSupported": null,
@@ -6844,6 +6845,15 @@
                         "variadic": false,
                         "by_reference": false,
                         "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "allowedRemoteRefHosts",
+                        "type": "array",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": [],
                         "attributes": []
                     }
                 ]


### PR DESCRIPTION
## Summary

- require an exact host allowlist whenever HTTP(S) `$ref` resolution is enabled
- enforce the policy against the PSR-7 request URI before sending any request, including nested cross-host refs
- add `RemoteRefHostDisallowed` and a repeatable Doctor `--remote-ref-host=<host>` option
- document the v2 migration, redirect boundary, and SSRF trust model

## Root cause

`allowRemoteRefs: true` previously allowed an opted-in spec to send requests to any HTTP(S) destination. An attacker-controlled or compromised spec could therefore target loopback, link-local metadata services, or other internal endpoints from the test runner (CWE-918).

The new policy uses an allowlist rather than a destination denylist. It checks the host parsed by the same PSR-7 request object that is passed to the HTTP client, avoiding parser disagreement between validation and transport. Each nested remote ref is checked independently, and a rejected host is never sent to the PSR-18 client.

This follows the [OWASP SSRF Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html), which recommends allowlisting trusted destinations and disabling redirect following where possible.

## Impact

This intentionally tightens the pre-v2 public contract. Existing callers that enable remote refs must add an allowlist:

```php
OpenApiSpecLoader::configure(
    // ...
    allowRemoteRefs: true,
    allowedRemoteRefHosts: ['specs.example.com'],
);
```

Doctor users must pair `--allow-remote-refs` with one or more `--remote-ref-host=<host>` options. Clients should keep redirect following disabled and use canonical URLs because PSR-18 does not expose redirect destinations to this library consistently.

## Verification

- `npm_config_cache=/tmp/gesso-npm-cache vendor/bin/phpunit --do-not-cache-result` — 2,135 tests, 5,892 assertions
- `vendor/bin/phpstan analyse --debug --no-progress --memory-limit=1G`
- both PHP-CS-Fixer configurations in sequential dry-run mode
- `npm run docs:build`
- `git diff --check`

The aggregate `composer cs-check` wrapper could not open its parallel local TCP worker inside the sandbox; both underlying PHP-CS-Fixer configurations passed sequentially.
