### PR TITLE
fix(refs): redact response body read errors

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -602,8 +602,9 @@ The library does not bundle an HTTP client — pick whichever your project alrea
 Remote-reference diagnostics remove URL userinfo and query values before they
 reach exception messages or CI logs. Configure authentication on the HTTP
 client instead of embedding credentials in a `$ref` URL. Raw PSR-18 transport
-exceptions are not chained into the public exception because a nested cause may
-contain unsanitized request data; the sanitized top-level message is retained.
+and response-body stream exceptions are not chained into the public exception
+because a nested cause may contain unsanitized request data; the sanitized
+top-level message is retained.
 The original `$ref` argument is also replaced with its diagnostic-safe form
 before network operations, so exception traces remain redacted even when
 `zend.exception_ignore_args=Off`.

--- a/src/Internal/HttpRefLoader.php
+++ b/src/Internal/HttpRefLoader.php
@@ -138,11 +138,16 @@ final class HttpRefLoader
             }
             $body = $bodyStream->getContents();
         } catch (RuntimeException $e) {
+            $safeBodyMessage = self::redactSensitiveUrlData($e->getMessage());
+
             throw new InvalidOpenApiSpecException(
                 InvalidOpenApiSpecReason::RemoteRefFetchFailed,
-                sprintf('HTTP $ref response body unreadable: %s (%s)', $safeUrl, $e->getMessage()),
+                sprintf('HTTP $ref response body unreadable: %s (%s)', $safeUrl, $safeBodyMessage),
                 ref: $safeUrl,
-                previous: $e,
+                // A response stream is supplied by the injected HTTP client
+                // and may include request credentials in its exception or
+                // nested causes. Do not reconnect the raw chain to a public
+                // exception that is commonly rendered in CI logs.
             );
         }
 

--- a/tests/Unit/Internal/HttpRefLoaderTest.php
+++ b/tests/Unit/Internal/HttpRefLoaderTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Studio\Gesso\Tests\Unit\Internal;
 
+use GuzzleHttp\Psr7\FnStream;
 use GuzzleHttp\Psr7\HttpFactory;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
@@ -422,6 +424,45 @@ class HttpRefLoaderTest extends TestCase
         } finally {
             ini_set('zend.exception_ignore_args', $previousIgnoreArgs);
             ini_set('zend.exception_string_param_max_len', $previousMaxLength);
+        }
+    }
+
+    #[Test]
+    public function redacts_credentials_from_response_body_exception_chain(): void
+    {
+        $url = 'https://example.com/private/pet.json';
+        $cause = new RuntimeException(
+            'socket failed for https://nested:nested-secret@example.com/body.json?token=nested-query-secret',
+        );
+        $stream = FnStream::decorate(Utils::streamFor(''), [
+            'isSeekable' => static fn(): bool => false,
+            'getContents' => static function () use ($cause): never {
+                throw new RuntimeException(
+                    'body read failed for https://alice:secret@example.com/body.json?token=query-secret',
+                    0,
+                    $cause,
+                );
+            },
+        ]);
+        $client = new FakeHttpClient([
+            $url => new Response(200, ['Content-Type' => 'application/json'], $stream),
+        ]);
+
+        try {
+            $cache = [];
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $rendered = (string) $e;
+
+            $this->assertSame(InvalidOpenApiSpecReason::RemoteRefFetchFailed, $e->reason);
+            $this->assertStringContainsString('body read failed', $rendered);
+            $this->assertStringContainsString('https://example.com/body.json?token=[redacted]', $rendered);
+            $this->assertStringNotContainsString('alice', $rendered);
+            $this->assertStringNotContainsString('secret', $rendered);
+            $this->assertStringNotContainsString('query-secret', $rendered);
+            $this->assertStringNotContainsString('nested-query-secret', $rendered);
+            $this->assertNull($e->getPrevious());
         }
     }
 


### PR DESCRIPTION
## Summary

- sanitize response-body stream exception messages before surfacing remote `$ref` failures
- omit the raw stream exception chain from the public exception
- add a regression test covering credentials and query tokens in both the outer stream error and a nested cause
- document the same redaction guarantee for transport and response-body failures

## Root cause

PR #365 protected PSR-18 transport failures, but the later response-body read path still interpolated the raw `RuntimeException` message and attached it as `previous`. Exception stringification traverses the full previous chain, so a PSR-7 stream supplied by the injected HTTP client could expose URL userinfo, passwords, or query tokens in CI logs.

The response-body path now applies the same policy as the transport path: retain a sanitized top-level diagnostic and do not reconnect an exception chain whose contents cannot be proven safe.

This follows the [OWASP Logging Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html), which recommends removing or masking passwords, access tokens, and other secrets before log output.

## Impact

Remote-reference read failures still report the safe target URL and sanitized top-level stream error. Raw client exception objects are no longer available through `getPrevious()` because their nested messages may contain credentials.

## Verification

- focused remote-ref suites: 42 tests, 88 assertions
- full PHPUnit suite: 2,136 tests, 5,902 assertions
- full PHPStan analysis
- both PHP-CS-Fixer configurations in sequential dry-run mode
- VitePress documentation build
- Markdown link check
- `git diff --check`
