### PR TITLE
fix(spec)!: confine entry specs to base path

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,6 +45,8 @@ release notes (with permission).
 
 This is a test-only library — it has no runtime production surface. The
 relevant attack vectors are:
+- Selecting entry specs by name — nested names are allowed, but traversal,
+  absolute paths, and symlinks cannot escape `spec_base_path`
 - Resolving local external `$ref`s — canonical targets are confined to
   `spec_base_path`; use the narrowest trusted common directory
 - Resolving HTTP(S) `$ref`s (opt-in, off by default) — verify any untrusted

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -74,6 +74,12 @@ example, `spec_base_path=openapi` with `specs=bundled/front`). Doctor uses the
 same policy; pass `--local-ref-root=openapi` for that layout. Code branching on
 resolver reasons should handle the new `LocalRefOutsideAllowedRoot` case.
 
+Entry spec lookup is confined to the same canonical `spec_base_path`. Nested
+names such as `bundled/front` remain supported, while names containing a `..`
+segment, absolute paths, and symlinks that resolve outside the root are reported
+as `SpecFileNotFoundException`. This intentionally uses the same diagnostic for
+existing and missing outside targets so lookup cannot reveal their existence.
+
 HTTP(S) `$ref` resolution now requires an explicit destination allowlist.
 Pass `allowedRemoteRefHosts: ['specs.example.com']` together with
 `allowRemoteRefs: true`; list every trusted host used by nested references.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -32,10 +32,11 @@ openapi/
 
 HTTP(S) `$ref` (`https://example.com/schemas/pet.yaml`) is **opt-in** for security and CI predictability — see [HTTP `$ref` resolution](#http-ref-resolution-opt-in) below. If you prefer the legacy bundled-spec workflow, the loader still accepts the output of `npx @redocly/cli bundle --dereferenced` unchanged.
 
-`spec_base_path` is also the filesystem trust boundary for local external
-references. Gesso canonicalizes each target before reading it and rejects a
-`../` path, absolute path, or symlink when its final target escapes that
-directory.
+`spec_base_path` is also the filesystem trust boundary for entry documents and
+local external references. Entry spec names may include nested directories but
+cannot use `..`, an absolute path, or a symlink to escape that root. Gesso also
+canonicalizes each local `$ref` target before reading it and rejects the target
+when its final location escapes the directory.
 When entry documents and shared schemas live in sibling directories, configure
 their narrowest trusted common parent and include the entry subdirectory in the
 spec name:

--- a/src/Spec/OpenApiSpecLoader.php
+++ b/src/Spec/OpenApiSpecLoader.php
@@ -403,7 +403,7 @@ final class OpenApiSpecLoader
         }
 
         foreach (self::SEARCH_EXTENSIONS as $extension) {
-            $candidate = "{$basePath}/{$specName}.{$extension}";
+            $candidate = self::joinBasePath($basePath, "{$specName}.{$extension}");
             if (!file_exists($candidate)) {
                 continue;
             }
@@ -421,6 +421,20 @@ final class OpenApiSpecLoader
         }
 
         throw self::specFileNotFound($specName, $basePath);
+    }
+
+    private static function joinBasePath(
+        string $basePath,
+        string $relativePath,
+        string $separator = DIRECTORY_SEPARATOR,
+    ): string {
+        if ($basePath === '') {
+            return $relativePath;
+        }
+
+        $basePath = rtrim($basePath, '/\\');
+
+        return ($basePath === '' ? $separator : $basePath . $separator) . $relativePath;
     }
 
     private static function isPathInsideRoot(string $path, string $root): bool

--- a/src/Spec/OpenApiSpecLoader.php
+++ b/src/Spec/OpenApiSpecLoader.php
@@ -180,8 +180,8 @@ final class OpenApiSpecLoader
             );
         }
 
-        self::$basePath = rtrim($basePath, '/');
-        self::$enumBasePath = $enumBasePath !== null ? rtrim($enumBasePath, '/') : null;
+        self::$basePath = self::normalizeConfiguredBasePath($basePath);
+        self::$enumBasePath = $enumBasePath !== null ? self::normalizeConfiguredBasePath($enumBasePath) : null;
         self::$stripPrefixes = $stripPrefixes;
         self::$httpClient = $httpClient;
         self::$requestFactory = $requestFactory;
@@ -432,6 +432,19 @@ final class OpenApiSpecLoader
         }
 
         return $path === $root || str_starts_with($path, $root . DIRECTORY_SEPARATOR);
+    }
+
+    private static function normalizeConfiguredBasePath(string $path): string
+    {
+        $trimmed = rtrim($path, '/');
+        if ($path !== '' && $trimmed === '') {
+            return '/';
+        }
+        if (preg_match('/^[A-Za-z]:$/', $trimmed) === 1 && str_ends_with($path, '/')) {
+            return $trimmed . '/';
+        }
+
+        return $trimmed;
     }
 
     private static function specFileNotFound(string $specName, string $basePath): SpecFileNotFoundException

--- a/src/Spec/OpenApiSpecLoader.php
+++ b/src/Spec/OpenApiSpecLoader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Studio\Gesso\Spec;
 
+use const DIRECTORY_SEPARATOR;
 use const E_USER_WARNING;
 use const JSON_THROW_ON_ERROR;
 
@@ -23,6 +24,7 @@ use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
 use function array_key_exists;
+use function explode;
 use function file_exists;
 use function file_get_contents;
 use function get_debug_type;
@@ -30,12 +32,15 @@ use function implode;
 use function in_array;
 use function is_array;
 use function json_decode;
+use function preg_match;
 use function realpath;
 use function rtrim;
 use function sprintf;
 use function str_contains;
 use function str_ends_with;
+use function str_replace;
 use function str_starts_with;
+use function strtolower;
 use function trigger_error;
 use function trim;
 
@@ -384,14 +389,54 @@ final class OpenApiSpecLoader
     {
         $basePath = self::getBasePath();
 
-        foreach (self::SEARCH_EXTENSIONS as $extension) {
-            $candidate = "{$basePath}/{$specName}.{$extension}";
-            if (file_exists($candidate)) {
-                return ['path' => $candidate, 'extension' => $extension];
-            }
+        // Spec names may include trusted nested directories (for example,
+        // `bundled/front`) but must never select a parent or an absolute
+        // filesystem location. Reject these shapes before checking existence
+        // so callers cannot use the exception category as an existence probe.
+        $portableSpecName = str_replace('\\', '/', $specName);
+        if (str_contains($portableSpecName, "\0") ||
+            str_starts_with($portableSpecName, '/') ||
+            preg_match('/^[A-Za-z]:\//', $portableSpecName) === 1 ||
+            in_array('..', explode('/', $portableSpecName), true)
+        ) {
+            throw self::specFileNotFound($specName, $basePath);
         }
 
-        throw new SpecFileNotFoundException(
+        foreach (self::SEARCH_EXTENSIONS as $extension) {
+            $candidate = "{$basePath}/{$specName}.{$extension}";
+            if (!file_exists($candidate)) {
+                continue;
+            }
+
+            $canonicalCandidate = realpath($candidate);
+            $canonicalBase = realpath($basePath);
+            if ($canonicalCandidate === false ||
+                $canonicalBase === false ||
+                !self::isPathInsideRoot($canonicalCandidate, $canonicalBase)
+            ) {
+                throw self::specFileNotFound($specName, $basePath);
+            }
+
+            return ['path' => $canonicalCandidate, 'extension' => $extension];
+        }
+
+        throw self::specFileNotFound($specName, $basePath);
+    }
+
+    private static function isPathInsideRoot(string $path, string $root): bool
+    {
+        $root = rtrim($root, '/\\');
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $path = strtolower($path);
+            $root = strtolower($root);
+        }
+
+        return $path === $root || str_starts_with($path, $root . DIRECTORY_SEPARATOR);
+    }
+
+    private static function specFileNotFound(string $specName, string $basePath): SpecFileNotFoundException
+    {
+        return new SpecFileNotFoundException(
             $specName,
             $basePath,
             sprintf(

--- a/tests/Unit/Spec/OpenApiSpecLoaderTest.php
+++ b/tests/Unit/Spec/OpenApiSpecLoaderTest.php
@@ -12,6 +12,7 @@ use GuzzleHttp\Psr7\HttpFactory;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 use stdClass;
 use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
@@ -102,6 +103,17 @@ class OpenApiSpecLoaderTest extends TestCase
             unlink($path);
             rmdir($scratchDir);
         }
+    }
+
+    #[Test]
+    public function joining_a_windows_root_does_not_create_a_unc_path(): void
+    {
+        $joinBasePath = new ReflectionMethod(OpenApiSpecLoader::class, 'joinBasePath');
+
+        $candidate = $joinBasePath->invoke(null, '/', 'server/share/spec.json', '\\');
+
+        $this->assertSame('\\server/share/spec.json', $candidate);
+        $this->assertStringStartsNotWith('\\\\', $candidate);
     }
 
     #[Test]

--- a/tests/Unit/Spec/OpenApiSpecLoaderTest.php
+++ b/tests/Unit/Spec/OpenApiSpecLoaderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Studio\Gesso\Tests\Unit\Spec;
 
+use const DIRECTORY_SEPARATOR;
 use const JSON_THROW_ON_ERROR;
 
 use GuzzleHttp\Client;
@@ -24,10 +25,12 @@ use Symfony\Component\Yaml\Yaml;
 use function class_exists;
 use function file_put_contents;
 use function json_encode;
+use function ltrim;
 use function mkdir;
 use function restore_error_handler;
 use function rmdir;
 use function set_error_handler;
+use function substr;
 use function symlink;
 use function sys_get_temp_dir;
 use function uniqid;
@@ -62,6 +65,43 @@ class OpenApiSpecLoaderTest extends TestCase
         OpenApiSpecLoader::configure('/path/to/specs/');
 
         $this->assertSame('/path/to/specs', OpenApiSpecLoader::getBasePath());
+    }
+
+    #[Test]
+    public function configure_preserves_filesystem_roots(): void
+    {
+        OpenApiSpecLoader::configure('/', enumBasePath: '/');
+
+        $this->assertSame('/', OpenApiSpecLoader::getBasePath());
+        $this->assertSame('/', OpenApiSpecLoader::getEnumBasePath());
+
+        OpenApiSpecLoader::configure('C:/', enumBasePath: 'C:/');
+
+        $this->assertSame('C:/', OpenApiSpecLoader::getBasePath());
+        $this->assertSame('C:/', OpenApiSpecLoader::getEnumBasePath());
+    }
+
+    #[Test]
+    public function load_supports_the_posix_filesystem_root_as_the_base_path(): void
+    {
+        if (DIRECTORY_SEPARATOR !== '/') {
+            $this->markTestSkipped('POSIX filesystem root regression');
+        }
+
+        $scratchDir = sys_get_temp_dir() . '/openapi-root-base-' . uniqid('', true);
+        $path = $scratchDir . '/root.json';
+        mkdir($scratchDir);
+        file_put_contents($path, '{"openapi":"3.0.3","info":{"title":"Root base","version":"1"},"paths":{}}');
+
+        try {
+            OpenApiSpecLoader::configure('/');
+            $specName = ltrim(substr($path, 0, -5), '/');
+
+            $this->assertSame('Root base', OpenApiSpecLoader::load($specName)['info']['title']);
+        } finally {
+            unlink($path);
+            rmdir($scratchDir);
+        }
     }
 
     #[Test]

--- a/tests/Unit/Spec/OpenApiSpecLoaderTest.php
+++ b/tests/Unit/Spec/OpenApiSpecLoaderTest.php
@@ -28,6 +28,7 @@ use function mkdir;
 use function restore_error_handler;
 use function rmdir;
 use function set_error_handler;
+use function symlink;
 use function sys_get_temp_dir;
 use function uniqid;
 use function unlink;
@@ -223,6 +224,72 @@ class OpenApiSpecLoaderTest extends TestCase
             $this->assertSame('nonexistent', $e->specName);
             $this->assertSame('/nonexistent/path', $e->basePath);
             $this->assertStringContainsString('OpenAPI bundled spec not found', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function load_confines_entry_specs_to_the_canonical_base_path(): void
+    {
+        $scratchDir = sys_get_temp_dir() . '/openapi-entry-root-' . uniqid('', true);
+        $specDir = $scratchDir . '/specs';
+        $nestedDir = $specDir . '/nested';
+        mkdir($scratchDir);
+        mkdir($specDir);
+        mkdir($nestedDir);
+        file_put_contents($scratchDir . '/outside.json', '{"openapi":"3.0.3","info":{"title":"Outside","version":"1"},"paths":{}}');
+        file_put_contents($nestedDir . '/inside.json', '{"openapi":"3.0.3","info":{"title":"Inside","version":"1"},"paths":{}}');
+
+        try {
+            OpenApiSpecLoader::configure($specDir);
+
+            foreach (['../outside', '..\\outside', '../absent', '/outside', 'C:/outside'] as $specName) {
+                try {
+                    OpenApiSpecLoader::load($specName);
+                    $this->fail('expected SpecFileNotFoundException');
+                } catch (SpecFileNotFoundException $e) {
+                    $this->assertSame($specName, $e->specName);
+                    $this->assertSame($specDir, $e->basePath);
+                    $this->assertStringContainsString('OpenAPI bundled spec not found', $e->getMessage());
+                }
+            }
+
+            $this->assertSame('Inside', OpenApiSpecLoader::load('nested/inside')['info']['title']);
+        } finally {
+            unlink($scratchDir . '/outside.json');
+            unlink($nestedDir . '/inside.json');
+            rmdir($nestedDir);
+            rmdir($specDir);
+            rmdir($scratchDir);
+        }
+    }
+
+    #[Test]
+    public function load_rejects_an_entry_spec_symlinked_outside_the_base_path(): void
+    {
+        $scratchDir = sys_get_temp_dir() . '/openapi-entry-symlink-' . uniqid('', true);
+        $specDir = $scratchDir . '/specs';
+        $outside = $scratchDir . '/outside.json';
+        $link = $specDir . '/linked.json';
+        mkdir($scratchDir);
+        mkdir($specDir);
+        file_put_contents($outside, '{"openapi":"3.0.3","info":{"title":"Outside","version":"1"},"paths":{}}');
+        if (!@symlink($outside, $link)) {
+            unlink($outside);
+            rmdir($specDir);
+            rmdir($scratchDir);
+            $this->markTestSkipped('symlinks are unavailable on this platform');
+        }
+
+        try {
+            OpenApiSpecLoader::configure($specDir);
+
+            $this->expectException(SpecFileNotFoundException::class);
+            OpenApiSpecLoader::load('linked');
+        } finally {
+            unlink($link);
+            unlink($outside);
+            rmdir($specDir);
+            rmdir($scratchDir);
         }
     }
 


### PR DESCRIPTION
## Summary

- confine entry spec lookup to the canonical `spec_base_path`
- reject parent traversal, absolute paths, and symlink escapes before decoding
- preserve nested spec names such as `bundled/front`
- use the same not-found diagnostic for existing and missing outside targets
- document the entry-document filesystem trust boundary and v2 upgrade impact

## Root cause

Local external `$ref` targets were confined to `spec_base_path`, but the initial
spec lookup still concatenated the caller-provided spec name directly onto that
base. A name such as `../outside` or a symlink inside the base could therefore
select and decode a JSON/YAML document outside the configured trust boundary.

## Impact

This intentionally tightens the v2 contract. Nested names remain supported, but
names containing a `..` segment, absolute paths, and symlinks resolving outside
`spec_base_path` now fail with `SpecFileNotFoundException`. Existing and missing
outside targets share the same diagnostic so lookup does not reveal their
existence.

## Verification

- `vendor/bin/phpunit --do-not-cache-result` — 2,154 tests, 5,954 assertions
- `vendor/bin/phpstan analyse --debug --no-progress --memory-limit=1G`
- both PHP-CS-Fixer configurations in sequential dry-run mode
- `npm run docs:build`
- `npm run docs:links`
- `git diff --check`

BREAKING CHANGE: entry spec names can no longer traverse or resolve outside the
configured `spec_base_path`.
