### PR TITLE
fix(refs)!: confine local references to spec root

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,6 +45,8 @@ release notes (with permission).
 
 This is a test-only library — it has no runtime production surface. The
 relevant attack vectors are:
+- Resolving local external `$ref`s — canonical targets are confined to
+  `spec_base_path`; use the narrowest trusted common directory
 - Resolving HTTP(S) `$ref`s (opt-in, off by default) — verify any untrusted
   spec source before enabling `allowRemoteRefs`
 - YAML spec loading (opt-in via `symfony/yaml`) — `symfony/yaml` is

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -59,10 +59,20 @@ required first argument.
 `InvalidOpenApiSpecReason::RemoteRefNotImplemented` have been removed. Neither
 case was emitted by production code by the end of v1. Use the specific resolver
 reason instead: local-reference failures use `LocalRefNotFound`,
-`LocalRefUnreadable`, or `LocalRefRequiresSourceFile`; remote-reference failures
+`LocalRefOutsideAllowedRoot`, `LocalRefUnreadable`, or
+`LocalRefRequiresSourceFile`; remote-reference failures
 use `RemoteRefDisallowed`, `HttpClientNotConfigured`,
 `RemoteRefHostDisallowed`, or `RemoteRefFetchFailed`; unsupported `file:` references use
 `FileSchemeNotSupported`.
+
+Local external `$ref` targets are now confined to `spec_base_path` after
+canonicalization. An absolute path, `../` traversal, or symlink is rejected
+when its canonical target resolves outside the configured directory. If entry
+documents and shared schemas are siblings, move `spec_base_path` to their narrowest
+trusted common parent and include the entry subdirectory in `specs` (for
+example, `spec_base_path=openapi` with `specs=bundled/front`). Doctor uses the
+same policy; pass `--local-ref-root=openapi` for that layout. Code branching on
+resolver reasons should handle the new `LocalRefOutsideAllowedRoot` case.
 
 HTTP(S) `$ref` resolution now requires an explicit destination allowlist.
 Pass `allowedRemoteRefHosts: ['specs.example.com']` together with

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -29,6 +29,22 @@ vendor/bin/gesso doctor \
 
 `--phpunit-snippet` prints the equivalent extension configuration when all entry documents share one directory. The snippet uses each entry document's filename without its extension as the configured spec name.
 
+Local external references are confined to each entry document's directory by
+default. If an entry and its shared schemas use sibling directories, pass their
+narrowest trusted common parent:
+
+```bash
+vendor/bin/gesso doctor \
+  --spec=openapi/bundled/front.yaml \
+  --local-ref-root=openapi \
+  --phpunit-snippet
+```
+
+The generated PHPUnit snippet then uses `spec_base_path="openapi"` and the
+spec name `bundled/front`. Targets that escape the canonical root through
+`../`, an absolute path, or a symlink are rejected; those forms remain valid
+when their canonical targets stay inside the root.
+
 ## HTTP references
 
 Remote references remain opt-in because diagnostics must not access the network unexpectedly:

--- a/docs/migration/v2-compatibility-inventory.md
+++ b/docs/migration/v2-compatibility-inventory.md
@@ -125,7 +125,9 @@ production-unused `InvalidOpenApiSpecReason::ExternalRef` and
 the specific local, remote, HTTP-client, fetch, or file-scheme reason described
 in the repository's `UPGRADING.md`. V2 also adds
 `InvalidOpenApiSpecReason::RemoteRefHostDisallowed` for the destination
-allowlist enforced before HTTP requests.
+allowlist enforced before HTTP requests and
+`InvalidOpenApiSpecReason::LocalRefOutsideAllowedRoot` for canonical local
+targets that escape `spec_base_path`.
 
 ### Spec loading
 
@@ -388,6 +390,7 @@ Accepted options:
 
 - repeated `--spec=<path[,path]>`;
 - repeated `--strip-prefix=<prefix>`;
+- `--local-ref-root=<directory>`;
 - `--format=text|json`;
 - `--allow-remote-refs`;
 - repeatable `--remote-ref-host=<host>` (required with `--allow-remote-refs`);
@@ -399,7 +402,10 @@ Exit codes are `0` for a usable contract, `1` for diagnostic failure, and `2`
 for invalid usage. JSON uses `schemaVersion: 1`; issue fields are `severity`,
 `category`, `spec`, `message`, and nullable `suggestion`.
 
-Migration status: v2 adds the host allowlist and remote response-size option.
+Migration status: v2 adds the local-reference root, remote host allowlist, and
+remote response-size options. Local external references are confined to the
+configured `spec_base_path` after canonicalization; projects that share schemas
+across sibling directories must use their trusted common parent as the base.
 The exact v1.9 help and invalid-usage output remain captured under
 `tests/fixtures/compatibility/`, while v2 fixtures pin the additive options.
 Both generations are exercised through the installed-style binary integration

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -32,6 +32,25 @@ openapi/
 
 HTTP(S) `$ref` (`https://example.com/schemas/pet.yaml`) is **opt-in** for security and CI predictability — see [HTTP `$ref` resolution](#http-ref-resolution-opt-in) below. If you prefer the legacy bundled-spec workflow, the loader still accepts the output of `npx @redocly/cli bundle --dereferenced` unchanged.
 
+`spec_base_path` is also the filesystem trust boundary for local external
+references. Gesso canonicalizes each target before reading it and rejects a
+`../` path, absolute path, or symlink when its final target escapes that
+directory.
+When entry documents and shared schemas live in sibling directories, configure
+their narrowest trusted common parent and include the entry subdirectory in the
+spec name:
+
+```xml
+<parameter name="spec_base_path" value="openapi"/>
+<parameter name="specs" value="bundled/front"/>
+```
+
+Here `openapi/bundled/front.yaml` may safely reference
+`../shared/error.json`, while files outside `openapi/` remain inaccessible.
+This follows the [OWASP path-traversal guidance](https://owasp.org/www-community/attacks/Path_Traversal)
+to canonicalize filesystem input before validating it against an allowed
+location.
+
 ## 2. Configure the PHPUnit extension
 
 Add the coverage extension to your `phpunit.xml`:

--- a/src/Cli/DoctorCommand.php
+++ b/src/Cli/DoctorCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Studio\Gesso\Cli;
 
+use const DIRECTORY_SEPARATOR;
 use const E_USER_WARNING;
 use const ENT_QUOTES;
 use const ENT_XML1;
@@ -52,6 +53,7 @@ use function implode;
 use function in_array;
 use function is_array;
 use function is_callable;
+use function is_dir;
 use function is_file;
 use function is_readable;
 use function is_string;
@@ -68,11 +70,12 @@ use function str_starts_with;
 use function strlen;
 use function strtoupper;
 use function substr;
+use function trim;
 
 /**
  * Pre-test compatibility diagnostics for one or more OpenAPI documents.
  *
- * @phpstan-type DoctorOptions array{specs?: list<string>, strip_prefixes?: list<string>, remote_ref_hosts?: list<string>, remote_ref_max_bytes?: int|string, format?: string, allow_remote_refs?: bool, phpunit_snippet?: bool, help?: bool, invalid_options?: list<string>}
+ * @phpstan-type DoctorOptions array{specs?: list<string>, strip_prefixes?: list<string>, remote_ref_hosts?: list<string>, remote_ref_max_bytes?: int|string, local_ref_root?: string, format?: string, allow_remote_refs?: bool, phpunit_snippet?: bool, help?: bool, invalid_options?: list<string>}
  * @phpstan-type DoctorIssue array{severity: 'error'|'warning'|'skipped', category: string, spec: ?string, message: string, suggestion: ?string}
  * @phpstan-type SpecResult array{path: string, name: string, openapi: string, dialect: string, operations: int, responses: int}
  *
@@ -155,6 +158,10 @@ final class DoctorCommand
                     $options['remote_ref_max_bytes'] = $value;
 
                     break;
+                case 'local_ref_root':
+                    $options['local_ref_root'] = $value;
+
+                    break;
                 case 'phpunit_snippet':
                     $options['phpunit_snippet'] = !in_array($value, ['0', 'false', 'no'], true);
 
@@ -178,6 +185,8 @@ final class DoctorCommand
             Options:
               --spec=<path[,path]>       JSON/YAML entry document. Repeat for multiple specs.
               --strip-prefix=<prefix>    Request-path prefix used by PHPUnit. Repeat as needed.
+              --local-ref-root=<dir>     Filesystem boundary for local refs (default: each
+                                         entry document's directory).
               --format=text|json         Output format (default: text).
               --allow-remote-refs        Resolve HTTP(S) refs with an installed Guzzle or
                                          Symfony PSR-18 implementation.
@@ -242,6 +251,16 @@ final class DoctorCommand
             return self::EXIT_USAGE;
         }
 
+        if (array_key_exists('local_ref_root', $options)) {
+            $localRefRoot = realpath(trim($options['local_ref_root']));
+            if ($localRefRoot === false || !is_dir($localRefRoot)) {
+                $this->writeUsageError('--local-ref-root must be an existing directory.');
+
+                return self::EXIT_USAGE;
+            }
+            $options['local_ref_root'] = $localRefRoot;
+        }
+
         $transport = $allowRemoteRefs ? $this->remoteTransport() : null;
         if ($allowRemoteRefs && $transport === null) {
             $report = $this->report([], [[
@@ -259,7 +278,17 @@ final class DoctorCommand
         $specResults = [];
         $issues = [];
         foreach ($options['specs'] as $path) {
-            $this->diagnoseSpec($path, $options['strip_prefixes'] ?? [], $allowRemoteRefs, $remoteRefHosts, $maxRemoteRefBytes, $transport, $specResults, $issues);
+            $this->diagnoseSpec(
+                $path,
+                $options['strip_prefixes'] ?? [],
+                $allowRemoteRefs,
+                $remoteRefHosts,
+                $maxRemoteRefBytes,
+                $options['local_ref_root'] ?? null,
+                $transport,
+                $specResults,
+                $issues,
+            );
         }
 
         $report = $this->report($specResults, $issues, $options);
@@ -274,10 +303,18 @@ final class DoctorCommand
         return self::EXIT_OK;
     }
 
+    private static function pathIsInsideRoot(string $path, string $root): bool
+    {
+        $root = rtrim($root, '/\\');
+
+        return $path === $root || str_starts_with($path, $root . DIRECTORY_SEPARATOR);
+    }
+
     /**
      * @param list<string> $stripPrefixes
      * @param list<string> $remoteRefHosts
      * @param positive-int $maxRemoteRefBytes
+     * @param null|string $localRefRoot canonical configured local-ref boundary
      * @param null|array{0: ClientInterface, 1: RequestFactoryInterface} $transport
      * @param list<SpecResult> $specResults
      * @param list<DoctorIssue> $issues
@@ -288,6 +325,7 @@ final class DoctorCommand
         bool $allowRemoteRefs,
         array $remoteRefHosts,
         int $maxRemoteRefBytes,
+        ?string $localRefRoot,
         ?array $transport,
         array &$specResults,
         array &$issues,
@@ -299,6 +337,7 @@ final class DoctorCommand
 
             return;
         }
+        $path = realpath($path) ?: $path;
 
         $extension = pathinfo($path, PATHINFO_EXTENSION);
         if (!in_array($extension, ['json', 'yaml', 'yml'], true)) {
@@ -307,8 +346,22 @@ final class DoctorCommand
             return;
         }
 
-        $name = pathinfo($path, PATHINFO_FILENAME);
-        $basePath = pathinfo($path, PATHINFO_DIRNAME);
+        $basePath = $localRefRoot ?? pathinfo($path, PATHINFO_DIRNAME);
+        if ($localRefRoot !== null && !self::pathIsInsideRoot($path, $localRefRoot)) {
+            $issues[] = $this->issue(
+                'error',
+                'configuration',
+                $label,
+                'The entry document is outside --local-ref-root.',
+                'Choose a common trusted directory that contains the entry document and its local refs.',
+            );
+
+            return;
+        }
+        $relativePath = $localRefRoot === null
+            ? pathinfo($path, PATHINFO_FILENAME) . '.' . $extension
+            : substr($path, strlen(rtrim($localRefRoot, '/\\')) + 1);
+        $name = substr($relativePath, 0, -(strlen($extension) + 1));
         foreach (['json', 'yaml', 'yml'] as $candidateExtension) {
             $candidate = $basePath . '/' . $name . '.' . $candidateExtension;
             if (!is_file($candidate)) {
@@ -648,7 +701,9 @@ final class DoctorCommand
             ],
             'specs' => $specs,
             'issues' => $issues,
-            'phpunit' => ($options['phpunit_snippet'] ?? false) ? $this->phpunitSnippet($specs, $options['strip_prefixes'] ?? []) : null,
+            'phpunit' => ($options['phpunit_snippet'] ?? false)
+                ? $this->phpunitSnippet($specs, $options['strip_prefixes'] ?? [], $options['local_ref_root'] ?? null)
+                : null,
         ];
     }
 
@@ -687,15 +742,17 @@ final class DoctorCommand
      * @param list<SpecResult> $specs
      * @param list<string> $stripPrefixes
      */
-    private function phpunitSnippet(array $specs, array $stripPrefixes): ?string
+    private function phpunitSnippet(array $specs, array $stripPrefixes, ?string $localRefRoot): ?string
     {
         if ($specs === []) {
             return null;
         }
-        $basePath = dirname($specs[0]['path']);
-        foreach ($specs as $spec) {
-            if (dirname($spec['path']) !== $basePath) {
-                return '<!-- Specs use different directories; one PHPUnit extension instance requires a shared spec_base_path. -->';
+        $basePath = $localRefRoot ?? dirname($specs[0]['path']);
+        if ($localRefRoot === null) {
+            foreach ($specs as $spec) {
+                if (dirname($spec['path']) !== $basePath) {
+                    return '<!-- Specs use different directories; one PHPUnit extension instance requires a shared spec_base_path. -->';
+                }
             }
         }
         $names = implode(',', array_map(static fn(array $spec): string => $spec['name'], $specs));
@@ -748,6 +805,7 @@ final class DoctorCommand
             'YamlLibraryMissing' => 'Run: composer require --dev symfony/yaml',
             'RemoteRefDisallowed' => 'Re-run with --allow-remote-refs and install a supported PSR-18 implementation, or bundle the spec.',
             'RemoteRefHostDisallowed' => 'Add the exact trusted host with --remote-ref-host, or bundle the spec.',
+            'LocalRefOutsideAllowedRoot' => 'Use --local-ref-root with the narrowest trusted common directory, or bundle the spec.',
             'HttpClientNotConfigured' => 'Install Guzzle or Symfony HttpClient and re-run with --allow-remote-refs.',
             default => null,
         };

--- a/src/Exception/InvalidOpenApiSpecReason.php
+++ b/src/Exception/InvalidOpenApiSpecReason.php
@@ -12,6 +12,7 @@ namespace Studio\Gesso\Exception;
 enum InvalidOpenApiSpecReason
 {
     case LocalRefNotFound;
+    case LocalRefOutsideAllowedRoot;
     case LocalRefUnreadable;
     case LocalRefRequiresSourceFile;
     case RemoteRefDisallowed;

--- a/src/Internal/ExternalRefLoader.php
+++ b/src/Internal/ExternalRefLoader.php
@@ -10,18 +10,23 @@ use const PATHINFO_EXTENSION;
 use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
 
+use function array_pop;
 use function dirname;
 use function error_clear_last;
 use function error_get_last;
+use function explode;
 use function file_exists;
 use function file_get_contents;
+use function implode;
 use function is_readable;
 use function pathinfo;
 use function realpath;
 use function rtrim;
 use function sprintf;
+use function str_replace;
 use function str_starts_with;
 use function strtolower;
+use function substr;
 
 /**
  * Resolves and decodes external `$ref` target documents from the local
@@ -79,8 +84,16 @@ final class ExternalRefLoader
         // the right reason category.
         $absolutePath = realpath($candidate);
         if ($absolutePath === false) {
-            $candidateParent = realpath(dirname($candidate));
-            if ($candidateParent !== false && !self::isInsideAllowedRoot($candidateParent, $allowedLocalRefRoots)) {
+            // Check both the lexical path (so missing components cannot hide a
+            // `..` escape) and the filesystem path (so existing symlink
+            // ancestors cannot hide an escape).
+            $lexicalAncestor = self::deepestCanonicalAncestor(self::normalizePathLexically($candidate));
+            $resolvedAncestor = self::deepestCanonicalAncestor($candidate);
+            if ($lexicalAncestor === null ||
+                $resolvedAncestor === null ||
+                !self::isInsideAllowedRoot($lexicalAncestor, $allowedLocalRefRoots) ||
+                !self::isInsideAllowedRoot($resolvedAncestor, $allowedLocalRefRoots)
+            ) {
                 throw self::outsideAllowedRoot($refPath);
             }
             if (!file_exists($candidate)) {
@@ -156,6 +169,61 @@ final class ExternalRefLoader
         }
 
         return false;
+    }
+
+    private static function deepestCanonicalAncestor(string $candidate): ?string
+    {
+        $ancestor = $candidate;
+
+        while (true) {
+            $canonicalAncestor = realpath($ancestor);
+            if ($canonicalAncestor !== false) {
+                return $canonicalAncestor;
+            }
+
+            $parent = dirname($ancestor);
+            if ($parent === $ancestor) {
+                return null;
+            }
+
+            $ancestor = $parent;
+        }
+    }
+
+    private static function normalizePathLexically(string $path): string
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $path = str_replace('/', '\\', $path);
+        }
+
+        $prefix = '';
+        if (DIRECTORY_SEPARATOR === '\\' && isset($path[2]) && $path[1] === ':' && $path[2] === '\\') {
+            $prefix = substr($path, 0, 3);
+            $path = substr($path, 3);
+        } elseif (str_starts_with($path, DIRECTORY_SEPARATOR)) {
+            $prefix = DIRECTORY_SEPARATOR;
+            $path = substr($path, 1);
+        }
+
+        $segments = [];
+        foreach (explode(DIRECTORY_SEPARATOR, $path) as $segment) {
+            if ($segment === '' || $segment === '.') {
+                continue;
+            }
+            if ($segment === '..') {
+                if ($segments !== []) {
+                    array_pop($segments);
+                } elseif ($prefix === '') {
+                    $segments[] = '..';
+                }
+
+                continue;
+            }
+
+            $segments[] = $segment;
+        }
+
+        return $prefix . implode(DIRECTORY_SEPARATOR, $segments);
     }
 
     private static function outsideAllowedRoot(string $refPath): InvalidOpenApiSpecException

--- a/src/Internal/ExternalRefLoader.php
+++ b/src/Internal/ExternalRefLoader.php
@@ -11,6 +11,7 @@ use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
 
 use function array_pop;
+use function array_slice;
 use function dirname;
 use function error_clear_last;
 use function error_get_last;
@@ -190,23 +191,31 @@ final class ExternalRefLoader
         }
     }
 
-    private static function normalizePathLexically(string $path): string
+    private static function normalizePathLexically(string $path, string $separator = DIRECTORY_SEPARATOR): string
     {
-        if (DIRECTORY_SEPARATOR === '\\') {
+        if ($separator === '\\') {
             $path = str_replace('/', '\\', $path);
         }
 
         $prefix = '';
-        if (DIRECTORY_SEPARATOR === '\\' && isset($path[2]) && $path[1] === ':' && $path[2] === '\\') {
+        if ($separator === '\\' && str_starts_with($path, '\\\\')) {
+            $prefix = '\\\\';
+            $path = substr($path, 2);
+            $uncSegments = explode($separator, $path);
+            if ($uncSegments[0] !== '' && isset($uncSegments[1]) && $uncSegments[1] !== '') {
+                $prefix .= $uncSegments[0] . $separator . $uncSegments[1] . $separator;
+                $path = implode($separator, array_slice($uncSegments, 2));
+            }
+        } elseif ($separator === '\\' && isset($path[2]) && $path[1] === ':' && $path[2] === '\\') {
             $prefix = substr($path, 0, 3);
             $path = substr($path, 3);
-        } elseif (str_starts_with($path, DIRECTORY_SEPARATOR)) {
-            $prefix = DIRECTORY_SEPARATOR;
+        } elseif (str_starts_with($path, $separator)) {
+            $prefix = $separator;
             $path = substr($path, 1);
         }
 
         $segments = [];
-        foreach (explode(DIRECTORY_SEPARATOR, $path) as $segment) {
+        foreach (explode($separator, $path) as $segment) {
             if ($segment === '' || $segment === '.') {
                 continue;
             }
@@ -223,7 +232,7 @@ final class ExternalRefLoader
             $segments[] = $segment;
         }
 
-        return $prefix . implode(DIRECTORY_SEPARATOR, $segments);
+        return $prefix . implode($separator, $segments);
     }
 
     private static function outsideAllowedRoot(string $refPath): InvalidOpenApiSpecException

--- a/src/Internal/ExternalRefLoader.php
+++ b/src/Internal/ExternalRefLoader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Studio\Gesso\Internal;
 
+use const DIRECTORY_SEPARATOR;
 use const PATHINFO_EXTENSION;
 
 use Studio\Gesso\Exception\InvalidOpenApiSpecException;
@@ -17,6 +18,7 @@ use function file_get_contents;
 use function is_readable;
 use function pathinfo;
 use function realpath;
+use function rtrim;
 use function sprintf;
 use function str_starts_with;
 use function strtolower;
@@ -31,13 +33,11 @@ use function strtolower;
  * different fragments of it. The cache lives only for the duration of
  * one `OpenApiRefResolver::resolve()` call.
  *
- * Path-traversal note: there is no sandbox check on resolved paths. A
- * `$ref` like `'../../etc/passwd.json'` will resolve and read whatever
- * the PHP process can access. Spec authors are trusted; treat the spec
- * directory as a trust boundary in the same way you treat your own
- * source tree. `file://` URLs are rejected separately because they
- * bypass the source-file-relative resolution rules and would surprise
- * a reader scanning paths visually.
+ * Canonical targets must remain inside an explicitly allowed root. When
+ * no root is supplied, the source document's directory is the boundary.
+ * Validation happens after realpath(), so both `../` traversal and symlinks
+ * that escape the boundary are rejected. `file://` URLs are rejected
+ * separately by the resolver.
  *
  * @internal Not part of the package's public API. Do not use from user code.
  */
@@ -55,14 +55,22 @@ final class ExternalRefLoader
      * that resolve to the same canonical target share a cache entry.
      *
      * @param array<string, array<string, mixed>> $documentCache by-ref cache keyed by absolute path
+     * @param list<string> $allowedLocalRefRoots canonical filesystem roots local refs may read from
      *
      * @throws InvalidOpenApiSpecException when the file cannot be located, decoded, or has an unsupported extension
      */
-    public static function loadDocument(string $refPath, string $sourceFile, array &$documentCache): LoadedDocument
-    {
+    public static function loadDocument(
+        string $refPath,
+        string $sourceFile,
+        array &$documentCache,
+        array $allowedLocalRefRoots = [],
+    ): LoadedDocument {
         $candidate = str_starts_with($refPath, '/')
             ? $refPath
             : dirname($sourceFile) . '/' . $refPath;
+        if ($allowedLocalRefRoots === []) {
+            $allowedLocalRefRoots = [dirname($sourceFile)];
+        }
 
         // realpath() returns false for several distinct conditions
         // (missing file, unreadable parent, broken symlink,
@@ -71,6 +79,10 @@ final class ExternalRefLoader
         // the right reason category.
         $absolutePath = realpath($candidate);
         if ($absolutePath === false) {
+            $candidateParent = realpath(dirname($candidate));
+            if ($candidateParent !== false && !self::isInsideAllowedRoot($candidateParent, $allowedLocalRefRoots)) {
+                throw self::outsideAllowedRoot($refPath);
+            }
             if (!file_exists($candidate)) {
                 throw new InvalidOpenApiSpecException(
                     InvalidOpenApiSpecReason::LocalRefNotFound,
@@ -92,6 +104,10 @@ final class ExternalRefLoader
                 ),
                 ref: $refPath,
             );
+        }
+
+        if (!self::isInsideAllowedRoot($absolutePath, $allowedLocalRefRoots)) {
+            throw self::outsideAllowedRoot($refPath);
         }
 
         if (isset($documentCache[$absolutePath])) {
@@ -120,6 +136,35 @@ final class ExternalRefLoader
         $documentCache[$absolutePath] = $decoded;
 
         return new LoadedDocument($absolutePath, $decoded);
+    }
+
+    /** @param list<string> $allowedLocalRefRoots */
+    private static function isInsideAllowedRoot(string $absolutePath, array $allowedLocalRefRoots): bool
+    {
+        foreach ($allowedLocalRefRoots as $root) {
+            $canonicalRoot = realpath($root);
+            if ($canonicalRoot === false) {
+                continue;
+            }
+
+            $canonicalRoot = rtrim($canonicalRoot, '/\\');
+            if ($absolutePath === $canonicalRoot ||
+                str_starts_with($absolutePath, $canonicalRoot . DIRECTORY_SEPARATOR)
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function outsideAllowedRoot(string $refPath): InvalidOpenApiSpecException
+    {
+        return new InvalidOpenApiSpecException(
+            InvalidOpenApiSpecReason::LocalRefOutsideAllowedRoot,
+            sprintf('Local $ref target is outside the configured local-ref roots: %s.', $refPath),
+            ref: $refPath,
+        );
     }
 
     /** @return array<string, mixed> */

--- a/src/Spec/OpenApiRefResolver.php
+++ b/src/Spec/OpenApiRefResolver.php
@@ -136,6 +136,7 @@ final class OpenApiRefResolver
      * @param array<string, mixed> $spec
      * @param list<string> $allowedRemoteRefHosts exact hosts allowed for HTTP(S) refs
      * @param int $maxRemoteRefBytes maximum response bytes read per remote document; must be positive
+     * @param list<string> $allowedLocalRefRoots canonical filesystem roots local refs may read from
      *
      * @return array<string, mixed>
      *
@@ -149,6 +150,7 @@ final class OpenApiRefResolver
         bool $allowRemoteRefs = false,
         array $allowedRemoteRefHosts = [],
         int $maxRemoteRefBytes = OpenApiSpecLoader::DEFAULT_MAX_REMOTE_REF_BYTES,
+        array $allowedLocalRefRoots = [],
     ): array {
         // OpenApiSpecLoader::configure() catches this earlier with an
         // InvalidArgumentException; this guard is for callers that
@@ -181,8 +183,15 @@ final class OpenApiRefResolver
         // After the guard above, allowRemoteRefs:true implies non-null
         // client + factory.
         $context = $allowRemoteRefs
-            ? RefResolutionContext::withRemoteRefs($httpClient, $requestFactory, $allowedRemoteRefHosts, $sourceFile, $maxRemoteRefBytes)
-            : RefResolutionContext::filesystemOnly($sourceFile);
+            ? RefResolutionContext::withRemoteRefs(
+                $httpClient,
+                $requestFactory,
+                $allowedRemoteRefHosts,
+                $sourceFile,
+                $maxRemoteRefBytes,
+                $allowedLocalRefRoots,
+            )
+            : RefResolutionContext::filesystemOnly($sourceFile, $allowedLocalRefRoots);
 
         // $root is a frozen snapshot used for pointer lookups. PHP array
         // copy-on-write keeps it untouched as we mutate $spec via $node refs.
@@ -480,9 +489,9 @@ final class OpenApiRefResolver
 
         if (str_starts_with($ref, 'file://')) {
             // Reject `file://` separately from ordinary path refs so a
-            // visual scan of the spec doesn't gloss over it. Path-traversal
-            // sandboxing for ordinary paths is intentionally absent — see
-            // ExternalRefLoader's class-level docblock for the trust model.
+            // visual scan of the spec doesn't gloss over it. Ordinary local
+            // paths are canonicalized and checked against the configured
+            // filesystem root by ExternalRefLoader.
             throw new InvalidOpenApiSpecException(
                 InvalidOpenApiSpecReason::FileSchemeNotSupported,
                 sprintf(
@@ -712,7 +721,12 @@ final class OpenApiRefResolver
         // sourceFile non-null asserted by the caller (resolveRef).
         /** @var string $sourceFile */
         $sourceFile = $context->sourceFile;
-        $document = ExternalRefLoader::loadDocument($pathPart, $sourceFile, $documentCache);
+        $document = ExternalRefLoader::loadDocument(
+            $pathPart,
+            $sourceFile,
+            $documentCache,
+            $context->allowedLocalRefRoots,
+        );
 
         self::descendIntoLoadedDocument(
             $node,

--- a/src/Spec/OpenApiSpecLoader.php
+++ b/src/Spec/OpenApiSpecLoader.php
@@ -287,6 +287,7 @@ final class OpenApiSpecLoader
                     self::$allowRemoteRefs,
                     self::$allowedRemoteRefHosts,
                     self::$maxRemoteRefBytes,
+                    [self::getBasePath()],
                 ),
             );
         } catch (InvalidOpenApiSpecException $e) {

--- a/src/Spec/RefResolutionContext.php
+++ b/src/Spec/RefResolutionContext.php
@@ -39,15 +39,19 @@ final class RefResolutionContext
         /** @var list<string> */
         public readonly array $allowedRemoteRefHosts,
         public readonly int $maxRemoteRefBytes,
+        /** @var list<string> */
+        public readonly array $allowedLocalRefRoots,
     ) {}
 
     /**
      * A context that can resolve internal `$ref` plus local-filesystem
      * external refs. HTTP refs reject with `RemoteRefDisallowed`.
+     *
+     * @param list<string> $allowedLocalRefRoots
      */
-    public static function filesystemOnly(?string $sourceFile = null): self
+    public static function filesystemOnly(?string $sourceFile = null, array $allowedLocalRefRoots = []): self
     {
-        return new self($sourceFile, null, null, false, [], HttpRefLoader::DEFAULT_MAX_RESPONSE_BYTES);
+        return new self($sourceFile, null, null, false, [], HttpRefLoader::DEFAULT_MAX_RESPONSE_BYTES, $allowedLocalRefRoots);
     }
 
     /**
@@ -56,6 +60,7 @@ final class RefResolutionContext
      * structurally impossible via this factory.
      *
      * @param list<string> $allowedRemoteRefHosts
+     * @param list<string> $allowedLocalRefRoots
      */
     public static function withRemoteRefs(
         ClientInterface $client,
@@ -63,8 +68,17 @@ final class RefResolutionContext
         array $allowedRemoteRefHosts,
         ?string $sourceFile = null,
         int $maxRemoteRefBytes = HttpRefLoader::DEFAULT_MAX_RESPONSE_BYTES,
+        array $allowedLocalRefRoots = [],
     ): self {
-        return new self($sourceFile, $client, $factory, true, $allowedRemoteRefHosts, $maxRemoteRefBytes);
+        return new self(
+            $sourceFile,
+            $client,
+            $factory,
+            true,
+            $allowedRemoteRefHosts,
+            $maxRemoteRefBytes,
+            $allowedLocalRefRoots,
+        );
     }
 
     /**
@@ -83,6 +97,7 @@ final class RefResolutionContext
             $this->allowRemoteRefs,
             $this->allowedRemoteRefHosts,
             $this->maxRemoteRefBytes,
+            $this->allowedLocalRefRoots,
         );
     }
 }

--- a/tests/Unit/Cli/DoctorCommandTest.php
+++ b/tests/Unit/Cli/DoctorCommandTest.php
@@ -55,6 +55,7 @@ class DoctorCommandTest extends TestCase
                 'format' => 'json',
                 'allow_remote_refs' => true,
                 'remote_ref_max_bytes' => '4096',
+                'local_ref_root' => '/trusted/openapi',
                 'phpunit_snippet' => true,
             ],
             DoctorCommand::parseArgv([
@@ -67,9 +68,59 @@ class DoctorCommandTest extends TestCase
                 '--remote-ref-host=specs.example.com',
                 '--remote-ref-host=schemas.example.com',
                 '--remote-ref-max-bytes=4096',
+                '--local-ref-root=/trusted/openapi',
                 '--phpunit-snippet',
             ]),
         );
+    }
+
+    #[Test]
+    public function local_ref_root_allows_shared_files_inside_an_explicit_common_boundary(): void
+    {
+        $specDir = $this->workDir . '/specs';
+        $sharedDir = $this->workDir . '/shared';
+        mkdir($specDir);
+        mkdir($sharedDir);
+        $root = $specDir . '/root.json';
+        file_put_contents($root, (string) json_encode([
+            'openapi' => '3.1.0',
+            'info' => ['title' => 'Test', 'version' => '1'],
+            'paths' => [],
+            'components' => ['schemas' => ['Shared' => ['$ref' => '../shared/schema.json']]],
+        ], JSON_THROW_ON_ERROR));
+        file_put_contents($sharedDir . '/schema.json', '{"type":"string"}');
+
+        try {
+            $output = '';
+            $command = new DoctorCommand(stdoutWriter: static function (string $message) use (&$output): void {
+                $output .= $message;
+            });
+            $exit = $command->run(['specs' => [$root], 'format' => 'json']);
+            $report = json_decode($output, true, flags: JSON_THROW_ON_ERROR);
+
+            $this->assertSame(DoctorCommand::EXIT_DIAGNOSTIC_FAILURE, $exit);
+            $this->assertStringContainsString('--local-ref-root', $report['issues'][0]['suggestion']);
+
+            $output = '';
+            $command = new DoctorCommand(stdoutWriter: static function (string $message) use (&$output): void {
+                $output .= $message;
+            });
+            $exit = $command->run([
+                'specs' => [$root],
+                'format' => 'json',
+                'local_ref_root' => $this->workDir,
+                'phpunit_snippet' => true,
+            ]);
+            $report = json_decode($output, true, flags: JSON_THROW_ON_ERROR);
+
+            $this->assertSame(DoctorCommand::EXIT_OK, $exit);
+            $this->assertStringContainsString('specs/root', $report['phpunit']);
+        } finally {
+            unlink($root);
+            unlink($sharedDir . '/schema.json');
+            rmdir($specDir);
+            rmdir($sharedDir);
+        }
     }
 
     #[Test]

--- a/tests/Unit/Compatibility/PublicApiBaselineTest.php
+++ b/tests/Unit/Compatibility/PublicApiBaselineTest.php
@@ -175,6 +175,9 @@ final class PublicApiBaselineTest extends TestCase
         $reasonCases = [];
         foreach ($expected[InvalidOpenApiSpecReason::class]['cases'] as $name => $value) {
             $reasonCases[$name] = $value;
+            if ($name === 'LocalRefNotFound') {
+                $reasonCases['LocalRefOutsideAllowedRoot'] = null;
+            }
             if ($name === 'RemoteRefDisallowed') {
                 $reasonCases['RemoteRefHostDisallowed'] = null;
             }

--- a/tests/Unit/Internal/ExternalRefLoaderTest.php
+++ b/tests/Unit/Internal/ExternalRefLoaderTest.php
@@ -121,6 +121,23 @@ class ExternalRefLoaderTest extends TestCase
     }
 
     #[Test]
+    public function rejects_a_missing_target_under_a_nonexistent_parent_outside_the_root(): void
+    {
+        $allowedRoot = $this->workDir . '/specs';
+        mkdir($allowedRoot);
+        $sourceFile = $allowedRoot . '/root.yaml';
+        file_put_contents($sourceFile, "openapi: 3.0.3\n");
+
+        try {
+            $cache = [];
+            ExternalRefLoader::loadDocument('../absent/missing.json', $sourceFile, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::LocalRefOutsideAllowedRoot, $e->reason);
+        }
+    }
+
+    #[Test]
     public function rejects_a_symlink_whose_canonical_target_is_outside_the_allowed_root(): void
     {
         $allowedRoot = $this->workDir . '/specs';

--- a/tests/Unit/Internal/ExternalRefLoaderTest.php
+++ b/tests/Unit/Internal/ExternalRefLoaderTest.php
@@ -6,6 +6,7 @@ namespace Studio\Gesso\Tests\Unit\Internal;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
 use Studio\Gesso\Internal\ExternalRefLoader;
@@ -40,6 +41,20 @@ class ExternalRefLoaderTest extends TestCase
         $this->removeDir($this->workDir);
         YamlAvailability::reset();
         parent::tearDown();
+    }
+
+    #[Test]
+    public function preserves_the_unc_server_and_share_as_the_windows_root_prefix(): void
+    {
+        $normalizePath = new ReflectionMethod(ExternalRefLoader::class, 'normalizePathLexically');
+
+        $normalized = $normalizePath->invoke(null, '\\\\server\\share\\root\\missing.json', '\\');
+
+        $this->assertSame('\\\\server\\share\\root\\missing.json', $normalized);
+
+        $normalizedAtShareRoot = $normalizePath->invoke(null, '\\\\server\\share\\..\\missing.json', '\\');
+
+        $this->assertSame('\\\\server\\share\\missing.json', $normalizedAtShareRoot);
     }
 
     #[Test]

--- a/tests/Unit/Internal/ExternalRefLoaderTest.php
+++ b/tests/Unit/Internal/ExternalRefLoaderTest.php
@@ -19,6 +19,7 @@ use function mkdir;
 use function posix_geteuid;
 use function rmdir;
 use function scandir;
+use function symlink;
 use function sys_get_temp_dir;
 use function uniqid;
 use function unlink;
@@ -77,9 +78,68 @@ class ExternalRefLoaderTest extends TestCase
         file_put_contents($this->workDir . '/shared.json', '{"name":"shared"}');
 
         $cache = [];
-        $result = ExternalRefLoader::loadDocument('../shared.json', $sourceFile, $cache);
+        $result = ExternalRefLoader::loadDocument('../shared.json', $sourceFile, $cache, [$this->workDir]);
 
         $this->assertSame(['name' => 'shared'], $result->decoded);
+    }
+
+    #[Test]
+    public function rejects_parent_traversal_outside_the_default_source_root(): void
+    {
+        $allowedRoot = $this->workDir . '/specs';
+        mkdir($allowedRoot);
+        $sourceFile = $allowedRoot . '/root.yaml';
+        file_put_contents($sourceFile, "openapi: 3.0.3\n");
+        file_put_contents($this->workDir . '/secret.json', '{"secret":true}');
+
+        try {
+            $cache = [];
+            ExternalRefLoader::loadDocument('../secret.json', $sourceFile, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::LocalRefOutsideAllowedRoot, $e->reason);
+            $this->assertStringContainsString('../secret.json', $e->getMessage());
+            $this->assertStringNotContainsString($this->workDir . '/secret.json', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function rejects_a_missing_target_outside_the_root_without_disclosing_its_existence(): void
+    {
+        $allowedRoot = $this->workDir . '/specs';
+        mkdir($allowedRoot);
+        $sourceFile = $allowedRoot . '/root.yaml';
+        file_put_contents($sourceFile, "openapi: 3.0.3\n");
+
+        try {
+            $cache = [];
+            ExternalRefLoader::loadDocument('../missing.json', $sourceFile, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::LocalRefOutsideAllowedRoot, $e->reason);
+        }
+    }
+
+    #[Test]
+    public function rejects_a_symlink_whose_canonical_target_is_outside_the_allowed_root(): void
+    {
+        $allowedRoot = $this->workDir . '/specs';
+        mkdir($allowedRoot);
+        $sourceFile = $allowedRoot . '/root.yaml';
+        file_put_contents($sourceFile, "openapi: 3.0.3\n");
+        $outsideTarget = $this->workDir . '/secret.json';
+        file_put_contents($outsideTarget, '{"secret":true}');
+        if (!@symlink($outsideTarget, $allowedRoot . '/linked.json')) {
+            $this->markTestSkipped('symlinks are unavailable on this platform');
+        }
+
+        try {
+            $cache = [];
+            ExternalRefLoader::loadDocument('./linked.json', $sourceFile, $cache);
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::LocalRefOutsideAllowedRoot, $e->reason);
+        }
     }
 
     #[Test]

--- a/tests/Unit/Spec/OpenApiSpecLoaderTest.php
+++ b/tests/Unit/Spec/OpenApiSpecLoaderTest.php
@@ -623,6 +623,46 @@ class OpenApiSpecLoaderTest extends TestCase
     }
 
     #[Test]
+    public function load_confines_local_refs_to_the_spec_base_path_and_allows_a_shared_common_base(): void
+    {
+        $scratchDir = sys_get_temp_dir() . '/openapi-local-ref-root-' . uniqid('', true);
+        $specDir = $scratchDir . '/specs';
+        $sharedDir = $scratchDir . '/shared';
+        mkdir($scratchDir);
+        mkdir($specDir);
+        mkdir($sharedDir);
+
+        try {
+            file_put_contents(
+                $specDir . '/root.json',
+                '{"openapi":"3.0.3","info":{"title":"Root","version":"1"},"paths":{},'
+                . '"components":{"schemas":{"Shared":{"$ref":"../shared/schema.json"}}}}',
+            );
+            file_put_contents($sharedDir . '/schema.json', '{"type":"string"}');
+
+            OpenApiSpecLoader::configure($specDir);
+
+            try {
+                OpenApiSpecLoader::load('root');
+                $this->fail('expected InvalidOpenApiSpecException');
+            } catch (InvalidOpenApiSpecException $e) {
+                $this->assertSame(InvalidOpenApiSpecReason::LocalRefOutsideAllowedRoot, $e->reason);
+            }
+
+            OpenApiSpecLoader::configure($scratchDir);
+            $spec = OpenApiSpecLoader::load('specs/root');
+
+            $this->assertSame('string', $spec['components']['schemas']['Shared']['type']);
+        } finally {
+            unlink($specDir . '/root.json');
+            unlink($sharedDir . '/schema.json');
+            rmdir($specDir);
+            rmdir($sharedDir);
+            rmdir($scratchDir);
+        }
+    }
+
+    #[Test]
     public function load_throws_on_unresolvable_ref(): void
     {
         $fixturesPath = __DIR__ . '/../../fixtures/specs';

--- a/tests/fixtures/compatibility/v2-gesso-doctor-help.txt
+++ b/tests/fixtures/compatibility/v2-gesso-doctor-help.txt
@@ -6,6 +6,8 @@ Usage:
 Options:
   --spec=<path[,path]>       JSON/YAML entry document. Repeat for multiple specs.
   --strip-prefix=<prefix>    Request-path prefix used by PHPUnit. Repeat as needed.
+  --local-ref-root=<dir>     Filesystem boundary for local refs (default: each
+                             entry document's directory).
   --format=text|json         Output format (default: text).
   --allow-remote-refs        Resolve HTTP(S) refs with an installed Guzzle or
                              Symfony PSR-18 implementation.

--- a/tests/fixtures/compatibility/v2-gesso-doctor-usage-error.txt
+++ b/tests/fixtures/compatibility/v2-gesso-doctor-usage-error.txt
@@ -8,6 +8,8 @@ Usage:
 Options:
   --spec=<path[,path]>       JSON/YAML entry document. Repeat for multiple specs.
   --strip-prefix=<prefix>    Request-path prefix used by PHPUnit. Repeat as needed.
+  --local-ref-root=<dir>     Filesystem boundary for local refs (default: each
+                             entry document's directory).
   --format=text|json         Output format (default: text).
   --allow-remote-refs        Resolve HTTP(S) refs with an installed Guzzle or
                              Symfony PSR-18 implementation.

--- a/tests/fixtures/compatibility/v2-public-api.json
+++ b/tests/fixtures/compatibility/v2-public-api.json
@@ -1402,6 +1402,7 @@
         "backing_type": null,
         "cases": {
             "LocalRefNotFound": null,
+            "LocalRefOutsideAllowedRoot": null,
             "LocalRefUnreadable": null,
             "LocalRefRequiresSourceFile": null,
             "RemoteRefDisallowed": null,


### PR DESCRIPTION
## Summary

- confine local external `$ref` targets to the canonical `spec_base_path`
- reject `../`, absolute-path, and symlink escapes before reading the target
- add `LocalRefOutsideAllowedRoot` and Doctor `--local-ref-root=<dir>` support
- update v2 compatibility fixtures, migration guidance, and the security policy

## Root cause

`ExternalRefLoader` previously resolved local references with `realpath()` but did not compare the canonical target against a trusted root. A contract could therefore use parent traversal, an absolute path, or a symlink to read any JSON/YAML file accessible to the test runner. Missing targets outside the root also produced a different diagnostic, allowing their existence to be probed.

This is a local file-read/path-traversal risk consistent with [CWE-22](https://cwe.mitre.org/data/definitions/22.html). The implementation follows [OWASP path-traversal guidance](https://owasp.org/www-community/attacks/Path_Traversal) by canonicalizing before enforcing the allowed location.

## Security design

- `OpenApiSpecLoader` treats `spec_base_path` as the local filesystem trust boundary
- direct resolver calls default to the source document directory
- canonical target and canonical parent checks cover existing targets, missing targets, absolute paths, and symlinks
- the same root remains active while resolving nested local documents
- diagnostics expose the authored `$ref`, not the resolved outside path

## Breaking change

Local refs whose canonical targets are outside `spec_base_path` now fail with `LocalRefOutsideAllowedRoot`.

Projects with entry documents and shared schemas in sibling directories must configure their narrowest trusted common parent and include the entry subdirectory in the spec name. For example:

```xml
<parameter name="spec_base_path" value="openapi"/>
<parameter name="specs" value="bundled/front"/>
```

Doctor users can express the same boundary with `--local-ref-root=openapi`; generated PHPUnit snippets retain the nested spec name.

## Verification

- full PHPUnit suite: 2,150 tests / 5,934 assertions
- full PHPStan analysis: no errors
- PHP-CS-Fixer: default and Pest configurations pass
- VitePress documentation build passes
- documentation link check passes
- `git diff --check` passes

BREAKING CHANGE: local external `$ref` targets are confined to `spec_base_path` after canonicalization. Configure a trusted common parent for intentionally shared schemas outside the previous entry directory.
