### PR TITLE
chore(metadata): name "Gesso" in description and expand keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "studio-design/gesso",
-    "description": "Gesso: framework-agnostic OpenAPI 3.0/3.1/3.2 contract testing for PHPUnit with endpoint coverage tracking",
+    "description": "Gesso — OpenAPI 3.0/3.1/3.2 contract testing for PHP. Framework-independent core with Laravel, Symfony, Pest, and PSR-7 adapters. PHPUnit coverage, request/response validation, fuzzing, and drift detection.",
     "homepage": "https://studio-design.github.io/gesso/",
-    "keywords": ["openapi", "openapi3", "openapi31", "contract-testing", "phpunit", "pest", "laravel", "symfony", "api-testing", "coverage", "fuzzing"],
+    "keywords": ["gesso", "openapi", "openapi3", "openapi31", "contract-testing", "api-testing", "validation", "openapi-validator", "phpunit", "pest", "laravel", "symfony", "psr7", "coverage", "fuzzing"],
     "license": "MIT",
     "type": "library",
     "require": {


### PR DESCRIPTION
Minor metadata polish so external catalogues and Packagist search reliably pick up the "Gesso" brand alongside the package slug.

- `composer.json`: rewrite `description` to lead with "Gesso — …" and expand `keywords` for OpenAPI, contract-testing, and the framework adapters.

No code changes.

### Deviations from the original request

- **`name` left as `studio-design/gesso`.** The request asked to set it back to `studio-design/openapi-contract-testing`, but that is the v1 slug; v2 renamed the package and `composer.json` declares a `conflict` against it. Rewriting `name` would break the published v2 package.
- **`README.md` untouched.** The opening already names Gesso as the product (H1, intro paragraph, and the "Gesso provides …" line), so the requested framing is already present.
- **PR title uses the `chore(metadata)` prefix** rather than a bare `metadata:` prefix, which `.github/workflows/pr-title.yml` would reject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BuVSGJXrzbTE3PhW4WHv68