### PR TITLE
docs: add /llms.txt and JSON-LD schema for AI discoverability

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -8,6 +8,30 @@ const repositoryUrl = `https://github.com/${repository}`
 const siteUrl = new URL(base, 'https://studio-design.github.io').toString()
 const socialPreviewUrl = new URL('gesso-social-preview.png', siteUrl).toString()
 
+// Anchors "Gesso" as a named software entity for engines that resolve entities
+// from JSON-LD, and disambiguates the package from the art-primer term.
+const homeStructuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'Gesso',
+  alternateName: repository,
+  description:
+    'OpenAPI 3.0/3.1/3.2 contract testing for PHP. Framework-independent core with Laravel, Symfony, Pest, and PSR-7 adapters. PHPUnit coverage, request/response validation, fuzzing, and drift detection.',
+  applicationCategory: 'DeveloperApplication',
+  operatingSystem: 'PHP 8.3+',
+  url: siteUrl,
+  codeRepository: repositoryUrl,
+  programmingLanguage: 'PHP',
+  license: 'https://opensource.org/licenses/MIT',
+  // Only tagged documentation builds know a published version; `next` does not.
+  ...(version.startsWith('v') ? { softwareVersion: version.slice(1) } : {}),
+  offers: {
+    '@type': 'Offer',
+    price: '0',
+    priceCurrency: 'USD'
+  }
+}
+
 export default defineConfig({
   title: 'Gesso',
   description: 'OpenAPI contract testing for PHP',
@@ -32,6 +56,29 @@ export default defineConfig({
   ],
   cleanUrls: true,
   lastUpdated: true,
+  transformPageData(pageData) {
+    if (pageData.relativePath !== 'index.md') {
+      return
+    }
+
+    const head = (pageData.frontmatter.head ??= [])
+    const isStructuredData = (entry: unknown[]) =>
+      entry[0] === 'script' &&
+      typeof entry[1] === 'object' &&
+      entry[1] !== null &&
+      (entry[1] as Record<string, string>).type === 'application/ld+json'
+
+    // `transformPageData` re-runs on hot reload; keep exactly one block.
+    if (head.some(isStructuredData)) {
+      return
+    }
+
+    head.push([
+      'script',
+      { type: 'application/ld+json' },
+      JSON.stringify(homeStructuredData)
+    ])
+  },
   sitemap: { hostname: siteUrl },
   vite: { define: { __DOCS_VERSION__: JSON.stringify(version) } },
   markdown: {

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,0 +1,43 @@
+# Gesso
+
+> Gesso provides framework-agnostic OpenAPI 3.0/3.1/3.2 contract testing for PHPUnit with endpoint coverage tracking.
+
+## Get started
+
+- [Overview](https://studio-design.github.io/gesso/): what Gesso is, what it validates, and how coverage tracking works.
+- [Core / PHPUnit](https://studio-design.github.io/gesso/quickstarts/core): validate a response with plain PHPUnit, no framework adapter.
+- [Laravel](https://studio-design.github.io/gesso/quickstarts/laravel): publish the config and assert responses with the `ValidatesOpenApiSchema` trait.
+- [Symfony](https://studio-design.github.io/gesso/quickstarts/symfony): register the PHPUnit extension and assert `WebTestCase` responses against a spec.
+- [Pest](https://studio-design.github.io/gesso/quickstarts/pest): use the `toMatchOpenApiResponseSchema()` expectation registered by the Pest plugin.
+
+## Guides
+
+- [Doctor command](https://studio-design.github.io/gesso/doctor): preflight a local spec for load and enforcement problems before tests run.
+- [PSR-7 validation](https://studio-design.github.io/gesso/psr7): validate PSR-7 requests and responses from any HTTP client or middleware.
+- [Laravel route parity](https://studio-design.github.io/gesso/laravel-route-parity): compare registered Laravel routes with spec operations to catch undocumented drift.
+- [Schema-driven fuzzing](https://studio-design.github.io/gesso/fuzzing): generate deterministic valid and invalid request cases from schemas, with replay tokens.
+- [Symfony contract testing](https://studio-design.github.io/gesso/contract-testing-symfony): full guide to spec-driven provider-side contract testing in a Symfony application.
+
+## Recipes
+
+- [GitHub Actions](https://studio-design.github.io/gesso/recipes/github-actions): publish the coverage report as a Step Summary and workflow artifact.
+- [Fuzzing and drift checks](https://studio-design.github.io/gesso/recipes/advanced-validation): wire fuzzing, enum drift, and strict-required detection into CI jobs.
+- [Parallel test runners](https://studio-design.github.io/gesso/parallel): merge per-worker coverage sidecars from paratest or `pest --parallel`.
+
+## Migration
+
+- [Prepare for Gesso 2.0](https://studio-design.github.io/gesso/migration/v2): staged path for the package rename and PHP namespace change.
+- [From other validators](https://studio-design.github.io/gesso/migration/from-other-validators): incremental migration from Spectator, league/openapi-psr7-validator, and osteel.
+
+## Reference
+
+- [Setup](https://studio-design.github.io/gesso/setup): end-to-end configuration, extension parameters, auto-validation, and per-test opt-out mechanisms.
+- [Coverage](https://studio-design.github.io/gesso/coverage): report formats, endpoint markers, and `(method, path, status, content-type)` coverage granularity.
+- [Supported features](https://studio-design.github.io/gesso/supported-features): what is validated, what is skipped, and known limitations per OpenAPI version.
+- [API reference](https://studio-design.github.io/gesso/api-reference): public classes — validators, spec loader, explorer, and coverage tracker.
+- [Versioning](https://studio-design.github.io/gesso/versioning): the v1.x compatibility policy and which symbols and formats it covers.
+
+## Optional
+
+- [Source](https://github.com/studio-design/gesso)
+- [Packagist](https://packagist.org/packages/studio-design/gesso)


### PR DESCRIPTION
Two small additions aimed at machine consumers of the docs.

### 1. `/llms.txt`

Serves a curated markdown index of the docs at `https://studio-design.github.io/gesso/llms.txt`, following the [llms.txt convention](https://llmstxt.org/). Entries are grouped by the same sections the VitePress sidebar uses, and each carries a short description a consumer can use to pick the right page without fetching the whole site.

**Please read the limits below before weighing the value of this file.** They are stated up front so the file is judged for what it actually does.

- **This PR does not claim a search or citation benefit.** No major AI crawler is publicly known to consume `llms.txt` today. Google's Search team has said it neither uses nor endorses the file, and a ~300k-domain study found no correlation between having one and being cited in AI answers — the file was noise in their model, not signal.
- **The realistic benefit is narrower**: coding agents and doc-fetching tools that are already pointed at this site get a cheap table of contents instead of crawling every page to find the right one. That audience is real — in a ~137k-domain study, the most frequent named AI bot fetching `llms.txt` was Claude-Code.
- **Discovery is by link, not by convention.** The same study found *zero* speculative 404s against sites without the file: AI bots do not probe for `/llms.txt`, they fetch it when a user hands them the URL. So the file's reach depends on us linking to it, not on where it sits.
- **Subpath note.** Because these docs are a GitHub Pages *project* site, the file lives at `/gesso/llms.txt` rather than the origin root. The spec explicitly permits this ("or, optionally, in a subpath"), and given the point above the practical cost is small. It does mean consumers that hardcode `/llms.txt` will not see it — including Chrome Lighthouse's `llms-txt` audit, whose gatherer resolves `new URL('/llms.txt', finalDisplayedUrl)`. Serving it where Lighthouse looks would require publishing from `studio-design.github.io` itself, which is outside this repository's control.
- **Entries link to rendered HTML pages.** The sites that get the most out of `llms.txt` (Stripe, Bun, Anthropic) also serve a raw `.md` for every page, and that is the part that actually saves an agent work — one set of server logs has Claude Code retrieving 76% of pages as Markdown. Doing that requires a build step that emits Markdown alongside the HTML, which is out of scope for a PR that only adds docs content; it is tracked in #398.

The file is 3.4 KB and adds no dependencies. It satisfies Lighthouse's pass conditions for the audit (an H1, at least one markdown link, more than 50 bytes) for any consumer that does find it.

### 2. JSON-LD `SoftwareApplication` on the homepage

Adds a single `application/ld+json` block to the docs homepage `<head>`, describing the package with its canonical URL, repository, license, language, and PHP floor. This is plain schema.org markup that makes the homepage self-describing to anything that reads structured data, and it disambiguates the name from the art-primer term. No specific ranking or citation effect is claimed for it either.

Implementation notes:

- Injected via `transformPageData`, scoped to `index.md`, so exactly one block ships and only on the homepage.
- URLs reuse the existing env-derived `siteUrl` / `repositoryUrl` values rather than hardcoding, so `DOCS_BASE` and `GITHUB_REPOSITORY` overrides keep working the way `verify-docs-base.mjs` expects.
- `softwareVersion` is emitted only for tagged documentation builds, since untagged builds have no published version to report.

### Verification

No content pages changed. Run locally:

- `npm run docs:build` passes.
- `docs/.vitepress/dist/llms.txt` is present, and `curl -sI` against `vitepress preview` returns `200` with `Content-Type: text/plain`, served verbatim.
- All 20 internal URLs in `llms.txt` resolve to pages that exist in the build output.
- `dist/index.html` contains exactly one `application/ld+json` block, no other built page contains one, and the JSON parses cleanly.
- `docs:verify-accessibility`, `docs:verify-base`, and `docs:verify-tombo` all pass.
- A `DOCS_VERSION=v2.0.0-beta.5` build was checked separately to confirm `softwareVersion` appears only there.
