### PR TITLE
fix(laravel): preserve multipart request body presence

### DIFF
--- a/src/DecodedBody.php
+++ b/src/DecodedBody.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Studio\Gesso;
 
 /**
- * Envelope for a request / response body after JSON decoding, carrying the
- * absent-vs-present distinction as a single value.
+ * Envelope for a request / response body, carrying the absent-vs-present
+ * distinction alongside its decoded value when available.
  *
  * A decoded body is one of four shapes — a JSON object/array, a JSON scalar,
  * the literal JSON `null`, or no body at all. PHP's `json_decode()` collapses
@@ -16,9 +16,11 @@ namespace Studio\Gesso;
  * patched with an internal marker enum and issue #248 closes properly here.
  *
  * `present` records whether the wire carried a body; `value` is the decoded
- * value (always `null` when `present` is false). A literal-null body is
- * `present === true` with `value === null` — exactly the state a bare `null`
- * could not express.
+ * value when the adapter can decode it (always `null` when `present` is
+ * false). A literal-null JSON body is `present === true` with `value === null`
+ * — exactly the state a bare `null` could not express. Adapters also use that
+ * shape for an opaque non-JSON body whose presence is known but whose value is
+ * intentionally not decoded.
  *
  * The framework adapters build this envelope; the body validators consume it.
  * The public `OpenApiResponseValidator::validate()` /
@@ -49,7 +51,7 @@ final readonly class DecodedBody
 
     /**
      * A body was carried on the wire; `$value` is its decoded value (which may
-     * itself be `null` for a literal JSON `null` body).
+     * itself be `null` for a literal JSON `null` or an opaque non-JSON body).
      */
     public static function present(mixed $value): self
     {

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -1135,8 +1135,10 @@ trait ValidatesOpenApiSchema
     /**
      * Extract the request body in the shape OpenApiRequestValidator expects.
      * Mirrors {@see self::extractJsonBody()} for the request side: the body is
-     * JSON-decoded only when the Content-Type is a JSON media type (or absent);
-     * an empty body, or a non-JSON Content-Type, yields an absent envelope.
+     * JSON-decoded only when the Content-Type is a JSON media type (or absent).
+     * For non-JSON media types, the envelope records only whether raw content,
+     * parsed form parameters, or uploaded files were present; its value stays
+     * `null` because the validator does not evaluate non-JSON body schemas.
      *
      * A non-JSON body is left undecoded rather than guessed at: the Content-Type
      * is forwarded to the validator separately, which resolves non-JSON media
@@ -1156,16 +1158,24 @@ trait ValidatesOpenApiSchema
     private function extractRequestBody(Request $request, string $contentType): DecodedBody
     {
         $content = $request->getContent();
-        if ($content === '') {
-            return DecodedBody::absent();
-        }
 
-        // Non-JSON Content-Type: leave the body undecoded and report it absent.
-        // The validator receives the Content-Type separately and decides the
-        // contract verdict from it (issue #251).
+        // Symfony does not retain a serialized multipart/form-data body when
+        // a request is created from parsed form values or uploaded files.
+        // Preserve the wire-presence bit from all three representations so a
+        // required non-JSON body is not mistaken for an empty request. The
+        // value is intentionally null: the validator receives Content-Type
+        // separately and does not evaluate non-JSON schemas (issue #251).
         if ($contentType !== '' && !ContentTypeMatcher::isJsonContentType(
             ContentTypeMatcher::normalizeMediaType($contentType),
         )) {
+            if ($content !== '' || $request->request->all() !== [] || $request->files->all() !== []) {
+                return DecodedBody::present(null);
+            }
+
+            return DecodedBody::absent();
+        }
+
+        if ($content === '') {
             return DecodedBody::absent();
         }
 

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -96,6 +96,13 @@ trait ValidatesOpenApiSchema
      */
     private static $skipWarningHandler;
 
+    /**
+     * @internal Laravel dispatch snapshot; not a consumer extension point.
+     *
+     * @var null|WeakMap<Request, Request>
+     */
+    private ?WeakMap $requestsBeforeDispatch = null;
+
     // Per-request skip flags set by withoutRequestValidation() /
     // withoutResponseValidation() / withoutValidation(). Consumed (and reset)
     // on the next auto-assert attempt, so the flag covers exactly one HTTP
@@ -331,6 +338,27 @@ trait ValidatesOpenApiSchema
     }
 
     /**
+     * Capture the immutable validation view immediately before Laravel sends
+     * the request through middleware and the application kernel. Request,
+     * file, query, cookie, server, and header bags are cloned by Symfony's
+     * Request::__clone(), so later mutations cannot rewrite the wire input
+     * that contract validation observes.
+     *
+     * @internal Laravel testing hook; not a consumer extension point.
+     *
+     * @param Request $symfonyRequest
+     */
+    protected function createTestRequest($symfonyRequest): Request
+    {
+        $request = parent::createTestRequest($symfonyRequest);
+
+        $this->requestsBeforeDispatch ??= new WeakMap();
+        $this->requestsBeforeDispatch[$request] = clone $request;
+
+        return $request;
+    }
+
+    /**
      * Overrides Laravel's MakesHttpRequests::createTestResponse hook so every
      * HTTP test call runs schema validation when auto_assert is enabled.
      * When the library is used outside Laravel, this method is never called.
@@ -346,14 +374,18 @@ trait ValidatesOpenApiSchema
     {
         $testResponse = parent::createTestResponse($response, $request);
 
-        $method = $request !== null ? HttpMethod::tryFrom(strtoupper($request->getMethod())) : null;
-        $path = $request?->getPathInfo();
+        $validationRequest = $request !== null
+            ? $this->takeRequestBeforeDispatch($request)
+            : null;
+
+        $method = $validationRequest !== null ? HttpMethod::tryFrom(strtoupper($validationRequest->getMethod())) : null;
+        $path = $validationRequest?->getPathInfo();
 
         // Request-side runs first so that the skipNextRequestValidation flag is
         // consumed at the HTTP boundary before the response hook gets a chance
         // to (defensively) clear it. The response status is forwarded so the
         // request validator can apply the documented-4xx downgrade (issue #179).
-        $this->maybeAutoValidateOpenApiRequest($request, $method, $path, $response->getStatusCode());
+        $this->maybeAutoValidateOpenApiRequest($validationRequest, $method, $path, $response->getStatusCode());
         $this->maybeAutoAssertOpenApiSchema($testResponse, $method, $path);
 
         return $testResponse;
@@ -597,6 +629,21 @@ trait ValidatesOpenApiSchema
         }
 
         return is_string($value) && $value !== '';
+    }
+
+    /**
+     * @internal Laravel dispatch snapshot plumbing.
+     */
+    private function takeRequestBeforeDispatch(Request $request): Request
+    {
+        if ($this->requestsBeforeDispatch === null || !isset($this->requestsBeforeDispatch[$request])) {
+            return $request;
+        }
+
+        $snapshot = $this->requestsBeforeDispatch[$request];
+        unset($this->requestsBeforeDispatch[$request]);
+
+        return $snapshot;
     }
 
     /**

--- a/tests/Integration/Laravel/AutoValidateRequestIntegrationTest.php
+++ b/tests/Integration/Laravel/AutoValidateRequestIntegrationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Studio\Gesso\Tests\Integration\Laravel;
 
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\AssertionFailedError;
@@ -175,6 +176,54 @@ class AutoValidateRequestIntegrationTest extends TestCase
         $this->postJson('/v1/pets', ['not_name' => 'x']);
     }
 
+    #[Test]
+    public function required_multipart_body_accepts_an_uploaded_file(): void
+    {
+        config()->set('gesso.auto_validate_request', true);
+        config()->set('gesso.default_spec', 'non-json-content-schema');
+
+        $response = $this
+            ->withHeader('Content-Type', 'multipart/form-data')
+            ->post('/multipart-required', [
+                'font_file' => UploadedFile::fake()->create('font.woff', 10, 'font/woff'),
+            ]);
+
+        $response->assertNoContent();
+
+        $covered = OpenApiCoverageTracker::getCovered();
+        $this->assertArrayHasKey(
+            'POST /multipart-required',
+            $covered['non-json-content-schema'] ?? [],
+        );
+    }
+
+    #[Test]
+    public function required_multipart_body_rejects_an_empty_request(): void
+    {
+        config()->set('gesso.auto_validate_request', true);
+        config()->set('gesso.default_spec', 'non-json-content-schema');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Request body is empty');
+
+        $this
+            ->withHeader('Content-Type', 'multipart/form-data')
+            ->post('/multipart-required');
+    }
+
+    #[Test]
+    public function required_form_body_accepts_parsed_parameters(): void
+    {
+        config()->set('gesso.auto_validate_request', true);
+        config()->set('gesso.default_spec', 'non-json-content-schema');
+
+        $response = $this
+            ->withHeader('Content-Type', 'application/x-www-form-urlencoded')
+            ->post('/form-required', ['name' => 'Fido']);
+
+        $response->assertNoContent();
+    }
+
     /** @return array<int, class-string> */
     protected function getPackageProviders($app): array
     {
@@ -187,6 +236,9 @@ class AutoValidateRequestIntegrationTest extends TestCase
             ['data' => ['id' => 42, 'name' => 'Buddy', 'tag' => null]],
             201,
         ));
+
+        Route::post('/multipart-required', static fn() => response()->noContent());
+        Route::post('/form-required', static fn() => response()->noContent());
 
         // Bearer-protected endpoint in the spec. Route implementation is
         // auth-free in the test app — the library validates against the

--- a/tests/Integration/Laravel/AutoValidateRequestIntegrationTest.php
+++ b/tests/Integration/Laravel/AutoValidateRequestIntegrationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Studio\Gesso\Tests\Integration\Laravel;
 
+use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
@@ -212,6 +213,41 @@ class AutoValidateRequestIntegrationTest extends TestCase
     }
 
     #[Test]
+    public function required_multipart_body_ignores_parameters_added_by_the_controller(): void
+    {
+        config()->set('gesso.auto_validate_request', true);
+        config()->set('gesso.default_spec', 'non-json-content-schema');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Request body is empty');
+
+        $this
+            ->withHeaders([
+                'Content-Type' => 'multipart/form-data',
+                'X-Gesso-Mutate-Request' => 'add-parameter',
+            ])
+            ->post('/multipart-required');
+    }
+
+    #[Test]
+    public function required_multipart_body_preserves_files_removed_by_the_controller(): void
+    {
+        config()->set('gesso.auto_validate_request', true);
+        config()->set('gesso.default_spec', 'non-json-content-schema');
+
+        $response = $this
+            ->withHeaders([
+                'Content-Type' => 'multipart/form-data',
+                'X-Gesso-Mutate-Request' => 'remove-files',
+            ])
+            ->post('/multipart-required', [
+                'font_file' => UploadedFile::fake()->create('font.woff', 10, 'font/woff'),
+            ]);
+
+        $response->assertNoContent();
+    }
+
+    #[Test]
     public function required_form_body_accepts_parsed_parameters(): void
     {
         config()->set('gesso.auto_validate_request', true);
@@ -237,7 +273,17 @@ class AutoValidateRequestIntegrationTest extends TestCase
             201,
         ));
 
-        Route::post('/multipart-required', static fn() => response()->noContent());
+        Route::post('/multipart-required', static function (Request $request) {
+            if ($request->header('X-Gesso-Mutate-Request') === 'add-parameter') {
+                $request->merge(['controller_only' => 'not-on-the-wire']);
+            }
+
+            if ($request->header('X-Gesso-Mutate-Request') === 'remove-files') {
+                $request->files->replace([]);
+            }
+
+            return response()->noContent();
+        });
         Route::post('/form-required', static fn() => response()->noContent());
 
         // Bearer-protected endpoint in the spec. Route implementation is

--- a/tests/fixtures/specs/non-json-content-schema.json
+++ b/tests/fixtures/specs/non-json-content-schema.json
@@ -24,6 +24,7 @@
             "post": {
                 "operationId": "postTextWithSchema",
                 "requestBody": {
+                    "required": true,
                     "content": {
                         "text/plain": {
                             "schema": {
@@ -60,6 +61,63 @@
                                 }
                             }
                         }
+                    }
+                }
+            }
+        },
+        "/multipart-required": {
+            "post": {
+                "operationId": "postRequiredMultipartBody",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "font_file"
+                                ],
+                                "properties": {
+                                    "font_file": {
+                                        "type": "string",
+                                        "format": "binary"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "Accepted"
+                    }
+                }
+            }
+        },
+        "/form-required": {
+            "post": {
+                "operationId": "postRequiredFormBody",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "name"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "204": {
+                        "description": "Accepted"
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- preserve request-body presence for Laravel non-JSON requests backed by raw content, parsed form fields, or uploaded files
- keep genuinely empty required multipart requests failing
- add end-to-end Laravel coverage for required multipart uploads and form-urlencoded bodies

## Root cause

Symfony stores parsed multipart fields and uploaded files in request/file bags and may leave `Request::getContent()` empty. The Laravel adapter treated every non-JSON body as absent, so the required-body enforcement added after beta.2 rejected valid multipart uploads.

## Impact

Valid Laravel multipart requests no longer fail with `Request body is empty`. Non-JSON schemas remain intentionally unevaluated by the JSON Schema engine; this change restores only the correct wire-presence signal.

## Verification

- `composer test` — 2,170 tests, 6,001 assertions
- `vendor/bin/phpstan analyse --debug --no-progress --memory-limit=1G`
- `vendor/bin/php-cs-fixer fix --dry-run --diff --sequential --config=.php-cs-fixer.dist.php ...`
- studio-api affected test — 5 tests, 42 assertions
- studio-api full suite — 5,863 tests, 28,483 assertions
