### PR TITLE
docs: clarify v2 beta installation guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,22 +144,28 @@ normal stable patch flow from its own release configuration.
    published package rather than a path repository. Ship any corrections as
    normal PRs and publish another beta through release-please when necessary.
 7. To promote the accepted beta, open a normal PR that changes `prerelease` to
-   `false`, temporarily sets `release-as: 2.0.0`, and updates the corresponding
-   invariant test. Keep `versioning: prerelease` so release-please promotes the
-   beta line instead of calculating an unrelated bump. After merge, verify that
-   the refreshed release PR proposes stable `2.0.0` and repeat the tag, GitHub
-   Release, manifest, Packagist, clean-install, and example checks before
-   announcing general availability. Remove `release-as` through a normal PR
-   immediately after the stable release is published.
+   `false`, temporarily sets `release-as: 2.0.0`, restores the stable-only
+   `changelog-sections` that keep the promotion commit visible, and updates the
+   corresponding invariant tests. In the same PR, replace the beta installation
+   commands with `studio-design/gesso:^2.0` and remove the pre-release evaluation
+   warnings; the documentation policy follows the configured `prerelease` mode
+   so both the promotion PR and the bot-managed release PR remain green. Keep
+   `versioning: prerelease` so release-please promotes the beta line instead of
+   calculating an unrelated bump. After merge, verify that the refreshed release
+   PR proposes stable `2.0.0` and repeat the tag, GitHub Release, manifest,
+   Packagist, clean-install, and example checks before announcing general
+   availability. Remove `release-as` through a normal PR immediately after the
+   stable release is published.
    If downstream evaluation finds another release-blocking defect before the
    stable release PR is merged, do not merge that release PR. First merge a
    normal PR that restores `prerelease: true`, removes `release-as` and the
-   stable-only `changelog-sections`, and updates the invariant test. Wait for
-   release-please to refresh the proposal to the next beta. For that beta,
-   perform the tag, GitHub Release, manifest, and Packagist checks from step 5,
-   then the published-artifact and downstream validation from step 6. The
-   beta.1-specific `release-as` cleanup in step 5 does not apply because this
-   recovery PR already removed it.
+   stable-only `changelog-sections`, restores the `^2.0@beta` installation
+   commands and pre-release evaluation warnings, and updates the invariant
+   tests. Wait for release-please to refresh the proposal to the next beta. For
+   that beta, perform the tag, GitHub Release, manifest, and Packagist checks
+   from step 5, then the published-artifact and downstream validation from
+   step 6. The beta.1-specific `release-as` cleanup in step 5 does not apply
+   because this recovery PR already removed it.
 8. Only after the stable package is installable and verified, mark
    `studio-design/openapi-contract-testing` abandoned on Packagist with
    `studio-design/gesso` as its suggested replacement. Do not delete its tags

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Gesso is the primer applied to a canvas before painting—a stable, receptive ground on which the finished work can be built. Gesso brings that same idea to APIs, providing a dependable foundation for OpenAPI contract testing in PHP.
 
 [![CI](https://github.com/studio-design/gesso/actions/workflows/ci.yml/badge.svg)](https://github.com/studio-design/gesso/actions/workflows/ci.yml)
-[![Latest Stable Version](https://poser.pugx.org/studio-design/gesso/v)](https://packagist.org/packages/studio-design/gesso)
+[![Latest Version](https://poser.pugx.org/studio-design/gesso/v)](https://packagist.org/packages/studio-design/gesso)
 [![Total Downloads](https://poser.pugx.org/studio-design/gesso/downloads)](https://packagist.org/packages/studio-design/gesso)
 [![PHP Version Require](https://poser.pugx.org/studio-design/gesso/require/php)](https://packagist.org/packages/studio-design/gesso)
 [![License](https://poser.pugx.org/studio-design/gesso/license)](https://packagist.org/packages/studio-design/gesso)
@@ -98,9 +98,18 @@ Choose based on the workflow you need rather than on a single yes/no feature cou
 
 ## Installation
 
+> **Pre-release evaluation only.** Gesso 2 has not reached a stable release.
+> Evaluate the beta in an isolated branch or CI job, and keep the existing v1
+> dependency in projects that require a stable contract.
+
 ```bash
-composer require --dev studio-design/gesso
+composer require --dev "studio-design/gesso:^2.0@beta"
 ```
+
+The explicit stability flag lets Composer select the published prerelease; it
+is not a stable-release recommendation. After v2.0.0 stable is published, new
+installations can use `composer require --dev "studio-design/gesso:^2.0"`
+instead.
 
 > **YAML specs require `symfony/yaml`.** It is listed under `suggest` so it isn't installed automatically. If your spec is JSON, you can skip this. If your spec is `.yaml` / `.yml`, add it explicitly:
 >
@@ -124,8 +133,12 @@ Choose the CI-tested five-minute path matching your stack:
 
 All paths start with the same development dependency:
 
+> The command below installs a prerelease for isolated evaluation. See the
+> [installation warning](#installation) before adopting it in an existing
+> project.
+
 ```bash
-composer require --dev studio-design/gesso
+composer require --dev "studio-design/gesso:^2.0@beta"
 ```
 
 The example below uses a PSR-7 request and response. The searchable documentation contains the complete [core](https://studio-design.github.io/gesso/quickstarts/core), [Laravel](https://studio-design.github.io/gesso/quickstarts/laravel), [Symfony](https://studio-design.github.io/gesso/quickstarts/symfony), and [Pest](https://studio-design.github.io/gesso/quickstarts/pest) quickstarts.

--- a/docs/quickstarts/core.md
+++ b/docs/quickstarts/core.md
@@ -1,7 +1,10 @@
 # Core / PHPUnit quickstart
 
+> **Pre-release evaluation only.** Run this beta in an isolated branch or CI
+> job; Gesso 2 has not reached a stable release.
+
 ```bash
-composer require --dev studio-design/gesso
+composer require --dev "studio-design/gesso:^2.0@beta"
 ```
 
 Copy the minimal [`examples/core`](https://github.com/studio-design/gesso/tree/main/examples/core) project. Its test validates a JSON response without a framework adapter:

--- a/docs/quickstarts/laravel.md
+++ b/docs/quickstarts/laravel.md
@@ -1,7 +1,10 @@
 # Laravel quickstart
 
+> **Pre-release evaluation only.** Run this beta in an isolated branch or CI
+> job; Gesso 2 has not reached a stable release.
+
 ```bash
-composer require --dev studio-design/gesso
+composer require --dev "studio-design/gesso:^2.0@beta"
 php artisan vendor:publish --tag=gesso
 ```
 

--- a/docs/quickstarts/pest.md
+++ b/docs/quickstarts/pest.md
@@ -1,7 +1,10 @@
 # Pest quickstart
 
+> **Pre-release evaluation only.** Run this beta in an isolated branch or CI
+> job; Gesso 2 has not reached a stable release.
+
 ```bash
-composer require --dev studio-design/gesso pestphp/pest
+composer require --dev "studio-design/gesso:^2.0@beta" pestphp/pest
 ```
 
 Use the automatically registered expectation with a Laravel response:

--- a/docs/quickstarts/symfony.md
+++ b/docs/quickstarts/symfony.md
@@ -1,7 +1,10 @@
 # Symfony quickstart
 
+> **Pre-release evaluation only.** Run this beta in an isolated branch or CI
+> job; Gesso 2 has not reached a stable release.
+
 ```bash
-composer require --dev studio-design/gesso symfony/http-foundation symfony/http-kernel
+composer require --dev "studio-design/gesso:^2.0@beta" symfony/http-foundation symfony/http-kernel
 ```
 
 Mix `Studio\Gesso\Symfony\OpenApiAssertions` into a PHPUnit or `WebTestCase` class:

--- a/examples/core/README.md
+++ b/examples/core/README.md
@@ -1,7 +1,10 @@
 # Core quickstart
 
+> **Pre-release evaluation only.** Run this beta in an isolated branch or CI
+> job; Gesso 2 has not reached a stable release.
+
 ```bash
-composer require --dev studio-design/gesso
+composer require --dev "studio-design/gesso:^2.0@beta"
 composer install
 composer test
 ```

--- a/examples/laravel/README.md
+++ b/examples/laravel/README.md
@@ -1,7 +1,10 @@
 # Laravel quickstart
 
+> **Pre-release evaluation only.** Run this beta in an isolated branch or CI
+> job; Gesso 2 has not reached a stable release.
+
 ```bash
-composer require --dev studio-design/gesso
+composer require --dev "studio-design/gesso:^2.0@beta"
 php artisan vendor:publish --tag=gesso
 composer install
 composer test

--- a/examples/pest/README.md
+++ b/examples/pest/README.md
@@ -6,6 +6,9 @@ Mirrors the patterns documented in the main README's
 
 ## Run it
 
+> **Pre-release evaluation only.** Run this beta in an isolated branch or CI
+> job; Gesso 2 has not reached a stable release.
+
 ```bash
 cd examples/pest
 composer install
@@ -20,7 +23,7 @@ chaining, and a coverage-tracker smoke assertion.
 
 | Path | Purpose |
 |---|---|
-| `composer.json` | Wires the library via a `path` repository (`../..`). In your real project, replace it with `composer require --dev studio-design/gesso pestphp/pest`. |
+| `composer.json` | Wires the library via a `path` repository (`../..`). In your real project, replace it with `composer require --dev "studio-design/gesso:^2.0@beta" pestphp/pest`. |
 | `openapi/petstore.json` | Tiny OpenAPI 3.1 spec with three endpoints (`GET /v1/pets`, `POST /v1/pets`, `GET /v1/health`). |
 | `phpunit.xml.dist` | Minimal PHPUnit config that registers `OpenApiCoverageExtension` and points it at `openapi/`. |
 | `tests/TestCase.php` | Base test case extending Orchestra Testbench, mixing in `ValidatesOpenApiSchema`, declaring sample routes, and resetting library state per test. |

--- a/examples/symfony/README.md
+++ b/examples/symfony/README.md
@@ -1,7 +1,10 @@
 # Symfony quickstart
 
+> **Pre-release evaluation only.** Run this beta in an isolated branch or CI
+> job; Gesso 2 has not reached a stable release.
+
 ```bash
-composer require --dev studio-design/gesso symfony/http-foundation symfony/http-kernel
+composer require --dev "studio-design/gesso:^2.0@beta" symfony/http-foundation symfony/http-kernel
 composer install
 composer test
 ```

--- a/tests/Unit/Build/DocumentationInstallPolicyTest.php
+++ b/tests/Unit/Build/DocumentationInstallPolicyTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Build;
+
+use const JSON_THROW_ON_ERROR;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function dirname;
+use function file_get_contents;
+use function json_decode;
+use function str_contains;
+
+final class DocumentationInstallPolicyTest extends TestCase
+{
+    #[Test]
+    public function prerelease_install_guides_are_explicitly_marked_for_evaluation(): void
+    {
+        $root = dirname(__DIR__, 3);
+        $manifestContents = file_get_contents($root . '/.release-please-manifest.json');
+        $this->assertNotFalse($manifestContents);
+
+        /** @var array{'.': string} $manifest */
+        $manifest = json_decode($manifestContents, true, flags: JSON_THROW_ON_ERROR);
+        $currentVersion = $manifest['.'];
+
+        foreach ([
+            'README.md',
+            'docs/quickstarts/core.md',
+            'docs/quickstarts/laravel.md',
+            'docs/quickstarts/pest.md',
+            'docs/quickstarts/symfony.md',
+            'examples/core/README.md',
+            'examples/laravel/README.md',
+            'examples/pest/README.md',
+            'examples/symfony/README.md',
+        ] as $relativePath) {
+            $contents = file_get_contents($root . '/' . $relativePath);
+            $this->assertIsString($contents);
+
+            if (!str_contains($currentVersion, '-')) {
+                $this->assertStringContainsString(
+                    'studio-design/gesso:^2.0',
+                    $contents,
+                    $relativePath . ' must install the stable Gesso 2 line.',
+                );
+                $this->assertStringNotContainsString(
+                    'studio-design/gesso:^2.0@beta',
+                    $contents,
+                    $relativePath . ' must stop opting in to prereleases after the stable release.',
+                );
+                $this->assertStringNotContainsString(
+                    'Pre-release evaluation only',
+                    $contents,
+                    $relativePath . ' must remove the prerelease warning after the stable release.',
+                );
+
+                continue;
+            }
+
+            $this->assertStringContainsString(
+                'studio-design/gesso:^2.0@beta',
+                $contents,
+                $relativePath . ' must opt in to the published Gesso 2 beta.',
+            );
+            $this->assertStringContainsString(
+                'Pre-release evaluation only',
+                $contents,
+                $relativePath . ' must not present the Gesso 2 beta as a stable recommendation.',
+            );
+            $this->assertStringNotContainsString(
+                'composer require --dev studio-design/gesso',
+                $contents,
+                $relativePath . ' must not present an unavailable stable release as the current install path.',
+            );
+        }
+    }
+}

--- a/tests/Unit/Build/DocumentationInstallPolicyTest.php
+++ b/tests/Unit/Build/DocumentationInstallPolicyTest.php
@@ -12,20 +12,20 @@ use PHPUnit\Framework\TestCase;
 use function dirname;
 use function file_get_contents;
 use function json_decode;
-use function str_contains;
 
 final class DocumentationInstallPolicyTest extends TestCase
 {
     #[Test]
-    public function prerelease_install_guides_are_explicitly_marked_for_evaluation(): void
+    public function installation_guides_follow_the_configured_release_channel(): void
     {
         $root = dirname(__DIR__, 3);
-        $manifestContents = file_get_contents($root . '/.release-please-manifest.json');
-        $this->assertNotFalse($manifestContents);
+        $configContents = file_get_contents($root . '/release-please-config.json');
+        $this->assertNotFalse($configContents);
 
-        /** @var array{'.': string} $manifest */
-        $manifest = json_decode($manifestContents, true, flags: JSON_THROW_ON_ERROR);
-        $currentVersion = $manifest['.'];
+        /** @var array<string, mixed> $config */
+        $config = json_decode($configContents, true, flags: JSON_THROW_ON_ERROR);
+        $isPrerelease = $config['prerelease'] ?? null;
+        $this->assertIsBool($isPrerelease);
 
         foreach ([
             'README.md',
@@ -41,7 +41,7 @@ final class DocumentationInstallPolicyTest extends TestCase
             $contents = file_get_contents($root . '/' . $relativePath);
             $this->assertIsString($contents);
 
-            if (!str_contains($currentVersion, '-')) {
+            if (!$isPrerelease) {
                 $this->assertStringContainsString(
                     'studio-design/gesso:^2.0',
                     $contents,
@@ -50,12 +50,12 @@ final class DocumentationInstallPolicyTest extends TestCase
                 $this->assertStringNotContainsString(
                     'studio-design/gesso:^2.0@beta',
                     $contents,
-                    $relativePath . ' must stop opting in to prereleases after the stable release.',
+                    $relativePath . ' must stop opting in to prereleases during stable promotion.',
                 );
                 $this->assertStringNotContainsString(
                     'Pre-release evaluation only',
                     $contents,
-                    $relativePath . ' must remove the prerelease warning after the stable release.',
+                    $relativePath . ' must remove the prerelease warning during stable promotion.',
                 );
 
                 continue;


### PR DESCRIPTION
## Summary

- mark Gesso 2 installation commands as prerelease evaluation guidance
- use the explicit Composer `^2.0@beta` stability opt-in across README, quickstarts, and example READMEs
- add a documentation policy test that follows release-please's configured beta/stable mode
- document that stable promotion and beta recovery must update the installation guidance in the same PR as the release mode
- rebase the change onto the current `main` after the beta.4 and documentation-site updates

## Why

Gesso 2 is currently published as `v2.0.0-beta.4`. An unqualified install command can read as a stable recommendation even though downstream validation is still part of the beta process. The documentation should make the release status and adoption boundary explicit.

The policy test prevents the beta warning and stability flag from remaining during stable promotion. It reads `release-please-config.json` rather than the release manifest so the normal promotion PR can update the release mode and documentation together; otherwise the bot-managed stable release PR would be the first place the manifest becomes stable and would fail its own CI.

## Validation

- clean Packagist resolution of `studio-design/gesso:^2.0@beta` selected `v2.0.0-beta.4`
- `php84 vendor/bin/phpunit tests/Unit/Build/DocumentationInstallPolicyTest.php` — 1 test, 38 assertions
- PHP-CS-Fixer, both configurations, sequential — clean
- PHPStan with single-process sandbox settings — no errors
- `npm run docs:build`
- `npm run docs:verify-accessibility`
- `npm run docs:verify-base`
- `npm run docs:verify-tombo`
- `npm run docs:verify-version`
- `git diff --check`

## ローカル実機確認

- 環境: 生成済み `docs/.vitepress/dist/quickstarts/core.html` / Chrome DevTools MCP
- 操作: Core / PHPUnit quickstartを1440pxと500pxで表示し、beta警告、Composerコマンド、ページ幅を確認
- 結果: `Pre-release evaluation only` と `composer require --dev "studio-design/gesso:^2.0@beta"` が読み上げツリーと画面の両方に表示され、PCではコマンドにoverflowなし、モバイルではコードブロック内だけスクロールしページ全体の横overflowなし
- Before/After: 無警告・無指定インストールコマンドから、beta評価用途の警告と明示的な安定度opt-inへ変更
- Console/Network: ローカルHTTPサーバーを利用できないため `file://` で確認。CSSは読み込み済み。module scriptとローカルfontはブラウザーの `file://` CORS制約で未読込
- 証跡: `/private/tmp/gesso-pr375-beta4-desktop.png`、`/private/tmp/gesso-pr375-beta4-mobile.png`
- 未確認事項: HTTP配信時のクライアントサイドナビゲーション。静的な表示内容とレスポンシブレイアウトは生成HTML/CSSで確認済み
