### PR TITLE
fix(coverage)!: harden sidecar merge trust boundary

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,7 +55,10 @@ relevant attack vectors are:
   spec source before enabling `allowRemoteRefs`
 - YAML spec loading (opt-in via `symfony/yaml`) — `symfony/yaml` is
   generally safe but spec inputs should still be trusted
-- Coverage sidecar files written under `sys_get_temp_dir()` in paratest mode
+- Coverage sidecar files written under `sys_get_temp_dir()` in paratest mode —
+  use a dedicated non-symlink directory that is not group/world writable;
+  merge rejects unsafe directories, symlink sidecars, and writable-by-others
+  sidecars
 
 Issues outside that scope (e.g. opis/json-schema validation behaviour) are
 forwarded upstream.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -87,6 +87,13 @@ symlinks resolving outside the selected root now fail with
 `EnumBindingReason::SpecFileNotFound`. Move the enum base to the narrowest
 trusted common parent instead of traversing out of it.
 
+Parallel coverage merge now applies the same sidecar trust boundary as worker
+writes. On POSIX, a `sidecar_dir` that is group/world writable is rejected;
+all platforms reject a symbolic-link sidecar directory, and individual
+sidecars must be regular non-symlink files that are not group/world writable on
+POSIX. If a custom shared directory was previously used, replace it with a
+dedicated directory owned by the test user.
+
 HTTP(S) `$ref` resolution now requires an explicit destination allowlist.
 Pass `allowedRemoteRefHosts: ['specs.example.com']` together with
 `allowRemoteRefs: true`; list every trusted host used by nested references.

--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -60,10 +60,13 @@ path if `sys_get_temp_dir()` is unavailable in your runner.
 
 On POSIX systems, Gesso creates a missing sidecar directory with mode `0700`
 and publishes sidecars and worker-failure markers with mode `0600`. For
-local-user safety, the writer rejects a `sidecar_dir` that is itself a symbolic
-link or is writable by group or other users. The permission-bit check is not
-applied on Windows, whose ACL model is not represented by POSIX mode bits. Use
-a dedicated directory rather than `/tmp` itself; the default already does this.
+local-user safety, both workers and the merge command reject a `sidecar_dir`
+that is itself a symbolic link or is writable by group or other users. The
+merge command also rejects symbolic-link sidecar files instead of following
+them, and requires each sidecar to be non-group/world-writable. The
+permission-bit checks are not applied on Windows, whose ACL model is not
+represented by POSIX mode bits. Use a dedicated directory rather than `/tmp`
+itself; the default already does this.
 
 ## Sidecar compatibility
 

--- a/src/Coverage/CoverageMergeCommand.php
+++ b/src/Coverage/CoverageMergeCommand.php
@@ -349,8 +349,8 @@ final class CoverageMergeCommand
                     : 'no coverage recorded across sidecars',
             ));
 
-            if ($cleanup) {
-                $this->cleanup($sidecarDir);
+            if ($cleanup && !$this->cleanupSafely($sidecarDir)) {
+                return 1;
             }
 
             return $strictGated ? 1 : 0;
@@ -368,11 +368,9 @@ final class CoverageMergeCommand
         // the coverage output users rely on for triage.
         $strictFailure = $this->evaluateStrictRequiredGate($strictRequiredMode, $githubSummaryPath, $strictRequiredTracker);
 
-        if ($cleanup) {
-            $this->cleanup($sidecarDir);
-        }
+        $cleanupFailure = $cleanup && !$this->cleanupSafely($sidecarDir);
 
-        return $writeFailures > 0 || $thresholdFailure || $strictFailure ? 1 : 0;
+        return $writeFailures > 0 || $thresholdFailure || $strictFailure || $cleanupFailure ? 1 : 0;
     }
 
     /**
@@ -647,7 +645,7 @@ final class CoverageMergeCommand
     private function reportThresholdProblem(bool $strict, string $detail): array
     {
         $severity = $strict ? 'FATAL' : 'WARNING';
-        $this->writeStderr(sprintf("[OpenAPI Coverage] %s: %s\n", $severity, $detail));
+        $this->writeCoverageDiagnostic($severity, $detail);
 
         return ['value' => null, 'fatal' => $strict];
     }
@@ -703,6 +701,27 @@ final class CoverageMergeCommand
                 ));
             }
         }
+    }
+
+    private function cleanupSafely(string $sidecarDir): bool
+    {
+        try {
+            $this->cleanup($sidecarDir);
+        } catch (RuntimeException $e) {
+            $this->writeCoverageDiagnostic(
+                'FATAL',
+                sprintf('failed to inspect sidecars for cleanup: %s', $e->getMessage()),
+            );
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private function writeCoverageDiagnostic(string $severity, string $detail): void
+    {
+        $this->writeStderr(sprintf("[OpenAPI Coverage] %s: %s\n", $severity, $detail));
     }
 
     private function absolutise(string $path): string

--- a/src/Coverage/CoverageMergeCommand.php
+++ b/src/Coverage/CoverageMergeCommand.php
@@ -270,18 +270,18 @@ final class CoverageMergeCommand
         // one missing worker means the report under-counts coverage, which
         // is exactly the silent failure parallel-mode introduced. Fail
         // loudly so CI gating sees a non-zero exit.
-        $failureMarkers = CoverageSidecarReader::listFailureMarkerPaths($sidecarDir);
-        if ($failureMarkers !== []) {
-            $this->writeStderr(sprintf(
-                "[OpenAPI Coverage] FATAL: %d worker(s) failed to write a sidecar; merge would under-count coverage. Markers in %s\n",
-                count($failureMarkers),
-                $sidecarDir,
-            ));
-
-            return 1;
-        }
-
         try {
+            $failureMarkers = CoverageSidecarReader::listFailureMarkerPaths($sidecarDir);
+            if ($failureMarkers !== []) {
+                $this->writeStderr(sprintf(
+                    "[OpenAPI Coverage] FATAL: %d worker(s) failed to write a sidecar; merge would under-count coverage. Markers in %s\n",
+                    count($failureMarkers),
+                    $sidecarDir,
+                ));
+
+                return 1;
+            }
+
             $payloads = CoverageSidecarReader::readDir($sidecarDir);
         } catch (RuntimeException $e) {
             $this->writeStderr(sprintf("[OpenAPI Coverage] FATAL: %s\n", $e->getMessage()));

--- a/src/Coverage/CoverageSidecarReader.php
+++ b/src/Coverage/CoverageSidecarReader.php
@@ -11,9 +11,12 @@ use JsonException;
 use RuntimeException;
 
 use function file_get_contents;
+use function fileperms;
 use function glob;
 use function is_array;
 use function is_dir;
+use function is_file;
+use function is_link;
 use function json_decode;
 use function rtrim;
 use function sort;
@@ -49,6 +52,16 @@ final class CoverageSidecarReader
     {
         $payloads = [];
         foreach (self::listPaths($sidecarDir) as $path) {
+            if (is_link($path) || !is_file($path)) {
+                throw new RuntimeException(sprintf('sidecar must be a regular non-symlink file: "%s"', $path));
+            }
+            if (DIRECTORY_SEPARATOR !== '\\') {
+                $permissions = @fileperms($path);
+                if ($permissions !== false && ($permissions & 0o022) !== 0) {
+                    throw new RuntimeException(sprintf('sidecar must not be writable by group or other users: "%s"', $path));
+                }
+            }
+
             $contents = @file_get_contents($path);
             if ($contents === false) {
                 throw new RuntimeException(sprintf('failed to read sidecar "%s"', $path));
@@ -94,8 +107,19 @@ final class CoverageSidecarReader
     private static function globPattern(string $sidecarDir, string $pattern): array
     {
         $dir = rtrim($sidecarDir, '/' . DIRECTORY_SEPARATOR);
+        if (is_link($dir)) {
+            throw new RuntimeException(sprintf('sidecar dir must not be a symbolic link: "%s"', $dir));
+        }
+
         if (!is_dir($dir)) {
             return [];
+        }
+
+        if (DIRECTORY_SEPARATOR !== '\\') {
+            $permissions = @fileperms($dir);
+            if ($permissions !== false && ($permissions & 0o022) !== 0) {
+                throw new RuntimeException(sprintf('sidecar dir must not be writable by group or other users: "%s"', $dir));
+            }
         }
 
         $matches = glob($dir . '/' . $pattern);

--- a/tests/Unit/Coverage/CoverageMergeCommandTest.php
+++ b/tests/Unit/Coverage/CoverageMergeCommandTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Studio\Gesso\Tests\Unit\Coverage;
 
+use const DIRECTORY_SEPARATOR;
+
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\Gesso\Coverage\CoverageMergeCommand;
@@ -13,6 +15,7 @@ use Studio\Gesso\Coverage\OpenApiCoverageTracker;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
 
+use function chmod;
 use function dirname;
 use function file_exists;
 use function file_get_contents;
@@ -208,6 +211,38 @@ class CoverageMergeCommandTest extends TestCase
         $this->assertSame(1, $exit);
         $this->assertStringContainsString('FATAL', $stderr);
         $this->assertStringContainsString('failed to decode', $stderr);
+    }
+
+    #[Test]
+    public function exits_one_when_sidecar_directory_is_not_private(): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('POSIX permission bits are not portable to Windows');
+        }
+
+        $this->assertTrue(chmod($this->sidecarDir, 0o777));
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            stdoutWriter: static fn(string $msg): null => null,
+        );
+
+        try {
+            $exit = $command->run([
+                'sidecar_dir' => $this->sidecarDir,
+                'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+                'specs' => ['petstore-3.0'],
+                'output_file' => $this->outputFile,
+            ]);
+        } finally {
+            chmod($this->sidecarDir, 0o755);
+        }
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('FATAL', $stderr);
+        $this->assertStringContainsString('must not be writable by group or other users', $stderr);
     }
 
     #[Test]

--- a/tests/Unit/Coverage/CoverageMergeCommandTest.php
+++ b/tests/Unit/Coverage/CoverageMergeCommandTest.php
@@ -147,6 +147,52 @@ class CoverageMergeCommandTest extends TestCase
     }
 
     #[Test]
+    public function exits_one_when_sidecar_directory_becomes_unsafe_before_cleanup(): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('POSIX permission bits are not portable to Windows');
+        }
+
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '1', OpenApiCoverageTracker::exportState());
+
+        $stderr = '';
+        $sidecarDir = $this->sidecarDir;
+        $command = new CoverageMergeCommand(
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            stdoutWriter: static function (string $msg) use ($sidecarDir): void {
+                chmod($sidecarDir, 0o777);
+            },
+        );
+
+        try {
+            $exit = $command->run([
+                'sidecar_dir' => $this->sidecarDir,
+                'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+                'specs' => ['petstore-3.0'],
+                'output_file' => $this->outputFile,
+                'cleanup' => true,
+            ]);
+        } finally {
+            chmod($this->sidecarDir, 0o755);
+        }
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('FATAL', $stderr);
+        $this->assertStringContainsString('failed to inspect sidecars for cleanup', $stderr);
+        $this->assertCount(1, $this->sidecars());
+    }
+
+    #[Test]
     public function appends_to_github_step_summary_once(): void
     {
         OpenApiCoverageTracker::recordResponse(

--- a/tests/Unit/Coverage/CoverageSidecarTest.php
+++ b/tests/Unit/Coverage/CoverageSidecarTest.php
@@ -361,6 +361,87 @@ class CoverageSidecarTest extends TestCase
     }
 
     #[Test]
+    #[DataProvider('provideWriter_rejects_a_group_or_world_writable_sidecar_directoryCases')]
+    public function reader_rejects_a_group_or_world_writable_sidecar_directory(int $mode): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('POSIX permission bits are not portable to Windows');
+        }
+
+        $this->assertTrue(chmod($this->tmpDir, $mode));
+
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('must not be writable by group or other users');
+            CoverageSidecarReader::readDir($this->tmpDir);
+        } finally {
+            chmod($this->tmpDir, 0o755);
+        }
+    }
+
+    #[Test]
+    public function reader_rejects_a_symlink_sidecar_directory(): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('symlink semantics differ on Windows');
+        }
+
+        $link = $this->tmpDir . '-reader-link';
+        if (!@symlink($this->tmpDir, $link)) {
+            $this->markTestSkipped('symlink creation is not available');
+        }
+
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('must not be a symbolic link');
+            CoverageSidecarReader::readDir($link);
+        } finally {
+            @unlink($link);
+        }
+    }
+
+    #[Test]
+    public function reader_rejects_a_symlink_sidecar_file(): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('symlink semantics differ on Windows');
+        }
+
+        $target = $this->tmpDir . '/attacker-controlled.json';
+        file_put_contents($target, '{"version":1,"specs":[]}');
+        $link = $this->tmpDir . '/part-1-9999.json';
+        if (!@symlink($target, $link)) {
+            $this->markTestSkipped('symlink creation is not available');
+        }
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('must be a regular non-symlink file');
+
+        CoverageSidecarReader::readDir($this->tmpDir);
+    }
+
+    #[Test]
+    #[DataProvider('provideWriter_rejects_a_group_or_world_writable_sidecar_directoryCases')]
+    public function reader_rejects_a_group_or_world_writable_sidecar_file(int $mode): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('POSIX permission bits are not portable to Windows');
+        }
+
+        $path = $this->tmpDir . '/part-1-9999.json';
+        file_put_contents($path, '{"version":1,"specs":[]}');
+        $this->assertTrue(chmod($path, $mode));
+
+        try {
+            $this->expectException(RuntimeException::class);
+            $this->expectExceptionMessage('sidecar must not be writable by group or other users');
+            CoverageSidecarReader::readDir($this->tmpDir);
+        } finally {
+            chmod($path, 0o600);
+        }
+    }
+
+    #[Test]
     public function reader_throws_on_malformed_json(): void
     {
         file_put_contents($this->tmpDir . '/part-1-9999.json', '{not valid json');


### PR DESCRIPTION
## Summary

- apply the writer's sidecar trust boundary to merge-time reads
- reject symlink directories, symlink/non-regular sidecars, and POSIX group/world-writable directories or files
- convert unsafe sidecar failures into a clear `FATAL` diagnostic with exit code 1
- document the v2 migration impact and security expectations

## Root cause

`CoverageSidecarWriter` created private files and rejected unsafe directories, but `CoverageSidecarReader` trusted any matching path returned by `glob()`. A merge could therefore follow a forged symlink or consume a sidecar that another local user could modify.

## Impact

Custom parallel-coverage setups must use a dedicated non-symlink sidecar directory. On POSIX, the directory and sidecar files must not be group/world writable. Windows keeps the existing ACL-neutral behavior because POSIX mode bits are not portable there.

## Verification

- `NPM_CONFIG_CACHE=/tmp/gesso-npm-cache vendor/bin/phpunit` — 2,166 tests, 5,987 assertions
- `vendor/bin/phpstan analyse --debug --no-progress --memory-limit=1G`
- both PHP-CS-Fixer configurations in dry-run mode
- `NPM_CONFIG_CACHE=/tmp/gesso-npm-cache npm run docs:build`
- `NPM_CONFIG_CACHE=/tmp/gesso-npm-cache npm run docs:links`
- `git diff --check`
