### PR TITLE
fix(docs): use wide layout for reference content

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1,6 +1,6 @@
 :root {
   --vp-layout-top-height: 36px;
-  --vp-layout-max-width: var(--tombo-shell-default);
+  --vp-layout-max-width: min(var(--tombo-shell-wide), 100vw);
   --vp-font-family-base: var(--tombo-font-body);
   --vp-font-family-mono: var(--tombo-font-mono);
   --vp-c-bg: var(--tombo-paper);
@@ -199,7 +199,13 @@ body {
   line-height: var(--tombo-lh-body);
 }
 
+.VPDoc.has-aside .content .content-container {
+  max-width: 1160px;
+}
+
 .vp-doc > :is(p, ul, ol, blockquote, .custom-block),
+.vp-doc > div > :is(p, ul, ol, blockquote, .custom-block),
+.vp-doc > div > :is(h1, h2, h3, h4),
 .vp-doc > :is(h1, h2, h3, h4) {
   max-inline-size: var(--tombo-shell-reading);
 }


### PR DESCRIPTION
## 概要

ワイド画面でドキュメント本文とコードブロックが過度に狭くなる問題を修正します。

- VitePress のレイアウト上限を、ビューポートを超えない Tombo wide shell に変更
- aside 付きドキュメントの本文領域を最大 1160px まで拡張
- Markdown の実際のラッパー構造にも reading measure を適用し、段落は 65ch のまま維持

## 背景・原因

従来は `--vp-layout-max-width` が Tombo default shell（1280px）に固定され、2560px の画面でも本文領域が 624px、コードの表示幅が 590px に制限されていました。そのため `/api-reference` のコードブロック 6 件すべてで横スクロールが必要でした。

単純に上限を 1792px へ固定すると、VitePress のレイアウト計算により 1440px 付近でサイドバーが縮むため、`min(var(--tombo-shell-wide), 100vw)` を使用して中間幅を保護しています。

## 影響

- 2560px: 本文コンテナ 624px → 1136px
- 1920px/2560px: `/api-reference` のコード横スクロール 6/6件 → 0/6件
- 段落の reading measure は約 621px（65ch）を維持
- 1440px: サイドバー幅 272pxを維持
- モバイル: ページ全体の横 overflow なし
- ホーム、フッター、サイドバーの整列を維持

## 確認

- `npm run docs:build`
- `npm run docs:verify-accessibility`
- `npm run docs:verify-base`
- `npm run docs:verify-tombo`
- `npm run docs:verify-version`
- `git diff --check`

## ローカル実機確認

- 環境: 生成済み `docs/.vitepress/dist/api-reference.html` / Chrome DevTools MCP
- 操作: `/api-reference` とホームを 2560px、1920px、1440px、モバイル幅で表示し、本文・コード・サイドバー・フッターの座標と overflow を実測
- 結果: 1920px/2560pxでコード6件すべての横スクロールが解消。段落は65chを維持し、1440pxのサイドバーとモバイルのページ幅も正常
- Before/After: 2560pxで本文624px・コード表示590px・6件overflow → 本文1136px・コード表示1102px・0件overflow
- Console/Network: ローカルHTTPサーバーの起動が実行環境の権限で拒否されたため `file://` で確認。CSSは読み込み済み。module scriptとローカルfontはブラウザーの `file://` CORS制約で未読込
- 証跡: `/private/tmp/gesso-doc-width-2560.png`、`/private/tmp/gesso-doc-width-mobile.png`
- 未確認事項: HTTP配信時のクライアントサイドナビゲーション。レイアウトはSSR HTMLと生成CSSで確認済み

## スコープ

Tombo v0.5.0 のvendor更新や他のドキュメント変更は含めていません。
