### PR TITLE
feat(dx): append curl reproduction commands to validation and exploration failures

### DIFF
--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -145,7 +145,10 @@ assertion failure prints the spec, operation ID, method/path, both seeds, case
 index, and a minimal `OpenApiEndpointExplorer::explore(...)` replay expression.
 Each case also exposes `replayToken()`, `replaySnippet($specName)`, and
 `curlSnippet($baseUrl)`. The token identifies generation inputs; the PHP and
-curl output include the concrete generated request.
+curl output include the concrete generated request. `curlSnippet()` redacts
+sensitive header values (`Authorization`, `Cookie`, API-key/token/secret-style
+names) as `<redacted>` so the command is safe to paste into CI logs; pass
+`redactSensitiveHeaders: false` to keep the raw values.
 
 Summaries are local immutable values; the explorer adds no process-global
 aggregation. Run one plan per parallel worker partition and use the existing

--- a/src/Fuzz/ExploredCase.php
+++ b/src/Fuzz/ExploredCase.php
@@ -10,10 +10,10 @@ use InvalidArgumentException;
 use JsonException;
 use LogicException;
 use Studio\Gesso\HttpMethod;
+use Studio\Gesso\Internal\CurlCommandFormatter;
 
 use function array_map;
 use function base64_encode;
-use function escapeshellarg;
 use function http_build_query;
 use function implode;
 use function is_array;
@@ -174,17 +174,23 @@ final readonly class ExploredCase
         );
     }
 
-    public function curlSnippet(string $baseUrl = ''): string
+    public function curlSnippet(string $baseUrl = '', bool $redactSensitiveHeaders = true): string
     {
-        $command = sprintf('curl -X %s %s', $this->method->value, escapeshellarg($this->uri($baseUrl)));
-        foreach ($this->headers as $name => $value) {
-            $command .= ' -H ' . escapeshellarg($name . ': ' . (string) $value);
-        }
+        $headers = $this->headers;
+        $body = null;
         if ($this->body !== null) {
-            $command .= " -H 'Content-Type: application/json' --data " . escapeshellarg((string) json_encode($this->body));
+            $headers['Content-Type'] = 'application/json';
+            $body = (string) json_encode($this->body);
         }
 
-        return $command;
+        return CurlCommandFormatter::format(
+            $this->method->value,
+            $this->uri($baseUrl),
+            $headers,
+            $body,
+            $body !== null ? 'application/json' : null,
+            $redactSensitiveHeaders,
+        );
     }
 
     private static function serialiseParameterValue(mixed $value): mixed

--- a/src/Fuzz/OpenApiSpecExploration.php
+++ b/src/Fuzz/OpenApiSpecExploration.php
@@ -468,7 +468,7 @@ final class OpenApiSpecExploration
     private function caseFailureMessage(ExploredOperation $operation, ExploredCase $case, int $caseIndex): string
     {
         return sprintf(
-            "Whole-spec exploration failed.\nSpec: %s\nOperation: %s\nMethod/path: %s %s\nGlobal seed: %d\nOperation seed: %d\nCase: %d\nReplay: %s",
+            "Whole-spec exploration failed.\nSpec: %s\nOperation: %s\nMethod/path: %s %s\nGlobal seed: %d\nOperation seed: %d\nCase: %d\nReplay: %s\nCurl: %s",
             $operation->specName,
             $operation->operationId ?? '(none)',
             $operation->method,
@@ -477,6 +477,7 @@ final class OpenApiSpecExploration
             $operation->seed,
             $caseIndex,
             $case->replaySnippet($operation->specName),
+            $case->curlSnippet(),
         );
     }
 

--- a/src/Internal/CurlCommandFormatter.php
+++ b/src/Internal/CurlCommandFormatter.php
@@ -4,16 +4,21 @@ declare(strict_types=1);
 
 namespace Studio\Gesso\Internal;
 
+use function count;
 use function escapeshellarg;
 use function explode;
+use function implode;
 use function in_array;
 use function is_array;
 use function is_scalar;
 use function preg_match;
+use function rawurldecode;
 use function sprintf;
 use function str_ends_with;
 use function str_replace;
+use function strpos;
 use function strtolower;
+use function substr;
 use function trim;
 
 /**
@@ -41,11 +46,14 @@ final class CurlCommandFormatter
         ?string $contentType,
         bool $redact = true,
     ): string {
+        if ($redact) {
+            $uri = self::redactQueryValues($uri);
+        }
         $command = sprintf('curl -X %s %s', $method, escapeshellarg($uri));
 
         foreach ($headers as $name => $value) {
             foreach (is_array($value) ? $value : [$value] as $single) {
-                $rendered = $redact && self::isSensitiveHeader($name)
+                $rendered = $redact && self::isSensitiveName($name)
                     ? self::REDACTED_PLACEHOLDER
                     : (is_scalar($single) ? (string) $single : '');
                 $command .= ' -H ' . escapeshellarg($name . ': ' . $rendered);
@@ -59,7 +67,34 @@ final class CurlCommandFormatter
         return str_replace(["\r", "\n"], ' ', $command);
     }
 
-    private static function isSensitiveHeader(string $name): bool
+    /**
+     * OpenAPI supports `apiKey` security in query parameters, so query values
+     * whose (URL-decoded) names match the sensitive-name pattern must not
+     * reach CI logs either. Pair order and encoding of names are preserved;
+     * valueless pairs have nothing to redact.
+     */
+    private static function redactQueryValues(string $uri): string
+    {
+        $queryStart = strpos($uri, '?');
+        if ($queryStart === false) {
+            return $uri;
+        }
+
+        $pairs = explode('&', substr($uri, $queryStart + 1));
+        foreach ($pairs as $index => $pair) {
+            $parts = explode('=', $pair, 2);
+            if (count($parts) !== 2) {
+                continue;
+            }
+            if (self::isSensitiveName(rawurldecode($parts[0]))) {
+                $pairs[$index] = $parts[0] . '=' . self::REDACTED_PLACEHOLDER;
+            }
+        }
+
+        return substr($uri, 0, $queryStart) . '?' . implode('&', $pairs);
+    }
+
+    private static function isSensitiveName(string $name): bool
     {
         return in_array(strtolower($name), self::SENSITIVE_HEADER_NAMES, true) ||
             preg_match(self::SENSITIVE_NAME_PATTERN, $name) === 1;

--- a/src/Internal/CurlCommandFormatter.php
+++ b/src/Internal/CurlCommandFormatter.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Internal;
+
+use function escapeshellarg;
+use function explode;
+use function in_array;
+use function is_array;
+use function is_scalar;
+use function preg_match;
+use function sprintf;
+use function str_ends_with;
+use function str_replace;
+use function strtolower;
+use function trim;
+
+/**
+ * Renders a one-line curl command that reproduces an HTTP request, with
+ * sensitive header values redacted by default so the command stays safe to
+ * print into CI logs and test failure output.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+final class CurlCommandFormatter
+{
+    private const REDACTED_PLACEHOLDER = '<redacted>';
+    private const SENSITIVE_HEADER_NAMES = ['authorization', 'proxy-authorization', 'cookie'];
+    private const SENSITIVE_NAME_PATTERN = '/api[-_]?key|token|secret/i';
+
+    /**
+     * @param array<string, mixed> $headers header name → scalar value or list of values
+     * @param ?string $body raw request body; rendered only for JSON content types
+     */
+    public static function format(
+        string $method,
+        string $uri,
+        array $headers,
+        ?string $body,
+        ?string $contentType,
+        bool $redact = true,
+    ): string {
+        $command = sprintf('curl -X %s %s', $method, escapeshellarg($uri));
+
+        foreach ($headers as $name => $value) {
+            foreach (is_array($value) ? $value : [$value] as $single) {
+                $rendered = $redact && self::isSensitiveHeader($name)
+                    ? self::REDACTED_PLACEHOLDER
+                    : (is_scalar($single) ? (string) $single : '');
+                $command .= ' -H ' . escapeshellarg($name . ': ' . $rendered);
+            }
+        }
+
+        if ($body !== null && $body !== '' && $contentType !== null && self::isJsonContentType($contentType)) {
+            $command .= ' --data ' . escapeshellarg($body);
+        }
+
+        return str_replace(["\r", "\n"], ' ', $command);
+    }
+
+    private static function isSensitiveHeader(string $name): bool
+    {
+        return in_array(strtolower($name), self::SENSITIVE_HEADER_NAMES, true) ||
+            preg_match(self::SENSITIVE_NAME_PATTERN, $name) === 1;
+    }
+
+    private static function isJsonContentType(string $contentType): bool
+    {
+        $mime = strtolower(trim(explode(';', $contentType, 2)[0]));
+
+        return $mime === 'application/json' || str_ends_with($mime, '+json');
+    }
+}

--- a/src/Internal/CurlCommandFormatter.php
+++ b/src/Internal/CurlCommandFormatter.php
@@ -49,7 +49,11 @@ final class CurlCommandFormatter
         if ($redact) {
             $uri = self::redactQueryValues($uri);
         }
-        $command = sprintf('curl -X %s %s', $method, escapeshellarg($uri));
+        // OpenAPI 3.2 additionalOperations allow arbitrary custom method
+        // strings, so anything beyond plain token characters must be quoted
+        // or a crafted method becomes an injected shell command on paste.
+        $safeMethod = preg_match('/^[A-Za-z0-9-]+$/', $method) === 1 ? $method : escapeshellarg($method);
+        $command = sprintf('curl -X %s %s', $safeMethod, escapeshellarg($uri));
 
         foreach ($headers as $name => $value) {
             foreach (is_array($value) ? $value : [$value] as $single) {

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -43,9 +43,11 @@ use function filter_var;
 use function function_exists;
 use function fwrite;
 use function get_debug_type;
+use function implode;
 use function is_array;
 use function is_int;
 use function is_numeric;
+use function is_scalar;
 use function is_string;
 use function json_decode;
 use function sprintf;
@@ -777,10 +779,23 @@ trait ValidatesOpenApiSchema
     {
         $body = $request->getContent();
 
+        // Cookies live in Request::$cookies, not the header bag, so a Cookie
+        // header has to be synthesized or cookie-based auth and cookie
+        // parameters would silently vanish from the curl command. The
+        // formatter redacts the value.
+        $headers = $request->headers->all();
+        $cookiePairs = [];
+        foreach ($request->cookies->all() as $name => $value) {
+            $cookiePairs[] = $name . '=' . (is_scalar($value) ? (string) $value : '');
+        }
+        if ($cookiePairs !== []) {
+            $headers['cookie'] = [implode('; ', $cookiePairs)];
+        }
+
         return CurlCommandFormatter::format(
             $request->getMethod(),
             $request->getUri(),
-            $request->headers->all(),
+            $headers,
             $body !== '' ? $body : null,
             $request->headers->get('Content-Type'),
         );

--- a/src/Laravel/ValidatesOpenApiSchema.php
+++ b/src/Laravel/ValidatesOpenApiSchema.php
@@ -20,6 +20,7 @@ use Studio\Gesso\Attribute\SkipOpenApi;
 use Studio\Gesso\Coverage\OpenApiCoverageTracker;
 use Studio\Gesso\DecodedBody;
 use Studio\Gesso\HttpMethod;
+use Studio\Gesso\Internal\CurlCommandFormatter;
 use Studio\Gesso\Internal\StackTraceFilter;
 use Studio\Gesso\OpenApiRequestValidator;
 use Studio\Gesso\OpenApiResponseValidator;
@@ -39,6 +40,7 @@ use WeakMap;
 use function array_key_first;
 use function array_merge;
 use function filter_var;
+use function function_exists;
 use function fwrite;
 use function get_debug_type;
 use function is_array;
@@ -575,7 +577,8 @@ trait ValidatesOpenApiSchema
         $this->assertOpenApi(
             $result->isValid(),
             "OpenAPI schema validation failed for {$resolvedMethod} {$resolvedPath} (spec: {$specName}):\n"
-            . $result->errorMessage(),
+            . $result->errorMessage()
+            . "\nReproduce: " . $this->responseReproduceCommand($resolvedMethod, $resolvedPath),
         );
     }
 
@@ -743,7 +746,43 @@ trait ValidatesOpenApiSchema
         $this->assertOpenApi(
             $result->isValid(),
             "OpenAPI request validation failed for {$resolvedMethod} {$resolvedPath} (spec: {$specName}):\n"
-            . $result->errorMessage(),
+            . $result->errorMessage()
+            . "\nReproduce: " . $this->requestReproduceCommand($request),
+        );
+    }
+
+    /**
+     * A full curl line is only possible when the container still holds the
+     * request that produced the response; the bound request is used only when
+     * its identity matches the resolved method/path, so an explicit assert
+     * against an unrelated response never renders a misleading command.
+     */
+    private function responseReproduceCommand(string $resolvedMethod, string $resolvedPath): string
+    {
+        if (function_exists('app') && app()->bound('request')) {
+            $request = app('request');
+            if (
+                $request instanceof Request &&
+                strtoupper($request->getMethod()) === $resolvedMethod &&
+                $request->getPathInfo() === $resolvedPath
+            ) {
+                return $this->requestReproduceCommand($request);
+            }
+        }
+
+        return CurlCommandFormatter::format($resolvedMethod, $resolvedPath, [], null, null);
+    }
+
+    private function requestReproduceCommand(Request $request): string
+    {
+        $body = $request->getContent();
+
+        return CurlCommandFormatter::format(
+            $request->getMethod(),
+            $request->getUri(),
+            $request->headers->all(),
+            $body !== '' ? $body : null,
+            $request->headers->get('Content-Type'),
         );
     }
 

--- a/src/Psr7/OpenApiAssertions.php
+++ b/src/Psr7/OpenApiAssertions.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\AssertionFailedError;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Studio\Gesso\Internal\CurlCommandFormatter;
 use Studio\Gesso\Internal\StackTraceFilter;
 use Studio\Gesso\OpenApiRequestValidator;
 use Studio\Gesso\OpenApiResponseValidator;
@@ -41,6 +42,7 @@ trait OpenApiAssertions
                 $request->getMethod(),
                 $request->getUri()->getPath() ?: '/',
             ),
+            $this->psr7ReproduceCommand($request),
         );
     }
 
@@ -57,6 +59,7 @@ trait OpenApiAssertions
                 $request->getMethod(),
                 $request->getUri()->getPath() ?: '/',
             ),
+            $this->psr7ReproduceCommand($request),
         );
     }
 
@@ -70,6 +73,7 @@ trait OpenApiAssertions
         $this->assertPsr7Result(
             $result,
             sprintf('OpenAPI PSR-7 response validation failed for %s %s', $method, $requestPath),
+            CurlCommandFormatter::format($method, $requestPath, [], null, null),
         );
     }
 
@@ -82,11 +86,12 @@ trait OpenApiAssertions
         $this->assertPsr7(
             $result->isValid(),
             sprintf(
-                "OpenAPI PSR-7 exchange validation failed for %s %s (spec: %s):\n%s",
+                "OpenAPI PSR-7 exchange validation failed for %s %s (spec: %s):\n%s\nReproduce: %s",
                 $request->getMethod(),
                 $request->getUri()->getPath() ?: '/',
                 $this->cachedPsr7SpecName,
                 $result->errorMessage(),
+                $this->psr7ReproduceCommand($request),
             ),
         );
     }
@@ -142,11 +147,36 @@ trait OpenApiAssertions
         return $this->cachedPsr7Validator;
     }
 
-    private function assertPsr7Result(OpenApiValidationResult $result, string $prefix): void
+    private function assertPsr7Result(OpenApiValidationResult $result, string $prefix, string $reproduceCommand): void
     {
         $this->assertPsr7(
             $result->isValid(),
-            sprintf("%s (spec: %s):\n%s", $prefix, $this->cachedPsr7SpecName, $result->errorMessage()),
+            sprintf(
+                "%s (spec: %s):\n%s\nReproduce: %s",
+                $prefix,
+                $this->cachedPsr7SpecName,
+                $result->errorMessage(),
+                $reproduceCommand,
+            ),
+        );
+    }
+
+    private function psr7ReproduceCommand(RequestInterface $request): string
+    {
+        $body = null;
+        $stream = $request->getBody();
+        if ($stream->isSeekable()) {
+            $stream->rewind();
+            $body = $stream->getContents();
+            $stream->rewind();
+        }
+
+        return CurlCommandFormatter::format(
+            $request->getMethod(),
+            (string) $request->getUri(),
+            $request->getHeaders(),
+            $body,
+            $request->getHeaderLine('Content-Type') ?: null,
         );
     }
 

--- a/src/Psr7/OpenApiAssertions.php
+++ b/src/Psr7/OpenApiAssertions.php
@@ -175,15 +175,25 @@ trait OpenApiAssertions
         $body = null;
         $stream = $request->getBody();
         if ($stream->isSeekable()) {
+            $position = null;
+
             try {
                 $position = $stream->tell();
                 $stream->rewind();
                 $body = $stream->getContents();
-                $stream->seek($position);
             } catch (Throwable) {
-                // An unreadable or unrestorable stream must not replace the
-                // real validation failure; degrade to a body-less command.
+                // An unreadable stream must not replace the real validation
+                // failure; degrade to a body-less command.
                 $body = null;
+            } finally {
+                if ($position !== null) {
+                    try {
+                        $stream->seek($position);
+                    } catch (Throwable) {
+                        // Restoring the cursor is best-effort; the command
+                        // must still render.
+                    }
+                }
             }
         }
 

--- a/src/Psr7/OpenApiAssertions.php
+++ b/src/Psr7/OpenApiAssertions.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Studio\Gesso\Psr7;
 
+use Closure;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\AssertionFailedError;
 use Psr\Http\Message\RequestInterface;
@@ -14,6 +15,7 @@ use Studio\Gesso\OpenApiRequestValidator;
 use Studio\Gesso\OpenApiResponseValidator;
 use Studio\Gesso\OpenApiValidationResult;
 use Studio\Gesso\Spec\OpenApiSpecResolver;
+use Throwable;
 
 use function sprintf;
 
@@ -42,7 +44,7 @@ trait OpenApiAssertions
                 $request->getMethod(),
                 $request->getUri()->getPath() ?: '/',
             ),
-            $this->psr7ReproduceCommand($request),
+            fn(): string => $this->psr7ReproduceCommand($request),
         );
     }
 
@@ -59,7 +61,7 @@ trait OpenApiAssertions
                 $request->getMethod(),
                 $request->getUri()->getPath() ?: '/',
             ),
-            $this->psr7ReproduceCommand($request),
+            fn(): string => $this->psr7ReproduceCommand($request),
         );
     }
 
@@ -73,7 +75,7 @@ trait OpenApiAssertions
         $this->assertPsr7Result(
             $result,
             sprintf('OpenAPI PSR-7 response validation failed for %s %s', $method, $requestPath),
-            CurlCommandFormatter::format($method, $requestPath, [], null, null),
+            static fn(): string => CurlCommandFormatter::format($method, $requestPath, [], null, null),
         );
     }
 
@@ -85,7 +87,7 @@ trait OpenApiAssertions
 
         $this->assertPsr7(
             $result->isValid(),
-            sprintf(
+            $result->isValid() ? '' : sprintf(
                 "OpenAPI PSR-7 exchange validation failed for %s %s (spec: %s):\n%s\nReproduce: %s",
                 $request->getMethod(),
                 $request->getUri()->getPath() ?: '/',
@@ -147,16 +149,23 @@ trait OpenApiAssertions
         return $this->cachedPsr7Validator;
     }
 
-    private function assertPsr7Result(OpenApiValidationResult $result, string $prefix, string $reproduceCommand): void
+    /**
+     * The reproduce command is a closure so the request body stream is only
+     * touched when the assertion actually fails; a passing assertion must not
+     * observe or move the caller's stream cursor.
+     *
+     * @param Closure(): string $reproduceCommand
+     */
+    private function assertPsr7Result(OpenApiValidationResult $result, string $prefix, Closure $reproduceCommand): void
     {
         $this->assertPsr7(
             $result->isValid(),
-            sprintf(
+            $result->isValid() ? '' : sprintf(
                 "%s (spec: %s):\n%s\nReproduce: %s",
                 $prefix,
                 $this->cachedPsr7SpecName,
                 $result->errorMessage(),
-                $reproduceCommand,
+                $reproduceCommand(),
             ),
         );
     }
@@ -166,9 +175,16 @@ trait OpenApiAssertions
         $body = null;
         $stream = $request->getBody();
         if ($stream->isSeekable()) {
-            $stream->rewind();
-            $body = $stream->getContents();
-            $stream->rewind();
+            try {
+                $position = $stream->tell();
+                $stream->rewind();
+                $body = $stream->getContents();
+                $stream->seek($position);
+            } catch (Throwable) {
+                // An unreadable or unrestorable stream must not replace the
+                // real validation failure; degrade to a body-less command.
+                $body = null;
+            }
         }
 
         return CurlCommandFormatter::format(

--- a/src/Symfony/OpenApiAssertions.php
+++ b/src/Symfony/OpenApiAssertions.php
@@ -26,6 +26,8 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelBrowser;
 
 use function array_merge;
+use function implode;
+use function is_scalar;
 use function json_decode;
 use function sprintf;
 use function strtolower;
@@ -306,10 +308,23 @@ trait OpenApiAssertions
     {
         $body = $request->getContent();
 
+        // Symfony keeps cookies in Request::$cookies, not in the header bag,
+        // so a Cookie header has to be synthesized or cookie-based auth and
+        // cookie parameters would silently vanish from the curl command. The
+        // formatter redacts the value.
+        $headers = $request->headers->all();
+        $cookiePairs = [];
+        foreach ($request->cookies->all() as $name => $value) {
+            $cookiePairs[] = $name . '=' . (is_scalar($value) ? (string) $value : '');
+        }
+        if ($cookiePairs !== []) {
+            $headers['cookie'] = [implode('; ', $cookiePairs)];
+        }
+
         return CurlCommandFormatter::format(
             $request->getMethod(),
             $request->getUri(),
-            $request->headers->all(),
+            $headers,
             $body !== '' ? $body : null,
             $request->headers->get('Content-Type'),
         );

--- a/src/Symfony/OpenApiAssertions.php
+++ b/src/Symfony/OpenApiAssertions.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\AssertionFailedError;
 use Studio\Gesso\Coverage\OpenApiCoverageTracker;
 use Studio\Gesso\DecodedBody;
 use Studio\Gesso\HttpMethod;
+use Studio\Gesso\Internal\CurlCommandFormatter;
 use Studio\Gesso\Internal\StackTraceFilter;
 use Studio\Gesso\OpenApiRequestValidator;
 use Studio\Gesso\OpenApiResponseValidator;
@@ -156,11 +157,12 @@ trait OpenApiAssertions
         $this->assertOpenApi(
             $result->isValid(),
             sprintf(
-                "OpenAPI schema validation failed for %s %s (spec: %s):\n%s",
+                "OpenAPI schema validation failed for %s %s (spec: %s):\n%s\nReproduce: %s",
                 $method->value,
                 $path,
                 $specName,
                 $result->errorMessage(),
+                $this->symfonyReproduceCommand($request),
             ),
         );
     }
@@ -210,11 +212,12 @@ trait OpenApiAssertions
         $this->assertOpenApi(
             $result->isValid(),
             sprintf(
-                "OpenAPI request validation failed for %s %s (spec: %s):\n%s",
+                "OpenAPI request validation failed for %s %s (spec: %s):\n%s\nReproduce: %s",
                 $method->value,
                 $path,
                 $specName,
                 $result->errorMessage(),
+                $this->symfonyReproduceCommand($request),
             ),
         );
     }
@@ -297,6 +300,19 @@ trait OpenApiAssertions
         }
 
         return $method;
+    }
+
+    private function symfonyReproduceCommand(Request $request): string
+    {
+        $body = $request->getContent();
+
+        return CurlCommandFormatter::format(
+            $request->getMethod(),
+            $request->getUri(),
+            $request->headers->all(),
+            $body !== '' ? $body : null,
+            $request->headers->get('Content-Type'),
+        );
     }
 
     private function resolveSymfonyOpenApiSpec(): string

--- a/tests/Unit/Compatibility/PublicApiBaselineTest.php
+++ b/tests/Unit/Compatibility/PublicApiBaselineTest.php
@@ -232,6 +232,15 @@ final class PublicApiBaselineTest extends TestCase
                 'attributes' => [],
             ]],
         ];
+        $expected[ExploredCase::class]['methods']['curlSnippet']['parameters'][] = [
+            'name' => 'redactSensitiveHeaders',
+            'type' => 'bool',
+            'optional' => true,
+            'variadic' => false,
+            'by_reference' => false,
+            'default' => true,
+            'attributes' => [],
+        ];
         ksort($expected[ExploredCase::class]['methods']);
 
         $responseValidatorConstructor = $expected[OpenApiResponseValidator::class]['methods']['__construct'];

--- a/tests/Unit/Fuzz/ExploredCaseTest.php
+++ b/tests/Unit/Fuzz/ExploredCaseTest.php
@@ -71,6 +71,29 @@ class ExploredCaseTest extends TestCase
     }
 
     #[Test]
+    public function redacts_sensitive_headers_in_curl_snippet_by_default(): void
+    {
+        $case = new ExploredCase(
+            body: null,
+            query: [],
+            headers: ['Authorization' => 'Bearer real-token', 'X-Trace' => 'abc'],
+            pathParams: [],
+            method: HttpMethod::GET,
+            matchedPath: '/v1/pets',
+        );
+
+        $redacted = $case->curlSnippet();
+
+        $this->assertStringContainsString("-H 'Authorization: <redacted>'", $redacted);
+        $this->assertStringContainsString("-H 'X-Trace: abc'", $redacted);
+        $this->assertStringNotContainsString('real-token', $redacted);
+        $this->assertStringContainsString(
+            "-H 'Authorization: Bearer real-token'",
+            $case->curlSnippet(redactSensitiveHeaders: false),
+        );
+    }
+
+    #[Test]
     public function builds_a_concrete_uri_with_encoded_path_and_query_values(): void
     {
         $case = new ExploredCase(

--- a/tests/Unit/Fuzz/OpenApiSpecExplorerTest.php
+++ b/tests/Unit/Fuzz/OpenApiSpecExplorerTest.php
@@ -278,6 +278,7 @@ class OpenApiSpecExplorerTest extends TestCase
             $this->assertStringContainsString('Method/path: POST /pets', $e->getMessage());
             $this->assertStringContainsString('Global seed: 77', $e->getMessage());
             $this->assertStringContainsString('OpenApiEndpointExplorer::explore(', $e->getMessage());
+            $this->assertStringContainsString("\nCurl: curl -X POST", $e->getMessage());
             $this->assertSame('application failure', $e->getPrevious()?->getMessage());
         }
     }

--- a/tests/Unit/Internal/CurlCommandFormatterTest.php
+++ b/tests/Unit/Internal/CurlCommandFormatterTest.php
@@ -70,6 +70,17 @@ final class CurlCommandFormatterTest extends TestCase
     }
 
     #[Test]
+    public function test_quotes_methods_containing_shell_metacharacters(): void
+    {
+        $injected = CurlCommandFormatter::format('GET; id', '/v1/pets', [], null, null);
+        $custom = CurlCommandFormatter::format('X-CUSTOM', '/v1/pets', [], null, null);
+
+        $this->assertStringContainsString("curl -X 'GET; id' ", $injected);
+        $this->assertFalse(str_contains($injected, 'curl -X GET; id'));
+        $this->assertStringContainsString('curl -X X-CUSTOM ', $custom);
+    }
+
+    #[Test]
     public function test_redacts_sensitive_query_parameter_values(): void
     {
         $command = CurlCommandFormatter::format(

--- a/tests/Unit/Internal/CurlCommandFormatterTest.php
+++ b/tests/Unit/Internal/CurlCommandFormatterTest.php
@@ -70,6 +70,41 @@ final class CurlCommandFormatterTest extends TestCase
     }
 
     #[Test]
+    public function test_redacts_sensitive_query_parameter_values(): void
+    {
+        $command = CurlCommandFormatter::format(
+            'GET',
+            'https://api.example.test/v1/pets?api_key=real-secret&access_token=tok-1&limit=5',
+            [],
+            null,
+            null,
+        );
+
+        $this->assertStringContainsString('api_key=<redacted>', $command);
+        $this->assertStringContainsString('access_token=<redacted>', $command);
+        $this->assertStringContainsString('limit=5', $command);
+        $this->assertFalse(str_contains($command, 'real-secret'));
+        $this->assertFalse(str_contains($command, 'tok-1'));
+    }
+
+    #[Test]
+    public function test_query_redaction_handles_encoded_names_and_valueless_pairs(): void
+    {
+        $command = CurlCommandFormatter::format(
+            'GET',
+            '/v1/pets?client%5Fsecret=s-1&flag&x=1',
+            [],
+            null,
+            null,
+        );
+
+        $this->assertStringContainsString('client%5Fsecret=<redacted>', $command);
+        $this->assertStringContainsString('flag', $command);
+        $this->assertStringContainsString('x=1', $command);
+        $this->assertFalse(str_contains($command, 's-1'));
+    }
+
+    #[Test]
     public function test_redaction_can_be_disabled(): void
     {
         $command = CurlCommandFormatter::format(

--- a/tests/Unit/Internal/CurlCommandFormatterTest.php
+++ b/tests/Unit/Internal/CurlCommandFormatterTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Internal;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Internal\CurlCommandFormatter;
+
+use function str_contains;
+
+final class CurlCommandFormatterTest extends TestCase
+{
+    #[Test]
+    public function test_renders_method_and_quoted_uri_without_headers_or_body(): void
+    {
+        $command = CurlCommandFormatter::format('GET', '/v1/pets?limit=5', [], null, null);
+
+        $this->assertSame("curl -X GET '/v1/pets?limit=5'", $command);
+    }
+
+    #[Test]
+    public function test_renders_headers_including_list_values(): void
+    {
+        $command = CurlCommandFormatter::format(
+            'GET',
+            'https://api.example.test/v1/pets',
+            [
+                'Accept' => 'application/json',
+                'X-Trace' => ['abc', 'def'],
+            ],
+            null,
+            null,
+        );
+
+        $this->assertStringContainsString("-H 'Accept: application/json'", $command);
+        $this->assertStringContainsString("-H 'X-Trace: abc'", $command);
+        $this->assertStringContainsString("-H 'X-Trace: def'", $command);
+    }
+
+    #[Test]
+    public function test_redacts_sensitive_headers_by_default(): void
+    {
+        $command = CurlCommandFormatter::format(
+            'GET',
+            '/v1/pets',
+            [
+                'Authorization' => 'Bearer real-token',
+                'cookie' => 'session=abc',
+                'Proxy-Authorization' => 'Basic dXNlcg==',
+                'X-Api-Key' => 'k-123',
+                'X-Auth-Token' => 't-456',
+                'Client-Secret' => 's-789',
+                'Accept' => 'application/json',
+            ],
+            null,
+            null,
+        );
+
+        $this->assertStringContainsString("-H 'Authorization: <redacted>'", $command);
+        $this->assertStringContainsString("-H 'cookie: <redacted>'", $command);
+        $this->assertStringContainsString("-H 'Proxy-Authorization: <redacted>'", $command);
+        $this->assertStringContainsString("-H 'X-Api-Key: <redacted>'", $command);
+        $this->assertStringContainsString("-H 'X-Auth-Token: <redacted>'", $command);
+        $this->assertStringContainsString("-H 'Client-Secret: <redacted>'", $command);
+        $this->assertStringContainsString("-H 'Accept: application/json'", $command);
+        $this->assertFalse(str_contains($command, 'real-token'));
+        $this->assertFalse(str_contains($command, 'session=abc'));
+    }
+
+    #[Test]
+    public function test_redaction_can_be_disabled(): void
+    {
+        $command = CurlCommandFormatter::format(
+            'GET',
+            '/v1/pets',
+            ['Authorization' => 'Bearer real-token'],
+            null,
+            null,
+            redact: false,
+        );
+
+        $this->assertStringContainsString("-H 'Authorization: Bearer real-token'", $command);
+        $this->assertFalse(str_contains($command, '<redacted>'));
+    }
+
+    #[Test]
+    public function test_appends_data_for_json_content_types(): void
+    {
+        $plain = CurlCommandFormatter::format(
+            'POST',
+            '/v1/pets',
+            [],
+            '{"name":"Snowy"}',
+            'application/json; charset=utf-8',
+        );
+        $vendor = CurlCommandFormatter::format(
+            'POST',
+            '/v1/pets',
+            [],
+            '{"name":"Snowy"}',
+            'application/vnd.example+json',
+        );
+
+        $this->assertStringContainsString('--data \'{"name":"Snowy"}\'', $plain);
+        $this->assertStringContainsString('--data \'{"name":"Snowy"}\'', $vendor);
+    }
+
+    #[Test]
+    public function test_omits_data_for_non_json_body_null_body_and_empty_body(): void
+    {
+        $multipart = CurlCommandFormatter::format('POST', '/v1/pets', [], 'raw-bytes', 'multipart/form-data');
+        $nullBody = CurlCommandFormatter::format('POST', '/v1/pets', [], null, 'application/json');
+        $emptyBody = CurlCommandFormatter::format('POST', '/v1/pets', [], '', 'application/json');
+
+        $this->assertFalse(str_contains($multipart, '--data'));
+        $this->assertFalse(str_contains($nullBody, '--data'));
+        $this->assertFalse(str_contains($emptyBody, '--data'));
+    }
+
+    #[Test]
+    public function test_output_is_a_single_line_even_with_multiline_body(): void
+    {
+        $command = CurlCommandFormatter::format(
+            'POST',
+            '/v1/pets',
+            ['X-Note' => "line1\nline2"],
+            "{\n  \"name\": \"Snowy\"\n}",
+            'application/json',
+        );
+
+        $this->assertFalse(str_contains($command, "\n"));
+    }
+
+    #[Test]
+    public function test_scalar_header_values_are_stringified(): void
+    {
+        $command = CurlCommandFormatter::format(
+            'GET',
+            '/v1/pets',
+            ['X-Count' => 3, 'X-Flag' => true, 'X-Null' => null],
+            null,
+            null,
+        );
+
+        $this->assertStringContainsString("-H 'X-Count: 3'", $command);
+        $this->assertStringContainsString("-H 'X-Flag: 1'", $command);
+        $this->assertStringContainsString("-H 'X-Null: '", $command);
+    }
+}

--- a/tests/Unit/Psr7/OpenApiAssertionsTest.php
+++ b/tests/Unit/Psr7/OpenApiAssertionsTest.php
@@ -164,6 +164,27 @@ final class OpenApiAssertionsTest extends TestCase
         }
     }
 
+    #[Test]
+    public function stream_cursor_is_restored_even_when_reading_the_body_throws(): void
+    {
+        $stream = FnStream::decorate(Utils::streamFor('{"x":1}'), [
+            'getContents' => static function (): string {
+                throw new RuntimeException('read failed mid-stream');
+            },
+        ]);
+        $request = new Request('GET', 'https://example.test/body/scalar', [], $stream);
+        $request->getBody()->seek(3);
+        $response = new Response(200, ['Content-Type' => 'application/json'], '"wrong"');
+
+        try {
+            $this->assertPsr7ResponseMatchesOpenApiSchema($request, $response);
+            $this->fail('Expected the PSR-7 assertion to fail.');
+        } catch (AssertionFailedError $e) {
+            $this->assertSame(3, $request->getBody()->tell());
+            $this->assertStringNotContainsString('--data', $e->getMessage());
+        }
+    }
+
     protected function openApiSpec(): string
     {
         return 'psr7';

--- a/tests/Unit/Psr7/OpenApiAssertionsTest.php
+++ b/tests/Unit/Psr7/OpenApiAssertionsTest.php
@@ -59,6 +59,61 @@ final class OpenApiAssertionsTest extends TestCase
         }
     }
 
+    #[Test]
+    public function assertion_failure_includes_a_redacted_curl_reproduction(): void
+    {
+        $request = new Request(
+            'GET',
+            'https://example.test/body/scalar',
+            ['Authorization' => 'Bearer real-token'],
+        );
+        $response = new Response(200, ['Content-Type' => 'application/json'], '"wrong"');
+
+        try {
+            $this->assertPsr7ResponseMatchesOpenApiSchema($request, $response);
+            $this->fail('Expected the PSR-7 assertion to fail.');
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString(
+                "Reproduce: curl -X GET 'https://example.test/body/scalar'",
+                $e->getMessage(),
+            );
+            $this->assertStringContainsString("-H 'Authorization: <redacted>'", $e->getMessage());
+            $this->assertStringNotContainsString('real-token', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function request_assertion_failure_includes_curl_with_json_body(): void
+    {
+        $request = new Request(
+            'POST',
+            'https://example.test/widgets/42',
+            ['Content-Type' => 'application/json'],
+            '{"message":123}',
+        );
+
+        try {
+            $this->assertPsr7RequestMatchesOpenApiSchema($request);
+            $this->fail('Expected the PSR-7 request assertion to fail.');
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString('Reproduce: curl -X POST', $e->getMessage());
+            $this->assertStringContainsString('--data \'{"message":123}\'', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function operation_assertion_failure_includes_a_method_and_path_curl(): void
+    {
+        $response = new Response(200, ['Content-Type' => 'application/json'], '"wrong"');
+
+        try {
+            $this->assertPsr7ResponseForOperationMatchesOpenApiSchema('GET', '/body/scalar', $response);
+            $this->fail('Expected the PSR-7 assertion to fail.');
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString("Reproduce: curl -X GET '/body/scalar'", $e->getMessage());
+        }
+    }
+
     protected function openApiSpec(): string
     {
         return 'psr7';

--- a/tests/Unit/Psr7/OpenApiAssertionsTest.php
+++ b/tests/Unit/Psr7/OpenApiAssertionsTest.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Studio\Gesso\Tests\Unit\Psr7;
 
+use GuzzleHttp\Psr7\FnStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use Studio\Gesso\Coverage\OpenApiCoverageTracker;
 use Studio\Gesso\Psr7\OpenApiAssertions;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
@@ -111,6 +114,53 @@ final class OpenApiAssertionsTest extends TestCase
             $this->fail('Expected the PSR-7 assertion to fail.');
         } catch (AssertionFailedError $e) {
             $this->assertStringContainsString("Reproduce: curl -X GET '/body/scalar'", $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function successful_assertion_does_not_disturb_the_request_body_stream_cursor(): void
+    {
+        $request = new Request('GET', 'https://example.test/body/scalar', [], 'ignored-body');
+        $request->getBody()->seek(3);
+        $response = new Response(200, ['Content-Type' => 'application/json'], '5');
+
+        $this->assertPsr7ResponseMatchesOpenApiSchema($request, $response);
+
+        $this->assertSame(3, $request->getBody()->tell());
+    }
+
+    #[Test]
+    public function failed_assertion_restores_the_request_body_stream_cursor(): void
+    {
+        $request = new Request('GET', 'https://example.test/body/scalar', [], 'ignored-body');
+        $request->getBody()->seek(3);
+        $response = new Response(200, ['Content-Type' => 'application/json'], '"wrong"');
+
+        try {
+            $this->assertPsr7ResponseMatchesOpenApiSchema($request, $response);
+            $this->fail('Expected the PSR-7 assertion to fail.');
+        } catch (AssertionFailedError) {
+            $this->assertSame(3, $request->getBody()->tell());
+        }
+    }
+
+    #[Test]
+    public function unreadable_seekable_stream_degrades_to_a_bodyless_curl(): void
+    {
+        $stream = FnStream::decorate(Utils::streamFor('{"x":1}'), [
+            'rewind' => static function (): void {
+                throw new RuntimeException('stream is not readable');
+            },
+        ]);
+        $request = new Request('GET', 'https://example.test/body/scalar', [], $stream);
+        $response = new Response(200, ['Content-Type' => 'application/json'], '"wrong"');
+
+        try {
+            $this->assertPsr7ResponseMatchesOpenApiSchema($request, $response);
+            $this->fail('Expected the PSR-7 assertion to fail.');
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString('Reproduce: curl -X GET', $e->getMessage());
+            $this->assertStringNotContainsString('--data', $e->getMessage());
         }
     }
 

--- a/tests/Unit/Symfony/OpenApiAssertionsTest.php
+++ b/tests/Unit/Symfony/OpenApiAssertionsTest.php
@@ -154,6 +154,47 @@ final class OpenApiAssertionsTest extends TestCase
     }
 
     #[Test]
+    public function request_failure_includes_a_redacted_curl_reproduction(): void
+    {
+        $request = Request::create(
+            '/v1/pets',
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => 'Bearer real-token'],
+            '{}',
+        );
+
+        try {
+            $this->assertRequestMatchesOpenApiSchema($request);
+            $this->fail('Expected the request assertion to fail.');
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString('Reproduce: curl -X POST', $e->getMessage());
+            $this->assertStringContainsString("--data '{}'", $e->getMessage());
+            $this->assertStringContainsString(': <redacted>', $e->getMessage());
+            $this->assertStringNotContainsString('real-token', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function response_failure_includes_a_curl_reproduction(): void
+    {
+        $request = Request::create('/v1/pets', 'GET', server: ['HTTP_AUTHORIZATION' => 'Bearer real-token']);
+        $response = new JsonResponse(['unexpected' => 'shape']);
+
+        try {
+            $this->assertResponseMatchesOpenApiSchema($request, $response);
+            $this->fail('Expected the response assertion to fail.');
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString('Reproduce: curl -X GET', $e->getMessage());
+            $this->assertStringContainsString('/v1/pets', $e->getMessage());
+            $this->assertStringContainsString(': <redacted>', $e->getMessage());
+            $this->assertStringNotContainsString('real-token', $e->getMessage());
+        }
+    }
+
+    #[Test]
     public function unsupported_http_method_fails_with_clear_message(): void
     {
         $request = Request::create('/v1/pets', 'TRACE');

--- a/tests/Unit/Symfony/OpenApiAssertionsTest.php
+++ b/tests/Unit/Symfony/OpenApiAssertionsTest.php
@@ -195,6 +195,28 @@ final class OpenApiAssertionsTest extends TestCase
     }
 
     #[Test]
+    public function request_failure_curl_includes_cookies_as_a_redacted_header(): void
+    {
+        $request = Request::create(
+            '/v1/pets',
+            'POST',
+            [],
+            ['session' => 'secret-session'],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            '{}',
+        );
+
+        try {
+            $this->assertRequestMatchesOpenApiSchema($request);
+            $this->fail('Expected the request assertion to fail.');
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString("-H 'cookie: <redacted>'", $e->getMessage());
+            $this->assertStringNotContainsString('secret-session', $e->getMessage());
+        }
+    }
+
+    #[Test]
     public function unsupported_http_method_fails_with_clear_message(): void
     {
         $request = Request::create('/v1/pets', 'TRACE');

--- a/tests/Unit/ValidatesOpenApiSchemaAutoValidateRequestTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaAutoValidateRequestTest.php
@@ -401,6 +401,30 @@ class ValidatesOpenApiSchemaAutoValidateRequestTest extends TestCase
     }
 
     #[Test]
+    public function request_failure_curl_includes_cookies_as_a_redacted_header(): void
+    {
+        $GLOBALS['__openapi_testing_config']['gesso.auto_validate_request'] = true;
+
+        $request = Request::create(
+            '/v1/pets',
+            'POST',
+            [],
+            ['session' => 'secret-session'],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            '{}',
+        );
+
+        try {
+            $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/v1/pets');
+            $this->fail('Expected the request assertion to fail.');
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString("-H 'cookie: <redacted>'", $e->getMessage());
+            $this->assertStringNotContainsString('secret-session', $e->getMessage());
+        }
+    }
+
+    #[Test]
     public function malformed_json_body_without_content_type_adds_hint(): void
     {
         // Missing Content-Type on a non-empty body falls through to the JSON

--- a/tests/Unit/ValidatesOpenApiSchemaAutoValidateRequestTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaAutoValidateRequestTest.php
@@ -375,6 +375,32 @@ class ValidatesOpenApiSchemaAutoValidateRequestTest extends TestCase
     }
 
     #[Test]
+    public function request_failure_includes_a_redacted_curl_reproduction(): void
+    {
+        $GLOBALS['__openapi_testing_config']['gesso.auto_validate_request'] = true;
+
+        $request = Request::create(
+            '/v1/pets',
+            'POST',
+            [],
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json', 'HTTP_AUTHORIZATION' => 'Bearer real-token'],
+            '{}',
+        );
+
+        try {
+            $this->maybeAutoValidateOpenApiRequest($request, HttpMethod::POST, '/v1/pets');
+            $this->fail('Expected the request assertion to fail.');
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString('Reproduce: curl -X POST', $e->getMessage());
+            $this->assertStringContainsString("--data '{}'", $e->getMessage());
+            $this->assertStringContainsString(': <redacted>', $e->getMessage());
+            $this->assertStringNotContainsString('real-token', $e->getMessage());
+        }
+    }
+
+    #[Test]
     public function malformed_json_body_without_content_type_adds_hint(): void
     {
         // Missing Content-Type on a non-empty body falls through to the JSON

--- a/tests/Unit/ValidatesOpenApiSchemaTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaTest.php
@@ -109,6 +109,20 @@ class ValidatesOpenApiSchemaTest extends TestCase
     }
 
     #[Test]
+    public function validation_failure_message_includes_a_curl_reproduction(): void
+    {
+        $body = (string) json_encode(['wrong_key' => 'value'], JSON_THROW_ON_ERROR);
+        $response = $this->makeTestResponse($body, 200);
+
+        try {
+            $this->assertResponseMatchesOpenApiSchema($response, HttpMethod::GET, '/v1/pets');
+            $this->fail('Expected the response assertion to fail.');
+        } catch (AssertionFailedError $e) {
+            $this->assertStringContainsString("Reproduce: curl -X GET '/v1/pets'", $e->getMessage());
+        }
+    }
+
+    #[Test]
     public function validation_failure_message_includes_spec_name(): void
     {
         $body = (string) json_encode(['wrong_key' => 'value'], JSON_THROW_ON_ERROR);

--- a/tests/fixtures/compatibility/v2-public-api.json
+++ b/tests/fixtures/compatibility/v2-public-api.json
@@ -4600,6 +4600,28 @@
                     "attributes": [],
                     "parameters": []
                 },
+                "requestReproduceCommand": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "string",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "request",
+                            "type": "Symfony\\Component\\HttpFoundation\\Request",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
+                },
                 "resolveAutoInjectCredentials": {
                     "visibility": "private",
                     "static": false,
@@ -4747,6 +4769,39 @@
                     "return_type": "array",
                     "attributes": [],
                     "parameters": []
+                },
+                "responseReproduceCommand": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "string",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "resolvedMethod",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        },
+                        {
+                            "name": "resolvedPath",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
                 },
                 "runRequestAssertion": {
                     "visibility": "private",
@@ -6172,6 +6227,17 @@
                                 "unavailable": true
                             },
                             "attributes": []
+                        },
+                        {
+                            "name": "reproduceCommand",
+                            "type": "string",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
                         }
                     ]
                 },
@@ -6246,6 +6312,28 @@
                     "return_type": "string",
                     "attributes": [],
                     "parameters": []
+                },
+                "psr7ReproduceCommand": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "string",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "request",
+                            "type": "Psr\\Http\\Message\\RequestInterface",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
                 },
                 "psr7Validator": {
                     "visibility": "private",
@@ -7407,6 +7495,28 @@
                     "return_type": "string",
                     "attributes": [],
                     "parameters": []
+                },
+                "symfonyReproduceCommand": {
+                    "visibility": "private",
+                    "static": false,
+                    "final": false,
+                    "abstract": false,
+                    "returns_reference": false,
+                    "return_type": "string",
+                    "attributes": [],
+                    "parameters": [
+                        {
+                            "name": "request",
+                            "type": "Symfony\\Component\\HttpFoundation\\Request",
+                            "optional": false,
+                            "variadic": false,
+                            "by_reference": false,
+                            "default": {
+                                "unavailable": true
+                            },
+                            "attributes": []
+                        }
+                    ]
                 },
                 "symfonyRequestValidator": {
                     "visibility": "private",

--- a/tests/fixtures/compatibility/v2-public-api.json
+++ b/tests/fixtures/compatibility/v2-public-api.json
@@ -2134,6 +2134,15 @@
                         "by_reference": false,
                         "default": "",
                         "attributes": []
+                    },
+                    {
+                        "name": "redactSensitiveHeaders",
+                        "type": "bool",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": true,
+                        "attributes": []
                     }
                 ]
             },

--- a/tests/fixtures/compatibility/v2-public-api.json
+++ b/tests/fixtures/compatibility/v2-public-api.json
@@ -6230,7 +6230,7 @@
                         },
                         {
                             "name": "reproduceCommand",
-                            "type": "string",
+                            "type": "Closure",
                             "optional": false,
                             "variadic": false,
                             "by_reference": false,


### PR DESCRIPTION
## Summary

Every validation failure (Laravel, Symfony, PSR-7, and Pest via delegation) and whole-spec exploration failure now prints a one-line `Reproduce: curl …` command. Sensitive header values (`Authorization`, `Proxy-Authorization`, `Cookie`, and api-key/token/secret-style names) are redacted as `<redacted>` so the command is safe to surface in CI logs. `ExploredCase::curlSnippet()` now redacts by default, with a `redactSensitiveHeaders: false` opt-out.

## Why

When a contract test fails in CI, the first question is "how do I hit this myself?". Reconstructing the request from PHPUnit failure text is manual work; a copy-pasteable curl line makes every failure immediately actionable. Closes #404.

## Verification

- [x] `composer test` passes (2,200 tests / 8,150 assertions, Unit + Integration)
- [ ] `composer stan` — locally reports one pre-existing `identical.alwaysFalse` error in `src/PHPUnit/OpenApiCoverageExtension.php:416` that reproduces identically on `main` (environment-specific, file untouched here); the diff introduces no new findings
- [x] `composer cs-check` passes (both configs)

New behavior is covered failing-test-first: formatter unit tests (redaction, escaping, JSON-only `--data`, single-line output), per-adapter failure-message tests including redaction, and whole-spec failure `Curl:` line.

## Notes for reviewers

- `CurlCommandFormatter` is `@internal`; adapters pass whatever request shape they have. Where no request object exists (`assertPsr7ResponseForOperationMatchesOpenApiSchema`, Laravel explicit response asserts), the command degrades to method + path only. Laravel response-side uses the container-bound request only when its method/path match the resolved operation, so asserting an unrelated response never renders a misleading command.
- Default-redacting `curlSnippet()` is a deliberate behavior change to the existing public method (documented in `docs/fuzzing.md`); the public API baseline and v1→v2 contract-change allowlist were regenerated per `scripts/export-public-api.php`.
- The structured-JSON field for this line is deferred to #282, per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqWR5DigRbDnzvSkMEXaLi