### PR TITLE
feat(docs): redesign site with tombo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,9 @@ jobs:
           DOCS_VERSION: next
         run: npm run docs:verify-version
 
+      - name: Verify documentation accessibility invariants
+        run: npm run docs:verify-accessibility
+
       - name: Verify documentation base path
         run: npm run docs:verify-base
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,9 @@ jobs:
       - name: Audit documentation dependencies
         run: npm audit --audit-level=high
 
+      - name: Verify vendored Tombo assets
+        run: npm run docs:verify-tombo
+
       - name: Build searchable documentation
         env:
           DOCS_VERSION: next

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,6 +44,9 @@ jobs:
           DOCS_VERSION: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'next' }}
         run: npm run docs:build
 
+      - name: Verify documentation accessibility invariants
+        run: npm run docs:verify-accessibility
+
       - name: Verify documentation base path
         run: npm run docs:verify-base
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Install documentation dependencies
         run: npm ci
 
+      - name: Verify vendored Tombo assets
+        run: npm run docs:verify-tombo
+
       - name: Build documentation
         env:
           DOCS_VERSION: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || 'next' }}

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -40,9 +40,32 @@ export default defineConfig({
       markdown.renderer.rules.table_open = (tokens, index, options, _env, renderer) => {
         tokens[index].attrJoin('class', 'tombo-table')
 
+        let tableNumber = 1
+        let heading = ''
+
+        for (let cursor = 0; cursor < index; cursor++) {
+          if (tokens[cursor].type === 'table_open') {
+            tableNumber++
+          }
+
+          if (tokens[cursor].type !== 'heading_open') {
+            continue
+          }
+
+          const inline = tokens[cursor + 1]
+          heading = inline?.children
+            ?.filter((token) => token.type === 'text' || token.type === 'code_inline')
+            .map((token) => token.content)
+            .join('')
+            .trim() ?? ''
+        }
+
+        const label = heading === ''
+          ? `Data table ${tableNumber}`
+          : `Data table ${tableNumber}: ${heading}`
         const table = renderer.renderToken(tokens, index, options)
 
-        return `<div class="tombo-table-wrap" role="region" aria-label="Scrollable data table" tabindex="0">\n${table}`
+        return `<div class="tombo-table-wrap" role="region" aria-label="${markdown.utils.escapeHtml(label)}" tabindex="0">\n${table}`
       }
 
       markdown.renderer.rules.table_close = (tokens, index, options, _env, renderer) => {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -13,6 +13,16 @@ export default defineConfig({
   description: 'OpenAPI contract testing for PHP',
   base,
   head: [
+    ['link', { rel: 'stylesheet', href: `${base}styles/tombo.css` }],
+    ['link', { rel: 'preconnect', href: 'https://fonts.googleapis.com' }],
+    ['link', { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: '' }],
+    [
+      'link',
+      {
+        rel: 'stylesheet',
+        href: 'https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@600;700&family=M+PLUS+2:wght@450;500;700&family=Martian+Mono:wdth,wght@75..112.5,400..600&display=swap'
+      }
+    ],
     ['link', { rel: 'icon', type: 'image/svg+xml', href: `${base}favicon.svg` }],
     ['link', { rel: 'apple-touch-icon', sizes: '180x180', href: `${base}apple-touch-icon.png` }],
     ['meta', { property: 'og:image', content: socialPreviewUrl }],
@@ -24,7 +34,24 @@ export default defineConfig({
   lastUpdated: true,
   sitemap: { hostname: siteUrl },
   vite: { define: { __DOCS_VERSION__: JSON.stringify(version) } },
-  markdown: { lineNumbers: true },
+  markdown: {
+    lineNumbers: true,
+    config(markdown) {
+      markdown.renderer.rules.table_open = (tokens, index, options, _env, renderer) => {
+        tokens[index].attrJoin('class', 'tombo-table')
+
+        const table = renderer.renderToken(tokens, index, options)
+
+        return `<div class="tombo-table-wrap" role="region" aria-label="Scrollable data table" tabindex="0">\n${table}`
+      }
+
+      markdown.renderer.rules.table_close = (tokens, index, options, _env, renderer) => {
+        const table = renderer.renderToken(tokens, index, options)
+
+        return `${table}</div>\n`
+      }
+    }
+  },
   themeConfig: {
     logo: '/favicon.svg',
     search: { provider: 'local' },
@@ -82,7 +109,6 @@ export default defineConfig({
     editLink: {
       pattern: `${repositoryUrl}/edit/main/docs/:path`,
       text: 'Edit this page on GitHub'
-    },
-    footer: { message: 'Released under the MIT License.' }
+    }
   }
 })

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -16,7 +16,7 @@ const docsVersion = __DOCS_VERSION__
       </div>
     </template>
     <template #layout-bottom>
-      <div class="tombo-site-footer tombo-shell" aria-label="Site design information">
+      <footer class="tombo-site-footer tombo-shell" aria-label="Site design information">
         <span class="tombo-logo" aria-hidden="true">
           <i class="h"></i><i class="b"></i><i class="w1"></i><i class="w2"></i><i class="t"></i>
         </span>
@@ -24,7 +24,7 @@ const docsVersion = __DOCS_VERSION__
           GESSO / STUDIO-DESIGN / MIT LICENSE<br>
           SET IN TOMBO — WADAKATU DESIGN SYSTEM
         </p>
-      </div>
+      </footer>
     </template>
   </Layout>
 </template>

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -11,8 +11,19 @@ const docsVersion = __DOCS_VERSION__
   <Layout>
     <template #layout-top>
       <div class="version-banner">
-        Documentation version: <strong>{{ docsVersion }}</strong>
-        <span v-if="docsVersion === 'next'"> — development documentation</span>
+        <span class="tombo-kicker">Documentation version: <strong>{{ docsVersion }}</strong></span>
+        <span v-if="docsVersion === 'next'" class="version-banner-note">development documentation</span>
+      </div>
+    </template>
+    <template #layout-bottom>
+      <div class="tombo-site-footer tombo-shell" aria-label="Site design information">
+        <span class="tombo-logo" aria-hidden="true">
+          <i class="h"></i><i class="b"></i><i class="w1"></i><i class="w2"></i><i class="t"></i>
+        </span>
+        <p>
+          GESSO / STUDIO-DESIGN / MIT LICENSE<br>
+          SET IN TOMBO — WADAKATU DESIGN SYSTEM
+        </p>
       </div>
     </template>
   </Layout>

--- a/docs/.vitepress/theme/components/TomboHome.vue
+++ b/docs/.vitepress/theme/components/TomboHome.vue
@@ -1,0 +1,679 @@
+<script setup lang="ts">
+import { withBase } from 'vitepress'
+
+declare const __DOCS_VERSION__: string
+
+const docsVersion = __DOCS_VERSION__
+
+const features = [
+  {
+    id: 'F-01',
+    title: 'Contract enforcement',
+    detail: 'Validate requests and responses with OpenAPI 3.0, 3.1, and 3.2 semantics.',
+    meta: 'SPEC / OPENAPI 3.0 · 3.1 · 3.2',
+    href: '/supported-features'
+  },
+  {
+    id: 'F-02',
+    title: 'Visible coverage',
+    detail: 'See untested operations, statuses, and content types in PHPUnit and CI.',
+    meta: 'UNIT / METHOD · PATH · STATUS · CONTENT-TYPE',
+    href: '/coverage'
+  },
+  {
+    id: 'F-03',
+    title: 'Framework choice',
+    detail: 'Use dedicated adapters or the framework-independent validation core.',
+    meta: 'ADAPTER / LARAVEL · SYMFONY · PEST · PSR-7',
+    href: '/setup'
+  }
+]
+
+const quickstarts = [
+  { id: 'Q-01', name: 'Core / PHPUnit', href: '/quickstarts/core' },
+  { id: 'Q-02', name: 'Laravel', href: '/quickstarts/laravel' },
+  { id: 'Q-03', name: 'Symfony', href: '/quickstarts/symfony' },
+  { id: 'Q-04', name: 'Pest', href: '/quickstarts/pest' }
+]
+</script>
+
+<template>
+  <main class="tombo-home">
+    <section class="tombo-hero tombo-vol-lp" aria-labelledby="tombo-hero-title">
+      <i class="frame-mark frame-mark-tl" aria-hidden="true"></i>
+      <i class="frame-mark frame-mark-tr" aria-hidden="true"></i>
+      <i class="frame-mark frame-mark-bl" aria-hidden="true"></i>
+      <i class="frame-mark frame-mark-br" aria-hidden="true"></i>
+
+      <div class="home-shell tombo-shell tombo-shell--wide hero-grid">
+        <div class="hero-copy">
+          <p class="tombo-kicker">GESSO — FIG. 00 / CONTRACTS, MEASURED</p>
+          <h1 id="tombo-hero-title" class="tombo-display">
+            OpenAPI contract<br>testing for PHP.
+            <small>Validate. Measure. Ship.</small>
+          </h1>
+
+          <div class="headline-measure" aria-hidden="true">
+            <div class="tombo-dim"></div>
+            <p class="tombo-dimlab">headline / 02 lines · spec / 3.0 · 3.1 · 3.2</p>
+          </div>
+
+          <p class="hero-lead">
+            PHPUnit coverage, request and response validation, fuzzing, and drift detection
+            for Laravel, Symfony, Pest, PSR-7, or plain PHP.
+          </p>
+
+          <div class="hero-actions">
+            <a class="tombo-btn tombo-btn--primary" :href="withBase('/quickstarts/core')">
+              Choose a quickstart
+            </a>
+            <a class="tombo-btn tombo-btn--secondary" href="https://github.com/studio-design/gesso">
+              View on GitHub
+            </a>
+            <span class="hero-license">MIT / PHP ≥ 8.3</span>
+          </div>
+        </div>
+
+        <figure class="coverage-instrument tombo-corners">
+          <b class="tombo-corner-tr" aria-hidden="true"></b>
+          <b class="tombo-corner-bl" aria-hidden="true"></b>
+          <figcaption class="tombo-fig">FIG. 01 — ILLUSTRATIVE ENDPOINT COVERAGE</figcaption>
+          <img class="instrument-logo" :src="withBase('/gesso-logo.png')" alt="">
+
+          <p class="instrument-label">OPERATIONS COVERED</p>
+          <p class="instrument-value">96.2<small>%</small></p>
+          <div
+            class="tombo-ruler"
+            style="--tombo-ruler-value: 96.2%"
+            role="img"
+            aria-label="Illustrative coverage value: 96.2 percent"
+          ></div>
+
+          <ul class="coverage-rows">
+            <li><code>GET /users/{id} · 200</code><span>covered</span></li>
+            <li><code>POST /orders · 201</code><span>covered</span></li>
+            <li><code>PATCH /users/{id} · 422</code><span>covered</span></li>
+            <li><code>DELETE /orders/{id} · 204</code><span class="is-missing">untested</span></li>
+          </ul>
+
+          <p class="instrument-foot">SIDECAR / MERGED 04 SHARDS / EXAMPLE DATA</p>
+        </figure>
+      </div>
+    </section>
+
+    <div class="home-shell tombo-shell tombo-shell--wide home-sections tombo-sections">
+      <section class="home-section" aria-labelledby="why-gesso-title">
+        <header class="section-heading">
+          <div>
+            <div class="tombo-dim"></div>
+            <p class="tombo-dimlab">section / 01 · capability</p>
+          </div>
+          <h2 id="why-gesso-title" class="tombo-sec">Why Gesso</h2>
+        </header>
+
+        <div class="feature-grid">
+          <a
+            v-for="feature in features"
+            :key="feature.id"
+            class="feature-card tombo-corners"
+            :href="withBase(feature.href)"
+          >
+            <span class="feature-id">{{ feature.id }}</span>
+            <strong>{{ feature.title }}</strong>
+            <p>{{ feature.detail }}</p>
+            <span class="feature-meta">{{ feature.meta }}</span>
+          </a>
+        </div>
+      </section>
+
+      <section class="home-section" aria-labelledby="quickstart-title">
+        <header class="section-heading">
+          <div>
+            <div class="tombo-dim"></div>
+            <p class="tombo-dimlab">section / 02 · five-minute path</p>
+          </div>
+          <h2 id="quickstart-title" class="tombo-sec">From contract to evidence</h2>
+          <p>
+            Install Gesso, choose the path matching your test stack, and reach one passing
+            contract assertion with a coverage report.
+          </p>
+        </header>
+
+        <div class="quickstart-layout">
+          <nav class="quickstart-list" aria-label="Gesso quickstarts">
+            <header><span>QUICKSTART / PICK ONE</span><span>04</span></header>
+            <a
+              v-for="(quickstart, index) in quickstarts"
+              :key="quickstart.id"
+              :class="{ 'tombo-current': index === 0 }"
+              :href="withBase(quickstart.href)"
+            >
+              <span>{{ quickstart.id }}</span>
+              <strong>{{ quickstart.name }}</strong>
+              <i aria-hidden="true">→</i>
+            </a>
+          </nav>
+
+          <div class="quickstart-proof">
+            <figure class="tombo-code">
+              <figcaption><span>SHELL — INSTALL &amp; RUN</span><span>02 STEPS</span></figcaption>
+              <pre><code><span class="code-line"><i>001</i><b>$</b> composer require --dev studio-design/gesso</span>
+<span class="code-line"><i>002</i><b>$</b> vendor/bin/phpunit</span>
+<span class="code-line code-comment"><i>003</i># coverage: method · path · status · content-type</span></code></pre>
+            </figure>
+            <aside class="tombo-callout">
+              <b>NOTE — 001</b>Every quickstart is installed and executed in this repository's CI.
+            </aside>
+          </div>
+        </div>
+      </section>
+
+      <section class="release-panel tombo-corners" aria-labelledby="release-title">
+        <div>
+          <p class="tombo-kicker">GESSO 2 / REV {{ docsVersion }}</p>
+          <h2 id="release-title" class="tombo-display">A clearer identity.<br>A stricter contract.</h2>
+        </div>
+        <div class="release-copy">
+          <p>
+            Gesso 2 brings the <code>Studio\Gesso</code> namespace, one <code>gesso</code>
+            CLI, modern runtime support, and explicit compatibility boundaries.
+          </p>
+          <div>
+            <a class="tombo-btn tombo-btn--primary" :href="withBase('/migration/v2')">
+              Read the migration guide
+            </a>
+            <a class="release-text-link" :href="withBase('/supported-features')">
+              Inspect supported features <span aria-hidden="true">→</span>
+            </a>
+          </div>
+        </div>
+      </section>
+    </div>
+  </main>
+</template>
+
+<style scoped>
+.tombo-home {
+  min-width: 0;
+  overflow: hidden;
+  background: var(--tombo-paper);
+  color: var(--tombo-ink);
+}
+
+.tombo-home .tombo-display {
+  font-family: var(--tombo-font-display);
+  font-size: var(--tombo-text-display);
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -0.015em;
+}
+
+.home-shell {
+  min-width: 0;
+}
+
+.tombo-hero {
+  position: relative;
+  padding-block: clamp(4.75rem, 9vw, 7.5rem);
+}
+
+.frame-mark {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border: 0 solid var(--tombo-ink);
+  opacity: 0.72;
+}
+
+.frame-mark-tl { top: 20px; left: 20px; border-top-width: 1.5px; border-left-width: 1.5px; }
+.frame-mark-tr { top: 20px; right: 20px; border-top-width: 1.5px; border-right-width: 1.5px; }
+.frame-mark-bl { bottom: 20px; left: 20px; border-bottom-width: 1.5px; border-left-width: 1.5px; }
+.frame-mark-br { right: 20px; bottom: 20px; border-right-width: 1.5px; border-bottom-width: 1.5px; }
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.96fr) minmax(420px, 1.04fr);
+  gap: clamp(2rem, 3vw, 3rem);
+  align-items: center;
+}
+
+.hero-copy h1 {
+  max-width: 13ch;
+  margin-top: 1.5rem;
+}
+
+.hero-copy h1 small {
+  display: block;
+  margin-top: 0.9rem;
+  color: var(--tombo-green);
+  font-family: var(--tombo-font-body);
+  font-size: var(--tombo-text-h2);
+  font-weight: 700;
+  line-height: var(--tombo-lh-h2);
+  letter-spacing: 0;
+}
+
+.headline-measure {
+  width: min(100%, 340px);
+  margin-top: 1.5rem;
+}
+
+.hero-lead {
+  max-width: 60ch;
+  margin-top: 1.25rem;
+  color: var(--tombo-ink-sub);
+  font-size: var(--tombo-text-body);
+  line-height: var(--tombo-lh-body);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  margin-top: 1.75rem;
+}
+
+.hero-actions .tombo-btn {
+  min-height: 48px;
+  text-decoration: none;
+}
+
+.tombo-home a.tombo-btn--primary {
+  color: var(--tombo-on-green);
+}
+
+.tombo-home a.tombo-btn--primary:hover {
+  color: var(--tombo-paper);
+}
+
+.hero-license {
+  color: var(--tombo-ink-faint);
+  font-family: var(--tombo-font-mono);
+  font-size: var(--tombo-text-label);
+  letter-spacing: 0.08em;
+}
+
+.coverage-instrument {
+  margin: 1.25rem 0 0;
+  padding: 1.6rem;
+  border: 1px solid var(--tombo-hairline);
+  background: var(--tombo-surface);
+}
+
+.coverage-instrument figcaption {
+  position: absolute;
+  top: -1.6rem;
+  left: 0;
+}
+
+.instrument-logo {
+  position: absolute;
+  top: 1.25rem;
+  right: 1.25rem;
+  width: 28px;
+  height: 28px;
+}
+
+.instrument-label {
+  color: var(--tombo-ink-sub);
+  font-family: var(--tombo-font-mono);
+  font-size: var(--tombo-text-label);
+  font-weight: 500;
+  letter-spacing: 0.14em;
+}
+
+.instrument-value {
+  margin-top: 0.35rem;
+  font-family: var(--tombo-font-mono);
+  font-size: clamp(2.4rem, 6vw, 4rem);
+  font-weight: 600;
+  line-height: 1.1;
+}
+
+.instrument-value small {
+  color: var(--tombo-ink-faint);
+  font-size: var(--tombo-text-body);
+  font-weight: 400;
+}
+
+.coverage-instrument .tombo-ruler {
+  margin-top: 0.75rem;
+}
+
+.coverage-rows {
+  margin-top: 1.1rem;
+  border-top: 1px solid var(--tombo-hairline);
+  list-style: none;
+}
+
+.coverage-rows li {
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  padding-block: 0.45rem;
+  border-bottom: 1px solid var(--tombo-hairline);
+  color: var(--tombo-ink-sub);
+  font-family: var(--tombo-font-mono);
+  font-size: var(--tombo-text-label);
+  line-height: var(--tombo-lh-label);
+}
+
+.coverage-rows code {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.coverage-rows span {
+  color: var(--tombo-ink);
+  font-weight: 500;
+}
+
+.coverage-rows .is-missing {
+  color: var(--tombo-error);
+}
+
+.instrument-foot {
+  margin-top: 0.85rem;
+  color: var(--tombo-ink-faint);
+  font-family: var(--tombo-font-mono);
+  font-size: var(--tombo-text-label);
+  line-height: var(--tombo-lh-label);
+  letter-spacing: 0.06em;
+}
+
+.home-sections {
+  padding-block: clamp(4rem, 8vw, 7rem);
+}
+
+.home-section + .home-section {
+  margin-top: clamp(4.5rem, 9vw, 7.5rem);
+}
+
+.section-heading > div:first-child {
+  max-width: 100%;
+}
+
+.section-heading h2 {
+  margin-top: 1.35rem;
+  color: var(--tombo-ink);
+  font-size: var(--tombo-text-h2);
+  line-height: var(--tombo-lh-h2);
+}
+
+.section-heading > p {
+  max-width: 62ch;
+  margin-top: 0.8rem;
+  color: var(--tombo-ink-sub);
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.1rem;
+  margin-top: 1.6rem;
+}
+
+.feature-card {
+  display: flex;
+  min-height: 230px;
+  flex-direction: column;
+  padding: 1.5rem;
+  border: 1px solid var(--tombo-hairline);
+  background: var(--tombo-surface);
+  color: var(--tombo-ink);
+  text-decoration: none;
+}
+
+.feature-card:hover {
+  border-color: var(--tombo-green);
+}
+
+.feature-id,
+.feature-meta {
+  color: var(--tombo-green);
+  font-family: var(--tombo-font-mono);
+  font-size: var(--tombo-text-label);
+  line-height: var(--tombo-lh-label);
+  letter-spacing: 0.1em;
+}
+
+.feature-card strong {
+  margin-top: 0.6rem;
+  font-size: var(--tombo-text-h3);
+  line-height: var(--tombo-lh-h3);
+}
+
+.feature-card p {
+  margin-top: 0.45rem;
+  color: var(--tombo-ink-sub);
+  font-size: var(--tombo-text-ui);
+  line-height: var(--tombo-lh-ui);
+}
+
+.feature-meta {
+  margin-top: auto;
+  padding-top: 0.9rem;
+  border-top: 1px solid var(--tombo-hairline);
+  color: var(--tombo-ink-faint);
+}
+
+.quickstart-layout {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: minmax(260px, 0.78fr) minmax(0, 1.22fr);
+  gap: 2rem;
+  align-items: start;
+  margin-top: 1.6rem;
+}
+
+.quickstart-list {
+  min-width: 0;
+  border: 1px solid var(--tombo-hairline);
+  background: var(--tombo-surface);
+}
+
+.quickstart-list header,
+.quickstart-list a {
+  display: flex;
+  gap: 0.9rem;
+  align-items: center;
+  min-height: 48px;
+  padding-inline: 1.2rem;
+  border-bottom: 1px solid var(--tombo-hairline);
+}
+
+.quickstart-list header {
+  justify-content: space-between;
+  color: var(--tombo-ink-faint);
+  font-family: var(--tombo-font-mono);
+  font-size: var(--tombo-text-label);
+  letter-spacing: 0.1em;
+}
+
+.quickstart-list a {
+  position: relative;
+  color: var(--tombo-ink);
+  font-size: var(--tombo-text-ui);
+  text-decoration: none;
+}
+
+.quickstart-list a:last-child {
+  border-bottom: 0;
+}
+
+.quickstart-list a:hover {
+  background: var(--tombo-paper);
+}
+
+.quickstart-list a > span {
+  color: var(--tombo-green);
+  font-family: var(--tombo-font-mono);
+  font-size: var(--tombo-text-label);
+}
+
+.quickstart-list a > i {
+  margin-left: auto;
+  color: var(--tombo-ink-faint);
+  font-family: var(--tombo-font-mono);
+  font-style: normal;
+}
+
+.quickstart-list .tombo-current {
+  padding-left: 2.2rem;
+}
+
+.quickstart-list .tombo-current::before {
+  left: 0.75rem;
+}
+
+.quickstart-proof {
+  min-width: 0;
+}
+
+.quickstart-proof .tombo-code {
+  width: 100%;
+  max-width: 100%;
+}
+
+.quickstart-proof .tombo-code pre {
+  max-width: 100%;
+  margin: 0;
+}
+
+.code-line {
+  display: block;
+  white-space: pre;
+}
+
+.code-line i {
+  display: inline-block;
+  width: 2.5rem;
+  color: var(--tombo-code-faint);
+  font-style: normal;
+  user-select: none;
+}
+
+.code-line b {
+  color: var(--tombo-code-green);
+  font-weight: 400;
+}
+
+.code-comment {
+  color: var(--tombo-code-faint);
+}
+
+.quickstart-proof .tombo-callout {
+  margin-top: 1rem;
+}
+
+.release-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 0.8fr);
+  gap: clamp(2rem, 6vw, 5rem);
+  margin-top: clamp(4.5rem, 9vw, 7.5rem);
+  padding: clamp(2rem, 5vw, 4rem);
+  border: 1px solid var(--tombo-hairline);
+  background: var(--tombo-surface);
+}
+
+.release-panel h2 {
+  margin-top: 1rem;
+  font-size: clamp(2.2rem, 5vw, 3.8rem);
+}
+
+.release-copy {
+  align-self: end;
+}
+
+.release-copy > p {
+  color: var(--tombo-ink-sub);
+}
+
+.release-copy > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.2rem;
+  align-items: center;
+  margin-top: 1.4rem;
+}
+
+.release-copy .tombo-btn {
+  min-height: 48px;
+  text-decoration: none;
+}
+
+.release-text-link {
+  min-height: 44px;
+  padding-block: 0.65rem;
+}
+
+@media (max-width: 1024px) {
+  .hero-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .coverage-instrument {
+    margin-top: 1.5rem;
+  }
+}
+
+@media (max-width: 900px) {
+  .release-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .feature-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 680px) {
+  .tombo-hero {
+    padding-block: 4.5rem;
+  }
+
+  .hero-grid {
+    gap: 3.75rem;
+  }
+
+  .feature-grid,
+  .quickstart-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .feature-card {
+    min-height: 0;
+  }
+
+  .frame-mark {
+    display: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .hero-actions .tombo-btn {
+    width: 100%;
+    text-align: center;
+  }
+
+  .coverage-instrument {
+    padding: 1.25rem;
+  }
+
+  .coverage-rows li {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+
+  .release-panel {
+    padding: 1.5rem;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,8 +1,13 @@
+import type { Theme } from 'vitepress'
 import DefaultTheme from 'vitepress/theme'
 import Layout from './Layout.vue'
+import TomboHome from './components/TomboHome.vue'
 import './style.css'
 
 export default {
   extends: DefaultTheme,
-  Layout
-}
+  Layout,
+  enhanceApp({ app }) {
+    app.component('TomboHome', TomboHome)
+  }
+} satisfies Theme

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1,10 +1,395 @@
+:root {
+  --vp-layout-top-height: 36px;
+  --vp-layout-max-width: var(--tombo-shell-default);
+  --vp-font-family-base: var(--tombo-font-body);
+  --vp-font-family-mono: var(--tombo-font-mono);
+  --vp-c-bg: var(--tombo-paper);
+  --vp-c-bg-alt: var(--tombo-surface);
+  --vp-c-bg-elv: var(--tombo-raised);
+  --vp-c-bg-soft: var(--tombo-surface);
+  --vp-c-border: var(--tombo-hairline);
+  --vp-c-divider: var(--tombo-hairline);
+  --vp-c-gutter: var(--tombo-hairline);
+  --vp-c-text-1: var(--tombo-ink);
+  --vp-c-text-2: var(--tombo-ink-sub);
+  --vp-c-text-3: var(--tombo-ink-faint);
+  --vp-c-brand-1: var(--tombo-green);
+  --vp-c-brand-2: var(--tombo-green);
+  --vp-c-brand-3: var(--tombo-green);
+  --vp-c-brand-soft: color-mix(in srgb, var(--tombo-green) 14%, transparent);
+  --vp-code-color: var(--tombo-code-green);
+  --vp-code-bg: var(--tombo-code-bg);
+  --vp-code-block-bg: var(--tombo-code-bg);
+  --vp-code-line-highlight-color: color-mix(in srgb, var(--tombo-code-green) 10%, transparent);
+  --vp-custom-block-info-border: var(--tombo-green);
+  --vp-custom-block-info-bg: var(--tombo-surface);
+  --vp-custom-block-warning-border: var(--tombo-warn);
+  --vp-custom-block-warning-bg: var(--tombo-surface);
+  --vp-custom-block-danger-border: var(--tombo-error);
+  --vp-custom-block-danger-bg: var(--tombo-surface);
+}
+
+html {
+  color-scheme: light;
+}
+
+html.dark {
+  color-scheme: dark;
+}
+
+body {
+  background: var(--tombo-paper);
+  color: var(--tombo-ink);
+}
+
 .version-banner {
-  position: relative;
-  z-index: 30;
-  padding: 0.45rem 1rem;
-  border-bottom: 1px solid var(--vp-c-divider);
-  background: var(--vp-c-bg-soft);
-  color: var(--vp-c-text-2);
-  font-size: 0.8rem;
+  position: fixed;
+  z-index: 31;
+  top: 0;
+  right: 0;
+  left: 0;
+  display: flex;
+  height: var(--vp-layout-top-height);
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding-inline: 1rem;
+  border-bottom: 1px solid var(--tombo-hairline);
+  background: var(--tombo-surface);
+  color: var(--tombo-ink-faint);
   text-align: center;
+}
+
+.version-banner .tombo-kicker {
+  white-space: nowrap;
+}
+
+.version-banner-note {
+  font-family: var(--tombo-font-mono);
+  font-size: var(--tombo-text-label);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.VPNav,
+.VPNavBar,
+.VPNavBar.has-sidebar .content,
+.VPNavBar:not(.home) {
+  background: color-mix(in srgb, var(--tombo-paper) 94%, transparent);
+}
+
+.VPNavBar {
+  border-bottom-color: var(--tombo-hairline);
+}
+
+.VPNavBarTitle .title {
+  color: var(--tombo-ink);
+  font-family: var(--tombo-font-display);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.VPNavBarTitle .logo {
+  width: 24px;
+  height: 24px;
+}
+
+.VPNavBarMenuLink {
+  position: relative;
+  color: var(--tombo-ink-sub);
+  font-size: var(--tombo-text-ui);
+}
+
+.VPNavBarMenuLink.active {
+  color: var(--tombo-ink);
+}
+
+.VPNavBarMenuLink.active::after {
+  content: "";
+  position: absolute;
+  right: 12px;
+  bottom: -1px;
+  left: 12px;
+  border-bottom: 2px solid var(--tombo-shu);
+}
+
+.VPNavBarSearchButton,
+.DocSearch-Button,
+.VPLocalSearchBox .shell {
+  border-color: var(--tombo-hairline);
+  border-radius: 0;
+  background: var(--tombo-surface);
+  box-shadow: none;
+}
+
+.VPNavBarSearch .DocSearch-Button .DocSearch-Button-Keys {
+  display: none;
+}
+
+.VPSwitch,
+.VPSwitchAppearance {
+  border-color: var(--tombo-hairline);
+  background: var(--tombo-surface);
+}
+
+.VPLocalNav,
+.VPSidebar {
+  background: var(--tombo-paper);
+}
+
+.VPSidebar {
+  border-right: 1px solid var(--tombo-hairline);
+}
+
+.VPSidebarItem.level-0 > .item > .text {
+  color: var(--tombo-ink-faint);
+  font-family: var(--tombo-font-mono);
+  font-size: var(--tombo-text-label);
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.VPSidebarItem .link {
+  color: var(--tombo-ink-sub);
+}
+
+.VPSidebarItem.is-active > .item .link > .text {
+  position: relative;
+  padding-left: 22px;
+  color: var(--tombo-ink);
+}
+
+.VPSidebarItem.is-active > .item .link > .text::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 12px;
+  border-top: 2px solid var(--tombo-shu);
+}
+
+.VPDocAsideOutline .outline-title,
+.VPDocAsideOutline .outline-link {
+  font-size: var(--tombo-text-ui);
+}
+
+.VPDocAsideOutline .outline-title {
+  color: var(--tombo-ink-faint);
+  font-family: var(--tombo-font-mono);
+  font-size: var(--tombo-text-label);
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.VPDocAsideOutline .outline-link.active {
+  color: var(--tombo-ink);
+}
+
+.VPDocAsideOutline .outline-marker {
+  width: 2px;
+  background: var(--tombo-shu);
+}
+
+.vp-doc {
+  color: var(--tombo-ink-sub);
+  font-size: var(--tombo-text-body);
+  line-height: var(--tombo-lh-body);
+}
+
+.vp-doc > :is(p, ul, ol, blockquote, .custom-block),
+.vp-doc > :is(h1, h2, h3, h4) {
+  max-inline-size: var(--tombo-shell-reading);
+}
+
+.vp-doc h1,
+.vp-doc h2,
+.vp-doc h3,
+.vp-doc h4 {
+  color: var(--tombo-ink);
+}
+
+.vp-doc h1 {
+  font-family: var(--tombo-font-display);
+  font-size: var(--tombo-text-display);
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -0.015em;
+}
+
+.vp-doc h2 {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--tombo-hairline);
+  font-size: var(--tombo-text-h2);
+  line-height: var(--tombo-lh-h2);
+}
+
+.vp-doc h3 {
+  font-size: var(--tombo-text-h3);
+  line-height: var(--tombo-lh-h3);
+}
+
+.vp-doc a {
+  color: var(--tombo-green);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+}
+
+.vp-doc :not(pre) > code {
+  border: 1px solid var(--tombo-hairline);
+  border-radius: 0;
+  background: var(--tombo-surface);
+  color: var(--tombo-green);
+}
+
+.vp-doc div[class*="language-"] {
+  border: 1px solid var(--tombo-code-border);
+  border-radius: 6px;
+  background: var(--tombo-code-bg);
+  box-shadow: none;
+}
+
+.vp-doc div[class*="language-"] code,
+.vp-doc div[class*="language-"] pre {
+  color: var(--tombo-code-ink);
+  font-family: var(--tombo-font-mono);
+}
+
+.vp-doc .shiki span[style*="#6A737D"] {
+  --shiki-light: var(--tombo-code-faint) !important;
+  --shiki-dark: var(--tombo-code-faint) !important;
+}
+
+.vp-doc .custom-block {
+  border: 1px solid var(--tombo-hairline);
+  border-left-width: 2px;
+  border-radius: 0;
+  background: var(--tombo-surface);
+}
+
+.vp-doc .custom-block.info,
+.vp-doc .custom-block.tip {
+  border-left-color: var(--tombo-green);
+}
+
+.vp-doc .custom-block.warning {
+  border-left-color: var(--tombo-warn);
+}
+
+.vp-doc .custom-block.danger {
+  border-left-color: var(--tombo-error);
+}
+
+.vp-doc .custom-block-title {
+  color: var(--tombo-ink);
+  font-family: var(--tombo-font-mono);
+  font-size: var(--tombo-text-label);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.vp-doc table {
+  display: table;
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.vp-doc .tombo-table-wrap {
+  margin: 20px 0;
+}
+
+.vp-doc .tombo-table-wrap table {
+  margin: 0;
+}
+
+.vp-doc th {
+  border: 0;
+  border-bottom: 1.5px solid var(--tombo-ink);
+  background: transparent;
+  color: var(--tombo-ink-sub);
+  font-family: var(--tombo-font-mono);
+  font-size: var(--tombo-text-label);
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-align: left;
+  text-transform: uppercase;
+}
+
+.vp-doc td {
+  border: 0;
+  border-bottom: 1px solid var(--tombo-hairline);
+}
+
+.vp-doc tr:nth-child(2n) {
+  background: var(--tombo-surface);
+}
+
+.vp-doc blockquote {
+  border-left-color: var(--tombo-shu);
+  color: var(--tombo-ink-sub);
+}
+
+.prev-next .pager-link {
+  border-color: var(--tombo-hairline);
+  border-radius: 0;
+  background: var(--tombo-surface);
+}
+
+.tombo-site-footer {
+  display: flex;
+  align-items: center;
+  gap: 1.1rem;
+  padding-block: 1.5rem 2.75rem;
+  border-top: 1px solid var(--tombo-hairline);
+  color: var(--tombo-ink-faint);
+}
+
+.tombo-site-footer p {
+  margin: 0;
+  font-family: var(--tombo-font-mono);
+  font-size: var(--tombo-text-label);
+  line-height: 1.9;
+  letter-spacing: 0.1em;
+}
+
+@media (min-width: 1440px) {
+  .VPDoc {
+    background-image:
+      linear-gradient(90deg, var(--tombo-grid) 1px, transparent 1px),
+      linear-gradient(var(--tombo-grid) 1px, transparent 1px);
+    background-position: right top;
+    background-size: 24px 24px;
+  }
+
+  .VPDoc .container {
+    background: var(--tombo-paper);
+  }
+}
+
+@media (max-width: 640px) {
+  :root {
+    --vp-layout-top-height: 48px;
+  }
+
+  .version-banner {
+    gap: 0.35rem;
+    flex-direction: column;
+    line-height: 1.15;
+  }
+
+  .version-banner .tombo-kicker,
+  .version-banner-note {
+    font-size: 9px;
+    line-height: 12px;
+  }
+
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
-layout: page
+layout: home
+markdownStyles: false
 sidebar: false
 title: Gesso — OpenAPI contract testing for PHP
 description: Validate requests and responses, expose endpoint coverage, explore schema boundaries, and detect drift with Gesso.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,37 +1,8 @@
 ---
-layout: home
-
-hero:
-  name: Gesso
-  text: OpenAPI contract testing for PHP
-  tagline: PHPUnit coverage, request and response validation, fuzzing, and drift detection for Laravel, Symfony, Pest, PSR-7, or plain PHP.
-  image:
-    src: /gesso-logo.png
-    alt: Gesso logo
-  actions:
-    - theme: brand
-      text: Choose a quickstart
-      link: /quickstarts/core
-    - theme: alt
-      text: View on GitHub
-      link: https://github.com/studio-design/gesso
-
-features:
-  - title: Contract enforcement
-    details: Validate requests and responses with OpenAPI 3.0, 3.1, and 3.2 semantics.
-  - title: Visible coverage
-    details: See untested operations, statuses, and content types in PHPUnit and CI.
-  - title: Framework choice
-    details: Use dedicated Laravel, Symfony, Pest, and PSR-7 adapters or the framework-independent core.
+layout: page
+sidebar: false
+title: Gesso — OpenAPI contract testing for PHP
+description: Validate requests and responses, expose endpoint coverage, explore schema boundaries, and detect drift with Gesso.
 ---
 
-## Five-minute path
-
-Install the package, select the quickstart matching your test stack, and reach one passing contract assertion with a coverage report:
-
-- [Core / PHPUnit](quickstarts/core.md)
-- [Laravel](quickstarts/laravel.md)
-- [Symfony](quickstarts/symfony.md)
-- [Pest](quickstarts/pest.md)
-
-Every example is installed and executed in this repository's CI.
+<TomboHome />

--- a/docs/public/styles/tombo.LICENSE
+++ b/docs/public/styles/tombo.LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 wadakatu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/public/styles/tombo.css
+++ b/docs/public/styles/tombo.css
@@ -1,0 +1,294 @@
+/*! TOMBO v0.4.0 — wadakatu design system. MIT. https://github.com/wadakatu/tombo */
+@layer tombo.reset, tombo.tokens, tombo.base, tombo.components, tombo.utilities;
+
+@layer tombo.tokens {
+  :root {
+    color-scheme: light dark;
+    /* surfaces */
+    --tombo-paper:    light-dark(#F2F4EF, #131714);
+    --tombo-surface:  light-dark(#FAFBF8, #1A201C);
+    --tombo-raised:   light-dark(#FAFBF8, #212824); /* light has no +2 step (spec §5) */
+    /* ink */
+    --tombo-ink:       light-dark(#1A211D, #E5EBE6);
+    --tombo-ink-sub:   light-dark(#4C5650, #9AA69F);
+    --tombo-ink-faint: light-dark(#667069, #808D86);
+    --tombo-hairline:  light-dark(rgba(26,33,29,.16), rgba(229,235,230,.14));
+    --tombo-grid:      light-dark(rgba(26,33,29,.07), rgba(229,235,230,.05));
+    --tombo-grid-bold: light-dark(rgba(26,33,29,.13), rgba(229,235,230,.09)); /* wide-screen gutters only */
+    /* shell — the container scale. `--tombo-shell` is the page's active width; the
+       steps below are the values you assign to it. `reading` is font-relative because
+       it IS a measure — it has to track whatever type it wraps. `default` and `wide`
+       are structural, so they stay px to match the px type scale: a rem container
+       under a px type scale lengthens the line without enlarging the text, which is
+       backwards. If the type scale ever moves to rem, these move with it.
+       No breakpoints — max-inline-size plus a clamp()ed gutter cover every viewport. */
+    --tombo-shell-reading: 65ch;    /* 621px at the body voice — 76 latin / 41 japanese per line */
+    --tombo-shell-default: 1280px;
+    --tombo-shell-wide:    1792px;
+    --tombo-shell-gutter:  clamp(20px, 3.25vw, 64px);
+    --tombo-shell: var(--tombo-shell-default); /* the page's width — reassign to pick a step */
+    --tombo-shell-max: var(--tombo-shell);     /* DEPRECATED since 0.4 — read --tombo-shell.
+                                                  NOTE: the value moved 1100px -> 1280px and the
+                                                  1600px step is gone. Removed in 0.5. */
+    /* instruments */
+    --tombo-green:    light-dark(#0E5A47, #4FC2A2);
+    --tombo-on-green: light-dark(#F2F4EF, #10201A);
+    --tombo-shu:      light-dark(#D8442B, #E5654C);
+    /* status (app volume only) */
+    --tombo-success: light-dark(#2C7A4B, #57B98A);
+    --tombo-warn:    light-dark(#B07818, #D9A441);
+    --tombo-error:   light-dark(#A6301C, #D06A5A);
+    --tombo-callout-label: light-dark(#A6301C, #E5654C); /* crimson by day, shu by night — shu text is a night-only privilege */
+    /* code block: day = night panel, night = outlined, never sunken (spec §10-5) */
+    --tombo-code-bg:     light-dark(#161B18, #1A201C);
+    --tombo-code-ink:    light-dark(#DDE5DF, #E5EBE6);
+    --tombo-code-border: light-dark(transparent, rgba(229,235,230,.14));
+    --tombo-code-faint:    #7D8A82;              /* captions on code-bg — the panel is dark in both themes */
+    --tombo-code-hairline: rgba(229,235,230,.09);
+    --tombo-code-green:    #4FC2A2;              /* syntax accent — night-side constant, panel is always dark */
+    --tombo-code-shu:      #E5654C;
+    /* type — three voices (spec 2026-07-21) */
+    --tombo-font-display: "Instrument Sans", "M PLUS 2", system-ui, sans-serif; /* Latin display only */
+    --tombo-font-body: "M PLUS 2", system-ui, sans-serif;
+    --tombo-font-mono: "Martian Mono", ui-monospace, SFMono-Regular, monospace;
+    --tombo-w-body: 450; /* variable weight — 400 thins out on hotaru */
+    /* type scale — no ad-hoc sizes: every font-size below references these */
+    --tombo-text-label: 10.5px;  --tombo-lh-label: 18px;
+    --tombo-text-note: 12px;     --tombo-lh-note: 18px;
+    --tombo-text-code: 12px;     --tombo-lh-code: 22px;
+    --tombo-text-ui: 13px;       --tombo-lh-ui: 24px;
+    --tombo-text-body: 15px;     --tombo-lh-body: 30px;
+    --tombo-text-h3: 19px;       --tombo-lh-h3: 30px;
+    --tombo-text-h2: 23px;       --tombo-lh-h2: 36px;
+    --tombo-text-h1: 29px;       --tombo-lh-h1: 42px;
+    --tombo-text-metric: 29px;   --tombo-lh-metric: 36px;
+    --tombo-text-display: clamp(44px, 6vw, 64px);
+    /* motion */
+    --tombo-ease: cubic-bezier(0.2, 0, 0, 1);
+    --tombo-dur: 150ms;
+  }
+  :root[data-theme="tombo"]  { color-scheme: light; }
+  :root[data-theme="hotaru"] { color-scheme: dark; }
+}
+
+@layer tombo.reset {
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  img, svg { max-width: 100%; display: block; }
+  button, input, select, textarea { font: inherit; color: inherit; }
+}
+
+@layer tombo.base {
+  html { font-family: var(--tombo-font-body); }
+  body {
+    background: var(--tombo-paper);
+    color: var(--tombo-ink);
+    font-size: var(--tombo-text-body);
+    font-weight: var(--tombo-w-body);
+    line-height: 2; /* = 30px at body size; unitless so larger text inherits safely */
+    transition: background var(--tombo-dur) var(--tombo-ease), color var(--tombo-dur) var(--tombo-ease);
+  }
+  h1, h2, h3, h4 { font-weight: 700; }
+  h1 { font-size: var(--tombo-text-h1); line-height: var(--tombo-lh-h1); }
+  h2 { font-size: var(--tombo-text-h2); line-height: var(--tombo-lh-h2); }
+  h3 { font-size: var(--tombo-text-h3); line-height: var(--tombo-lh-h3); }
+  h4 { line-height: 1.3; }
+  .tombo-display { font-family: var(--tombo-font-display); font-weight: 700; /* Instrument Sans has no 900 */
+    font-size: var(--tombo-text-display); line-height: 1.1; letter-spacing: -.015em; }
+  a { color: var(--tombo-green); text-decoration: underline; text-underline-offset: 4px; text-decoration-thickness: 1px; }
+  code, kbd, samp, pre { font-family: var(--tombo-font-mono); font-weight: 400; }
+  hr { border: 0; border-top: 1px solid var(--tombo-hairline); }
+  ::selection { background: var(--tombo-green); color: var(--tombo-on-green); }
+  :focus-visible { outline: 2px solid var(--tombo-green); outline-offset: 2px; }
+}
+
+@layer tombo.utilities {
+  /* S-06 方眼 — volume dial */
+  .tombo-vol-lp {
+    background-image:
+      repeating-linear-gradient(0deg,  var(--tombo-grid) 0 1px, transparent 1px 24px),
+      repeating-linear-gradient(90deg, var(--tombo-grid) 0 1px, transparent 1px 24px);
+  }
+  /* container scale — one class, four widths. The page runs at --tombo-shell-default;
+     reassign --tombo-shell on :root (only there — the deprecated --tombo-shell-max
+     alias is declared at :root and will not follow an override made lower down)
+     when a whole page wants another step. .tombo-gutters reads the same variable, so
+     the margins always meet the content edge. The modifiers rebind it per element. */
+  .tombo-shell {
+    inline-size: 100%;
+    max-inline-size: var(--tombo-shell);
+    margin-inline: auto;
+    padding-inline: var(--tombo-shell-gutter);
+  }
+  /* reading is a measure of TEXT, so the box has to carry the gutter on top of it —
+     the shell is border-box, and capping it at the bare 65ch would leave 65ch minus
+     two gutters of actual line (51.9ch at a 1920px viewport). default and wide are
+     frame widths and mean exactly what they say, so they are not compensated. */
+  .tombo-shell--reading { --tombo-shell: calc(var(--tombo-shell-reading) + 2 * var(--tombo-shell-gutter)); }
+  .tombo-shell--wide    { --tombo-shell: var(--tombo-shell-wide); }
+  /* full bleed leaves --tombo-shell untouched so a nested .tombo-shell keeps the page width */
+  .tombo-shell--full    { max-inline-size: none; padding-inline: 0; }
+
+  .tombo-gutters { position: relative; }
+  .tombo-gutters::before, .tombo-gutters::after {
+    content: ""; position: absolute; inset-block: 0; pointer-events: none;
+    /* reach the content edge, not the shell's outer edge: the margin outside the
+       shell PLUS the shell's own gutter. 100% (the body box) rather than 100vw so a
+       classic scrollbar does not push the grid past the content. Below the shell
+       width the first term is 0 and the grid is exactly the gutter. */
+    inline-size: calc(max(0px, (100% - var(--tombo-shell)) / 2) + var(--tombo-shell-gutter));
+    background-image:
+      repeating-linear-gradient(0deg,  var(--tombo-grid) 0 1px, transparent 1px 24px),
+      repeating-linear-gradient(90deg, var(--tombo-grid) 0 1px, transparent 1px 24px);
+  }
+  .tombo-gutters::before { inset-inline-start: 0; }
+  .tombo-gutters::after  { inset-inline-end: 0; }
+  @media (min-width: 1600px) {
+    /* wide screens: the margins become the trim area — bolder grid, and the
+       registration mark moves to the window's own corners (print puts tombo
+       outside the live area; here the viewport edge is that outside) */
+    .tombo-gutters::before, .tombo-gutters::after { --tombo-grid: var(--tombo-grid-bold); }
+    html:has(> body.tombo-gutters)::before {
+      content: ""; position: fixed; inset: 20px; pointer-events: none; opacity: .45;
+      background:
+        linear-gradient(var(--tombo-ink), var(--tombo-ink)) left 0 top 0 / 22px 1.5px,
+        linear-gradient(var(--tombo-ink), var(--tombo-ink)) left 0 top 0 / 1.5px 22px,
+        linear-gradient(var(--tombo-ink), var(--tombo-ink)) right 0 top 0 / 22px 1.5px,
+        linear-gradient(var(--tombo-ink), var(--tombo-ink)) right 0 top 0 / 1.5px 22px,
+        linear-gradient(var(--tombo-ink), var(--tombo-ink)) left 0 bottom 0 / 22px 1.5px,
+        linear-gradient(var(--tombo-ink), var(--tombo-ink)) left 0 bottom 0 / 1.5px 22px,
+        linear-gradient(var(--tombo-ink), var(--tombo-ink)) right 0 bottom 0 / 22px 1.5px,
+        linear-gradient(var(--tombo-ink), var(--tombo-ink)) right 0 bottom 0 / 1.5px 22px;
+      background-repeat: no-repeat;
+    }
+  }
+
+  .tombo-mono { font-family: var(--tombo-font-mono); }
+  .tombo-label {
+    font-family: var(--tombo-font-mono); font-size: var(--tombo-text-label);
+    line-height: var(--tombo-lh-label); font-weight: 500;
+    letter-spacing: .14em; text-transform: uppercase; color: var(--tombo-ink-sub);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { transition: none !important; animation: none !important; }
+  }
+}
+
+@layer tombo.components {
+  /* S-01 トンボ: 2 corners via pseudos; add <b class="tombo-corner-tr/bl"> for 4 */
+  .tombo-corners { position: relative; }
+  .tombo-corners::before, .tombo-corners::after,
+  .tombo-corner-tr, .tombo-corner-bl { position: absolute; width: 12px; height: 12px; border: 0 solid var(--tombo-ink); opacity: .8; content: ""; }
+  .tombo-corners::before { top: -1px; left: -1px; border-top-width: 1.5px; border-left-width: 1.5px; }
+  .tombo-corners::after  { bottom: -1px; right: -1px; border-bottom-width: 1.5px; border-right-width: 1.5px; }
+  .tombo-corner-tr { top: -1px; right: -1px; border-top-width: 1.5px; border-right-width: 1.5px; }
+  .tombo-corner-bl { bottom: -1px; left: -1px; border-bottom-width: 1.5px; border-left-width: 1.5px; }
+
+  /* S-02 寸法線 */
+  .tombo-dim { position: relative; height: 10px; border-left: 1px solid var(--tombo-ink); border-right: 1px solid var(--tombo-ink); }
+  .tombo-dim::after { content: ""; position: absolute; inset: 4.5px 0 auto; border-top: 1px solid var(--tombo-ink); }
+  .tombo-dimlab { font-family: var(--tombo-font-mono); font-size: var(--tombo-text-note); line-height: var(--tombo-lh-note); font-weight: 400; letter-spacing: .08em; color: var(--tombo-ink-faint); margin-top: 7px; }
+
+  /* S-03 目盛 */
+  .tombo-ticks { list-style: none; padding: 0; }
+  .tombo-ticks > li { position: relative; padding: 5px 0 5px 22px; }
+  .tombo-ticks > li::before { content: ""; position: absolute; left: 0; top: 50%; width: 12px; border-top: 1.5px solid var(--tombo-green); }
+
+  .tombo-ruler { position: relative; height: 20px; border-bottom: 1.5px solid var(--tombo-ink);
+    background-image: repeating-linear-gradient(90deg, var(--tombo-hairline) 0 1px, transparent 1px 10%); }
+  .tombo-ruler::before { content: ""; position: absolute; bottom: 0; left: 0; height: 6px;
+    width: var(--tombo-ruler-value, 0%); background: var(--tombo-green);
+    transition: width var(--tombo-dur) var(--tombo-ease); }
+  .tombo-ruler::after { content: ""; position: absolute; top: 0; bottom: -5px;
+    left: var(--tombo-ruler-value, 0%); border-left: 1.5px solid var(--tombo-shu); }
+
+  /* S-04 通し番号 */
+  .tombo-sections { counter-reset: tombo-section; }
+  .tombo-sec { counter-increment: tombo-section; }
+  .tombo-sec::before { content: counter(tombo-section, decimal-leading-zero) " — ";
+    font-family: var(--tombo-font-mono); font-weight: 500; font-size: .72em; color: var(--tombo-green); }
+  .tombo-fig { font-family: var(--tombo-font-mono); font-size: var(--tombo-text-note); line-height: var(--tombo-lh-note); font-weight: 400; letter-spacing: .08em; color: var(--tombo-ink-faint); text-transform: uppercase; }
+
+  /* S-05 朱の現在地 */
+  .tombo-current { position: relative; }
+  .tombo-current::before { content: ""; position: absolute; left: 0; top: 50%; width: 12px; border-top: 2px solid var(--tombo-shu); }
+  .tombo-kicker { font-family: var(--tombo-font-mono); font-size: var(--tombo-text-label); line-height: var(--tombo-lh-label); font-weight: 500; letter-spacing: .16em; color: var(--tombo-green); text-transform: uppercase; }
+  .tombo-kicker::before { content: ""; display: inline-block; width: 12px; border-top: 2px solid var(--tombo-shu); vertical-align: 4px; margin-right: 10px; }
+}
+
+@layer tombo.components {
+  .tombo-btn { display: inline-block; padding: 12px 26px; font-size: var(--tombo-text-ui); font-family: var(--tombo-font-body);
+    border: 1px solid transparent; cursor: pointer; background: none;
+    transition: background var(--tombo-dur) var(--tombo-ease), color var(--tombo-dur) var(--tombo-ease); }
+  .tombo-btn--primary { background: var(--tombo-green); color: var(--tombo-on-green); font-weight: 700; }
+  .tombo-btn--primary:hover { background: var(--tombo-ink); color: var(--tombo-paper); }
+  .tombo-btn--secondary { border-color: var(--tombo-ink); color: var(--tombo-ink); }
+  .tombo-btn--secondary:hover { background: var(--tombo-surface); }
+  .tombo-btn--ghost { color: var(--tombo-green); text-decoration: underline; text-underline-offset: 4px; padding: 12px 8px; }
+
+  .tombo-tabs { display: flex; gap: 22px; border-bottom: 1px solid var(--tombo-hairline); }
+  .tombo-tabs > * { padding: 6px 2px 9px; color: var(--tombo-ink-sub); text-decoration: none; position: relative; font-size: var(--tombo-text-ui); }
+  .tombo-tabs > [aria-current] { color: var(--tombo-ink); font-weight: 500; }
+  .tombo-tabs > [aria-current]::after { content: ""; position: absolute; left: 0; bottom: -1px; width: 100%; border-bottom: 2px solid var(--tombo-shu); }
+
+  .tombo-toc { font-size: var(--tombo-text-ui); }
+  .tombo-toc a { display: block; color: var(--tombo-ink-sub); text-decoration: none; padding: 7px 0 7px 22px; position: relative; }
+  .tombo-toc a[aria-current] { color: var(--tombo-ink); font-weight: 500; }
+  .tombo-toc a[aria-current]::before { content: ""; position: absolute; left: 0; top: 50%; width: 12px; border-top: 2px solid var(--tombo-shu); }
+
+  .tombo-code { background: var(--tombo-code-bg); color: var(--tombo-code-ink);
+    border: 1px solid var(--tombo-code-border); border-radius: 6px; overflow: hidden; }
+  .tombo-code > figcaption { display: flex; justify-content: space-between; font-family: var(--tombo-font-mono);
+    font-size: var(--tombo-text-label); font-weight: 500; letter-spacing: .1em; text-transform: uppercase; color: var(--tombo-code-faint);
+    padding: 8px 14px; border-bottom: 1px solid var(--tombo-code-hairline); }
+  .tombo-code pre { font-size: var(--tombo-text-code); line-height: var(--tombo-lh-code); font-stretch: 87.5%; padding: 14px 18px; overflow-x: auto; }
+
+  .tombo-callout { border: 1px solid var(--tombo-hairline); border-left: 2px solid var(--tombo-shu);
+    padding: 12px 16px; font-size: var(--tombo-text-ui); line-height: var(--tombo-lh-ui); color: var(--tombo-ink-sub); }
+  .tombo-callout--warn { border-left-color: var(--tombo-warn); }
+  .tombo-callout > b:first-child { font-family: var(--tombo-font-mono); font-weight: 500; font-size: var(--tombo-text-label);
+    letter-spacing: .14em; color: var(--tombo-callout-label); margin-right: 10px; text-transform: uppercase; }
+
+  .tombo-table { width: 100%; border-collapse: collapse; font-size: var(--tombo-text-ui); }
+  .tombo-table th { font-family: var(--tombo-font-mono); font-size: var(--tombo-text-label); letter-spacing: .12em;
+    text-transform: uppercase; color: var(--tombo-ink-sub); font-weight: 500; text-align: left;
+    padding: 11px 14px; border-bottom: 1.5px solid var(--tombo-ink); }
+  .tombo-table td { padding: 10px 14px; border-bottom: 1px solid var(--tombo-hairline); }
+  /* A data table is a reflow exception under WCAG 2.2 SC 1.4.10, but the scroll
+     belongs to the table, not the page. Wrap every .tombo-table that can outgrow
+     its column. The region must be focusable or a keyboard user cannot scroll it,
+     and role="region" needs an accessible name:
+     <div class="tombo-table-wrap" role="region" aria-labelledby="ID" tabindex="0">
+       <table class="tombo-table"> … */
+  .tombo-table-wrap { overflow-x: auto; }
+
+  .tombo-chip { font-family: var(--tombo-font-mono); font-size: var(--tombo-text-label); font-weight: 500; letter-spacing: .08em;
+    padding: 3px 10px; border: 1px solid var(--tombo-hairline); border-radius: 99px; }
+  .tombo-chip::before { content: ""; display: inline-block; width: .5em; height: .5em; border-radius: 50%;
+    background: currentColor; margin-right: .55em; vertical-align: .08em; color: var(--tombo-ink-faint); }
+  .tombo-chip[data-status="ok"]::before   { color: var(--tombo-success); }
+  .tombo-chip[data-status="warn"]::before { color: var(--tombo-warn); }
+  .tombo-chip[data-status="err"]::before  { color: var(--tombo-error); }
+
+  .tombo-metric { background: var(--tombo-surface); border: 1px solid var(--tombo-hairline); padding: 20px 24px; }
+  .tombo-metric > .k { font-family: var(--tombo-font-mono); font-size: var(--tombo-text-label); font-weight: 500; letter-spacing: .14em;
+    text-transform: uppercase; color: var(--tombo-ink-sub); }
+  .tombo-metric > .v { font-family: var(--tombo-font-mono); font-size: var(--tombo-text-metric); line-height: var(--tombo-lh-metric); font-weight: 600; margin: 8px 0 12px; }
+
+  .tombo-footer { border-top: 1px solid var(--tombo-hairline); padding: 22px 0 46px;
+    font-family: var(--tombo-font-mono); font-size: var(--tombo-text-label); font-weight: 400; letter-spacing: .12em; color: var(--tombo-ink-faint); line-height: 1.9; }
+
+  /* S-04 — the mark, engraved: C-01 見当 (assets/logo/tombo-mark.svg) drawn in CSS.
+     markup: <span class="tombo-logo" aria-hidden="true"><i class="h"></i><i class="b"></i><i class="w1"></i><i class="w2"></i><i class="t"></i></span> */
+  .tombo-logo { position: relative; display: inline-block; width: 24px; height: 24px; color: var(--tombo-green); }
+  .tombo-logo > i { position: absolute; display: block; }
+  .tombo-logo > .h { top: 0; left: 50%; width: 5px; height: 5px; transform: translateX(-50%);
+    border: 1.5px solid currentColor; border-radius: 50%; }
+  .tombo-logo > .b { top: 5px; bottom: 4px; left: calc(50% - .75px); border-left: 1.5px solid currentColor; }
+  .tombo-logo > .w1 { top: 8.5px; left: 2px; right: 2px; border-top: 1.5px solid currentColor; }
+  .tombo-logo > .w2 { top: 11.5px; left: 5px; right: 5px; border-top: 1.5px solid currentColor; }
+  .tombo-logo > .t { bottom: 0; left: calc(50% - .75px); height: 4px; border-left: 1.5px solid var(--tombo-shu); }
+  /* spec §9 — the single glow exception: at night the LP hero tail is a firefly, not a mark */
+  .tombo-logo--glow > .t { border-color: light-dark(var(--tombo-shu), var(--tombo-green));
+    box-shadow: 0 0 7px light-dark(transparent, var(--tombo-green)); }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",
+    "docs:verify-accessibility": "node scripts/verify-docs-accessibility.mjs",
     "docs:verify-base": "node scripts/verify-docs-base.mjs",
     "docs:verify-tombo": "node scripts/verify-tombo-vendor.mjs",
     "docs:verify-version": "node scripts/verify-docs-version.mjs",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",
     "docs:verify-base": "node scripts/verify-docs-base.mjs",
+    "docs:verify-tombo": "node scripts/verify-tombo-vendor.mjs",
     "docs:verify-version": "node scripts/verify-docs-version.mjs",
     "docs:links": "markdown-link-check --config .markdown-link-check.json README.md docs/*.md docs/**/*.md examples/*/README.md"
   },

--- a/scripts/verify-docs-accessibility.mjs
+++ b/scripts/verify-docs-accessibility.mjs
@@ -1,0 +1,37 @@
+import { readFile, readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const docsIndex = await readFile('docs/index.md', 'utf8')
+
+if (!/^layout: home$/mu.test(docsIndex) || !/^markdownStyles: false$/mu.test(docsIndex)) {
+  throw new Error('The documentation homepage must use the home layout without Markdown styles')
+}
+
+const distDirectory = 'docs/.vitepress/dist'
+const home = await readFile(join(distDirectory, 'index.html'), 'utf8')
+
+if (!home.includes('<footer class="tombo-site-footer tombo-shell"')) {
+  throw new Error('The documentation homepage does not expose its site footer as a footer landmark')
+}
+
+let tableCount = 0
+
+for (const entry of await readdir(distDirectory, { recursive: true })) {
+  if (!entry.endsWith('.html')) {
+    continue
+  }
+
+  const html = await readFile(join(distDirectory, entry), 'utf8')
+  const labels = [...html.matchAll(/class="tombo-table-wrap"[^>]*aria-label="([^"]+)"/gu)]
+    .map((match) => match[1])
+
+  if (new Set(labels).size !== labels.length) {
+    throw new Error(`Generated documentation contains duplicate table region names in ${entry}`)
+  }
+
+  tableCount += labels.length
+}
+
+if (tableCount === 0) {
+  throw new Error('Generated documentation does not contain any named table regions')
+}

--- a/scripts/verify-tombo-vendor.mjs
+++ b/scripts/verify-tombo-vendor.mjs
@@ -1,0 +1,26 @@
+import { createHash } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+
+const files = [
+  {
+    path: new URL('../docs/public/styles/tombo.css', import.meta.url),
+    source: 'wadakatu/tombo v0.4.0 / tombo.css',
+    sha256: '2e21dee3720d21a6dfecb16c1d4e5443d72d21189cab11fba1349d4f3f0a5782'
+  },
+  {
+    path: new URL('../docs/public/styles/tombo.LICENSE', import.meta.url),
+    source: 'wadakatu/tombo v0.4.0 / LICENSE',
+    sha256: '72a8d3918494449985a5544ae70e35e9ad0ff5f6da8711969abd64952a9e3bd5'
+  }
+]
+
+for (const file of files) {
+  const contents = await readFile(file.path)
+  const actual = createHash('sha256').update(contents).digest('hex')
+
+  if (actual !== file.sha256) {
+    throw new Error(`${file.source} does not match the pinned vendored bytes`)
+  }
+
+  console.log(`Verified ${file.source}: ${actual}`)
+}


### PR DESCRIPTION
## 概要

GessoのVitePressドキュメントサイトを、wadakatuのデザインシステム「Tombo」で再設計します。

## 背景

v2の公開に合わせて、既定のVitePressホームからGesso固有の情報設計へ移行し、広い画面でも余白を持て余さず、OSS・サービス間で一貫したwadakatuブランドを表現できる状態にします。

## 変更内容

- Gesso専用のトップページコンポーネントを追加
  - contract validation、coverage、framework quickstart、v2 migrationを一画面で案内
  - Tomboの計測線、通し番号、グリッド、朱の現在地、registration cornersを使用
- Tombo v0.4.0の`tombo.css`とLICENSEをタグ内容のままvendor
  - SHA-256固定スクリプトとCI検証を追加
- Tombo v0.4.0のcontainer scaleへ移行
  - landing page: `wide`（最大1792px）
  - documentation: `default`（1280px）
  - prose: `reading`（65ch）
- Heroを左右0.96:1.04、最大48px gapへ調整し、右のcoverage panelを拡大
- Markdownテーブルを、キーボードフォーカス可能でアクセシブルな局所横スクロール領域へ変換
  - ページ内の通し番号と直前の見出しから、一意なランドマーク名を生成
- ホームをVitePress標準の`home`レイアウトへ移し、空のモバイルローカルナビを除外
- サイトフッターをネイティブ`footer`要素にして`contentinfo`ランドマークを保持
- VitePressのnavigation、sidebar、outline、code、callout、table、footerをTomboトークンへ統一
- Tombo推奨のInstrument Sans、M PLUS 2、Martian Monoを適用
- ホームレイアウト、フッター、全生成ページのテーブル名重複を検査するCI不変条件を追加

## 影響

ドキュメントサイトの表示とCI検証のみが対象です。PHPライブラリのruntime APIや依存関係には変更ありません。

## 検証

- `npm run docs:build`
- `npm run docs:verify-accessibility`（14ページ / 31テーブルの一意なregion名）
- `npm run docs:verify-base`
- `npm run docs:verify-version`
- `npm run docs:verify-tombo`
- `npm audit --audit-level=high`（0 vulnerabilities）
- `vendor/bin/phpunit tests/Unit/Build/GitHubActionsSecurityPolicyTest.php tests/Unit/Build/RuntimeSupportPolicyTest.php`（10 tests / 223 assertions）
- `git diff --check`

## ローカル実機確認

- 環境: `file:///.../docs/.vitepress/dist/index.html`（`DOCS_BASE=./`の確認用ビルド）/ Chrome DevTools MCP
- 操作: 1920px、1440px、1025px、1024px、320pxへviewportを変更し、light/dark表示、Hero配置、CTA、カード、通常ドキュメントのテーブルを確認
- 結果:
  - 1920pxでは1792px shell内で左777px・右842px・gap 48pxとなり、Hero中央の余白を抑制
  - 1025pxでは2カラム、1024px以下では1カラムへ切替
  - 320pxでは左右20px、CTA幅280px、document scrollWidth 320pxでページ横溢れなし
  - ホームは`VPContent is-home`で、`.VPLocalNav`と「Return to top」は0件
  - サイトフッターはaccessibility treeで`contentinfo "Site design information"`として認識
  - Setupページの3テーブルは、一意な名前を持つfocusable regionとして認識
  - 幅広テーブルは272pxのscroll region内に留まり、ページ自体は横スクロールしない
- Before/After: Heroの広い未使用領域を、右panelの拡大とgap縮小で再調整
- Console/Network: 実行環境ではローカルHTTPサーバーのlistenが禁止されています。`file://`ではVitePressのES moduleがCORSでhydrateされないため、静的DOM/CSSとaccessibility treeを確認し、動的なhome除外はVitePress本体の条件とCI不変条件で確認
- 証跡: `/private/tmp/gesso-tombo-v040-pr-balanced.png`、`/private/tmp/gesso-tombo-v040-pr-mobile.png`、`/private/tmp/gesso-pr382-accessibility-mobile.png`
- 未確認事項: hydrate後のtheme toggleとclient-side navigationは、GitHub PagesのPR/branch previewまたはHTTP配信環境で要確認
