### PR TITLE
perf(spec): index OpenAPI path matches

### DIFF
--- a/src/Spec/OpenApiPathMatcher.php
+++ b/src/Spec/OpenApiPathMatcher.php
@@ -17,6 +17,7 @@ use function str_ends_with;
 use function str_starts_with;
 use function strlen;
 use function substr;
+use function substr_count;
 use function trim;
 use function usort;
 
@@ -25,8 +26,11 @@ use function usort;
  */
 final class OpenApiPathMatcher
 {
-    /** @var array{pattern: string, path: string, paramNames: string[], literalSegments: int}[] */
-    private array $compiledPaths;
+    /** @var array<string, string> normalized request path => original spec path */
+    private array $literalPaths;
+
+    /** @var array<int, array{pattern: string, path: string, paramNames: string[], literalSegments: int}[]> */
+    private array $compiledPathsBySegmentCount;
 
     /**
      * @param string[] $specPaths
@@ -37,6 +41,7 @@ final class OpenApiPathMatcher
         private readonly array $stripPrefixes = [],
     ) {
         $compiled = [];
+        $literalPaths = [];
         foreach ($specPaths as $specPath) {
             $segments = explode('/', trim($specPath, '/'));
             $literalCount = 0;
@@ -65,6 +70,19 @@ final class OpenApiPathMatcher
                 }
             }
 
+            if ($paramNames === []) {
+                // Requests are normalized by removing trailing slashes before
+                // matching. Preserve the first declaration when two literal
+                // spec paths normalize to the same request path, matching the
+                // stable ordering of the previous compiled-regex scan.
+                $literalPath = '/' . implode('/', $segments);
+                if (!isset($literalPaths[$literalPath])) {
+                    $literalPaths[$literalPath] = $specPath;
+                }
+
+                continue;
+            }
+
             $pattern = '#^/' . implode('/', $regexSegments) . '$#';
             $compiled[] = [
                 'pattern' => $pattern,
@@ -77,7 +95,14 @@ final class OpenApiPathMatcher
         // Sort by literal segment count descending so more specific paths match first
         usort($compiled, static fn(array $a, array $b): int => $b['literalSegments'] <=> $a['literalSegments']);
 
-        $this->compiledPaths = $compiled;
+        $compiledPathsBySegmentCount = [];
+        foreach ($compiled as $path) {
+            $segmentCount = self::segmentCount($path['path']);
+            $compiledPathsBySegmentCount[$segmentCount][] = $path;
+        }
+
+        $this->literalPaths = $literalPaths;
+        $this->compiledPathsBySegmentCount = $compiledPathsBySegmentCount;
     }
 
     public function match(string $requestPath): ?string
@@ -151,7 +176,12 @@ final class OpenApiPathMatcher
     {
         $normalizedPath = $this->normalizeRequestPath($requestPath)['path'];
 
-        foreach ($this->compiledPaths as $compiled) {
+        if (isset($this->literalPaths[$normalizedPath])) {
+            return ['path' => $this->literalPaths[$normalizedPath], 'variables' => []];
+        }
+
+        $compiledPaths = $this->compiledPathsBySegmentCount[self::segmentCount($normalizedPath)] ?? [];
+        foreach ($compiledPaths as $compiled) {
             if (preg_match($compiled['pattern'], $normalizedPath, $matches) !== 1) {
                 continue;
             }
@@ -166,5 +196,10 @@ final class OpenApiPathMatcher
         }
 
         return null;
+    }
+
+    private static function segmentCount(string $path): int
+    {
+        return substr_count(trim($path, '/'), '/') + 1;
     }
 }

--- a/tests/Unit/Spec/OpenApiPathMatcherTest.php
+++ b/tests/Unit/Spec/OpenApiPathMatcherTest.php
@@ -99,6 +99,28 @@ class OpenApiPathMatcherTest extends TestCase
     }
 
     #[Test]
+    public function equivalent_literal_paths_preserve_declaration_order(): void
+    {
+        $matcher = new OpenApiPathMatcher([
+            '/v2/account/',
+            '/v2/account',
+        ]);
+
+        $this->assertSame('/v2/account/', $matcher->match('/v2/account'));
+    }
+
+    #[Test]
+    public function equally_specific_templates_preserve_declaration_order(): void
+    {
+        $matcher = new OpenApiPathMatcher([
+            '/{first}/fixed',
+            '/fixed/{second}',
+        ]);
+
+        $this->assertSame('/{first}/fixed', $matcher->match('/fixed/fixed'));
+    }
+
+    #[Test]
     #[DataProvider('provideMatches_paths_with_strip_prefixCases')]
     public function matches_paths_with_strip_prefix(string $requestPath, ?string $expected): void
     {


### PR DESCRIPTION
## Summary

- resolve literal OpenAPI paths through a direct lookup
- group templated paths by segment count before running their compiled regular expressions
- preserve existing specificity and declaration-order behavior

## Why

`OpenApiPathMatcher` previously scanned every compiled path expression for each request, including literal paths and templates with an incompatible number of segments. This makes route resolution scale linearly with the total number of operations in a spec.

Literal paths can be matched exactly, while a template can only match a request with the same number of path segments. Indexing those two cases removes most unnecessary regular-expression evaluations without changing the matching contract.

## Impact

Using a representative bundled spec with 292 paths on PHP 8.4:

| Workload | Before | After |
| --- | ---: | ---: |
| Match every path 20 times | 79.6 ms | 13.5 ms |
| 10,000 unmatched paths | 261.9 ms | 47.1 ms |

This is approximately a 5.6–5.9x speedup for path resolution. Public APIs and returned path templates remain unchanged.

## Verification

- focused matcher and request-validator suites — 216 tests, 448 assertions
- full PHPUnit suite excluding the two Markdown lint wrapper tests — 2,174 tests, 8,035 assertions
- PHPStan on both changed files — no errors
- PHP-CS-Fixer with the main and Pest configurations — clean
- PHP 8.3 syntax checks on both changed files — clean

The two Markdown lint wrapper tests were not run locally because the host npm cache is not writable; GitHub Actions will run them in a clean environment.
