### PR TITLE
fix(enum)!: confine bound spec paths to enum root

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,6 +49,8 @@ relevant attack vectors are:
   absolute paths, and symlinks cannot escape `spec_base_path`
 - Resolving local external `$ref`s — canonical targets are confined to
   `spec_base_path`; use the narrowest trusted common directory
+- Resolving `#[BoundToOpenApiEnum]` files — canonical targets are confined to
+  `enum_spec_base_path`, falling back to `spec_base_path` when unset
 - Resolving HTTP(S) `$ref`s (opt-in, off by default) — verify any untrusted
   spec source before enabling `allowRemoteRefs`
 - YAML spec loading (opt-in via `symfony/yaml`) — `symfony/yaml` is

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -80,6 +80,13 @@ segment, absolute paths, and symlinks that resolve outside the root are reported
 as `SpecFileNotFoundException`. This intentionally uses the same diagnostic for
 existing and missing outside targets so lookup cannot reveal their existence.
 
+`#[BoundToOpenApiEnum]` paths are likewise confined to the canonical
+`enum_spec_base_path`, or to `spec_base_path` when the enum-specific root is
+unset. Nested relative paths remain supported; `..`, absolute paths, and
+symlinks resolving outside the selected root now fail with
+`EnumBindingReason::SpecFileNotFound`. Move the enum base to the narrowest
+trusted common parent instead of traversing out of it.
+
 HTTP(S) `$ref` resolution now requires an explicit destination allowlist.
 Pass `allowedRemoteRefHosts: ['specs.example.com']` together with
 `allowRemoteRefs: true`; list every trusted host used by nested references.

--- a/docs/enum-drift.md
+++ b/docs/enum-drift.md
@@ -77,6 +77,13 @@ enum NotificationCodeEnum: string
 
 When this parameter is omitted (the default), `#[BoundToOpenApiEnum]` paths resolve against `spec_base_path` exactly as before — single-root projects don't need to change anything. Setting it to the same value as `spec_base_path` is functionally equivalent (the opt-in branch additionally validates that the directory exists with `is_dir()` before resolving any binding, while the fallback branch defers that check to per-file `file_exists()` lookups).
 
+The selected base path is a filesystem trust boundary. Attribute paths may use
+nested directories, but a `..` segment, an absolute path, or a symlink whose
+canonical target escapes the base is rejected as `SpecFileNotFound`. Existing
+and missing outside targets use the same reason so bindings cannot probe their
+existence. Configure `enum_spec_base_path` to the narrowest common directory
+that intentionally contains every bound enum schema.
+
 If `enum_spec_base_path` is configured but the directory does not exist, the asserter throws `EnumBindingException` with `EnumBindingReason::EnumBasePathNotFound` so a typo cannot silently fall through to a misleading `SpecFileNotFound` on every binding. From PHP, the manual `OpenApiSpecLoader::configure(basePath: …, enumBasePath: …)` call accepts the same parameter for non-PHPUnit setups (e.g. dedicated drift CI scripts).
 
 ## `EnumDriftAsserter::assertNoDrift()`

--- a/docs/enum-drift.md
+++ b/docs/enum-drift.md
@@ -30,7 +30,7 @@ enum NotificationCodeEnum: string
 }
 ```
 
-The path is resolved relative to the configured spec root (`OpenApiSpecLoader::getBasePath()` — the same root used by the bundler and PHPUnit extension). The bound JSON file must contain an `enum:` array, e.g.:
+The path is resolved relative to the configured enum root (`OpenApiSpecLoader::getEnumBasePath()`), falling back to the spec root (`OpenApiSpecLoader::getBasePath()`) when the enum-specific root is unset. The bound JSON file must contain an `enum:` array, e.g.:
 
 ```json
 {

--- a/src/Attribute/BoundToOpenApiEnum.php
+++ b/src/Attribute/BoundToOpenApiEnum.php
@@ -11,7 +11,8 @@ use Studio\Gesso\Schema\EnumDriftAsserter;
  * Bind a backed PHP enum to its OpenAPI `enum` definition file. Pure
  * marker — carries no runtime behavior outside {@see EnumDriftAsserter},
  * which reads it via reflection and resolves `$specPath` relative to the
- * configured spec root (`OpenApiSpecLoader::getBasePath()`).
+ * configured enum root (`OpenApiSpecLoader::getEnumBasePath()`, falling
+ * back to `OpenApiSpecLoader::getBasePath()`).
  */
 #[Attribute(Attribute::TARGET_CLASS)]
 final class BoundToOpenApiEnum

--- a/src/Schema/EnumDriftAsserter.php
+++ b/src/Schema/EnumDriftAsserter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Studio\Gesso\Schema;
 
+use const DIRECTORY_SEPARATOR;
 use const E_USER_WARNING;
 use const JSON_THROW_ON_ERROR;
 
@@ -25,17 +26,25 @@ use function array_values;
 use function count;
 use function enum_exists;
 use function error_get_last;
+use function explode;
 use function file_exists;
 use function file_get_contents;
 use function get_debug_type;
 use function implode;
+use function in_array;
 use function is_array;
 use function is_dir;
 use function is_int;
 use function is_string;
 use function json_decode;
+use function preg_match;
+use function realpath;
 use function rtrim;
 use function sprintf;
+use function str_contains;
+use function str_replace;
+use function str_starts_with;
+use function strtolower;
 use function trigger_error;
 
 /**
@@ -340,20 +349,28 @@ final class EnumDriftAsserter
     {
         $basePath = self::resolveEnumBasePath($fqcn, $specPath);
 
-        $absolute = rtrim($basePath, '/') . '/' . $specPath;
+        $portableSpecPath = str_replace('\\', '/', $specPath);
+        if (str_contains($portableSpecPath, "\0") ||
+            str_starts_with($portableSpecPath, '/') ||
+            preg_match('/^[A-Za-z]:\//', $portableSpecPath) === 1 ||
+            in_array('..', explode('/', $portableSpecPath), true)
+        ) {
+            throw self::specFileNotFound($fqcn, $specPath);
+        }
 
-        if (!file_exists($absolute)) {
-            throw new EnumBindingException(
-                EnumBindingReason::SpecFileNotFound,
-                sprintf(
-                    'Bound spec file not found: %s (resolved to %s) for %s',
-                    $specPath,
-                    $absolute,
-                    $fqcn,
-                ),
-                enumFqcn: $fqcn,
-                specPath: $specPath,
-            );
+        $candidate = self::joinBasePath($basePath, $specPath);
+
+        if (!file_exists($candidate)) {
+            throw self::specFileNotFound($fqcn, $specPath, $candidate);
+        }
+
+        $absolute = realpath($candidate);
+        $canonicalBase = realpath($basePath);
+        if ($absolute === false ||
+            $canonicalBase === false ||
+            !self::isPathInsideRoot($absolute, $canonicalBase)
+        ) {
+            throw self::specFileNotFound($fqcn, $specPath, $candidate);
         }
 
         $content = @file_get_contents($absolute);
@@ -452,6 +469,43 @@ final class EnumDriftAsserter
         }
 
         return $values;
+    }
+
+    private static function joinBasePath(string $basePath, string $relativePath): string
+    {
+        if ($basePath === '') {
+            return $relativePath;
+        }
+
+        $basePath = rtrim($basePath, '/\\');
+
+        return ($basePath === '' ? DIRECTORY_SEPARATOR : $basePath . DIRECTORY_SEPARATOR) . $relativePath;
+    }
+
+    private static function isPathInsideRoot(string $path, string $root): bool
+    {
+        $root = rtrim($root, '/\\');
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $path = strtolower($path);
+            $root = strtolower($root);
+        }
+
+        return $path === $root || str_starts_with($path, $root . DIRECTORY_SEPARATOR);
+    }
+
+    private static function specFileNotFound(
+        string $fqcn,
+        string $specPath,
+        ?string $candidate = null,
+    ): EnumBindingException {
+        $resolved = $candidate !== null ? sprintf(' (resolved to %s)', $candidate) : '';
+
+        return new EnumBindingException(
+            EnumBindingReason::SpecFileNotFound,
+            sprintf('Bound spec file not found: %s%s for %s', $specPath, $resolved, $fqcn),
+            enumFqcn: $fqcn,
+            specPath: $specPath,
+        );
     }
 
     /**

--- a/src/Schema/EnumDriftAsserter.php
+++ b/src/Schema/EnumDriftAsserter.php
@@ -72,7 +72,9 @@ use function trigger_error;
  * ```
  *
  * The bound spec path on each `#[BoundToOpenApiEnum]` is resolved relative
- * to the configured spec root (`OpenApiSpecLoader::getBasePath()`).
+ * to the configured enum root (`OpenApiSpecLoader::getEnumBasePath()`). When
+ * no enum-specific root is configured, it falls back to the spec root
+ * (`OpenApiSpecLoader::getBasePath()`).
  */
 final class EnumDriftAsserter
 {

--- a/tests/Unit/Schema/EnumDriftAsserterTest.php
+++ b/tests/Unit/Schema/EnumDriftAsserterTest.php
@@ -15,6 +15,7 @@ use Studio\Gesso\Schema\EnumDriftAsserter;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 use Studio\Gesso\Tests\Unit\Schema\Fixture\EmptySpecEnum;
 use Studio\Gesso\Tests\Unit\Schema\Fixture\EnumKeyNotArrayEnum;
+use Studio\Gesso\Tests\Unit\Schema\Fixture\EscapingSpecEnum;
 use Studio\Gesso\Tests\Unit\Schema\Fixture\IntegerBackedDriftEnum;
 use Studio\Gesso\Tests\Unit\Schema\Fixture\IntegerBackedEnum;
 use Studio\Gesso\Tests\Unit\Schema\Fixture\MalformedSpecEnum;
@@ -28,10 +29,16 @@ use Studio\Gesso\Tests\Unit\Schema\Fixture\SpecExtraEnum;
 use Studio\Gesso\Tests\Unit\Schema\Fixture\SpecFileMissingEnum;
 use Studio\Gesso\Tests\Unit\Schema\Fixture\UnattributedEnum;
 
+use function file_exists;
+use function file_put_contents;
+use function mkdir;
 use function restore_error_handler;
+use function rmdir;
 use function set_error_handler;
+use function symlink;
 use function sys_get_temp_dir;
 use function uniqid;
+use function unlink;
 
 class EnumDriftAsserterTest extends TestCase
 {
@@ -488,6 +495,83 @@ class EnumDriftAsserterTest extends TestCase
         } catch (EnumBindingException $e) {
             $this->assertSame(EnumBindingReason::SpecFileNotFound, $e->reason);
             $this->assertSame('enum-drift/matching.json', $e->specPath);
+        }
+    }
+
+    #[Test]
+    public function enum_binding_cannot_escape_its_base_path_with_parent_traversal(): void
+    {
+        $scratchDir = sys_get_temp_dir() . '/gesso-enum-root-' . uniqid('', true);
+        $enumRoot = $scratchDir . '/enums';
+        $outside = $scratchDir . '/outside.json';
+        mkdir($scratchDir);
+        mkdir($enumRoot);
+
+        try {
+            OpenApiSpecLoader::configure(basePath: $enumRoot, enumBasePath: $enumRoot);
+
+            try {
+                EnumDriftAsserter::assertNoDrift([EscapingSpecEnum::class]);
+                $this->fail('expected EnumBindingException for missing outside target');
+            } catch (EnumBindingException $e) {
+                $this->assertSame(EnumBindingReason::SpecFileNotFound, $e->reason);
+                $this->assertStringNotContainsString($outside, $e->getMessage());
+            }
+
+            file_put_contents($outside, '{"enum":["red","green","blue"]}');
+
+            try {
+                EnumDriftAsserter::assertNoDrift([EscapingSpecEnum::class]);
+                $this->fail('expected EnumBindingException for existing outside target');
+            } catch (EnumBindingException $e) {
+                $this->assertSame(EnumBindingReason::SpecFileNotFound, $e->reason);
+                $this->assertStringNotContainsString($outside, $e->getMessage());
+            }
+        } finally {
+            if (file_exists($outside)) {
+                unlink($outside);
+            }
+            rmdir($enumRoot);
+            rmdir($scratchDir);
+        }
+    }
+
+    #[Test]
+    public function enum_binding_cannot_follow_a_symlink_outside_its_base_path(): void
+    {
+        $scratchDir = sys_get_temp_dir() . '/gesso-enum-link-' . uniqid('', true);
+        $enumRoot = $scratchDir . '/enums';
+        $enumDir = $enumRoot . '/enum-drift';
+        $outside = $scratchDir . '/outside.json';
+        $link = $enumDir . '/matching.json';
+        mkdir($scratchDir);
+        mkdir($enumRoot);
+        mkdir($enumDir);
+        file_put_contents($outside, '{"enum":["red","green","blue"]}');
+        if (!@symlink($outside, $link)) {
+            unlink($outside);
+            rmdir($enumDir);
+            rmdir($enumRoot);
+            rmdir($scratchDir);
+            $this->markTestSkipped('symlinks are unavailable on this platform');
+        }
+
+        try {
+            OpenApiSpecLoader::configure(basePath: $enumRoot, enumBasePath: $enumRoot);
+
+            try {
+                EnumDriftAsserter::assertNoDrift([MatchingEnum::class]);
+                $this->fail('expected EnumBindingException for symlink outside target');
+            } catch (EnumBindingException $e) {
+                $this->assertSame(EnumBindingReason::SpecFileNotFound, $e->reason);
+                $this->assertStringNotContainsString($outside, $e->getMessage());
+            }
+        } finally {
+            unlink($link);
+            unlink($outside);
+            rmdir($enumDir);
+            rmdir($enumRoot);
+            rmdir($scratchDir);
         }
     }
 

--- a/tests/Unit/Schema/Fixture/EscapingSpecEnum.php
+++ b/tests/Unit/Schema/Fixture/EscapingSpecEnum.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Schema\Fixture;
+
+use Studio\Gesso\Attribute\BoundToOpenApiEnum;
+
+#[BoundToOpenApiEnum('../outside.json')]
+enum EscapingSpecEnum: string
+{
+    case Red = 'red';
+    case Green = 'green';
+    case Blue = 'blue';
+}


### PR DESCRIPTION
## Summary

- confine `#[BoundToOpenApiEnum]` JSON files to the canonical enum-spec root
- reject parent traversal, absolute paths, NUL bytes, and symlink escapes before reading
- use `enum_spec_base_path`, falling back to `spec_base_path`, as the filesystem trust boundary
- preserve nested relative paths and the existing `SpecFileNotFound` reason
- document the security boundary and v2 migration impact

## Root cause

Enum binding paths were joined directly to `enum_spec_base_path` (or
`spec_base_path`) and read without canonical containment validation. A binding
using `../outside.json`, or an in-root symlink targeting an outside JSON file,
could therefore read a document beyond the configured enum root.

## Impact

This intentionally tightens the v2 contract. Nested paths remain supported,
while parent traversal, absolute paths, and symlinks resolving outside the
selected root now fail with `EnumBindingReason::SpecFileNotFound`. Existing and
missing outside targets share the same reason, and diagnostics do not expose
the outside canonical path.

## Verification

- `vendor/bin/phpunit --do-not-cache-result` — 2,159 tests, 5,967 assertions
- `vendor/bin/phpstan analyse --debug --no-progress --memory-limit=1G`
- both PHP-CS-Fixer configurations in sequential dry-run mode
- `npm run docs:build`
- `npm run docs:links`
- `git diff --check`

BREAKING CHANGE: `#[BoundToOpenApiEnum]` paths can no longer traverse or resolve
outside `enum_spec_base_path`, or `spec_base_path` when the enum-specific root
is unset.
