### PR TITLE
chore(release): continue v2 beta line

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,9 +153,13 @@ normal stable patch flow from its own release configuration.
    immediately after the stable release is published.
    If downstream evaluation finds another release-blocking defect before the
    stable release PR is merged, do not merge that release PR. First merge a
-   normal PR that restores `prerelease: true`, removes `release-as`, and updates
-   the invariant test. Wait for release-please to refresh the proposal to the
-   next beta, then repeat steps 5 and 6 before attempting stable promotion again.
+   normal PR that restores `prerelease: true`, removes `release-as` and the
+   stable-only `changelog-sections`, and updates the invariant test. Wait for
+   release-please to refresh the proposal to the next beta. For that beta,
+   perform the tag, GitHub Release, manifest, and Packagist checks from step 5,
+   then the published-artifact and downstream validation from step 6. The
+   beta.1-specific `release-as` cleanup in step 5 does not apply because this
+   recovery PR already removed it.
 8. Only after the stable package is installable and verified, mark
    `studio-design/openapi-contract-testing` abandoned on Packagist with
    `studio-design/gesso` as its suggested replacement. Do not delete its tags

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,11 @@ normal stable patch flow from its own release configuration.
    Release, manifest, Packagist, clean-install, and example checks before
    announcing general availability. Remove `release-as` through a normal PR
    immediately after the stable release is published.
+   If downstream evaluation finds another release-blocking defect before the
+   stable release PR is merged, do not merge that release PR. First merge a
+   normal PR that restores `prerelease: true`, removes `release-as`, and updates
+   the invariant test. Wait for release-please to refresh the proposal to the
+   next beta, then repeat steps 5 and 6 before attempting stable promotion again.
 8. Only after the stable package is installable and verified, mark
    `studio-design/openapi-contract-testing` abandoned on Packagist with
    `studio-design/gesso` as its suggested replacement. Do not delete its tags

--- a/docs/adr/0001-gesso-v2-identity.md
+++ b/docs/adr/0001-gesso-v2-identity.md
@@ -396,7 +396,7 @@ Gesso 2.0 is not ready for stable release until all of the following pass:
 - [Composer repositories and package renaming](https://getcomposer.org/doc/05-repositories.md)
 - [Packagist package naming](https://packagist.org/about)
 - [PSR-4 autoloading](https://www.php-fig.org/psr/psr-4/)
-- [PHP `class_alias()`](https://www.php.net/class-alias)
+- [PHP `class_alias()`](https://www.php.net/manual/en/function.class-alias.php)
 - [Composer autoloader optimization](https://getcomposer.org/doc/articles/autoloader-optimization.md)
 - [Laravel package configuration](https://laravel.com/docs/packages#configuration)
 - [Symfony backward compatibility promise](https://symfony.com/doc/current/contributing/code/bc.html)

--- a/docs/migration/v2-namespace-compatibility-spike.md
+++ b/docs/migration/v2-namespace-compatibility-spike.md
@@ -74,6 +74,6 @@ supported API accidentally.
 
 ## Sources
 
-- [PHP `class_alias()`](https://www.php.net/class-alias)
+- [PHP `class_alias()`](https://www.php.net/manual/en/function.class-alias.php)
 - [Composer autoload `files`](https://getcomposer.org/doc/04-schema.md#files)
 - [Composer autoloader optimization](https://getcomposer.org/doc/articles/autoloader-optimization.md)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,61 +8,8 @@
   "draft": false,
   "versioning": "prerelease",
   "prerelease-type": "beta",
-  "prerelease": false,
-  "release-as": "2.0.0",
+  "prerelease": true,
   "changelog-path": "CHANGELOG.md",
-  "changelog-sections": [
-    {
-      "type": "feat",
-      "section": "Features"
-    },
-    {
-      "type": "fix",
-      "section": "Bug Fixes"
-    },
-    {
-      "type": "perf",
-      "section": "Performance Improvements"
-    },
-    {
-      "type": "revert",
-      "section": "Reverts"
-    },
-    {
-      "type": "chore",
-      "section": "Miscellaneous Chores"
-    },
-    {
-      "type": "docs",
-      "section": "Documentation",
-      "hidden": true
-    },
-    {
-      "type": "style",
-      "section": "Styles",
-      "hidden": true
-    },
-    {
-      "type": "refactor",
-      "section": "Code Refactoring",
-      "hidden": true
-    },
-    {
-      "type": "test",
-      "section": "Tests",
-      "hidden": true
-    },
-    {
-      "type": "build",
-      "section": "Build System",
-      "hidden": true
-    },
-    {
-      "type": "ci",
-      "section": "Continuous Integration",
-      "hidden": true
-    }
-  ],
   "packages": {
     ".": {
       "package-name": "gesso"

--- a/tests/Unit/Build/ReleasePleaseConfigTest.php
+++ b/tests/Unit/Build/ReleasePleaseConfigTest.php
@@ -136,6 +136,11 @@ class ReleasePleaseConfigTest extends TestCase
             $this->config,
             'release-as MUST be absent after v2.0.0-beta.1 so later beta releases can increment normally.',
         );
+        $this->assertArrayNotHasKey(
+            'changelog-sections',
+            $this->config,
+            'Stable-promotion changelog overrides MUST be absent while publishing beta releases.',
+        );
 
         $rootPackage = $this->config['packages']['.'] ?? null;
         $this->assertIsArray($rootPackage);

--- a/tests/Unit/Build/ReleasePleaseConfigTest.php
+++ b/tests/Unit/Build/ReleasePleaseConfigTest.php
@@ -114,7 +114,7 @@ class ReleasePleaseConfigTest extends TestCase
     }
 
     #[Test]
-    public function main_is_configured_for_v2_stable_promotion(): void
+    public function main_is_configured_for_the_v2_beta_line(): void
     {
         $this->assertSame(
             'prerelease',
@@ -127,31 +127,14 @@ class ReleasePleaseConfigTest extends TestCase
             'The v2 prerelease line MUST use the documented beta identifier.',
         );
         $this->assertSame(
-            false,
+            true,
             $this->config['prerelease'] ?? null,
-            'The stable v2 release MUST not be tagged as a GitHub prerelease.',
+            'The v2 beta must be tagged as a GitHub prerelease. Set this to false only in the stable-promotion PR.',
         );
-        $this->assertSame(
-            '2.0.0',
-            $this->config['release-as'] ?? null,
-            'The stable-promotion PR MUST temporarily force exactly v2.0.0.',
-        );
-        $this->assertSame(
-            [
-                ['type' => 'feat', 'section' => 'Features'],
-                ['type' => 'fix', 'section' => 'Bug Fixes'],
-                ['type' => 'perf', 'section' => 'Performance Improvements'],
-                ['type' => 'revert', 'section' => 'Reverts'],
-                ['type' => 'chore', 'section' => 'Miscellaneous Chores'],
-                ['type' => 'docs', 'section' => 'Documentation', 'hidden' => true],
-                ['type' => 'style', 'section' => 'Styles', 'hidden' => true],
-                ['type' => 'refactor', 'section' => 'Code Refactoring', 'hidden' => true],
-                ['type' => 'test', 'section' => 'Tests', 'hidden' => true],
-                ['type' => 'build', 'section' => 'Build System', 'hidden' => true],
-                ['type' => 'ci', 'section' => 'Continuous Integration', 'hidden' => true],
-            ],
-            $this->config['changelog-sections'] ?? null,
-            'The stable-promotion chore MUST be visible so release-please does not skip an empty changelog.',
+        $this->assertArrayNotHasKey(
+            'release-as',
+            $this->config,
+            'release-as MUST be absent after v2.0.0-beta.1 so later beta releases can increment normally.',
         );
 
         $rootPackage = $this->config['packages']['.'] ?? null;
@@ -159,7 +142,7 @@ class ReleasePleaseConfigTest extends TestCase
         $this->assertArrayNotHasKey(
             'release-as',
             $rootPackage,
-            'Package-level release-as MUST stay absent so it cannot override the stable-promotion version.',
+            'Package-level release-as MUST be absent after v2.0.0-beta.1 so it cannot override the root configuration.',
         );
     }
 


### PR DESCRIPTION
## Summary

- restore release-please to the v2 beta line
- remove the temporary stable `release-as` and changelog overrides
- document how to return to beta releases when downstream validation finds a release blocker
- restore invariant coverage for incrementing prerelease versions

## Why

Downstream validation found and fixed a Laravel multipart request regression after stable promotion had already been prepared. The currently open release PR proposes v2.0.0, while the published Packagist artifact is still v2.0.0-beta.2. This change keeps stable promotion paused and allows release-please to propose v2.0.0-beta.3 for another published-artifact validation cycle.

## Impact

After this PR merges, wait for release-please to refresh the release proposal to v2.0.0-beta.3. Do not merge the existing stable v2.0.0 proposal.

## Verification

- `vendor/bin/phpunit tests/Unit/Build/ReleasePleaseConfigTest.php` — 7 tests, 18 assertions
- `php -d memory_limit=1G vendor/bin/phpstan analyse --debug`
- PHP-CS-Fixer dry run for `ReleasePleaseConfigTest.php`
- `git diff --check`
