### PR TITLE
fix(refs): bound remote response bodies

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -70,6 +70,11 @@ Pass `allowedRemoteRefHosts: ['specs.example.com']` together with
 The Doctor equivalent is repeatable `--remote-ref-host=<host>`. Unlisted hosts
 are rejected before a request is sent. Keep PSR-18 redirect following disabled
 and use canonical URLs so a redirect cannot move below this policy boundary.
+Remote documents are also limited to 10 MiB each by default. `OpenApiSpecLoader`
+configuration can raise the positive `maxRemoteRefBytes` value, and Doctor uses
+`--remote-ref-max-bytes=<bytes>`. Configure transport-level timeouts and body
+limits too because a PSR-18 implementation may buffer the response before
+returning its PSR-7 stream.
 
 Several orchestration types that were unintentionally part of the v1 PHP API
 are marked `@internal` in v2. Do not call coverage renderer, sidecar I/O,

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -37,10 +37,11 @@ Remote references remain opt-in because diagnostics must not access the network 
 vendor/bin/gesso doctor \
   --spec=openapi/root.yaml \
   --allow-remote-refs \
-  --remote-ref-host=specs.example.com
+  --remote-ref-host=specs.example.com \
+  --remote-ref-max-bytes=10485760
 ```
 
-The command automatically uses an installed Guzzle (`guzzlehttp/guzzle` plus `guzzlehttp/psr7`) or Symfony HttpClient PSR-18 implementation. Every permitted host must be listed with `--remote-ref-host`; repeat the option when a trusted contract intentionally spans hosts. A nested `$ref` that switches to an unlisted host is rejected before any request is sent. Without `--allow-remote-refs`, an HTTP(S) `$ref` is reported as a reference error with an actionable hint. Network failures, malformed remote documents, content-type mismatches, and reference cycles also exit non-zero.
+The command automatically uses an installed Guzzle (`guzzlehttp/guzzle` plus `guzzlehttp/psr7`) or Symfony HttpClient PSR-18 implementation. Every permitted host must be listed with `--remote-ref-host`; repeat the option when a trusted contract intentionally spans hosts. A nested `$ref` that switches to an unlisted host is rejected before any request is sent. Each remote document is limited to 10 MiB by default; use `--remote-ref-max-bytes=<positive integer>` only when a trusted contract requires a larger bound. Without `--allow-remote-refs`, an HTTP(S) `$ref` is reported as a reference error with an actionable hint. Network failures, oversized or malformed remote documents, content-type mismatches, and reference cycles also exit non-zero.
 
 ## Machine-readable output
 

--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -137,7 +137,9 @@ Studio\OpenApiContractTesting\Spec\OpenApiSpecResolver
 The loader's static configuration, base paths, strip prefixes, local/remote
 reference inputs, cache behavior exposed through non-internal methods, and
 exception taxonomy are observable contracts. Remote resolution in v2 requires
-the new `allowedRemoteRefHosts` argument whenever `allowRemoteRefs` is enabled.
+the new `allowedRemoteRefHosts` argument whenever `allowRemoteRefs` is enabled
+and limits each remote document to 10 MiB by default. A positive
+`maxRemoteRefBytes` value can raise that bound for trusted contracts.
 
 ### Coverage
 
@@ -389,6 +391,7 @@ Accepted options:
 - `--format=text|json`;
 - `--allow-remote-refs`;
 - repeatable `--remote-ref-host=<host>` (required with `--allow-remote-refs`);
+- `--remote-ref-max-bytes=<positive integer>` (10 MiB default);
 - `--phpunit-snippet`;
 - `--help` / `-h`.
 
@@ -396,10 +399,11 @@ Exit codes are `0` for a usable contract, `1` for diagnostic failure, and `2`
 for invalid usage. JSON uses `schemaVersion: 1`; issue fields are `severity`,
 `category`, `spec`, `message`, and nullable `suggestion`.
 
-Migration status: unchanged. The exact v1.9 help and invalid-usage output are
-captured under `tests/fixtures/compatibility/` and exercised through the
-installed-style binary integration test, including exit code and output
-channel.
+Migration status: v2 adds the host allowlist and remote response-size option.
+The exact v1.9 help and invalid-usage output remain captured under
+`tests/fixtures/compatibility/`, while v2 fixtures pin the additive options.
+Both generations are exercised through the installed-style binary integration
+test, including exit code and output channel.
 
 ### Coverage merge
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -594,6 +594,7 @@ OpenApiSpecLoader::configure(
     requestFactory: new HttpFactory(), // PSR-17 RequestFactoryInterface
     allowRemoteRefs: true,
     allowedRemoteRefHosts: ['specs.example.com'],
+    maxRemoteRefBytes: 10_485_760, // optional; 10 MiB default per document
 );
 ```
 
@@ -622,6 +623,15 @@ following. DNS and network-layer controls remain the application's
 responsibility because PSR-18 does not expose connection-level address policy.
 [See the OWASP SSRF Prevention Cheat Sheet.](https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html)
 
+Each remote document is limited to 10 MiB by default. Gesso checks a valid
+`Content-Length`, the PSR-7 stream's known size, and the bytes actually read, so
+a missing or false size header cannot bypass the limit. Set
+`maxRemoteRefBytes` to a positive integer only when a trusted contract is
+larger. A PSR-18 client may buffer a response before returning its PSR-7 stream;
+also configure client-level timeouts and transfer limits where the selected
+implementation supports them. This bounds the transport as well as Gesso's
+parser boundary. See the [PSR-7 stream rationale](https://www.php-fig.org/psr/psr-7/#13-streams).
+
 Misconfiguration is caught early:
 
 | Setup | Result |
@@ -632,6 +642,7 @@ Misconfiguration is caught early:
 | `$httpClient` set but `allowRemoteRefs: false` | `InvalidArgumentException` at `configure()` (silent misuse impossible) |
 | `allowRemoteRefs: true` + client + ref to URL that 4xx/5xx | `InvalidOpenApiSpecException` with reason `RemoteRefFetchFailed` |
 | `allowRemoteRefs: true` + client + ref to URL that 3xx | `RemoteRefFetchFailed` with redirect target — keep redirects disabled and use the canonical URL |
+| Remote response exceeds `maxRemoteRefBytes` | `RemoteRefFetchFailed` before parsing; raise the limit only for a trusted contract |
 | `allowRemoteRefs: true` + client + ref to URL with no detectable format | reason `UnsupportedExtension` (URL extension or `Content-Type` header is required) |
 
 Format detection prefers the URL's filename extension (`.json` / `.yaml` / `.yml`) and falls back to the response's `Content-Type` (`application/json`, `application/*+json`, `application/yaml`, `text/yaml`, etc.). URLs without a recognisable extension still work as long as the server sets a usable `Content-Type`.

--- a/src/Cli/DoctorCommand.php
+++ b/src/Cli/DoctorCommand.php
@@ -7,6 +7,7 @@ namespace Studio\Gesso\Cli;
 use const E_USER_WARNING;
 use const ENT_QUOTES;
 use const ENT_XML1;
+use const FILTER_VALIDATE_INT;
 use const JSON_PRETTY_PRINT;
 use const JSON_THROW_ON_ERROR;
 use const JSON_UNESCAPED_SLASHES;
@@ -23,6 +24,7 @@ use Psr\Http\Message\RequestFactoryInterface;
 use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\Exception\MalformedDiscriminatorException;
 use Studio\Gesso\Exception\SpecFileNotFoundException;
+use Studio\Gesso\Internal\HttpRefLoader;
 use Studio\Gesso\OpenApiVersion;
 use Studio\Gesso\Spec\OpenApiOperationResolver;
 use Studio\Gesso\Spec\OpenApiSchemaConverter;
@@ -42,6 +44,7 @@ use function compact;
 use function count;
 use function dirname;
 use function explode;
+use function filter_var;
 use function fwrite;
 use function getcwd;
 use function htmlspecialchars;
@@ -69,7 +72,7 @@ use function substr;
 /**
  * Pre-test compatibility diagnostics for one or more OpenAPI documents.
  *
- * @phpstan-type DoctorOptions array{specs?: list<string>, strip_prefixes?: list<string>, remote_ref_hosts?: list<string>, format?: string, allow_remote_refs?: bool, phpunit_snippet?: bool, help?: bool, invalid_options?: list<string>}
+ * @phpstan-type DoctorOptions array{specs?: list<string>, strip_prefixes?: list<string>, remote_ref_hosts?: list<string>, remote_ref_max_bytes?: int|string, format?: string, allow_remote_refs?: bool, phpunit_snippet?: bool, help?: bool, invalid_options?: list<string>}
  * @phpstan-type DoctorIssue array{severity: 'error'|'warning'|'skipped', category: string, spec: ?string, message: string, suggestion: ?string}
  * @phpstan-type SpecResult array{path: string, name: string, openapi: string, dialect: string, operations: int, responses: int}
  *
@@ -148,6 +151,10 @@ final class DoctorCommand
                     ];
 
                     break;
+                case 'remote_ref_max_bytes':
+                    $options['remote_ref_max_bytes'] = $value;
+
+                    break;
                 case 'phpunit_snippet':
                     $options['phpunit_snippet'] = !in_array($value, ['0', 'false', 'no'], true);
 
@@ -176,6 +183,8 @@ final class DoctorCommand
                                          Symfony PSR-18 implementation.
               --remote-ref-host=<host>   Exact host allowed for HTTP(S) refs. Required with
                                          --allow-remote-refs; repeat as needed.
+              --remote-ref-max-bytes=<n> Maximum bytes read per remote document
+                                         (default: 10485760).
               --phpunit-snippet          Include the equivalent PHPUnit extension XML.
               --help                     Show this message.
 
@@ -218,6 +227,21 @@ final class DoctorCommand
             return self::EXIT_USAGE;
         }
 
+        $hasRemoteRefMaxBytes = array_key_exists('remote_ref_max_bytes', $options);
+        if ($hasRemoteRefMaxBytes && !$allowRemoteRefs) {
+            $this->writeUsageError('--remote-ref-max-bytes requires --allow-remote-refs.');
+
+            return self::EXIT_USAGE;
+        }
+        $maxRemoteRefBytes = $hasRemoteRefMaxBytes
+            ? filter_var($options['remote_ref_max_bytes'], FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]])
+            : HttpRefLoader::DEFAULT_MAX_RESPONSE_BYTES;
+        if ($maxRemoteRefBytes === false) {
+            $this->writeUsageError('--remote-ref-max-bytes must be a positive integer.');
+
+            return self::EXIT_USAGE;
+        }
+
         $transport = $allowRemoteRefs ? $this->remoteTransport() : null;
         if ($allowRemoteRefs && $transport === null) {
             $report = $this->report([], [[
@@ -235,7 +259,7 @@ final class DoctorCommand
         $specResults = [];
         $issues = [];
         foreach ($options['specs'] as $path) {
-            $this->diagnoseSpec($path, $options['strip_prefixes'] ?? [], $allowRemoteRefs, $remoteRefHosts, $transport, $specResults, $issues);
+            $this->diagnoseSpec($path, $options['strip_prefixes'] ?? [], $allowRemoteRefs, $remoteRefHosts, $maxRemoteRefBytes, $transport, $specResults, $issues);
         }
 
         $report = $this->report($specResults, $issues, $options);
@@ -253,6 +277,7 @@ final class DoctorCommand
     /**
      * @param list<string> $stripPrefixes
      * @param list<string> $remoteRefHosts
+     * @param positive-int $maxRemoteRefBytes
      * @param null|array{0: ClientInterface, 1: RequestFactoryInterface} $transport
      * @param list<SpecResult> $specResults
      * @param list<DoctorIssue> $issues
@@ -262,6 +287,7 @@ final class DoctorCommand
         array $stripPrefixes,
         bool $allowRemoteRefs,
         array $remoteRefHosts,
+        int $maxRemoteRefBytes,
         ?array $transport,
         array &$specResults,
         array &$issues,
@@ -322,6 +348,7 @@ final class DoctorCommand
                 $transport[1] ?? null,
                 $allowRemoteRefs,
                 allowedRemoteRefHosts: $remoteRefHosts,
+                maxRemoteRefBytes: $maxRemoteRefBytes,
             );
             $spec = OpenApiSpecLoader::load($name);
             $version = OpenApiVersion::fromSpec($spec);

--- a/src/Internal/HttpRefLoader.php
+++ b/src/Internal/HttpRefLoader.php
@@ -51,6 +51,7 @@ final class HttpRefLoader
 {
     public const DEFAULT_MAX_RESPONSE_BYTES = 10_485_760;
     private const READ_CHUNK_BYTES = 8192;
+    private const MAX_EMPTY_READ_RETRIES = 3;
 
     private function __construct() {}
 
@@ -225,6 +226,7 @@ final class HttpRefLoader
     private static function readLimitedBody(StreamInterface $stream, string $safeUrl, int $maxResponseBytes): string
     {
         $body = '';
+        $emptyReadRetries = 0;
         while (!$stream->eof()) {
             $remaining = $maxResponseBytes - strlen($body);
             $readLength = $remaining >= self::READ_CHUNK_BYTES
@@ -232,9 +234,18 @@ final class HttpRefLoader
                 : $remaining + 1;
             $chunk = $stream->read($readLength);
             if ($chunk === '') {
-                throw new RuntimeException('response body stream returned no data before EOF');
+                $emptyReadRetries++;
+                if ($emptyReadRetries > self::MAX_EMPTY_READ_RETRIES) {
+                    throw new RuntimeException(sprintf(
+                        'response body stream made no progress after %d retries before EOF',
+                        self::MAX_EMPTY_READ_RETRIES,
+                    ));
+                }
+
+                continue;
             }
 
+            $emptyReadRetries = 0;
             $body .= $chunk;
             if (strlen($body) > $maxResponseBytes) {
                 throw self::responseTooLarge($safeUrl, $maxResponseBytes);

--- a/src/Internal/HttpRefLoader.php
+++ b/src/Internal/HttpRefLoader.php
@@ -9,17 +9,22 @@ use const PATHINFO_EXTENSION;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
 
+use function ctype_digit;
+use function ltrim;
 use function pathinfo;
 use function preg_replace;
 use function preg_split;
 use function rtrim;
 use function sprintf;
 use function str_ends_with;
+use function strcmp;
 use function strcspn;
+use function strlen;
 use function strtolower;
 use function substr;
 use function trim;
@@ -44,6 +49,9 @@ use function trim;
  */
 final class HttpRefLoader
 {
+    public const DEFAULT_MAX_RESPONSE_BYTES = 10_485_760;
+    private const READ_CHUNK_BYTES = 8192;
+
     private function __construct() {}
 
     /**
@@ -66,6 +74,7 @@ final class HttpRefLoader
         RequestFactoryInterface $requestFactory,
         array &$documentCache,
         array $allowedRemoteRefHosts,
+        int $maxResponseBytes = self::DEFAULT_MAX_RESPONSE_BYTES,
     ): LoadedDocument {
         $canonicalUri = self::canonicalizeUri($url);
         $safeUrl = self::redactSensitiveUrlData($url);
@@ -126,17 +135,27 @@ final class HttpRefLoader
             );
         }
 
-        // Read via getContents() rather than (string) cast so a stream
-        // I/O failure surfaces as a real exception (PSR-7 permits
-        // __toString() to silently return '' on read errors, which
-        // would then mis-classify as MalformedJson/Yaml).
+        $contentLength = trim($response->getHeaderLine('Content-Length'));
+        if ($contentLength !== '' && ctype_digit($contentLength) && self::decimalExceeds($contentLength, $maxResponseBytes)) {
+            throw self::responseTooLarge($safeUrl, $maxResponseBytes);
+        }
+
+        // Read incrementally rather than casting or calling getContents().
+        // PSR-7 bodies may be arbitrarily large or have no known size, so
+        // the configured limit must be enforced against bytes actually read.
         $bodyStream = $response->getBody();
 
         try {
+            $knownSize = $bodyStream->getSize();
+            if ($knownSize !== null && $knownSize > $maxResponseBytes) {
+                throw self::responseTooLarge($safeUrl, $maxResponseBytes);
+            }
             if ($bodyStream->isSeekable()) {
                 $bodyStream->rewind();
             }
-            $body = $bodyStream->getContents();
+            $body = self::readLimitedBody($bodyStream, $safeUrl, $maxResponseBytes);
+        } catch (InvalidOpenApiSpecException $e) {
+            throw $e;
         } catch (RuntimeException $e) {
             $safeBodyMessage = self::redactSensitiveUrlData($e->getMessage());
 
@@ -201,6 +220,51 @@ final class HttpRefLoader
         $withoutQueryValues = preg_replace('~([?&][^=\s&#]+)=([^&#\s]*)~', '$1=[redacted]', $redacted);
 
         return $withoutQueryValues ?? $redacted;
+    }
+
+    private static function readLimitedBody(StreamInterface $stream, string $safeUrl, int $maxResponseBytes): string
+    {
+        $body = '';
+        while (!$stream->eof()) {
+            $remaining = $maxResponseBytes - strlen($body);
+            $readLength = $remaining >= self::READ_CHUNK_BYTES
+                ? self::READ_CHUNK_BYTES
+                : $remaining + 1;
+            $chunk = $stream->read($readLength);
+            if ($chunk === '') {
+                throw new RuntimeException('response body stream returned no data before EOF');
+            }
+
+            $body .= $chunk;
+            if (strlen($body) > $maxResponseBytes) {
+                throw self::responseTooLarge($safeUrl, $maxResponseBytes);
+            }
+        }
+
+        return $body;
+    }
+
+    private static function responseTooLarge(string $safeUrl, int $maxResponseBytes): InvalidOpenApiSpecException
+    {
+        return new InvalidOpenApiSpecException(
+            InvalidOpenApiSpecReason::RemoteRefFetchFailed,
+            sprintf(
+                'HTTP $ref response exceeds the configured limit of %d bytes: %s.',
+                $maxResponseBytes,
+                $safeUrl,
+            ),
+            ref: $safeUrl,
+        );
+    }
+
+    private static function decimalExceeds(string $decimal, int $limit): bool
+    {
+        $decimal = ltrim($decimal, '0');
+        $decimal = $decimal === '' ? '0' : $decimal;
+        $limitString = (string) $limit;
+
+        return strlen($decimal) > strlen($limitString) ||
+            (strlen($decimal) === strlen($limitString) && strcmp($decimal, $limitString) > 0);
     }
 
     /** @param list<string> $allowedRemoteRefHosts */

--- a/src/Spec/OpenApiRefResolver.php
+++ b/src/Spec/OpenApiRefResolver.php
@@ -135,6 +135,7 @@ final class OpenApiRefResolver
      *
      * @param array<string, mixed> $spec
      * @param list<string> $allowedRemoteRefHosts exact hosts allowed for HTTP(S) refs
+     * @param int $maxRemoteRefBytes maximum response bytes read per remote document; must be positive
      *
      * @return array<string, mixed>
      *
@@ -147,6 +148,7 @@ final class OpenApiRefResolver
         ?RequestFactoryInterface $requestFactory = null,
         bool $allowRemoteRefs = false,
         array $allowedRemoteRefHosts = [],
+        int $maxRemoteRefBytes = OpenApiSpecLoader::DEFAULT_MAX_REMOTE_REF_BYTES,
     ): array {
         // OpenApiSpecLoader::configure() catches this earlier with an
         // InvalidArgumentException; this guard is for callers that
@@ -169,10 +171,17 @@ final class OpenApiRefResolver
             );
         }
 
+        if ($allowRemoteRefs && $maxRemoteRefBytes < 1) {
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::RemoteRefFetchFailed,
+                'OpenApiRefResolver::resolve(): $maxRemoteRefBytes must be greater than zero.',
+            );
+        }
+
         // After the guard above, allowRemoteRefs:true implies non-null
         // client + factory.
         $context = $allowRemoteRefs
-            ? RefResolutionContext::withRemoteRefs($httpClient, $requestFactory, $allowedRemoteRefHosts, $sourceFile)
+            ? RefResolutionContext::withRemoteRefs($httpClient, $requestFactory, $allowedRemoteRefHosts, $sourceFile, $maxRemoteRefBytes)
             : RefResolutionContext::filesystemOnly($sourceFile);
 
         // $root is a frozen snapshot used for pointer lookups. PHP array
@@ -781,6 +790,7 @@ final class OpenApiRefResolver
                 $context->requestFactory,
                 $documentCache,
                 $context->allowedRemoteRefHosts,
+                $context->maxRemoteRefBytes,
             );
         } catch (InvalidOpenApiSpecException $e) {
             // Re-wrap remote-fetch failures with the resolution chain so

--- a/src/Spec/OpenApiSpecLoader.php
+++ b/src/Spec/OpenApiSpecLoader.php
@@ -41,6 +41,8 @@ use function trim;
 
 final class OpenApiSpecLoader
 {
+    public const DEFAULT_MAX_REMOTE_REF_BYTES = HttpRefLoader::DEFAULT_MAX_RESPONSE_BYTES;
+
     /**
      * Extensions are searched in the order listed; the first hit wins.
      * JSON is first for back-compat with the pre-existing bundle workflow.
@@ -69,6 +71,7 @@ final class OpenApiSpecLoader
 
     /** @var list<string> */
     private static array $allowedRemoteRefHosts = [];
+    private static int $maxRemoteRefBytes = self::DEFAULT_MAX_REMOTE_REF_BYTES;
 
     /**
      * Configure the spec loader.
@@ -97,6 +100,8 @@ final class OpenApiSpecLoader
      * @param list<string> $allowedRemoteRefHosts Exact hostnames or IP literals permitted when
      *                                            `$allowRemoteRefs` is true. Ports and URL paths
      *                                            are not accepted. Matching is case-insensitive.
+     * @param int $maxRemoteRefBytes Maximum HTTP response-body bytes read for each remote
+     *                               document. Must be positive; the default is 10 MiB.
      *
      * @throws InvalidArgumentException for any misconfigured pair: `$allowRemoteRefs` true
      *                                  without client/factory, OR client provided without
@@ -111,6 +116,7 @@ final class OpenApiSpecLoader
         bool $allowRemoteRefs = false,
         ?string $enumBasePath = null,
         array $allowedRemoteRefHosts = [],
+        int $maxRemoteRefBytes = self::DEFAULT_MAX_REMOTE_REF_BYTES,
     ): void {
         if ($allowRemoteRefs && ($httpClient === null || $requestFactory === null)) {
             throw new InvalidArgumentException(
@@ -147,6 +153,12 @@ final class OpenApiSpecLoader
             );
         }
 
+        if ($maxRemoteRefBytes < 1) {
+            throw new InvalidArgumentException(
+                'OpenApiSpecLoader::configure(): $maxRemoteRefBytes must be greater than zero.',
+            );
+        }
+
         $allowedRemoteRefHosts = self::normalizeAllowedRemoteRefHosts($allowedRemoteRefHosts);
 
         if ($enumBasePath !== null && trim($enumBasePath) === '') {
@@ -170,6 +182,7 @@ final class OpenApiSpecLoader
         self::$requestFactory = $requestFactory;
         self::$allowRemoteRefs = $allowRemoteRefs;
         self::$allowedRemoteRefHosts = $allowedRemoteRefHosts;
+        self::$maxRemoteRefBytes = $maxRemoteRefBytes;
         // A previous configure() call may have cached specs under a
         // different remote-refs policy. Evict so the next load() runs
         // with the new client/flag combination.
@@ -273,6 +286,7 @@ final class OpenApiSpecLoader
                     self::$requestFactory,
                     self::$allowRemoteRefs,
                     self::$allowedRemoteRefHosts,
+                    self::$maxRemoteRefBytes,
                 ),
             );
         } catch (InvalidOpenApiSpecException $e) {
@@ -325,6 +339,7 @@ final class OpenApiSpecLoader
         self::$requestFactory = null;
         self::$allowRemoteRefs = false;
         self::$allowedRemoteRefHosts = [];
+        self::$maxRemoteRefBytes = self::DEFAULT_MAX_REMOTE_REF_BYTES;
         YamlAvailability::reset();
     }
 

--- a/src/Spec/RefResolutionContext.php
+++ b/src/Spec/RefResolutionContext.php
@@ -6,6 +6,7 @@ namespace Studio\Gesso\Spec;
 
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Studio\Gesso\Internal\HttpRefLoader;
 
 /**
  * Carries the per-resolution state that `OpenApiRefResolver::walk()` needs
@@ -37,6 +38,7 @@ final class RefResolutionContext
         public readonly bool $allowRemoteRefs,
         /** @var list<string> */
         public readonly array $allowedRemoteRefHosts,
+        public readonly int $maxRemoteRefBytes,
     ) {}
 
     /**
@@ -45,7 +47,7 @@ final class RefResolutionContext
      */
     public static function filesystemOnly(?string $sourceFile = null): self
     {
-        return new self($sourceFile, null, null, false, []);
+        return new self($sourceFile, null, null, false, [], HttpRefLoader::DEFAULT_MAX_RESPONSE_BYTES);
     }
 
     /**
@@ -60,8 +62,9 @@ final class RefResolutionContext
         RequestFactoryInterface $factory,
         array $allowedRemoteRefHosts,
         ?string $sourceFile = null,
+        int $maxRemoteRefBytes = HttpRefLoader::DEFAULT_MAX_RESPONSE_BYTES,
     ): self {
-        return new self($sourceFile, $client, $factory, true, $allowedRemoteRefHosts);
+        return new self($sourceFile, $client, $factory, true, $allowedRemoteRefHosts, $maxRemoteRefBytes);
     }
 
     /**
@@ -79,6 +82,7 @@ final class RefResolutionContext
             $this->requestFactory,
             $this->allowRemoteRefs,
             $this->allowedRemoteRefHosts,
+            $this->maxRemoteRefBytes,
         );
     }
 }

--- a/tests/Unit/Cli/DoctorCommandTest.php
+++ b/tests/Unit/Cli/DoctorCommandTest.php
@@ -54,6 +54,7 @@ class DoctorCommandTest extends TestCase
                 'invalid_options' => [],
                 'format' => 'json',
                 'allow_remote_refs' => true,
+                'remote_ref_max_bytes' => '4096',
                 'phpunit_snippet' => true,
             ],
             DoctorCommand::parseArgv([
@@ -65,6 +66,7 @@ class DoctorCommandTest extends TestCase
                 '--allow-remote-refs',
                 '--remote-ref-host=specs.example.com',
                 '--remote-ref-host=schemas.example.com',
+                '--remote-ref-max-bytes=4096',
                 '--phpunit-snippet',
             ]),
         );
@@ -173,6 +175,44 @@ class DoctorCommandTest extends TestCase
 
         $this->assertSame(DoctorCommand::EXIT_USAGE, $exit);
         $this->assertStringContainsString('--remote-ref-host', $stderr);
+    }
+
+    #[Test]
+    public function remote_ref_max_bytes_requires_remote_refs(): void
+    {
+        $spec = $this->writeSpec('root.json', $this->validSpec('/pets'));
+        $stderr = '';
+        $command = new DoctorCommand(stderrWriter: static function (string $message) use (&$stderr): void {
+            $stderr .= $message;
+        });
+
+        $exit = $command->run([
+            'specs' => [$spec],
+            'remote_ref_max_bytes' => '1024',
+        ]);
+
+        $this->assertSame(DoctorCommand::EXIT_USAGE, $exit);
+        $this->assertStringContainsString('--remote-ref-max-bytes requires --allow-remote-refs', $stderr);
+    }
+
+    #[Test]
+    public function remote_ref_max_bytes_must_be_a_positive_integer(): void
+    {
+        $spec = $this->writeSpec('root.json', $this->validSpec('/pets'));
+        $stderr = '';
+        $command = new DoctorCommand(stderrWriter: static function (string $message) use (&$stderr): void {
+            $stderr .= $message;
+        });
+
+        $exit = $command->run([
+            'specs' => [$spec],
+            'allow_remote_refs' => true,
+            'remote_ref_hosts' => ['example.com'],
+            'remote_ref_max_bytes' => '0',
+        ]);
+
+        $this->assertSame(DoctorCommand::EXIT_USAGE, $exit);
+        $this->assertStringContainsString('positive integer', $stderr);
     }
 
     #[Test]

--- a/tests/Unit/Compatibility/PublicApiBaselineTest.php
+++ b/tests/Unit/Compatibility/PublicApiBaselineTest.php
@@ -180,6 +180,7 @@ final class PublicApiBaselineTest extends TestCase
             }
         }
         $expected[InvalidOpenApiSpecReason::class]['cases'] = $reasonCases;
+        $expected[OpenApiSpecLoader::class]['constants']['DEFAULT_MAX_REMOTE_REF_BYTES'] = 10_485_760;
         $expected[OpenApiSpecLoader::class]['methods']['configure']['parameters'][] = [
             'name' => 'allowedRemoteRefHosts',
             'type' => 'array',
@@ -187,6 +188,18 @@ final class PublicApiBaselineTest extends TestCase
             'variadic' => false,
             'by_reference' => false,
             'default' => [],
+            'attributes' => [],
+        ];
+        $expected[OpenApiSpecLoader::class]['methods']['configure']['parameters'][] = [
+            'name' => 'maxRemoteRefBytes',
+            'type' => 'int',
+            'optional' => true,
+            'variadic' => false,
+            'by_reference' => false,
+            'default' => [
+                'constant' => 'self::DEFAULT_MAX_REMOTE_REF_BYTES',
+                'value' => 10_485_760,
+            ],
             'attributes' => [],
         ];
         $expected[JsonCoverageRenderer::class]['constants']['SCHEMA_VERSION'] = 2;

--- a/tests/Unit/Internal/HttpRefLoaderTest.php
+++ b/tests/Unit/Internal/HttpRefLoaderTest.php
@@ -19,6 +19,7 @@ use Studio\Gesso\Tests\Helpers\FakeHttpClient;
 use Studio\Gesso\Tests\Helpers\FakeHttpClientUnexpectedRequest;
 
 use function ini_set;
+use function substr;
 
 class HttpRefLoaderTest extends TestCase
 {
@@ -463,6 +464,68 @@ class HttpRefLoaderTest extends TestCase
             $this->assertStringNotContainsString('query-secret', $rendered);
             $this->assertStringNotContainsString('nested-query-secret', $rendered);
             $this->assertNull($e->getPrevious());
+        }
+    }
+
+    #[Test]
+    public function tolerates_a_transient_empty_read_before_response_data_is_available(): void
+    {
+        $url = 'https://example.com/delayed.json';
+        $readCount = 0;
+        $finished = false;
+        $stream = FnStream::decorate(Utils::streamFor(''), [
+            'getSize' => static fn(): ?int => null,
+            'eof' => static function () use (&$finished): bool {
+                return $finished;
+            },
+            'read' => static function (int $length) use (&$readCount, &$finished): string {
+                $readCount++;
+                if ($readCount === 1) {
+                    return '';
+                }
+
+                $finished = true;
+
+                return substr('{"type":"object"}', 0, $length);
+            },
+        ]);
+        $client = new FakeHttpClient([
+            $url => new Response(200, ['Content-Type' => 'application/json'], $stream),
+        ]);
+
+        $cache = [];
+        $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
+
+        $this->assertSame(['type' => 'object'], $result->decoded);
+        $this->assertSame(2, $readCount);
+    }
+
+    #[Test]
+    public function rejects_a_response_stream_that_repeatedly_makes_no_progress(): void
+    {
+        $url = 'https://example.com/stalled.json';
+        $readCount = 0;
+        $stream = FnStream::decorate(Utils::streamFor(''), [
+            'getSize' => static fn(): ?int => null,
+            'eof' => static fn(): bool => false,
+            'read' => static function (int $length) use (&$readCount): string {
+                $readCount++;
+
+                return '';
+            },
+        ]);
+        $client = new FakeHttpClient([
+            $url => new Response(200, ['Content-Type' => 'application/json'], $stream),
+        ]);
+
+        try {
+            $cache = [];
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com']);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::RemoteRefFetchFailed, $e->reason);
+            $this->assertStringContainsString('made no progress', $e->getMessage());
+            $this->assertLessThanOrEqual(10, $readCount);
         }
     }
 

--- a/tests/Unit/Internal/HttpRefLoaderTest.php
+++ b/tests/Unit/Internal/HttpRefLoaderTest.php
@@ -436,7 +436,7 @@ class HttpRefLoaderTest extends TestCase
         );
         $stream = FnStream::decorate(Utils::streamFor(''), [
             'isSeekable' => static fn(): bool => false,
-            'getContents' => static function () use ($cause): never {
+            'read' => static function (int $length) use ($cause): never {
                 throw new RuntimeException(
                     'body read failed for https://alice:secret@example.com/body.json?token=query-secret',
                     0,
@@ -463,6 +463,64 @@ class HttpRefLoaderTest extends TestCase
             $this->assertStringNotContainsString('query-secret', $rendered);
             $this->assertStringNotContainsString('nested-query-secret', $rendered);
             $this->assertNull($e->getPrevious());
+        }
+    }
+
+    #[Test]
+    public function accepts_response_exactly_at_the_configured_limit(): void
+    {
+        $url = 'https://example.com/exact.json';
+        $client = new FakeHttpClient([
+            $url => new Response(200, ['Content-Type' => 'application/json'], '{"a":1}'),
+        ]);
+
+        $cache = [];
+        $result = HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com'], 7);
+
+        $this->assertSame(['a' => 1], $result->decoded);
+    }
+
+    #[Test]
+    public function rejects_response_whose_content_length_exceeds_the_configured_limit(): void
+    {
+        $url = 'https://example.com/oversized.json';
+        $client = new FakeHttpClient([
+            $url => new Response(200, [
+                'Content-Type' => 'application/json',
+                'Content-Length' => '1024',
+            ], '{}'),
+        ]);
+
+        try {
+            $cache = [];
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com'], 10);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::RemoteRefFetchFailed, $e->reason);
+            $this->assertStringContainsString('exceeds', $e->getMessage());
+            $this->assertStringContainsString('10 bytes', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function rejects_streamed_response_that_exceeds_the_configured_limit(): void
+    {
+        $url = 'https://example.com/streamed.json';
+        $stream = FnStream::decorate(Utils::streamFor('{"value":"too large"}'), [
+            'getSize' => static fn(): ?int => null,
+        ]);
+        $client = new FakeHttpClient([
+            $url => new Response(200, ['Content-Type' => 'application/json'], $stream),
+        ]);
+
+        try {
+            $cache = [];
+            HttpRefLoader::loadDocument($url, $client, $this->factory, $cache, ['example.com'], 10);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::RemoteRefFetchFailed, $e->reason);
+            $this->assertStringContainsString('exceeds', $e->getMessage());
+            $this->assertStringContainsString('10 bytes', $e->getMessage());
         }
     }
 

--- a/tests/Unit/Spec/OpenApiSpecLoaderTest.php
+++ b/tests/Unit/Spec/OpenApiSpecLoaderTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Studio\Gesso\Tests\Unit\Spec;
 
+use const JSON_THROW_ON_ERROR;
+
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\HttpFactory;
 use InvalidArgumentException;
@@ -15,6 +17,7 @@ use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
 use Studio\Gesso\Exception\SpecFileNotFoundException;
 use Studio\Gesso\Internal\YamlAvailability;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
+use Studio\Gesso\Tests\Helpers\FakeHttpClient;
 use Studio\Gesso\Validation\Request\SecurityValidator;
 use Symfony\Component\Yaml\Yaml;
 
@@ -462,6 +465,49 @@ class OpenApiSpecLoaderTest extends TestCase
         );
 
         $this->assertSame('/path/to/specs', OpenApiSpecLoader::getBasePath());
+    }
+
+    #[Test]
+    public function configure_rejects_non_positive_remote_response_limit(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('maxRemoteRefBytes');
+
+        OpenApiSpecLoader::configure('/path/to/specs', maxRemoteRefBytes: 0);
+    }
+
+    #[Test]
+    public function load_enforces_the_configured_remote_response_limit(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/openapi-remote-limit-' . uniqid('', true);
+        mkdir($tempDir);
+        $url = 'https://example.com/schema.json';
+        file_put_contents($tempDir . '/root.json', (string) json_encode([
+            'openapi' => '3.1.0',
+            'info' => ['title' => 'Test', 'version' => '1'],
+            'paths' => [],
+            'components' => ['schemas' => ['Remote' => ['$ref' => $url]]],
+        ], JSON_THROW_ON_ERROR));
+
+        try {
+            OpenApiSpecLoader::configure(
+                $tempDir,
+                httpClient: new FakeHttpClient([
+                    $url => FakeHttpClient::jsonResponse('{"type":"object"}'),
+                ]),
+                requestFactory: new HttpFactory(),
+                allowRemoteRefs: true,
+                allowedRemoteRefHosts: ['example.com'],
+                maxRemoteRefBytes: 10,
+            );
+
+            $this->expectException(InvalidOpenApiSpecException::class);
+            $this->expectExceptionMessage('configured limit of 10 bytes');
+            OpenApiSpecLoader::load('root');
+        } finally {
+            @unlink($tempDir . '/root.json');
+            @rmdir($tempDir);
+        }
     }
 
     #[Test]

--- a/tests/fixtures/compatibility/v2-gesso-doctor-help.txt
+++ b/tests/fixtures/compatibility/v2-gesso-doctor-help.txt
@@ -11,6 +11,8 @@ Options:
                              Symfony PSR-18 implementation.
   --remote-ref-host=<host>   Exact host allowed for HTTP(S) refs. Required with
                              --allow-remote-refs; repeat as needed.
+  --remote-ref-max-bytes=<n> Maximum bytes read per remote document
+                             (default: 10485760).
   --phpunit-snippet          Include the equivalent PHPUnit extension XML.
   --help                     Show this message.
 

--- a/tests/fixtures/compatibility/v2-gesso-doctor-usage-error.txt
+++ b/tests/fixtures/compatibility/v2-gesso-doctor-usage-error.txt
@@ -13,6 +13,8 @@ Options:
                              Symfony PSR-18 implementation.
   --remote-ref-host=<host>   Exact host allowed for HTTP(S) refs. Required with
                              --allow-remote-refs; repeat as needed.
+  --remote-ref-max-bytes=<n> Maximum bytes read per remote document
+                             (default: 10485760).
   --phpunit-snippet          Include the equivalent PHPUnit extension XML.
   --help                     Show this message.
 

--- a/tests/fixtures/compatibility/v2-public-api.json
+++ b/tests/fixtures/compatibility/v2-public-api.json
@@ -6780,7 +6780,9 @@
         "attributes": [],
         "backing_type": null,
         "cases": [],
-        "constants": [],
+        "constants": {
+            "DEFAULT_MAX_REMOTE_REF_BYTES": 10485760
+        },
         "properties": [],
         "methods": {
             "configure": {
@@ -6854,6 +6856,18 @@
                         "variadic": false,
                         "by_reference": false,
                         "default": [],
+                        "attributes": []
+                    },
+                    {
+                        "name": "maxRemoteRefBytes",
+                        "type": "int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "constant": "self::DEFAULT_MAX_REMOTE_REF_BYTES",
+                            "value": 10485760
+                        },
                         "attributes": []
                     }
                 ]


### PR DESCRIPTION
## Summary

- limit each HTTP(S) `$ref` document to 10 MiB by default
- enforce the bound using `Content-Length`, PSR-7 stream size, and actual streamed bytes
- expose `maxRemoteRefBytes` and the Doctor `--remote-ref-max-bytes` option
- document client-side timeout/transfer limits and update the v2 compatibility contracts

## Root cause

`HttpRefLoader` materialized the complete response body without a library-enforced bound. An allowlisted but compromised or misbehaving specification host could therefore return an arbitrarily large body and exhaust a CI runner's memory. `Content-Length` alone is insufficient because it can be absent or inaccurate.

PSR-7 also notes that converting an entire stream to a string can consume more memory than intended: https://www.php-fig.org/psr/psr-7/#13-streams

## Impact

- the default limit is 10 MiB per remote document; a body exactly at the limit is accepted
- larger trusted specifications can raise the positive `maxRemoteRefBytes` value or Doctor flag
- remote references that remain disabled are unaffected
- client-side timeout and transfer limits remain recommended because a PSR-18 client may buffer the body before returning the PSR-7 response
- the public API change is additive through a trailing optional parameter and a public default constant
- the Doctor CLI gains an additive v2 option, with its compatibility fixtures updated

## Verification

- full PHPUnit suite: 2,143 tests / 5,917 assertions
- PHPStan: no errors
- PHP-CS-Fixer: default and Pest configurations pass
- documentation build and external-link checks pass
- `git diff --check` passes
