### PR TITLE
fix(extension): keep empty defaultTestSuite guard analyzable on phpunit 13.2.6

### DIFF
--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -411,6 +411,13 @@ final class OpenApiCoverageExtension implements Extension
             return null;
         }
 
+        // PHPUnit 13.2.6 documents defaultTestSuite() as non-empty-string,
+        // but an XML `defaultTestSuite=""` attribute still reaches this code
+        // as '' at runtime (pinned by OpenApiCoverageExtensionBootstrapTest),
+        // and PHPUnit 12 does not carry the narrowed PHPDoc at all. Widen the
+        // type locally so the guard below stays analyzable on every PHPUnit
+        // version in the support matrix.
+        /** @var string $value */
         $value = $configuration->defaultTestSuite();
 
         if ($value === '') {


### PR DESCRIPTION
## Summary

PHPUnit 13.2.6 (released 2026-07-28) added a `@return non-empty-string` PHPDoc to `Configuration::defaultTestSuite()`. PHPStan then reports the defensive `$value === ''` guard in `OpenApiCoverageExtension::readDefaultTestSuite()` as `identical.alwaysFalse`. This widens the type locally with an inline `/** @var string */` so the guard stays analyzable across the whole PHPUnit 12/13 support matrix.

## Why

The guard is real behavior, not dead code: an XML `defaultTestSuite=""` attribute still reaches the extension as `''` at runtime on PHPUnit 13.2.6 — pinned by the existing subprocess test in `tests/Integration/OpenApiCoverageExtensionBootstrapTest.php`, which passes against 13.2.6 — so the new upstream PHPDoc is narrower than observed behavior and the warning branch must stay.

Because this repository intentionally has no `composer.lock`, the CI `static-analysis` job (PHP 8.3 → resolves PHPUnit 12.5.33, which lacks the narrowed PHPDoc) is still green while any environment resolving PHPUnit 13.2.6 fails `composer stan`. If the PHPDoc is backported to a PHPUnit 12.5.x patch, the CI job would start failing at an uncontrolled time. An inline `@phpstan-ignore` was not an option: it would be an unmatched ignore (its own error) on the PHPUnit-12 side of the matrix.

## Verification

- [x] `composer stan` passes locally against PHPUnit 13.2.6 (was: 1 error)
- [x] `tests/Integration/OpenApiCoverageExtensionBootstrapTest.php` passes (8 tests) — empty-attribute warning behavior unchanged
- [x] `composer cs-check` passes

## Notes for reviewers

Comment-plus-annotation only; no runtime behavior change. Arguably the upstream PHPDoc is a PHPUnit bug (documented non-empty, observably empty for `defaultTestSuite=""`); if it gets fixed upstream the annotation can be dropped, but it is harmless to keep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqWR5DigRbDnzvSkMEXaLi