### PR TITLE
perf(validation): reuse compiled schemas across validations

### DIFF
--- a/src/Validation/Support/SchemaValidatorRunner.php
+++ b/src/Validation/Support/SchemaValidatorRunner.php
@@ -19,13 +19,16 @@ use function array_keys;
 use function array_values;
 use function count;
 use function get_object_vars;
+use function hash;
 use function implode;
 use function in_array;
 use function is_array;
 use function is_int;
+use function is_object;
 use function is_string;
 use function preg_match;
 use function property_exists;
+use function serialize;
 use function sprintf;
 
 /**
@@ -33,8 +36,24 @@ use function sprintf;
  */
 final class SchemaValidatorRunner
 {
+    /**
+     * Bound the canonical schema set retained by this runner. Opis keeps every
+     * parsed schema object in a SplObjectStorage cache, so accepting a fresh
+     * but equivalent stdClass on every validation grows memory linearly with
+     * the number of assertions. Reusing one canonical object per schema lets
+     * Opis reuse its parsed representation instead.
+     *
+     * A runner is normally shared by one request or response validator. 1,024
+     * entries covers large multi-spec suites while keeping dynamically-created
+     * schema workloads bounded. Reaching the limit clears both sides of the
+     * cache atomically so Opis cannot retain objects we no longer own.
+     */
+    private const MAX_CANONICAL_SCHEMAS = 1024;
     private readonly Validator $opisValidator;
     private readonly ErrorFormatter $errorFormatter;
+
+    /** @var array<string, object> SHA-256 of the serialized converted schema => canonical schema object */
+    private array $canonicalSchemas = [];
 
     public function __construct(int $maxErrors)
     {
@@ -74,6 +93,7 @@ final class SchemaValidatorRunner
      */
     public function validate(mixed $jsonSchema, mixed $data): array
     {
+        $jsonSchema = $this->canonicalSchema($jsonSchema);
         $result = $this->opisValidator->validate($data, $jsonSchema);
 
         if ($result->isValid()) {
@@ -321,5 +341,36 @@ final class SchemaValidatorRunner
         }
 
         return array_keys(get_object_vars($current->properties));
+    }
+
+    /**
+     * Return the stable object identity Opis uses for its parsed-schema cache.
+     *
+     * Callers intentionally convert PHP schema arrays to stdClass before
+     * every validation. Object equality is not enough for Opis: its loader is
+     * keyed by identity, so equivalent fresh objects are parsed and retained
+     * independently. A content fingerprint maps them back to one canonical
+     * object without changing validation semantics. Boolean schemas bypass
+     * the cache because Opis does not retain them by object identity.
+     */
+    private function canonicalSchema(mixed $schema): mixed
+    {
+        if (!is_object($schema)) {
+            return $schema;
+        }
+
+        $fingerprint = hash('sha256', serialize($schema));
+        if (isset($this->canonicalSchemas[$fingerprint])) {
+            return $this->canonicalSchemas[$fingerprint];
+        }
+
+        if (count($this->canonicalSchemas) >= self::MAX_CANONICAL_SCHEMAS) {
+            $this->canonicalSchemas = [];
+            $this->opisValidator->loader()->clearCache();
+        }
+
+        $this->canonicalSchemas[$fingerprint] = $schema;
+
+        return $schema;
     }
 }

--- a/tests/Unit/Validation/Support/SchemaValidatorRunnerTest.php
+++ b/tests/Unit/Validation/Support/SchemaValidatorRunnerTest.php
@@ -7,13 +7,16 @@ namespace Studio\Gesso\Tests\Unit\Validation\Support;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 use Studio\Gesso\OpenApiVersion;
 use Studio\Gesso\Spec\OpenApiSchemaConverter;
 use Studio\Gesso\Validation\Support\ObjectConverter;
 use Studio\Gesso\Validation\Support\SchemaValidatorRunner;
 
 use function count;
+use function gc_collect_cycles;
 use function implode;
+use function memory_get_usage;
 use function sprintf;
 use function str_contains;
 
@@ -56,6 +59,76 @@ class SchemaValidatorRunnerTest extends TestCase
         $errors = $runner->validate($schema, $data);
 
         $this->assertArrayHasKey('/count', $errors);
+    }
+
+    #[Test]
+    public function equivalent_fresh_schema_objects_reuse_one_canonical_opis_schema(): void
+    {
+        $runner = new SchemaValidatorRunner(20);
+        $schema = [
+            'type' => 'object',
+            'required' => ['data'],
+            'properties' => [
+                'data' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'object',
+                        'required' => ['id', 'name'],
+                        'properties' => [
+                            'id' => ['type' => 'integer'],
+                            'name' => ['type' => 'string'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $data = ObjectConverter::convert(['data' => [['id' => 1, 'name' => 'Ada']]]);
+
+        gc_collect_cycles();
+        $memoryBefore = memory_get_usage();
+        for ($i = 0; $i < 1_000; $i++) {
+            // Reproduce the real request/response-validator path: schema
+            // conversion returns a fresh object graph on every assertion.
+            $freshSchema = ObjectConverter::convert(
+                OpenApiSchemaConverter::convert($schema, OpenApiVersion::V3_1),
+            );
+            $this->assertSame([], $runner->validate($freshSchema, $data));
+        }
+        gc_collect_cycles();
+
+        $retainedBytes = memory_get_usage() - $memoryBefore;
+        $this->assertLessThan(
+            4 * 1024 * 1024,
+            $retainedBytes,
+            sprintf(
+                'Equivalent schema validations retained %.2f MiB; Opis schema identities are growing per assertion.',
+                $retainedBytes / 1024 / 1024,
+            ),
+        );
+
+        $cache = (new ReflectionProperty($runner, 'canonicalSchemas'))->getValue($runner);
+        $this->assertCount(1, $cache);
+    }
+
+    #[Test]
+    public function canonical_schema_cache_is_bounded_for_dynamic_schema_workloads(): void
+    {
+        $runner = new SchemaValidatorRunner(20);
+
+        for ($i = 0; $i < 1_025; $i++) {
+            $schema = ObjectConverter::convert([
+                'type' => 'integer',
+                'const' => $i,
+            ]);
+            $this->assertSame([], $runner->validate($schema, $i));
+        }
+
+        $cache = (new ReflectionProperty($runner, 'canonicalSchemas'))->getValue($runner);
+        $this->assertCount(
+            1,
+            $cache,
+            'Crossing the cache limit must release both Gesso and Opis schema caches before retaining new identities.',
+        );
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- reuse a canonical converted schema object across equivalent validations
- bound the canonical schema cache at 1,024 entries and clear the corresponding Opis loader cache when the limit is reached
- add regression coverage for repeated equivalent schemas and dynamic-schema cache growth

## Why

Request and response validation converts the same OpenAPI schema into a fresh object graph for every assertion. Opis keys its parsed-schema cache by object identity, so it reparsed and retained every fresh object. Repeated validation therefore increased memory linearly and missed the compiled-schema cache.

The canonical content fingerprint gives equivalent converted schemas a stable identity. Clearing both Gesso and Opis caches together at the configured bound prevents dynamically generated schemas from growing memory without limit.

## Impact

In a local PHP 8.4 benchmark of 5,000 validations:

| Path | Before | After |
| --- | --- | --- |
| Response validation | ~795 ms / +81.0 MiB | ~213 ms / +0.94 MiB |
| Request validation | ~569 ms / +50.3 MiB | ~127 ms / +0.06 MiB |

This does not change the public API or validation results.

## Verification

- `vendor/bin/phpunit tests/Unit/Validation/Support/SchemaValidatorRunnerTest.php` — 34 tests, 2,095 assertions
- full PHPUnit suite excluding the two Markdown lint wrapper tests — 2,172 tests, 8,033 assertions
- PHPStan on both changed files — no errors
- PHP-CS-Fixer with the main and Pest configurations — clean
- PHP 8.3 syntax checks on both changed files — clean

The two Markdown lint wrapper tests were not run locally because the host npm cache is not writable; GitHub Actions will run them in a clean environment.
