### PR TITLE
docs: use stable v2 install constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,18 +98,9 @@ Choose based on the workflow you need rather than on a single yes/no feature cou
 
 ## Installation
 
-> **Pre-release evaluation only.** Gesso 2 has not reached a stable release.
-> Evaluate the beta in an isolated branch or CI job, and keep the existing v1
-> dependency in projects that require a stable contract.
-
 ```bash
-composer require --dev "studio-design/gesso:^2.0@beta"
+composer require --dev "studio-design/gesso:^2.0"
 ```
-
-The explicit stability flag lets Composer select the published prerelease; it
-is not a stable-release recommendation. After v2.0.0 stable is published, new
-installations can use `composer require --dev "studio-design/gesso:^2.0"`
-instead.
 
 > **YAML specs require `symfony/yaml`.** It is listed under `suggest` so it isn't installed automatically. If your spec is JSON, you can skip this. If your spec is `.yaml` / `.yml`, add it explicitly:
 >
@@ -133,12 +124,8 @@ Choose the CI-tested five-minute path matching your stack:
 
 All paths start with the same development dependency:
 
-> The command below installs a prerelease for isolated evaluation. See the
-> [installation warning](#installation) before adopting it in an existing
-> project.
-
 ```bash
-composer require --dev "studio-design/gesso:^2.0@beta"
+composer require --dev "studio-design/gesso:^2.0"
 ```
 
 The example below uses a PSR-7 request and response. The searchable documentation contains the complete [core](https://studio-design.github.io/gesso/quickstarts/core), [Laravel](https://studio-design.github.io/gesso/quickstarts/laravel), [Symfony](https://studio-design.github.io/gesso/quickstarts/symfony), and [Pest](https://studio-design.github.io/gesso/quickstarts/pest) quickstarts.

--- a/docs/.vitepress/theme/components/TomboHome.vue
+++ b/docs/.vitepress/theme/components/TomboHome.vue
@@ -160,7 +160,7 @@ const quickstarts = [
           <div class="quickstart-proof">
             <figure class="tombo-code">
               <figcaption><span>SHELL — INSTALL &amp; RUN</span><span>02 STEPS</span></figcaption>
-              <pre><code><span class="code-line"><i>001</i><b>$</b> composer require --dev &quot;studio-design/gesso:^2.0@beta&quot;</span>
+              <pre><code><span class="code-line"><i>001</i><b>$</b> composer require --dev &quot;studio-design/gesso:^2.0&quot;</span>
 <span class="code-line"><i>002</i><b>$</b> vendor/bin/phpunit</span>
 <span class="code-line code-comment"><i>003</i># coverage: method · path · status · content-type</span></code></pre>
             </figure>

--- a/docs/quickstarts/core.md
+++ b/docs/quickstarts/core.md
@@ -1,10 +1,7 @@
 # Core / PHPUnit quickstart
 
-> **Pre-release evaluation only.** Run this beta in an isolated branch or CI
-> job; Gesso 2 has not reached a stable release.
-
 ```bash
-composer require --dev "studio-design/gesso:^2.0@beta"
+composer require --dev "studio-design/gesso:^2.0"
 ```
 
 Copy the minimal [`examples/core`](https://github.com/studio-design/gesso/tree/main/examples/core) project. Its test validates a JSON response without a framework adapter:

--- a/docs/quickstarts/laravel.md
+++ b/docs/quickstarts/laravel.md
@@ -1,10 +1,7 @@
 # Laravel quickstart
 
-> **Pre-release evaluation only.** Run this beta in an isolated branch or CI
-> job; Gesso 2 has not reached a stable release.
-
 ```bash
-composer require --dev "studio-design/gesso:^2.0@beta"
+composer require --dev "studio-design/gesso:^2.0"
 php artisan vendor:publish --tag=gesso
 ```
 

--- a/docs/quickstarts/pest.md
+++ b/docs/quickstarts/pest.md
@@ -1,10 +1,7 @@
 # Pest quickstart
 
-> **Pre-release evaluation only.** Run this beta in an isolated branch or CI
-> job; Gesso 2 has not reached a stable release.
-
 ```bash
-composer require --dev "studio-design/gesso:^2.0@beta" pestphp/pest
+composer require --dev "studio-design/gesso:^2.0" pestphp/pest
 ```
 
 Use the automatically registered expectation with a Laravel response:

--- a/docs/quickstarts/symfony.md
+++ b/docs/quickstarts/symfony.md
@@ -1,10 +1,7 @@
 # Symfony quickstart
 
-> **Pre-release evaluation only.** Run this beta in an isolated branch or CI
-> job; Gesso 2 has not reached a stable release.
-
 ```bash
-composer require --dev "studio-design/gesso:^2.0@beta" symfony/http-foundation symfony/http-kernel
+composer require --dev "studio-design/gesso:^2.0" symfony/http-foundation symfony/http-kernel
 ```
 
 Mix `Studio\Gesso\Symfony\OpenApiAssertions` into a PHPUnit or `WebTestCase` class:

--- a/examples/core/README.md
+++ b/examples/core/README.md
@@ -1,10 +1,7 @@
 # Core quickstart
 
-> **Pre-release evaluation only.** Run this beta in an isolated branch or CI
-> job; Gesso 2 has not reached a stable release.
-
 ```bash
-composer require --dev "studio-design/gesso:^2.0@beta"
+composer require --dev "studio-design/gesso:^2.0"
 composer install
 composer test
 ```

--- a/examples/laravel/README.md
+++ b/examples/laravel/README.md
@@ -1,10 +1,7 @@
 # Laravel quickstart
 
-> **Pre-release evaluation only.** Run this beta in an isolated branch or CI
-> job; Gesso 2 has not reached a stable release.
-
 ```bash
-composer require --dev "studio-design/gesso:^2.0@beta"
+composer require --dev "studio-design/gesso:^2.0"
 php artisan vendor:publish --tag=gesso
 composer install
 composer test

--- a/examples/pest/README.md
+++ b/examples/pest/README.md
@@ -6,9 +6,6 @@ Mirrors the patterns documented in the main README's
 
 ## Run it
 
-> **Pre-release evaluation only.** Run this beta in an isolated branch or CI
-> job; Gesso 2 has not reached a stable release.
-
 ```bash
 cd examples/pest
 composer install
@@ -23,7 +20,7 @@ chaining, and a coverage-tracker smoke assertion.
 
 | Path | Purpose |
 |---|---|
-| `composer.json` | Wires the library via a `path` repository (`../..`). In your real project, replace it with `composer require --dev "studio-design/gesso:^2.0@beta" pestphp/pest`. |
+| `composer.json` | Wires the library via a `path` repository (`../..`). In your real project, replace it with `composer require --dev "studio-design/gesso:^2.0" pestphp/pest`. |
 | `openapi/petstore.json` | Tiny OpenAPI 3.1 spec with three endpoints (`GET /v1/pets`, `POST /v1/pets`, `GET /v1/health`). |
 | `phpunit.xml.dist` | Minimal PHPUnit config that registers `OpenApiCoverageExtension` and points it at `openapi/`. |
 | `tests/TestCase.php` | Base test case extending Orchestra Testbench, mixing in `ValidatesOpenApiSchema`, declaring sample routes, and resetting library state per test. |

--- a/examples/symfony/README.md
+++ b/examples/symfony/README.md
@@ -1,10 +1,7 @@
 # Symfony quickstart
 
-> **Pre-release evaluation only.** Run this beta in an isolated branch or CI
-> job; Gesso 2 has not reached a stable release.
-
 ```bash
-composer require --dev "studio-design/gesso:^2.0@beta" symfony/http-foundation symfony/http-kernel
+composer require --dev "studio-design/gesso:^2.0" symfony/http-foundation symfony/http-kernel
 composer install
 composer test
 ```

--- a/tests/Unit/Build/DocumentationInstallPolicyTest.php
+++ b/tests/Unit/Build/DocumentationInstallPolicyTest.php
@@ -13,7 +13,7 @@ use function file_get_contents;
 final class DocumentationInstallPolicyTest extends TestCase
 {
     #[Test]
-    public function installation_guides_keep_the_beta_constraint_until_stable_is_published(): void
+    public function installation_guides_use_the_stable_v2_constraint(): void
     {
         $root = dirname(__DIR__, 3);
 
@@ -32,19 +32,19 @@ final class DocumentationInstallPolicyTest extends TestCase
             $this->assertIsString($contents);
 
             $this->assertStringContainsString(
-                'studio-design/gesso:^2.0@beta',
+                'studio-design/gesso:^2.0',
                 $contents,
-                $relativePath . ' must keep using the published beta until v2.0.0 stable is installable.',
-            );
-            $this->assertStringContainsString(
-                'Pre-release evaluation only',
-                $contents,
-                $relativePath . ' must retain the prerelease warning until v2.0.0 stable is installable.',
+                $relativePath . ' must use the stable v2 constraint.',
             );
             $this->assertStringNotContainsString(
-                'composer require --dev studio-design/gesso',
+                'studio-design/gesso:^2.0@beta',
                 $contents,
-                $relativePath . ' must not present an unpublished stable release as the current install path.',
+                $relativePath . ' must not opt stable users into beta releases.',
+            );
+            $this->assertStringNotContainsString(
+                'Pre-release evaluation only',
+                $contents,
+                $relativePath . ' must not present v2 as a prerelease.',
             );
         }
 
@@ -52,14 +52,14 @@ final class DocumentationInstallPolicyTest extends TestCase
         $this->assertIsString($homeContents);
 
         $this->assertStringContainsString(
-            'studio-design/gesso:^2.0@beta',
+            'studio-design/gesso:^2.0',
             $homeContents,
-            'The home page must keep using the published beta until v2.0.0 stable is installable.',
+            'The home page must use the stable v2 constraint.',
         );
         $this->assertStringNotContainsString(
-            'composer require --dev studio-design/gesso',
+            'studio-design/gesso:^2.0@beta',
             $homeContents,
-            'The home page must not present an unpublished stable release as the current install path.',
+            'The home page must not opt stable users into beta releases.',
         );
     }
 }


### PR DESCRIPTION
## Summary

- replace the active `^2.0@beta` installation commands with `^2.0`
- remove prerelease-only warnings from the README, documentation quickstarts, and example READMEs
- update the documentation install policy test to reject beta opt-in on stable installation surfaces
- preserve the explicit beta migration example in `docs/migration/v2.md`

## Why

The v2.0.0 release candidate is ready for stable publication. Keeping `@beta`
in the primary installation path would continue to opt users into prerelease
resolution after the stable tag exists and would leave the v2.0.0 tag with
prerelease guidance.

## Impact

New installations use the normal stable Composer constraint. Historical
instructions for explicitly testing a beta remain available in the migration
guide.

## Verification

- stable install guidance policy reproduced with PHP 8.3 across all affected files
- PHP syntax check for `DocumentationInstallPolicyTest.php`
- `git diff --check`
- full PHPUnit, PHP-CS-Fixer, Markdown lint, and documentation build delegated to CI because the existing local vendor requires PHP 8.4.1 while the local CLI is PHP 8.3.31
