### PR TITLE
perf(spec): combine templated path patterns

### DIFF
--- a/src/Spec/OpenApiPathMatcher.php
+++ b/src/Spec/OpenApiPathMatcher.php
@@ -6,7 +6,7 @@ namespace Studio\Gesso\Spec;
 
 use InvalidArgumentException;
 
-use function array_chunk;
+use function count;
 use function explode;
 use function implode;
 use function in_array;
@@ -30,13 +30,22 @@ final class OpenApiPathMatcher
     /** Keep each combined PCRE bounded for specs with thousands of templates. */
     private const MAX_TEMPLATES_PER_PATTERN = 32;
 
+    /** Bound total captures in a combined pattern at PCRE's 10,000 named-capture ceiling. */
+    private const MAX_CAPTURES_PER_COMBINED_PATTERN = 10_000;
+
+    /** Leave headroom below PCRE's compiled-pattern size ceiling. */
+    private const MAX_COMBINED_PATTERN_BYTES = 30_000;
+
+    /** Reject one template that cannot be split below PCRE's named-capture ceiling. */
+    private const MAX_PARAMETERS_PER_TEMPLATE = 10_000;
+
     /** @var array<string, string> normalized request path => original spec path */
     private array $literalPaths;
 
     /**
      * @var array<int, list<array{
      *     pattern: string,
-     *     matches: array<int, array{path: string, parameters: array<string, string>}>,
+     *     matches: array<int, array{path: string, parameters: array<string, int>}>,
      * }>>
      */
     private array $compiledPathsBySegmentCount;
@@ -56,6 +65,7 @@ final class OpenApiPathMatcher
             $literalCount = 0;
             $compiledSegments = [];
             $paramNames = [];
+            $patternBytes = 16; // anchors, non-capturing wrapper, and MARK
 
             foreach ($segments as $segment) {
                 if (preg_match('/^\{(.+)\}$/', $segment, $m)) {
@@ -73,10 +83,22 @@ final class OpenApiPathMatcher
 
                     $compiledSegments[] = ['parameter' => $m[1]];
                     $paramNames[] = $m[1];
+                    $patternBytes += 8; // slash plus `([^/]+)`
                 } else {
                     $compiledSegments[] = ['literal' => $segment];
                     $literalCount++;
+                    $patternBytes += strlen(preg_quote($segment, '#')) + 1;
                 }
+            }
+
+            $parameterCount = count($paramNames);
+            if ($parameterCount > self::MAX_PARAMETERS_PER_TEMPLATE) {
+                throw new InvalidArgumentException(sprintf(
+                    "Spec path '%s' declares %d placeholders; a single template may declare at most %d.",
+                    $specPath,
+                    $parameterCount,
+                    self::MAX_PARAMETERS_PER_TEMPLATE,
+                ));
             }
 
             if ($paramNames === []) {
@@ -96,6 +118,8 @@ final class OpenApiPathMatcher
                 'segments' => $compiledSegments,
                 'path' => $specPath,
                 'literalSegments' => $literalCount,
+                'parameterCount' => $parameterCount,
+                'patternBytes' => $patternBytes,
             ];
         }
 
@@ -110,13 +134,38 @@ final class OpenApiPathMatcher
 
         $compiledPathsBySegmentCount = [];
         foreach ($pathsBySegmentCount as $segmentCount => $paths) {
-            foreach (array_chunk($paths, self::MAX_TEMPLATES_PER_PATTERN) as $chunk) {
+            $chunks = [];
+            $chunk = [];
+            $chunkCaptureCount = 0;
+            $chunkPatternBytes = 0;
+            foreach ($paths as $path) {
+                if ($chunk !== [] && (
+                    count($chunk) >= self::MAX_TEMPLATES_PER_PATTERN ||
+                    $chunkCaptureCount + $path['parameterCount'] > self::MAX_CAPTURES_PER_COMBINED_PATTERN ||
+                    $chunkPatternBytes + $path['patternBytes'] > self::MAX_COMBINED_PATTERN_BYTES
+                )) {
+                    $chunks[] = $chunk;
+                    $chunk = [];
+                    $chunkCaptureCount = 0;
+                    $chunkPatternBytes = 0;
+                }
+
+                // A single long-literal template can exceed the combination
+                // byte budget but still compile on its own, as in the legacy
+                // one-pattern-per-template implementation.
+                $chunk[] = $path;
+                $chunkCaptureCount += $path['parameterCount'];
+                $chunkPatternBytes += $path['patternBytes'];
+            }
+            $chunks[] = $chunk;
+
+            foreach ($chunks as $chunk) {
                 $alternatives = [];
                 $matches = [];
+                $captureIndex = 1;
                 foreach ($chunk as $pathIndex => $path) {
                     $regexSegments = [];
                     $parameters = [];
-                    $parameterIndex = 0;
                     foreach ($path['segments'] as $segment) {
                         if (isset($segment['literal'])) {
                             $regexSegments[] = preg_quote($segment['literal'], '#');
@@ -124,9 +173,8 @@ final class OpenApiPathMatcher
                             continue;
                         }
 
-                        $captureName = sprintf('p%d_%d', $pathIndex, $parameterIndex++);
-                        $regexSegments[] = sprintf('(?<%s>[^/]+)', $captureName);
-                        $parameters[$segment['parameter']] = $captureName;
+                        $regexSegments[] = '([^/]+)';
+                        $parameters[$segment['parameter']] = $captureIndex++;
                     }
 
                     $marker = (string) $pathIndex;
@@ -231,8 +279,8 @@ final class OpenApiPathMatcher
             // MARK capture is the corresponding numeric string.
             $matched = $compiled['matches'][(int) $captures['MARK']];
             $variables = [];
-            foreach ($matched['parameters'] as $name => $captureName) {
-                $variables[$name] = $captures[$captureName];
+            foreach ($matched['parameters'] as $name => $captureIndex) {
+                $variables[$name] = $captures[$captureIndex];
             }
 
             return ['path' => $matched['path'], 'variables' => $variables];

--- a/src/Spec/OpenApiPathMatcher.php
+++ b/src/Spec/OpenApiPathMatcher.php
@@ -6,6 +6,7 @@ namespace Studio\Gesso\Spec;
 
 use InvalidArgumentException;
 
+use function array_chunk;
 use function explode;
 use function implode;
 use function in_array;
@@ -26,10 +27,18 @@ use function usort;
  */
 final class OpenApiPathMatcher
 {
+    /** Keep each combined PCRE bounded for specs with thousands of templates. */
+    private const MAX_TEMPLATES_PER_PATTERN = 32;
+
     /** @var array<string, string> normalized request path => original spec path */
     private array $literalPaths;
 
-    /** @var array<int, array{pattern: string, path: string, paramNames: string[], literalSegments: int}[]> */
+    /**
+     * @var array<int, list<array{
+     *     pattern: string,
+     *     matches: array<int, array{path: string, parameters: array<string, string>}>,
+     * }>>
+     */
     private array $compiledPathsBySegmentCount;
 
     /**
@@ -45,7 +54,7 @@ final class OpenApiPathMatcher
         foreach ($specPaths as $specPath) {
             $segments = explode('/', trim($specPath, '/'));
             $literalCount = 0;
-            $regexSegments = [];
+            $compiledSegments = [];
             $paramNames = [];
 
             foreach ($segments as $segment) {
@@ -62,10 +71,10 @@ final class OpenApiPathMatcher
                         ));
                     }
 
-                    $regexSegments[] = '([^/]+)';
+                    $compiledSegments[] = ['parameter' => $m[1]];
                     $paramNames[] = $m[1];
                 } else {
-                    $regexSegments[] = preg_quote($segment, '#');
+                    $compiledSegments[] = ['literal' => $segment];
                     $literalCount++;
                 }
             }
@@ -83,11 +92,9 @@ final class OpenApiPathMatcher
                 continue;
             }
 
-            $pattern = '#^/' . implode('/', $regexSegments) . '$#';
             $compiled[] = [
-                'pattern' => $pattern,
+                'segments' => $compiledSegments,
                 'path' => $specPath,
-                'paramNames' => $paramNames,
                 'literalSegments' => $literalCount,
             ];
         }
@@ -95,10 +102,43 @@ final class OpenApiPathMatcher
         // Sort by literal segment count descending so more specific paths match first
         usort($compiled, static fn(array $a, array $b): int => $b['literalSegments'] <=> $a['literalSegments']);
 
-        $compiledPathsBySegmentCount = [];
+        $pathsBySegmentCount = [];
         foreach ($compiled as $path) {
             $segmentCount = self::segmentCount($path['path']);
-            $compiledPathsBySegmentCount[$segmentCount][] = $path;
+            $pathsBySegmentCount[$segmentCount][] = $path;
+        }
+
+        $compiledPathsBySegmentCount = [];
+        foreach ($pathsBySegmentCount as $segmentCount => $paths) {
+            foreach (array_chunk($paths, self::MAX_TEMPLATES_PER_PATTERN) as $chunk) {
+                $alternatives = [];
+                $matches = [];
+                foreach ($chunk as $pathIndex => $path) {
+                    $regexSegments = [];
+                    $parameters = [];
+                    $parameterIndex = 0;
+                    foreach ($path['segments'] as $segment) {
+                        if (isset($segment['literal'])) {
+                            $regexSegments[] = preg_quote($segment['literal'], '#');
+
+                            continue;
+                        }
+
+                        $captureName = sprintf('p%d_%d', $pathIndex, $parameterIndex++);
+                        $regexSegments[] = sprintf('(?<%s>[^/]+)', $captureName);
+                        $parameters[$segment['parameter']] = $captureName;
+                    }
+
+                    $marker = (string) $pathIndex;
+                    $alternatives[] = '/' . implode('/', $regexSegments) . sprintf('(*MARK:%s)', $marker);
+                    $matches[$marker] = ['path' => $path['path'], 'parameters' => $parameters];
+                }
+
+                $compiledPathsBySegmentCount[$segmentCount][] = [
+                    'pattern' => '#^(?:' . implode('|', $alternatives) . ')$#',
+                    'matches' => $matches,
+                ];
+            }
         }
 
         $this->literalPaths = $literalPaths;
@@ -180,19 +220,22 @@ final class OpenApiPathMatcher
             return ['path' => $this->literalPaths[$normalizedPath], 'variables' => []];
         }
 
-        $compiledPaths = $this->compiledPathsBySegmentCount[self::segmentCount($normalizedPath)] ?? [];
-        foreach ($compiledPaths as $compiled) {
-            if (preg_match($compiled['pattern'], $normalizedPath, $matches) !== 1) {
+        $compiledPatterns = $this->compiledPathsBySegmentCount[self::segmentCount($normalizedPath)] ?? [];
+        foreach ($compiledPatterns as $compiled) {
+            $captures = [];
+            if (preg_match($compiled['pattern'], $normalizedPath, $captures) !== 1) {
                 continue;
             }
 
+            // Numeric-string array keys are stored as integers by PHP; PCRE's
+            // MARK capture is the corresponding numeric string.
+            $matched = $compiled['matches'][(int) $captures['MARK']];
             $variables = [];
-            foreach ($compiled['paramNames'] as $i => $name) {
-                // $matches[0] is the full match; capture groups start at index 1.
-                $variables[$name] = $matches[$i + 1];
+            foreach ($matched['parameters'] as $name => $captureName) {
+                $variables[$name] = $captures[$captureName];
             }
 
-            return ['path' => $compiled['path'], 'variables' => $variables];
+            return ['path' => $matched['path'], 'variables' => $variables];
         }
 
         return null;

--- a/src/Spec/OpenApiPathMatcher.php
+++ b/src/Spec/OpenApiPathMatcher.php
@@ -30,8 +30,8 @@ final class OpenApiPathMatcher
     /** Keep each combined PCRE bounded for specs with thousands of templates. */
     private const MAX_TEMPLATES_PER_PATTERN = 32;
 
-    /** Bound total captures in a combined pattern at PCRE's 10,000 named-capture ceiling. */
-    private const MAX_CAPTURES_PER_COMBINED_PATTERN = 10_000;
+    /** Keep JIT patterns at the largest capture count exercised safely by the legacy matcher. */
+    private const MAX_CAPTURES_PER_JIT_PATTERN = 400;
 
     /** Leave headroom below PCRE's compiled-pattern size ceiling. */
     private const MAX_COMBINED_PATTERN_BYTES = 30_000;
@@ -141,7 +141,7 @@ final class OpenApiPathMatcher
             foreach ($paths as $path) {
                 if ($chunk !== [] && (
                     count($chunk) >= self::MAX_TEMPLATES_PER_PATTERN ||
-                    $chunkCaptureCount + $path['parameterCount'] > self::MAX_CAPTURES_PER_COMBINED_PATTERN ||
+                    $chunkCaptureCount + $path['parameterCount'] > self::MAX_CAPTURES_PER_JIT_PATTERN ||
                     $chunkPatternBytes + $path['patternBytes'] > self::MAX_COMBINED_PATTERN_BYTES
                 )) {
                     $chunks[] = $chunk;
@@ -182,8 +182,11 @@ final class OpenApiPathMatcher
                     $matches[$marker] = ['path' => $path['path'], 'parameters' => $parameters];
                 }
 
+                $jitControl = $captureIndex - 1 > self::MAX_CAPTURES_PER_JIT_PATTERN
+                    ? '(*NO_JIT)'
+                    : '';
                 $compiledPathsBySegmentCount[$segmentCount][] = [
-                    'pattern' => '#^(?:' . implode('|', $alternatives) . ')$#',
+                    'pattern' => '#' . $jitControl . '^(?:' . implode('|', $alternatives) . ')$#',
                     'matches' => $matches,
                 ];
             }

--- a/tests/Unit/Spec/OpenApiPathMatcherTest.php
+++ b/tests/Unit/Spec/OpenApiPathMatcherTest.php
@@ -10,6 +10,8 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\Gesso\Spec\OpenApiPathMatcher;
 
+use function array_fill;
+use function implode;
 use function sprintf;
 
 class OpenApiPathMatcherTest extends TestCase
@@ -147,6 +149,35 @@ class OpenApiPathMatcherTest extends TestCase
             ['path' => '/resource35/{parameter35}', 'variables' => ['parameter35' => 'value']],
             $matcher->matchWithVariables('/resource35/value'),
         );
+    }
+
+    #[Test]
+    public function combined_patterns_split_before_the_pcre_named_capture_limit(): void
+    {
+        $paths = [];
+        for ($i = 0; $i < 32; $i++) {
+            $paths[] = self::pathWithParameters("/resource{$i}", "parameter{$i}_", 400);
+        }
+        $matcher = new OpenApiPathMatcher($paths);
+        $requestPath = '/resource31/' . implode('/', array_fill(0, 400, 'value'));
+
+        $matched = $matcher->matchWithVariables($requestPath);
+
+        $this->assertNotNull($matched);
+        $this->assertSame($paths[31], $matched['path']);
+        $this->assertCount(400, $matched['variables']);
+        $this->assertSame('value', $matched['variables']['parameter31_399']);
+    }
+
+    #[Test]
+    public function a_single_template_above_the_pcre_capture_limit_is_rejected_explicitly(): void
+    {
+        $path = self::pathWithParameters('/large', 'parameter', 10_001);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('declares 10001 placeholders; a single template may declare at most 10000');
+
+        new OpenApiPathMatcher([$path]);
     }
 
     #[Test]
@@ -366,5 +397,15 @@ class OpenApiPathMatcherTest extends TestCase
             '/v2/workspace/{workspace_id}/members',
             '/v2/add-on/plans',
         ]);
+    }
+
+    private static function pathWithParameters(string $prefix, string $parameterPrefix, int $count): string
+    {
+        $segments = [$prefix];
+        for ($i = 0; $i < $count; $i++) {
+            $segments[] = sprintf('{%s%d}', $parameterPrefix, $i);
+        }
+
+        return implode('/', $segments);
     }
 }

--- a/tests/Unit/Spec/OpenApiPathMatcherTest.php
+++ b/tests/Unit/Spec/OpenApiPathMatcherTest.php
@@ -10,6 +10,8 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\Gesso\Spec\OpenApiPathMatcher;
 
+use function sprintf;
+
 class OpenApiPathMatcherTest extends TestCase
 {
     /** @return array<string, array{string, ?string}> */
@@ -121,6 +123,33 @@ class OpenApiPathMatcherTest extends TestCase
     }
 
     #[Test]
+    public function combined_template_patterns_preserve_order_across_bounded_chunks(): void
+    {
+        $paths = [];
+        for ($i = 0; $i < 40; $i++) {
+            $paths[] = sprintf('/{parameter%d}/fixed', $i);
+        }
+        $matcher = new OpenApiPathMatcher($paths);
+
+        $this->assertSame('/{parameter0}/fixed', $matcher->match('/value/fixed'));
+    }
+
+    #[Test]
+    public function combined_template_patterns_extract_variables_from_later_chunks(): void
+    {
+        $paths = [];
+        for ($i = 0; $i < 40; $i++) {
+            $paths[] = sprintf('/resource%d/{parameter%d}', $i, $i);
+        }
+        $matcher = new OpenApiPathMatcher($paths);
+
+        $this->assertSame(
+            ['path' => '/resource35/{parameter35}', 'variables' => ['parameter35' => 'value']],
+            $matcher->matchWithVariables('/resource35/value'),
+        );
+    }
+
+    #[Test]
     #[DataProvider('provideMatches_paths_with_strip_prefixCases')]
     public function matches_paths_with_strip_prefix(string $requestPath, ?string $expected): void
     {
@@ -202,6 +231,23 @@ class OpenApiPathMatcherTest extends TestCase
         $matcher = self::createMatcher();
 
         $this->assertNull($matcher->matchWithVariables('/v2/unknown/path'));
+    }
+
+    #[Test]
+    public function parameterized_paths_require_one_leading_slash(): void
+    {
+        $matcher = new OpenApiPathMatcher(['/v2/projects/{project_id}']);
+
+        $this->assertNull($matcher->matchWithVariables('v2/projects/abc123'));
+        $this->assertNull($matcher->matchWithVariables('//v2/projects/abc123'));
+    }
+
+    #[Test]
+    public function parameterized_paths_reject_empty_segments(): void
+    {
+        $matcher = new OpenApiPathMatcher(['/v2/projects/{project_id}/assets']);
+
+        $this->assertNull($matcher->matchWithVariables('/v2/projects//assets'));
     }
 
     #[Test]

--- a/tests/Unit/Spec/OpenApiPathMatcherTest.php
+++ b/tests/Unit/Spec/OpenApiPathMatcherTest.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 use Studio\Gesso\Spec\OpenApiPathMatcher;
 
 use function array_fill;
@@ -178,6 +179,21 @@ class OpenApiPathMatcherTest extends TestCase
         $this->expectExceptionMessage('declares 10001 placeholders; a single template may declare at most 10000');
 
         new OpenApiPathMatcher([$path]);
+    }
+
+    #[Test]
+    public function a_single_template_above_the_jit_capture_budget_disables_jit(): void
+    {
+        $path = self::pathWithParameters('/large', 'parameter', 401);
+        $matcher = new OpenApiPathMatcher([$path]);
+        $compiled = (new ReflectionProperty($matcher, 'compiledPathsBySegmentCount'))->getValue($matcher);
+
+        $this->assertStringStartsWith('#(*NO_JIT)', $compiled[402][0]['pattern']);
+
+        $requestPath = '/large/' . implode('/', array_fill(0, 401, 'x'));
+        $matched = $matcher->matchWithVariables($requestPath);
+        $this->assertNotNull($matched);
+        $this->assertCount(401, $matched['variables']);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- combine templated OpenAPI paths of the same segment count into a single PCRE match
- keep each combined pattern bounded by template count, capture count, and estimated pattern size
- preserve specificity, declaration order, percent-encoded captures, and empty-segment behavior

## Why

After literal paths and segment counts were indexed, templated requests still evaluated one regular expression per candidate until a match was found. Unmatched requests therefore paid for every template in their segment-count bucket.

Each bounded combined pattern uses ordered alternatives and PCRE `MARK` metadata to identify the matching path. Numbered captures map values back to their original OpenAPI placeholder names, avoiding PCRE's 10,000 named-capture ceiling. JIT-enabled chunks are split at 32 templates, 400 total captures, or an estimated 30 KB pattern size. A single template above 400 captures uses `(*NO_JIT)` explicitly because PCRE2 does not document a portable JIT size ceiling; a template above 10,000 placeholders is rejected instead of degrading to a warning and an unmatched request.

## Impact

Compared with the current `main` implementation using a representative bundled spec with 292 paths on PHP 8.4:

| Workload | Before | After |
| --- | ---: | ---: |
| Match every path 20 times | 13.5 ms | ~9.6 ms |
| 10,000 unmatched paths | 47.1 ms | ~15.1 ms |

This improves successful path resolution by approximately 29% and unmatched-path resolution by approximately 68%. The additional retained memory in the benchmark was approximately 11 KiB.

## Verification

- focused matcher and request-validator suites — 223 tests, 462 assertions
- full PHPUnit suite excluding the two Markdown lint wrapper tests — 2,181 tests, 8,049 assertions
- PHPStan on both changed files — no errors
- PHP-CS-Fixer with the main and Pest configurations — clean
- PHP 8.3 syntax checks on both changed files — clean

The two Markdown lint wrapper tests were not run locally because the host npm cache is not writable; GitHub Actions will run them in a clean environment.
