### PR TITLE
fix(docs): keep footer clear of sidebar

### DIFF
--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import DefaultTheme from 'vitepress/theme'
+import DefaultTheme, { useSidebar } from 'vitepress/theme'
 
 declare const __DOCS_VERSION__: string
 
 const { Layout } = DefaultTheme
+const { hasSidebar } = useSidebar()
 const docsVersion = __DOCS_VERSION__
 </script>
 
@@ -16,15 +17,17 @@ const docsVersion = __DOCS_VERSION__
       </div>
     </template>
     <template #layout-bottom>
-      <footer class="tombo-site-footer tombo-shell" aria-label="Site design information">
-        <span class="tombo-logo" aria-hidden="true">
-          <i class="h"></i><i class="b"></i><i class="w1"></i><i class="w2"></i><i class="t"></i>
-        </span>
-        <p>
-          GESSO / STUDIO-DESIGN / MIT LICENSE<br>
-          SET IN TOMBO — WADAKATU DESIGN SYSTEM
-        </p>
-      </footer>
+      <div class="tombo-site-footer-frame" :class="{ 'has-sidebar': hasSidebar }">
+        <footer class="tombo-site-footer tombo-shell" aria-label="Site design information">
+          <span class="tombo-logo" aria-hidden="true">
+            <i class="h"></i><i class="b"></i><i class="w1"></i><i class="w2"></i><i class="t"></i>
+          </span>
+          <p>
+            GESSO / STUDIO-DESIGN / MIT LICENSE<br>
+            SET IN TOMBO — WADAKATU DESIGN SYSTEM
+          </p>
+        </footer>
+      </div>
     </template>
   </Layout>
 </template>

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -338,6 +338,10 @@ body {
   background: var(--tombo-surface);
 }
 
+.tombo-site-footer-frame {
+  width: 100%;
+}
+
 .tombo-site-footer {
   display: flex;
   align-items: center;
@@ -355,7 +359,18 @@ body {
   letter-spacing: 0.1em;
 }
 
+@media (min-width: 960px) {
+  .tombo-site-footer-frame.has-sidebar {
+    padding-left: var(--vp-sidebar-width);
+  }
+}
+
 @media (min-width: 1440px) {
+  .tombo-site-footer-frame.has-sidebar {
+    padding-right: calc((100vw - var(--vp-layout-max-width)) / 2);
+    padding-left: calc((100vw - var(--vp-layout-max-width)) / 2 + var(--vp-sidebar-width));
+  }
+
   .VPDoc {
     background-image:
       linear-gradient(90deg, var(--tombo-grid) 1px, transparent 1px),

--- a/scripts/verify-docs-accessibility.mjs
+++ b/scripts/verify-docs-accessibility.mjs
@@ -9,9 +9,23 @@ if (!/^layout: home$/mu.test(docsIndex) || !/^markdownStyles: false$/mu.test(doc
 
 const distDirectory = 'docs/.vitepress/dist'
 const home = await readFile(join(distDirectory, 'index.html'), 'utf8')
+const documentationPage = await readFile(join(distDirectory, 'coverage.html'), 'utf8')
+const footerFrameClasses = (html) => {
+  const classAttribute = html.match(/<div class="([^"]*tombo-site-footer-frame[^"]*)">/u)?.[1]
+
+  return new Set(classAttribute?.split(/\s+/u) ?? [])
+}
 
 if (!home.includes('<footer class="tombo-site-footer tombo-shell"')) {
   throw new Error('The documentation homepage does not expose its site footer as a footer landmark')
+}
+
+if (!footerFrameClasses(home).has('tombo-site-footer-frame') || footerFrameClasses(home).has('has-sidebar')) {
+  throw new Error('The documentation homepage footer must remain aligned to the page shell')
+}
+
+if (!footerFrameClasses(documentationPage).has('has-sidebar')) {
+  throw new Error('Documentation page footers must account for the desktop sidebar')
 }
 
 let tableCount = 0


### PR DESCRIPTION
## 概要

- ドキュメントページのサイトフッターをVitePressのサイドバー状態に連動させます
- デスクトップでは本文と同じレスポンシブ余白を適用し、固定サイドバーの背面へ潜らないようにします
- ホームページとモバイルでは従来の全幅配置を維持します
- 生成HTMLの回帰検査を追加します

## 原因

`layout-bottom`のフッターだけが画面全体を基準に`tombo-shell`で中央配置されていました。固定サイドバーを持つドキュメントページでは、フッター左端がサイドバー右端より左になり、先頭部分がサイドバーの下に隠れていました。

## 影響

ドキュメントページ下部のGesso / Tombo表記がデスクトップでも欠けずに表示されます。`footer`要素と`contentinfo`ランドマークは維持されます。

## スコープと順序

このPRはフッター修正だけを含みます。Tombo v0.5.0への更新、本文幅、テーブル、フォントの変更は含めません。本文幅の拡張は、このPRのマージ後に`--vp-layout-max-width`とフッター余白を一組として再検証します。

## 検証

- `npm run docs:build`
- `npm run docs:verify-accessibility`
- `npm run docs:verify-base`
- `npm run docs:verify-tombo`
- `npm run docs:verify-version`
- `git diff --check`

## ローカル実機確認

- 環境: `file:///private/tmp/gesso-footer-pr/docs/.vitepress/dist/coverage.html` / Chrome DevTools MCP
- 操作: Coverageページ最下部へ移動し、2048pxデスクトップと390pxモバイルでフッター位置・横幅・ランドマークを確認
- 結果: 2048pxではサイドバー右端とフッター左端がともに656pxで重なりなし。390pxではフッターが0–390pxに収まり、横スクロールなし。`aria-label="Site design information"`を維持
- Before/After: 公開中ページでは2048px時にサイドバー右端656pxに対してフッター左端384px。修正後はフッター左端656px
- Console/Network: ビルド済みCSSとTombo CSSは読み込み成功。`file://`由来のES module・フォントCORS警告のみ発生
- 証跡: `/private/tmp/gesso-footer-before.png`, `/private/tmp/gesso-footer-pr-after.png`
- 未確認事項: 実行環境のポート制約によりローカルHTTP previewは未実施。対象のSSR HTML/CSSレイアウトは上記ブラウザ計測で確認済み
