### PR TITLE
fix(docs): show beta constraint on home page

### DIFF
--- a/docs/.vitepress/theme/components/TomboHome.vue
+++ b/docs/.vitepress/theme/components/TomboHome.vue
@@ -55,7 +55,10 @@ const quickstarts = [
 
           <div class="headline-measure" aria-hidden="true">
             <div class="tombo-dim"></div>
-            <p class="tombo-dimlab">headline / 02 lines · spec / 3.0 · 3.1 · 3.2</p>
+            <p class="tombo-dimlab headline-dim-label">
+              <span>headline / 02 lines</span>
+              <span class="headline-dim-spec">spec / 3.0 · 3.1 · 3.2</span>
+            </p>
           </div>
 
           <p class="hero-lead">
@@ -157,7 +160,7 @@ const quickstarts = [
           <div class="quickstart-proof">
             <figure class="tombo-code">
               <figcaption><span>SHELL — INSTALL &amp; RUN</span><span>02 STEPS</span></figcaption>
-              <pre><code><span class="code-line"><i>001</i><b>$</b> composer require --dev studio-design/gesso</span>
+              <pre><code><span class="code-line"><i>001</i><b>$</b> composer require --dev &quot;studio-design/gesso:^2.0@beta&quot;</span>
 <span class="code-line"><i>002</i><b>$</b> vendor/bin/phpunit</span>
 <span class="code-line code-comment"><i>003</i># coverage: method · path · status · content-type</span></code></pre>
             </figure>
@@ -254,8 +257,18 @@ const quickstarts = [
 }
 
 .headline-measure {
-  width: min(100%, 340px);
+  width: min(100%, 430px);
   margin-top: 1.5rem;
+}
+
+.headline-dim-label {
+  display: flex;
+  gap: 0.6em;
+  white-space: nowrap;
+}
+
+.headline-dim-spec::before {
+  content: "· ";
 }
 
 .hero-lead {
@@ -652,6 +665,16 @@ const quickstarts = [
 }
 
 @media (max-width: 480px) {
+  .headline-dim-label {
+    display: grid;
+    gap: 0.1rem;
+    white-space: normal;
+  }
+
+  .headline-dim-spec::before {
+    content: "";
+  }
+
   .hero-actions {
     align-items: stretch;
     flex-direction: column;

--- a/tests/Unit/Build/DocumentationInstallPolicyTest.php
+++ b/tests/Unit/Build/DocumentationInstallPolicyTest.php
@@ -77,5 +77,34 @@ final class DocumentationInstallPolicyTest extends TestCase
                 $relativePath . ' must not present an unavailable stable release as the current install path.',
             );
         }
+
+        $homeContents = file_get_contents($root . '/docs/.vitepress/theme/components/TomboHome.vue');
+        $this->assertIsString($homeContents);
+
+        if (!$isPrerelease) {
+            $this->assertStringContainsString(
+                'studio-design/gesso:^2.0',
+                $homeContents,
+                'The home page must install the stable Gesso 2 line.',
+            );
+            $this->assertStringNotContainsString(
+                'studio-design/gesso:^2.0@beta',
+                $homeContents,
+                'The home page must stop opting in to prereleases during stable promotion.',
+            );
+
+            return;
+        }
+
+        $this->assertStringContainsString(
+            'studio-design/gesso:^2.0@beta',
+            $homeContents,
+            'The home page must opt in to the published Gesso 2 beta.',
+        );
+        $this->assertStringNotContainsString(
+            'composer require --dev studio-design/gesso',
+            $homeContents,
+            'The home page must not present an unavailable stable release as the current install path.',
+        );
     }
 }


### PR DESCRIPTION
## 概要

- トップページのインストール例を `studio-design/gesso:^2.0@beta` に更新
- release-please の prerelease 設定とトップページの表示が同期する回帰テストを追加
- Hero の測定ラベルを、PCでは1行、480px以下では意味単位の2段で表示

## 背景

README と各 Quickstart は beta 制約へ更新済みでしたが、
`TomboHome.vue` はドキュメントインストール方針テストの対象外でした。
そのため、トップページだけ Composer のデフォルト `stable` 方針では
解決できないコマンドを表示していました。

測定ラベルも固定幅内でブラウザ任せに折り返していたため、
末尾の `3.1 · 3.2` だけが次の行へ落ちていました。

## 影響

beta 期間中にトップページからコピーするコマンドで、公開済みの最新
Gesso 2 beta を正しくインストールできます。Hero の測定ラベルは、
デスクトップでは1行、モバイルでは情報単位を保った2段になります。
ランタイムコードへの変更はありません。

## 検証

- `vendor/bin/phpunit tests/Unit/Build/DocumentationInstallPolicyTest.php`
  - 1 test / 41 assertions
- `vendor/bin/phpstan analyse --debug --no-progress --memory-limit=1G`
  - No errors
- PHP-CS-Fixer（通常・Pest設定、逐次モード）
  - 差分なし
- `npm run docs:build`
  - 成功
- `npm run docs:verify-accessibility`
  - 成功
- `npm run docs:verify-base`
  - 成功
- `npm run docs:verify-tombo`
  - 成功
- `npm run docs:verify-version`
  - 成功
- `git diff --check`
  - 成功

## ローカル実機確認

- 環境: ビルド済みVitePress成果物 / Chrome DevTools MCP
- 操作: トップページを1440×1000と390×844で確認
- 結果:
  - `composer require --dev "studio-design/gesso:^2.0@beta"` を表示
  - PCでは測定ラベルを1行で表示
  - モバイルでは `headline / 02 lines` と
    `spec / 3.0 · 3.1 · 3.2` を意図した2段で表示
  - ページ全体の横溢れなし
- Before/After:
  - 制約なしの `studio-design/gesso` からbeta制約付きへ変更
  - 偶発的な末尾折返しから、viewport別の明示的レイアウトへ変更
- Console/Network:
  - 実行環境でローカルTCP bindが禁止されたためHTTP previewは利用不可
  - 実際のSSRビルド成果物を開き、公開済み共通CSSと同一commitの
    `TomboHome.vue` style blockで表示を確認
- 証跡:
  - `/private/tmp/gesso-home-beta-install-label-desktop.png`
  - `/private/tmp/gesso-home-beta-install-label-mobile.png`
- 未確認事項: ローカルHTTP preview上のhydration
  （変更対象は静的テキストとレスポンシブCSSのみ）
