### PR TITLE
docs: fix Symfony quickstart, trait surface, fuzzing scope, doctor scope

### DIFF
--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -4,6 +4,10 @@
 
 It is not a replacement for a semantic or style linter such as Spectral or Redocly.
 
+## Scope
+
+`gesso doctor` is a preflight for a local OpenAPI file. It confirms Gesso can load and enforce the document — version and dialect, references, warned-about keywords, structurally valid operations — and exits non-zero when it can't. It does not fetch a deployed spec URL, and it does not compare the checked-in spec against what a running service returns. `--allow-remote-refs` only covers `$ref` targets from the local entry document.
+
 ## Basic usage
 
 ```bash

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -1,7 +1,10 @@
 # Schema-driven request fuzzing
 
-The `ExploresOpenApiEndpoint` trait generates deterministic request inputs for
-one operation or a filtered whole spec. Its workflow is inspired by
+The `ExploresOpenApiEndpoint` trait ships for Laravel only. It generates
+deterministic request inputs for one operation or a filtered whole spec. Symfony,
+Pest, and plain PHPUnit users call the framework-agnostic
+[`OpenApiSpecExplorer::explore()`](#framework-agnostic-exploration) instead. The
+workflow is inspired by
 [Schemathesis][schemathesis], but the supported strategy matrix below is the
 contract; this package does not claim feature parity.
 
@@ -87,11 +90,26 @@ class ApiContractTest extends TestCase
 }
 ```
 
-Framework-agnostic code starts with
-`OpenApiSpecExplorer::explore('front', casesPerOperation: 20, seed: 1)` and
-adds `assertResponseUsing()` to validate whatever the dispatcher returns. The
-runnable [`examples/psr7`](https://github.com/studio-design/gesso/tree/main/examples/psr7) suite demonstrates this with
-`OpenApiPsr7Validator` assertions.
+### Framework-agnostic exploration
+
+`ExploresOpenApiEndpoint` is Laravel-only; there is no Symfony equivalent.
+Symfony, Pest, and plain PHPUnit users call `OpenApiSpecExplorer::explore()`
+directly. It returns the same filter/hook builder, so everything below applies
+unchanged:
+
+```php
+use Studio\Gesso\Fuzz\ExploredCase;
+use Studio\Gesso\Fuzz\OpenApiSpecExplorer;
+
+$summary = OpenApiSpecExplorer::explore('petstore', casesPerOperation: 20, seed: 7)
+    ->dispatchUsing(fn (ExploredCase $case) => $this->sendRequest($case))
+    ->assertResponseUsing(fn (mixed $exchange) => $this->assertExchangeIsValid($exchange));
+```
+
+`dispatchUsing()` returns whatever your client produces and
+`assertResponseUsing()` validates it. The runnable
+[`examples/psr7`](https://github.com/studio-design/gesso/tree/main/examples/psr7)
+suite demonstrates this with `OpenApiPsr7Validator` assertions.
 
 ### Filters and hooks
 

--- a/docs/quickstarts/symfony.md
+++ b/docs/quickstarts/symfony.md
@@ -4,16 +4,49 @@
 composer require --dev "studio-design/gesso:^2.0" symfony/http-foundation symfony/http-kernel
 ```
 
-Mix `Studio\Gesso\Symfony\OpenApiAssertions` into a PHPUnit or `WebTestCase` class:
+Register the extension in `phpunit.xml`. Gesso finds spec files through the
+PHPUnit extension, not a Symfony bundle:
+
+```xml
+<extensions>
+    <bootstrap class="Studio\Gesso\PHPUnit\OpenApiCoverageExtension">
+        <parameter name="spec_base_path" value="openapi"/>
+        <parameter name="specs" value="petstore"/>
+    </bootstrap>
+</extensions>
+```
+
+Mix `Studio\Gesso\Symfony\OpenApiAssertions` into a PHPUnit or `WebTestCase`
+class and name the spec with `#[OpenApiSpec]` (or override `openApiSpec()`):
 
 ```php
-$request = Request::create('/pets', 'GET');
-$response = new Response('[{"id":1,"name":"Fido"}]', 200, [
-    'Content-Type' => 'application/json',
-]);
+use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Attribute\OpenApiSpec;
+use Studio\Gesso\Symfony\OpenApiAssertions;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
-$this->assertResponseMatchesOpenApiSchema($request, $response);
+#[OpenApiSpec('petstore')]
+class PetsApiTest extends TestCase
+{
+    use OpenApiAssertions;
+
+    public function test_pets_index(): void
+    {
+        $request = Request::create('/pets', 'GET');
+        $response = new Response('[{"id":1,"name":"Fido"}]', 200, [
+            'Content-Type' => 'application/json',
+        ]);
+
+        $this->assertResponseMatchesOpenApiSchema($request, $response);
+    }
+}
 ```
+
+The trait adds three assertions: `assertResponseMatchesOpenApiSchema($request, $response)`,
+`assertRequestMatchesOpenApiSchema($request)`, and
+`assertClientMatchesOpenApiSchema($client)`, which runs both against the last
+client call.
 
 Run the CI-tested [`examples/symfony`](https://github.com/studio-design/gesso/tree/main/examples/symfony) fixture:
 


### PR DESCRIPTION
Four docs corrections surfaced while code-verifying an external Symfony tutorial. Each was cross-checked against the source; no code changes.

### 1. Symfony quickstart snippet did not run
The quickstart used `OpenApiAssertions` without `#[OpenApiSpec]` and without registering `OpenApiCoverageExtension` in `phpunit.xml`, so every assertion failed at `src/Symfony/OpenApiAssertions.php:305` (`resolveSymfonyOpenApiSpec()` calls `failOpenApi()` on an empty spec name). Added the attribute plus a minimal `phpunit.xml` block matching `examples/symfony/phpunit.xml.dist`.

The snippet is now a complete class mirroring `examples/symfony/tests/PetContractTest.php`, including the `Request`/`Response` imports. It extends `TestCase` rather than `WebTestCase` so the copy-pasted code works with the `composer require` line directly above it (which installs `symfony/http-foundation` and `symfony/http-kernel`, not `symfony/framework-bundle`); the `WebTestCase`/`KernelBrowser` path stays documented in the closing paragraph.

### 2. Quickstart named only 2 of 3 trait assertions
Added `assertRequestMatchesOpenApiSchema` alongside the response and client assertions (`src/Symfony/OpenApiAssertions.php:102`, `:179`, `:235`).

### 3. Fuzzing docs implied a Symfony trait
`ExploresOpenApiEndpoint` is Laravel-only (`src/Laravel/ExploresOpenApiEndpoint.php`; there is no `src/Symfony/` equivalent). Clarified this in the opening paragraph and promoted the framework-agnostic path to its own `### Framework-agnostic exploration` subsection with a runnable snippet modelled on `examples/psr7/tests/PetContractTest.php:44`.

### 4. Doctor docs suggested a spec-URL / drift mode
Doctor is a local-file preflight per `src/Cli/DoctorCommand.php:177-206`; it has no live-spec mode. Added a Scope paragraph so readers stop assuming otherwise.

### Verification
`npm run docs:build` passes, which exercises VitePress dead-link checking and confirms the new `#framework-agnostic-exploration` anchor resolves. No PHP sources changed, so `composer ci` is unaffected; the `MarkdownCoverageRendererLintTest` CI job lints generated coverage-renderer output and does not read `docs/`.
