### PR TITLE
feat(result): expose structured validation issues with stable categories

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -35,9 +35,21 @@ $result->isValid();      // bool (true for both successes AND skipped results)
 $result->isSkipped();    // bool (true when the status code matched skip_response_codes)
 $result->errors();       // string[]
 $result->errorMessage(); // string (joined errors)
+$result->issues();       // list<ValidationIssue> (structured view of errors())
 $result->matchedPath();  // ?string (e.g., '/v1/pets/{petId}')
 $result->skipReason();   // ?string (non-null when skipped)
 ```
+
+`issues()` mirrors `errors()` one-to-one: each `ValidationIssue` carries the
+same `message` plus a stable `category` slug (e.g. `request.security`,
+`response.body` — the full list is in
+[versioning.md](versioning.md#whats-covered-by-semver)) and the operation
+context the validator resolved (`method`, `path`, `statusCode`,
+`contentType`). Assert on `category` and context instead of message wording —
+the prose is not a compatibility surface. `instancePath` and `keyword` are
+reserved for body-schema errors and are always `null` today (issue #282,
+stage 2). Results built by code that predates the structured API derive
+issues with category `unknown`.
 
 Prefer `outcome()` when you need to distinguish all three states explicitly — PHPStan enforces `match` exhaustiveness, so adding a future outcome cannot silently slip past a caller:
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -45,7 +45,10 @@ same `message` plus a stable `category` slug (e.g. `request.security`,
 `response.body` — the full list is in
 [versioning.md](versioning.md#whats-covered-by-semver)) and the operation
 context the validator resolved (`method`, `path`, `statusCode`,
-`contentType`). Assert on `category` and context instead of message wording —
+`contentType`). A context field is `null` when that dimension does not apply
+or was not resolved — request-side issues never carry a `statusCode`, and
+`contentType` is set only on body issues (the resolved spec media-type key).
+Assert on `category` and context instead of message wording —
 the prose is not a compatibility surface. `instancePath` and `keyword` are
 reserved for body-schema errors and are always `null` today (issue #282,
 stage 2). Results built by code that predates the structured API derive

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -16,7 +16,16 @@ This library follows [Semantic Versioning 2.0](https://semver.org/). v1.0.0 is t
 - Every non-`@internal` member composed by a public trait, including protected
   and private methods, properties, and constants
 - Enum cases (additions are minor; removals or renames are major)
-- The `OpenApiValidationResult` shape (`outcome()`, `errors()`, `matchedPath()`, `skipReason()`, `isValid()`, `isSkipped()`)
+- The `OpenApiValidationResult` shape (`outcome()`, `errors()`, `issues()`, `matchedPath()`, `skipReason()`, `isValid()`, `isSkipped()`)
+- The `ValidationIssue` shape and its `category` slugs (`request.spec`,
+  `request.path_match`, `request.method`, `request.parameter.path`,
+  `request.parameter.query`, `request.parameter.header`, `request.security`,
+  `request.body`, `response.spec`, `response.request_context`,
+  `response.status`, `response.body`, `response.header`, and the legacy
+  fallback `unknown`). New categories may be added in minor releases;
+  renaming or removing one is major. `instancePath` / `keyword` are reserved
+  and currently always `null` (issue #282, stage 2). `message` remains
+  explicitly outside the contract (see below).
 - CLI surfaces by major (commands, flags, exit codes, and versioned inputs and
   output where applicable):
   - v1.x: `bin/openapi-contract`, `bin/openapi-coverage-merge`, and the v1.10

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -366,7 +366,17 @@ final class OpenApiRequestValidator
             }
         }
 
-        return OpenApiValidationResult::failure($errors, $matchedPath, issues: $issues);
+        // Carry the resolved media-type key at result level here too, so all
+        // three outcomes (Success / Skipped above, Failure) expose it
+        // consistently — adapters fall back to it when the failure has no
+        // request.body issue to borrow the key from (e.g. only sibling
+        // parameter errors alongside an adapter-level body error).
+        return OpenApiValidationResult::failure(
+            $errors,
+            $matchedPath,
+            matchedContentType: $bodyResult->matchedContentType,
+            issues: $issues,
+        );
     }
 
     /**

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -300,11 +300,22 @@ final class OpenApiRequestValidator
             // is non-failing — but the body went unchecked, so surface a
             // Skipped result (rather than a clean Success) and forward the
             // reason to coverage tracking.
+            // Both outcomes carry the media-type key the body validator
+            // resolved (null when no `requestBody` lookup happened) so
+            // adapters can tag their own body-level diagnostics with it even
+            // when this result contributes no issues of its own.
             if ($bodyResult->skipReason !== null) {
-                return OpenApiValidationResult::skipped($matchedPath, $bodyResult->skipReason);
+                return OpenApiValidationResult::skipped(
+                    $matchedPath,
+                    $bodyResult->skipReason,
+                    matchedContentType: $bodyResult->matchedContentType,
+                );
             }
 
-            return OpenApiValidationResult::success($matchedPath);
+            return OpenApiValidationResult::success(
+                $matchedPath,
+                matchedContentType: $bodyResult->matchedContentType,
+            );
         }
 
         // Issue #179: when the response is a documented 4xx and the test

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -27,6 +27,7 @@ use Studio\Gesso\Validation\Support\ValidatorErrorBoundary;
 
 use function array_key_exists;
 use function array_keys;
+use function array_map;
 use function is_array;
 use function sprintf;
 
@@ -144,15 +145,18 @@ final class OpenApiRequestValidator
         // `?? []`. Surface it as a loud spec error instead, mirroring the
         // response-side traversal guards (issue #259).
         if (array_key_exists('paths', $spec) && MalformedSpecNode::isMalformed($spec['paths'])) {
-            return OpenApiValidationResult::failure([
-                sprintf(
-                    "Malformed 'paths' for %s %s in '%s' spec: expected object, got %s.",
-                    $method,
-                    $requestPath,
-                    $specName,
-                    MalformedSpecNode::describe($spec['paths']),
-                ),
-            ]);
+            $message = sprintf(
+                "Malformed 'paths' for %s %s in '%s' spec: expected object, got %s.",
+                $method,
+                $requestPath,
+                $specName,
+                MalformedSpecNode::describe($spec['paths']),
+            );
+
+            return OpenApiValidationResult::failure(
+                [$message],
+                issues: [new ValidationIssue('request.spec', $message, method: $method)],
+            );
         }
 
         /** @var string[] $specPaths */
@@ -161,9 +165,12 @@ final class OpenApiRequestValidator
         $matched = $matcher->matchWithVariables($requestPath);
 
         if ($matched === null) {
-            return OpenApiValidationResult::failure([
-                PathDiagnosticsFormatter::pathNotFound($specName, $method, $requestPath, $matcher, $spec),
-            ]);
+            $message = PathDiagnosticsFormatter::pathNotFound($specName, $method, $requestPath, $matcher, $spec);
+
+            return OpenApiValidationResult::failure(
+                [$message],
+                issues: [new ValidationIssue('request.path_match', $message, method: $method)],
+            );
         }
 
         $matchedPath = $matched['path'];
@@ -182,24 +189,32 @@ final class OpenApiRequestValidator
         // raising an uncaught TypeError, and a list mis-resolves silently.
         // Surface it loudly instead (issue #259).
         if (MalformedSpecNode::isMalformed($pathSpec)) {
-            return OpenApiValidationResult::failure([
-                sprintf(
-                    "Malformed 'paths[\"%s\"]' for %s %s in '%s' spec: expected object, got %s.",
-                    $matchedPath,
-                    $method,
-                    $matchedPath,
-                    $specName,
-                    MalformedSpecNode::describe($pathSpec),
-                ),
-            ], $matchedPath);
+            $message = sprintf(
+                "Malformed 'paths[\"%s\"]' for %s %s in '%s' spec: expected object, got %s.",
+                $matchedPath,
+                $method,
+                $matchedPath,
+                $specName,
+                MalformedSpecNode::describe($pathSpec),
+            );
+
+            return OpenApiValidationResult::failure(
+                [$message],
+                $matchedPath,
+                issues: [new ValidationIssue('request.spec', $message, method: $method, path: $matchedPath)],
+            );
         }
 
         /** @var array<string, mixed> $pathSpec */
         $resolvedOperation = OpenApiOperationResolver::resolve($pathSpec, $method);
         if (!$resolvedOperation['found']) {
-            return OpenApiValidationResult::failure([
-                PathDiagnosticsFormatter::methodNotDefined($specName, $method, $matchedPath, $spec),
-            ], $matchedPath);
+            $message = PathDiagnosticsFormatter::methodNotDefined($specName, $method, $matchedPath, $spec);
+
+            return OpenApiValidationResult::failure(
+                [$message],
+                $matchedPath,
+                issues: [new ValidationIssue('request.method', $message, method: $method, path: $matchedPath)],
+            );
         }
 
         $operation = $resolvedOperation['operation'];
@@ -211,17 +226,21 @@ final class OpenApiRequestValidator
         // parameter (the first scalar-typed sink) and raise an uncaught
         // TypeError; a list mis-resolves silently (issue #259).
         if (MalformedSpecNode::isMalformed($operation)) {
-            return OpenApiValidationResult::failure([
-                sprintf(
-                    "Malformed 'paths[\"%s\"].%s' for %s %s in '%s' spec: expected object, got %s.",
-                    $matchedPath,
-                    $operationLocation,
-                    $method,
-                    $matchedPath,
-                    $specName,
-                    MalformedSpecNode::describe($operation),
-                ),
-            ], $matchedPath);
+            $message = sprintf(
+                "Malformed 'paths[\"%s\"].%s' for %s %s in '%s' spec: expected object, got %s.",
+                $matchedPath,
+                $operationLocation,
+                $method,
+                $matchedPath,
+                $specName,
+                MalformedSpecNode::describe($operation),
+            );
+
+            return OpenApiValidationResult::failure(
+                [$message],
+                $matchedPath,
+                issues: [new ValidationIssue('request.spec', $message, method: $method, path: $matchedPath)],
+            );
         }
 
         // Collect merged path/operation parameters once so path + query + header
@@ -252,14 +271,25 @@ final class OpenApiRequestValidator
         $discriminatorContext = new DiscriminatorContext($spec, DiscriminatorEnforcement::isEnabled());
         $bodyResult = $this->validateBody($specName, $method, $matchedPath, $operation, $body, $contentType, $version, $discriminatorContext, $jsonSchemaDialect);
 
-        $errors = [
-            ...$collected->specErrors,
-            ...ValidatorErrorBoundary::safely('path', $specName, $method, $matchedPath, fn(): array => $this->pathValidator->validate($method, $matchedPath, $collected->parameters, $pathVariables, $version, $jsonSchemaDialect)),
-            ...ValidatorErrorBoundary::safely('query', $specName, $method, $matchedPath, fn(): array => $this->queryValidator->validate($method, $matchedPath, $collected->parameters, $queryParams, $version, $jsonSchemaDialect)),
-            ...ValidatorErrorBoundary::safely('header', $specName, $method, $matchedPath, fn(): array => $this->headerValidator->validate($method, $matchedPath, $collected->parameters, $headers, $version, $jsonSchemaDialect)),
-            ...ValidatorErrorBoundary::safely('security', $specName, $method, $matchedPath, fn(): array => $this->securityValidator->validate($method, $matchedPath, $spec, $operation, $headers, $queryParams, $cookies)),
-            ...$bodyResult->errors,
+        // Category tags mirror the sub-validator that produced each message so
+        // issues() can expose a structured view without touching the
+        // sub-validators themselves (#282, stage 1).
+        $issueGroups = [
+            ['request.spec', $collected->specErrors],
+            ['request.parameter.path', ValidatorErrorBoundary::safely('path', $specName, $method, $matchedPath, fn(): array => $this->pathValidator->validate($method, $matchedPath, $collected->parameters, $pathVariables, $version, $jsonSchemaDialect))],
+            ['request.parameter.query', ValidatorErrorBoundary::safely('query', $specName, $method, $matchedPath, fn(): array => $this->queryValidator->validate($method, $matchedPath, $collected->parameters, $queryParams, $version, $jsonSchemaDialect))],
+            ['request.parameter.header', ValidatorErrorBoundary::safely('header', $specName, $method, $matchedPath, fn(): array => $this->headerValidator->validate($method, $matchedPath, $collected->parameters, $headers, $version, $jsonSchemaDialect))],
+            ['request.security', ValidatorErrorBoundary::safely('security', $specName, $method, $matchedPath, fn(): array => $this->securityValidator->validate($method, $matchedPath, $spec, $operation, $headers, $queryParams, $cookies))],
+            ['request.body', $bodyResult->errors],
         ];
+
+        $issues = [];
+        foreach ($issueGroups as [$category, $messages]) {
+            foreach ($messages as $message) {
+                $issues[] = new ValidationIssue($category, $message, method: $method, path: $matchedPath);
+            }
+        }
+        $errors = array_map(static fn(ValidationIssue $issue): string => $issue->message, $issues);
 
         if ($errors === []) {
             // Issue #254: a non-JSON request Content-Type matched a spec
@@ -317,7 +347,7 @@ final class OpenApiRequestValidator
             }
         }
 
-        return OpenApiValidationResult::failure($errors, $matchedPath);
+        return OpenApiValidationResult::failure($errors, $matchedPath, issues: $issues);
     }
 
     /**

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -16,6 +16,7 @@ use Studio\Gesso\Validation\Request\QueryParameterValidator;
 use Studio\Gesso\Validation\Request\RequestBodyValidationResult;
 use Studio\Gesso\Validation\Request\RequestBodyValidator;
 use Studio\Gesso\Validation\Request\SecurityValidator;
+use Studio\Gesso\Validation\Support\ContentTypeMatcher;
 use Studio\Gesso\Validation\Support\DiscriminatorContext;
 use Studio\Gesso\Validation\Support\DiscriminatorEnforcement;
 use Studio\Gesso\Validation\Support\MalformedSpecNode;
@@ -352,6 +353,30 @@ final class OpenApiRequestValidator
     }
 
     /**
+     * Media-type key for the synthetic boundary error above. A
+     * `RuntimeException` can only originate on the JSON schema path — schema
+     * conversion and validation run after {@see RequestBodyValidator} resolved
+     * the JSON media-type key (the non-JSON and malformed-spec paths return
+     * before touching the converter) — so re-resolving the key from the same
+     * `content` map reproduces exactly what the validator matched before it
+     * threw.
+     *
+     * @param array<string, mixed> $operation
+     */
+    private static function thrownBodyContentType(array $operation): ?string
+    {
+        $requestBody = $operation['requestBody'] ?? null;
+        if (!is_array($requestBody) || !is_array($requestBody['content'] ?? null)) {
+            return null;
+        }
+
+        /** @var array<string, mixed> $content */
+        $content = $requestBody['content'];
+
+        return ContentTypeMatcher::findJsonContentType($content);
+    }
+
+    /**
      * Run the request-body validator behind the same narrow
      * `RuntimeException` boundary {@see ValidatorErrorBoundary::safely()}
      * applies to the other sub-validators: a `RuntimeException` (typically
@@ -385,16 +410,19 @@ final class OpenApiRequestValidator
                 ? sprintf(' (caused by %s: %s)', $previous::class, $previous->getMessage())
                 : '';
 
-            return new RequestBodyValidationResult([sprintf(
-                "[%s] %s %s in '%s' spec: %s threw: %s%s",
-                'request-body',
-                $method,
-                $matchedPath,
-                $specName,
-                $e::class,
-                $e->getMessage(),
-                $previousSuffix,
-            )]);
+            return new RequestBodyValidationResult(
+                [sprintf(
+                    "[%s] %s %s in '%s' spec: %s threw: %s%s",
+                    'request-body',
+                    $method,
+                    $matchedPath,
+                    $specName,
+                    $e::class,
+                    $e->getMessage(),
+                    $previousSuffix,
+                )],
+                matchedContentType: self::thrownBodyContentType($operation),
+            );
         }
     }
 

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -273,20 +273,21 @@ final class OpenApiRequestValidator
 
         // Category tags mirror the sub-validator that produced each message so
         // issues() can expose a structured view without touching the
-        // sub-validators themselves (#282, stage 1).
+        // sub-validators themselves (#282, stage 1). Only body issues have a
+        // resolved spec media-type key; parameter/security issues carry null.
         $issueGroups = [
-            ['request.spec', $collected->specErrors],
-            ['request.parameter.path', ValidatorErrorBoundary::safely('path', $specName, $method, $matchedPath, fn(): array => $this->pathValidator->validate($method, $matchedPath, $collected->parameters, $pathVariables, $version, $jsonSchemaDialect))],
-            ['request.parameter.query', ValidatorErrorBoundary::safely('query', $specName, $method, $matchedPath, fn(): array => $this->queryValidator->validate($method, $matchedPath, $collected->parameters, $queryParams, $version, $jsonSchemaDialect))],
-            ['request.parameter.header', ValidatorErrorBoundary::safely('header', $specName, $method, $matchedPath, fn(): array => $this->headerValidator->validate($method, $matchedPath, $collected->parameters, $headers, $version, $jsonSchemaDialect))],
-            ['request.security', ValidatorErrorBoundary::safely('security', $specName, $method, $matchedPath, fn(): array => $this->securityValidator->validate($method, $matchedPath, $spec, $operation, $headers, $queryParams, $cookies))],
-            ['request.body', $bodyResult->errors],
+            ['request.spec', $collected->specErrors, null],
+            ['request.parameter.path', ValidatorErrorBoundary::safely('path', $specName, $method, $matchedPath, fn(): array => $this->pathValidator->validate($method, $matchedPath, $collected->parameters, $pathVariables, $version, $jsonSchemaDialect)), null],
+            ['request.parameter.query', ValidatorErrorBoundary::safely('query', $specName, $method, $matchedPath, fn(): array => $this->queryValidator->validate($method, $matchedPath, $collected->parameters, $queryParams, $version, $jsonSchemaDialect)), null],
+            ['request.parameter.header', ValidatorErrorBoundary::safely('header', $specName, $method, $matchedPath, fn(): array => $this->headerValidator->validate($method, $matchedPath, $collected->parameters, $headers, $version, $jsonSchemaDialect)), null],
+            ['request.security', ValidatorErrorBoundary::safely('security', $specName, $method, $matchedPath, fn(): array => $this->securityValidator->validate($method, $matchedPath, $spec, $operation, $headers, $queryParams, $cookies)), null],
+            ['request.body', $bodyResult->errors, $bodyResult->matchedContentType],
         ];
 
         $issues = [];
-        foreach ($issueGroups as [$category, $messages]) {
+        foreach ($issueGroups as [$category, $messages, $issueContentType]) {
             foreach ($messages as $message) {
-                $issues[] = new ValidationIssue($category, $message, method: $method, path: $matchedPath);
+                $issues[] = new ValidationIssue($category, $message, method: $method, path: $matchedPath, contentType: $issueContentType);
             }
         }
         $errors = array_map(static fn(ValidationIssue $issue): string => $issue->message, $issues);

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -335,6 +335,11 @@ final class OpenApiRequestValidator
                         SpecResponseKeyResolver::warnSuspiciousKeys($specName, $method, $matchedPath, $responses);
                     }
 
+                    // Carry the media-type key the body validator resolved
+                    // before the downgrade: the Skipped result has no issues,
+                    // so this is the only channel through which adapters
+                    // (e.g. PSR-7 body-decode errors) can keep tagging their
+                    // request.body issues with the resolved key.
                     return OpenApiValidationResult::skipped(
                         $matchedPath,
                         sprintf(
@@ -344,6 +349,7 @@ final class OpenApiRequestValidator
                             $matchingPattern,
                         ),
                         $matchedResponseKey,
+                        $bodyResult->matchedContentType,
                     );
                 }
             }

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -117,15 +117,18 @@ final class OpenApiResponseValidator
         // traversal-level sibling of the per-response content/schema guards
         // (issue #259).
         if (array_key_exists('paths', $spec) && MalformedSpecNode::isMalformed($spec['paths'])) {
-            return OpenApiValidationResult::failure([
-                sprintf(
-                    "Malformed 'paths' for %s %s in '%s' spec: expected object, got %s.",
-                    $method,
-                    $requestPath,
-                    $specName,
-                    MalformedSpecNode::describe($spec['paths']),
-                ),
-            ]);
+            $message = sprintf(
+                "Malformed 'paths' for %s %s in '%s' spec: expected object, got %s.",
+                $method,
+                $requestPath,
+                $specName,
+                MalformedSpecNode::describe($spec['paths']),
+            );
+
+            return OpenApiValidationResult::failure(
+                [$message],
+                issues: [new ValidationIssue('response.spec', $message, method: $method)],
+            );
         }
 
         /** @var string[] $specPaths */
@@ -134,9 +137,12 @@ final class OpenApiResponseValidator
         $matchedPath = $matcher->match($requestPath);
 
         if ($matchedPath === null) {
-            return OpenApiValidationResult::failure([
-                PathDiagnosticsFormatter::pathNotFound($specName, $method, $requestPath, $matcher, $spec),
-            ]);
+            $message = PathDiagnosticsFormatter::pathNotFound($specName, $method, $requestPath, $matcher, $spec);
+
+            return OpenApiValidationResult::failure(
+                [$message],
+                issues: [new ValidationIssue('response.request_context', $message, method: $method)],
+            );
         }
 
         // `$matchedPath` is always a key of `$spec['paths']` (the matcher was
@@ -151,23 +157,31 @@ final class OpenApiResponseValidator
         // (uncaught TypeError) and a list mis-resolves silently. Surface it
         // loudly instead (issue #259).
         if (MalformedSpecNode::isMalformed($pathSpec)) {
-            return OpenApiValidationResult::failure([
-                sprintf(
-                    "Malformed 'paths[\"%s\"]' for %s %s in '%s' spec: expected object, got %s.",
-                    $matchedPath,
-                    $method,
-                    $matchedPath,
-                    $specName,
-                    MalformedSpecNode::describe($pathSpec),
-                ),
-            ], $matchedPath);
+            $message = sprintf(
+                "Malformed 'paths[\"%s\"]' for %s %s in '%s' spec: expected object, got %s.",
+                $matchedPath,
+                $method,
+                $matchedPath,
+                $specName,
+                MalformedSpecNode::describe($pathSpec),
+            );
+
+            return OpenApiValidationResult::failure(
+                [$message],
+                $matchedPath,
+                issues: [new ValidationIssue('response.spec', $message, method: $method, path: $matchedPath)],
+            );
         }
 
         $resolvedOperation = OpenApiOperationResolver::resolve($pathSpec, $method);
         if (!$resolvedOperation['found']) {
-            return OpenApiValidationResult::failure([
-                PathDiagnosticsFormatter::methodNotDefined($specName, $method, $matchedPath, $spec),
-            ], $matchedPath);
+            $message = PathDiagnosticsFormatter::methodNotDefined($specName, $method, $matchedPath, $spec);
+
+            return OpenApiValidationResult::failure(
+                [$message],
+                $matchedPath,
+                issues: [new ValidationIssue('response.request_context', $message, method: $method, path: $matchedPath)],
+            );
         }
 
         $operation = $resolvedOperation['operation'];
@@ -178,17 +192,21 @@ final class OpenApiResponseValidator
         // non-array reaches the `array_key_exists()` `responses` lookup below
         // (uncaught TypeError) and a list mis-resolves silently (issue #259).
         if (MalformedSpecNode::isMalformed($operation)) {
-            return OpenApiValidationResult::failure([
-                sprintf(
-                    "Malformed 'paths[\"%s\"].%s' for %s %s in '%s' spec: expected object, got %s.",
-                    $matchedPath,
-                    $operationLocation,
-                    $method,
-                    $matchedPath,
-                    $specName,
-                    MalformedSpecNode::describe($operation),
-                ),
-            ], $matchedPath);
+            $message = sprintf(
+                "Malformed 'paths[\"%s\"].%s' for %s %s in '%s' spec: expected object, got %s.",
+                $matchedPath,
+                $operationLocation,
+                $method,
+                $matchedPath,
+                $specName,
+                MalformedSpecNode::describe($operation),
+            );
+
+            return OpenApiValidationResult::failure(
+                [$message],
+                $matchedPath,
+                issues: [new ValidationIssue('response.spec', $message, method: $method, path: $matchedPath)],
+            );
         }
 
         /** @var array<string, mixed> $operation */
@@ -209,17 +227,21 @@ final class OpenApiResponseValidator
         // not hide it. This is the traversal-level sibling of the #258
         // `responses[$status]` per-entry guard (issue #259).
         if (MalformedSpecNode::isMalformed($responses)) {
-            return OpenApiValidationResult::failure([
-                sprintf(
-                    "Malformed 'paths[\"%s\"].%s.responses' for %s %s in '%s' spec: expected object, got %s.",
-                    $matchedPath,
-                    $operationLocation,
-                    $method,
-                    $matchedPath,
-                    $specName,
-                    MalformedSpecNode::describe($responses),
-                ),
-            ], $matchedPath);
+            $message = sprintf(
+                "Malformed 'paths[\"%s\"].%s.responses' for %s %s in '%s' spec: expected object, got %s.",
+                $matchedPath,
+                $operationLocation,
+                $method,
+                $matchedPath,
+                $specName,
+                MalformedSpecNode::describe($responses),
+            );
+
+            return OpenApiValidationResult::failure(
+                [$message],
+                $matchedPath,
+                issues: [new ValidationIssue('response.spec', $message, method: $method, path: $matchedPath)],
+            );
         }
 
         // Skip-by-status-code: applied before the "Status code not defined"
@@ -256,9 +278,13 @@ final class OpenApiResponseValidator
         // typically use `default` for the error envelope).
         $matchedResponseKey = SpecResponseKeyResolver::resolve($statusCodeStr, $responses);
         if ($matchedResponseKey === null) {
-            return OpenApiValidationResult::failure([
-                "Status code {$statusCode} not defined for {$method} {$matchedPath} in '{$specName}' spec.",
-            ], $matchedPath);
+            $message = "Status code {$statusCode} not defined for {$method} {$matchedPath} in '{$specName}' spec.";
+
+            return OpenApiValidationResult::failure(
+                [$message],
+                $matchedPath,
+                issues: [new ValidationIssue('response.status', $message, method: $method, path: $matchedPath, statusCode: $statusCodeStr)],
+            );
         }
         // Before silently surfacing a `default` fallback, surface any keys
         // that LOOK like attempted spec keys but don't satisfy the exact /
@@ -290,16 +316,21 @@ final class OpenApiResponseValidator
         // content-level guards in validateBody() and RequestBodyValidator's
         // `requestBody` guard.
         if (MalformedSpecNode::isMalformed($responseSpec)) {
-            return OpenApiValidationResult::failure([
-                sprintf(
-                    "Malformed 'responses[%s]' for %s %s in '%s' spec: expected object, got %s.",
-                    $matchedResponseKey,
-                    $method,
-                    $matchedPath,
-                    $specName,
-                    MalformedSpecNode::describe($responseSpec),
-                ),
-            ], $matchedPath, $statusCodeStr);
+            $message = sprintf(
+                "Malformed 'responses[%s]' for %s %s in '%s' spec: expected object, got %s.",
+                $matchedResponseKey,
+                $method,
+                $matchedPath,
+                $specName,
+                MalformedSpecNode::describe($responseSpec),
+            );
+
+            return OpenApiValidationResult::failure(
+                [$message],
+                $matchedPath,
+                $statusCodeStr,
+                issues: [new ValidationIssue('response.spec', $message, method: $method, path: $matchedPath, statusCode: $statusCodeStr)],
+            );
         }
 
         // Carry the resolved root + enforce gate so the body validator can
@@ -376,7 +407,15 @@ final class OpenApiResponseValidator
 
         // Order is body errors first, headers second. Tests that pin
         // specific positions rely on this; reordering would silently
-        // change diagnostic flow without breaking behaviour.
+        // change diagnostic flow without breaking behaviour. Category tags
+        // mirror the producing sub-validator (#282, stage 1).
+        $issues = [];
+        foreach ($bodyResult->errors as $message) {
+            $issues[] = new ValidationIssue('response.body', $message, method: $method, path: $matchedPath, statusCode: $statusCodeStr, contentType: $bodyResult->matchedContentType);
+        }
+        foreach ($headerErrors as $message) {
+            $issues[] = new ValidationIssue('response.header', $message, method: $method, path: $matchedPath, statusCode: $statusCodeStr, contentType: $bodyResult->matchedContentType);
+        }
         $errors = array_merge($bodyResult->errors, $headerErrors);
 
         if ($errors === []) {
@@ -409,6 +448,7 @@ final class OpenApiResponseValidator
             $matchedPath,
             $statusCodeStr,
             $bodyResult->matchedContentType,
+            issues: $issues,
         );
     }
 

--- a/src/OpenApiValidationResult.php
+++ b/src/OpenApiValidationResult.php
@@ -147,10 +147,13 @@ final readonly class OpenApiValidationResult
      * `matchedContentType` is null for most skip cases (status-code skip,
      * non-JSON-only specs with no Content-Type header — no spec media-type
      * key was resolved). It carries the spec media-type key only when the
-     * skip happened *after* a content-type lookup matched a declared key —
-     * the "non-JSON media type with an unvalidatable `schema`" case (issue
-     * #254). Passing it through lets coverage record the skip against that
-     * exact media-type row instead of the wildcard bucket.
+     * skip happened *after* a content-type lookup matched a declared key:
+     * the "non-JSON media type with an unvalidatable `schema`" response case
+     * (issue #254), where it lets coverage record the skip against that exact
+     * media-type row instead of the wildcard bucket, and the documented-4xx
+     * request downgrade (issue #179), where it preserves the request
+     * media-type key the body validator resolved before the downgrade so
+     * adapters can still tag their `request.body` issues with it.
      */
     public static function skipped(
         ?string $matchedPath = null,

--- a/src/OpenApiValidationResult.php
+++ b/src/OpenApiValidationResult.php
@@ -148,9 +148,10 @@ final readonly class OpenApiValidationResult
      * non-JSON-only specs with no Content-Type header — no spec media-type
      * key was resolved). It carries the spec media-type key only when the
      * skip happened *after* a content-type lookup matched a declared key:
-     * the "non-JSON media type with an unvalidatable `schema`" response case
-     * (issue #254), where it lets coverage record the skip against that exact
-     * media-type row instead of the wildcard bucket, and the documented-4xx
+     * the "non-JSON media type with an unvalidatable `schema`" case (issue
+     * #254, request and response sides), where it lets coverage record the
+     * response skip against that exact media-type row instead of the
+     * wildcard bucket, and the documented-4xx
      * request downgrade (issue #179), where it preserves the request
      * media-type key the body validator resolved before the downgrade so
      * adapters can still tag their `request.body` issues with it.

--- a/src/OpenApiValidationResult.php
+++ b/src/OpenApiValidationResult.php
@@ -6,6 +6,8 @@ namespace Studio\Gesso;
 
 use InvalidArgumentException;
 
+use function array_values;
+use function count;
 use function implode;
 
 final readonly class OpenApiValidationResult
@@ -30,7 +32,12 @@ final readonly class OpenApiValidationResult
      * only for the issue #254 case — a non-JSON media type whose declared
      * `schema` this JSON-Schema engine cannot evaluate.
      *
+     * `issues` mirrors `errors` one-to-one when provided (guarded in
+     * {@see self::failure()}); an empty list means the caller predates the
+     * structured API and {@see self::issues()} derives untagged issues.
+     *
      * @param string[] $errors
+     * @param list<ValidationIssue> $issues
      */
     private function __construct(
         private OpenApiValidationOutcome $outcome,
@@ -39,6 +46,7 @@ final readonly class OpenApiValidationResult
         private ?string $skipReason = null,
         private ?string $matchedStatusCode = null,
         private ?string $matchedContentType = null,
+        private array $issues = [],
     ) {}
 
     public static function success(
@@ -73,21 +81,43 @@ final readonly class OpenApiValidationResult
      * observed to emit whitespace-only errors in practice, tightening
      * this guard (e.g. rejecting all-blank arrays) can be reconsidered.
      *
-     * @param non-empty-array<string> $errors
+     * When `$issues` is provided it must mirror `$errors` exactly — same
+     * count, and `issues[$i]->message === errors[$i]` — so the two views can
+     * never drift apart. Callers either tag every error or none.
      *
-     * @throws InvalidArgumentException when $errors is empty
+     * @param non-empty-array<string> $errors
+     * @param list<ValidationIssue> $issues
+     *
+     * @throws InvalidArgumentException when $errors is empty or $issues does not mirror $errors
      */
     public static function failure(
         array $errors,
         ?string $matchedPath = null,
         ?string $matchedStatusCode = null,
         ?string $matchedContentType = null,
+        array $issues = [],
     ): self {
         // @phpstan-ignore-next-line identical.alwaysFalse — PHPDoc bound is not enforced at runtime; keep guard for consumers without static analysis
         if ($errors === []) {
             throw new InvalidArgumentException(
                 'OpenApiValidationResult::failure() requires at least one error message.',
             );
+        }
+
+        if ($issues !== []) {
+            $errorList = array_values($errors);
+            if (count($issues) !== count($errorList)) {
+                throw new InvalidArgumentException(
+                    'OpenApiValidationResult::failure() issues must mirror errors one-to-one (count mismatch).',
+                );
+            }
+            foreach ($issues as $index => $issue) {
+                if ($issue->message !== $errorList[$index]) {
+                    throw new InvalidArgumentException(
+                        'OpenApiValidationResult::failure() issues must mirror errors one-to-one (message mismatch at index ' . $index . ').',
+                    );
+                }
+            }
         }
 
         return new self(
@@ -97,6 +127,7 @@ final readonly class OpenApiValidationResult
             null,
             $matchedStatusCode,
             $matchedContentType,
+            $issues,
         );
     }
 
@@ -164,6 +195,35 @@ final readonly class OpenApiValidationResult
     public function errorMessage(): string
     {
         return implode("\n", $this->errors);
+    }
+
+    /**
+     * Structured view of {@see self::errors()}. Results built by the current
+     * orchestrators carry tagged issues; results built by legacy callers of
+     * `failure()` derive one issue per error string with category `unknown`
+     * and this result's matched operation context, so consumers can rely on
+     * `count(issues()) === count(errors())` either way.
+     *
+     * @return list<ValidationIssue>
+     */
+    public function issues(): array
+    {
+        if ($this->issues !== []) {
+            return $this->issues;
+        }
+
+        $derived = [];
+        foreach (array_values($this->errors) as $message) {
+            $derived[] = new ValidationIssue(
+                'unknown',
+                $message,
+                path: $this->matchedPath,
+                statusCode: $this->matchedStatusCode,
+                contentType: $this->matchedContentType,
+            );
+        }
+
+        return $derived;
     }
 
     public function matchedPath(): ?string

--- a/src/Psr7/OpenApiPsr7Validator.php
+++ b/src/Psr7/OpenApiPsr7Validator.php
@@ -102,7 +102,14 @@ final class OpenApiPsr7Validator
             $cookies,
             $responseStatusCode,
         );
-        $result = self::withAdapterErrors($result, $decoded['errors'], 'request.body', $method);
+        $result = self::withAdapterErrors(
+            $result,
+            $decoded['errors'],
+            'request.body',
+            $method,
+            statusCode: null,
+            contentType: self::requestBodyIssueContentType($result),
+        );
 
         if ($result->matchedPath() !== null) {
             OpenApiCoverageTracker::recordRequest(
@@ -149,7 +156,14 @@ final class OpenApiPsr7Validator
             $contentType,
             $response->getHeaders(),
         );
-        $result = self::withAdapterErrors($result, $decoded['errors'], 'response.body', $method);
+        $result = self::withAdapterErrors(
+            $result,
+            $decoded['errors'],
+            'response.body',
+            $method,
+            statusCode: $result->matchedStatusCode(),
+            contentType: $result->matchedContentType(),
+        );
 
         if ($result->matchedPath() !== null) {
             OpenApiCoverageTracker::recordResponse(
@@ -195,6 +209,13 @@ final class OpenApiPsr7Validator
      * validator's structured issues are kept as-is, in the same order as
      * `errors()`, so `issues()` never degrades to `unknown` here.
      *
+     * `$statusCode` / `$contentType` are the issue context for the adapter
+     * entries and are side-specific: the caller passes the result's matched
+     * values on the response side, and `statusCode: null` on the request side
+     * — request issues never carry a status, and the result-level
+     * matchedStatusCode of a downgraded (documented-4xx) request result is a
+     * response spec key that must not leak into request issue context.
+     *
      * @param list<string> $adapterErrors
      */
     private static function withAdapterErrors(
@@ -202,6 +223,8 @@ final class OpenApiPsr7Validator
         array $adapterErrors,
         string $category,
         string $method,
+        ?string $statusCode,
+        ?string $contentType,
     ): OpenApiValidationResult {
         if ($adapterErrors === []) {
             return $result;
@@ -214,8 +237,8 @@ final class OpenApiPsr7Validator
                 $message,
                 method: $method,
                 path: $result->matchedPath(),
-                statusCode: $result->matchedStatusCode(),
-                contentType: $result->matchedContentType(),
+                statusCode: $statusCode,
+                contentType: $contentType,
             );
         }
 
@@ -226,6 +249,24 @@ final class OpenApiPsr7Validator
             $result->matchedContentType(),
             array_merge($adapterIssues, $result->issues()),
         );
+    }
+
+    /**
+     * Media-type key for a request-side adapter body issue. A request result
+     * does not expose the resolved request media-type at result level, but its
+     * tagged `request.body` issues do — reuse theirs so the adapter entry and
+     * its sibling body issues report the same key. Null when the result has no
+     * tagged body issue (no `requestBody` in the spec, success, or skip).
+     */
+    private static function requestBodyIssueContentType(OpenApiValidationResult $result): ?string
+    {
+        foreach ($result->issues() as $issue) {
+            if ($issue->category === 'request.body') {
+                return $issue->contentType;
+            }
+        }
+
+        return null;
     }
 
     private static function requestPath(RequestInterface $request): string

--- a/src/Psr7/OpenApiPsr7Validator.php
+++ b/src/Psr7/OpenApiPsr7Validator.php
@@ -252,11 +252,13 @@ final class OpenApiPsr7Validator
     }
 
     /**
-     * Media-type key for a request-side adapter body issue. A request result
-     * does not expose the resolved request media-type at result level, but its
-     * tagged `request.body` issues do — reuse theirs so the adapter entry and
-     * its sibling body issues report the same key. Null when the result has no
-     * tagged body issue (no `requestBody` in the spec, success, or skip).
+     * Media-type key for a request-side adapter body issue. A failed request
+     * result carries the resolved request media-type on its tagged
+     * `request.body` issues — reuse theirs so the adapter entry and its
+     * sibling body issues report the same key. A downgraded (documented-4xx)
+     * request result is Skipped and has no issues; there the key resolved
+     * before the downgrade is carried at result level instead. Null when
+     * neither channel has one (no `requestBody` in the spec, success).
      */
     private static function requestBodyIssueContentType(OpenApiValidationResult $result): ?string
     {
@@ -266,7 +268,7 @@ final class OpenApiPsr7Validator
             }
         }
 
-        return null;
+        return $result->matchedContentType();
     }
 
     private static function requestPath(RequestInterface $request): string

--- a/src/Psr7/OpenApiPsr7Validator.php
+++ b/src/Psr7/OpenApiPsr7Validator.php
@@ -19,6 +19,7 @@ use Studio\Gesso\OpenApiResponseValidator;
 use Studio\Gesso\OpenApiValidationResult;
 use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
 use Studio\Gesso\Validation\Support\ContentTypeMatcher;
+use Studio\Gesso\ValidationIssue;
 
 use function array_key_exists;
 use function array_merge;
@@ -101,7 +102,7 @@ final class OpenApiPsr7Validator
             $cookies,
             $responseStatusCode,
         );
-        $result = self::withAdapterErrors($result, $decoded['errors']);
+        $result = self::withAdapterErrors($result, $decoded['errors'], 'request.body', $method);
 
         if ($result->matchedPath() !== null) {
             OpenApiCoverageTracker::recordRequest(
@@ -148,7 +149,7 @@ final class OpenApiPsr7Validator
             $contentType,
             $response->getHeaders(),
         );
-        $result = self::withAdapterErrors($result, $decoded['errors']);
+        $result = self::withAdapterErrors($result, $decoded['errors'], 'response.body', $method);
 
         if ($result->matchedPath() !== null) {
             OpenApiCoverageTracker::recordResponse(
@@ -187,13 +188,35 @@ final class OpenApiPsr7Validator
         ];
     }
 
-    /** @param list<string> $adapterErrors */
+    /**
+     * Prepend adapter-level body errors (unreadable/non-seekable stream, JSON
+     * parse failure) to the validator result. Adapter errors are tagged with
+     * the given body category (`request.body` / `response.body`) and the
+     * validator's structured issues are kept as-is, in the same order as
+     * `errors()`, so `issues()` never degrades to `unknown` here.
+     *
+     * @param list<string> $adapterErrors
+     */
     private static function withAdapterErrors(
         OpenApiValidationResult $result,
         array $adapterErrors,
+        string $category,
+        string $method,
     ): OpenApiValidationResult {
         if ($adapterErrors === []) {
             return $result;
+        }
+
+        $adapterIssues = [];
+        foreach ($adapterErrors as $message) {
+            $adapterIssues[] = new ValidationIssue(
+                $category,
+                $message,
+                method: $method,
+                path: $result->matchedPath(),
+                statusCode: $result->matchedStatusCode(),
+                contentType: $result->matchedContentType(),
+            );
         }
 
         return OpenApiValidationResult::failure(
@@ -201,6 +224,7 @@ final class OpenApiPsr7Validator
             $result->matchedPath(),
             $result->matchedStatusCode(),
             $result->matchedContentType(),
+            array_merge($adapterIssues, $result->issues()),
         );
     }
 

--- a/src/Validation/Request/RequestBodyValidationResult.php
+++ b/src/Validation/Request/RequestBodyValidationResult.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use Studio\Gesso\OpenApiRequestValidator;
 use Studio\Gesso\OpenApiValidationResult;
 use Studio\Gesso\Validation\Response\ResponseBodyValidationResult;
+use Studio\Gesso\ValidationIssue;
 
 /**
  * Outcome of {@see RequestBodyValidator::validate()}.
@@ -27,9 +28,13 @@ use Studio\Gesso\Validation\Response\ResponseBodyValidationResult;
  * orchestrator builds a `failure()` instead and the `skipReason` is dropped
  * — a genuine failure takes precedence over a skip.
  *
- * This mirrors {@see ResponseBodyValidationResult} on the response side;
- * request-side coverage has no per-content-type dimension, so no
- * `matchedContentType` is carried.
+ * This mirrors {@see ResponseBodyValidationResult} on the response side.
+ * `matchedContentType` is the spec media-type key the body was resolved
+ * against, or null when validation stopped before a media-type lookup
+ * (missing/malformed `requestBody` nodes, Content-Type not defined).
+ * Request-side coverage has no per-content-type dimension; the key is
+ * carried so the orchestrator can attach it to `request.body`
+ * {@see ValidationIssue}s (issue #282).
  *
  * @internal Not part of the package's public API. Do not use from user code.
  */
@@ -46,6 +51,7 @@ final readonly class RequestBodyValidationResult
     public function __construct(
         public array $errors,
         public ?string $skipReason = null,
+        public ?string $matchedContentType = null,
     ) {
         if ($skipReason !== null && $errors !== []) {
             throw new InvalidArgumentException(

--- a/src/Validation/Request/RequestBodyValidator.php
+++ b/src/Validation/Request/RequestBodyValidator.php
@@ -175,7 +175,7 @@ final class RequestBodyValidator
                     }
 
                     if (isset($content[$matchedKey]['itemSchema'])) {
-                        return self::unsupportedItemSchemaResult($normalizedType);
+                        return self::unsupportedItemSchemaResult($normalizedType, $matchedKey);
                     }
 
                     // A matched non-JSON media type that declares a `schema`
@@ -200,10 +200,11 @@ final class RequestBodyValidator
                                 $normalizedType,
                                 $matchedKey,
                             ),
+                            $matchedKey,
                         );
                     }
 
-                    return new RequestBodyValidationResult([]);
+                    return new RequestBodyValidationResult([], matchedContentType: $matchedKey);
                 }
 
                 $defined = implode(', ', array_keys($content));
@@ -236,7 +237,7 @@ final class RequestBodyValidator
         if ($jsonContentType === null) {
             foreach ($content as $mediaType => $mediaTypeSpec) {
                 if (isset($mediaTypeSpec['itemSchema'])) {
-                    return self::unsupportedItemSchemaResult((string) $mediaType);
+                    return self::unsupportedItemSchemaResult((string) $mediaType, (string) $mediaType);
                 }
             }
 
@@ -245,10 +246,10 @@ final class RequestBodyValidator
 
         if (!isset($content[$jsonContentType]['schema'])) {
             if (isset($content[$jsonContentType]['itemSchema'])) {
-                return self::unsupportedItemSchemaResult($jsonContentType);
+                return self::unsupportedItemSchemaResult($jsonContentType, $jsonContentType);
             }
 
-            return new RequestBodyValidationResult([]);
+            return new RequestBodyValidationResult([], matchedContentType: $jsonContentType);
         }
 
         // Required absence was rejected before content negotiation. An absent
@@ -257,7 +258,7 @@ final class RequestBodyValidator
         // #248), so it falls through to schema type-checking below instead of
         // taking this branch.
         if (!$requestBody->present) {
-            return new RequestBodyValidationResult([]);
+            return new RequestBodyValidationResult([], matchedContentType: $jsonContentType);
         }
 
         $bodyValue = $requestBody->value;
@@ -308,8 +309,10 @@ final class RequestBodyValidator
         );
     }
 
-    private static function unsupportedItemSchemaResult(string $mediaType): RequestBodyValidationResult
-    {
+    private static function unsupportedItemSchemaResult(
+        string $mediaType,
+        ?string $matchedContentType = null,
+    ): RequestBodyValidationResult {
         return new RequestBodyValidationResult(
             [],
             sprintf(
@@ -317,6 +320,7 @@ final class RequestBodyValidator
                 . 'stream items cannot be validated from the buffered request body and were explicitly skipped',
                 $mediaType,
             ),
+            $matchedContentType,
         );
     }
 

--- a/src/Validation/Request/RequestBodyValidator.php
+++ b/src/Validation/Request/RequestBodyValidator.php
@@ -171,7 +171,7 @@ final class RequestBodyValidator
                 $matchedKey = ContentTypeMatcher::findContentTypeKey($normalizedType, $content);
                 if ($matchedKey !== null) {
                     if ($required && !$requestBody->present) {
-                        return self::missingRequiredBodyResult($specName, $method, $matchedPath);
+                        return self::missingRequiredBodyResult($specName, $method, $matchedPath, $matchedKey);
                     }
 
                     if (isset($content[$matchedKey]['itemSchema'])) {
@@ -227,7 +227,7 @@ final class RequestBodyValidator
         // matching so an unknown actual Content-Type remains the primary
         // diagnostic, but before the no-JSON/no-schema early returns below.
         if ($required && !$requestBody->present) {
-            return self::missingRequiredBodyResult($specName, $method, $matchedPath);
+            return self::missingRequiredBodyResult($specName, $method, $matchedPath, $jsonContentType);
         }
 
         // If no JSON-compatible content type is defined, skip body validation.
@@ -291,17 +291,21 @@ final class RequestBodyValidator
             }
         }
 
-        return new RequestBodyValidationResult($errors);
+        return new RequestBodyValidationResult($errors, matchedContentType: $jsonContentType);
     }
 
     private static function missingRequiredBodyResult(
         string $specName,
         string $method,
         string $matchedPath,
+        ?string $matchedContentType = null,
     ): RequestBodyValidationResult {
-        return new RequestBodyValidationResult([
-            "Request body is empty but {$method} {$matchedPath} defines a required request body in '{$specName}' spec.",
-        ]);
+        return new RequestBodyValidationResult(
+            [
+                "Request body is empty but {$method} {$matchedPath} defines a required request body in '{$specName}' spec.",
+            ],
+            matchedContentType: $matchedContentType,
+        );
     }
 
     private static function unsupportedItemSchemaResult(string $mediaType): RequestBodyValidationResult

--- a/src/ValidationIssue.php
+++ b/src/ValidationIssue.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso;
+
+/**
+ * One structured validation finding, carried alongside the flat error strings
+ * on {@see OpenApiValidationResult}.
+ *
+ * `category` is a stable slug and part of the documented compatibility
+ * surface (see docs/versioning.md); `message` is the exact human-readable
+ * error text and remains explicitly outside the compatibility contract.
+ * `instancePath` and `keyword` are reserved for body-schema errors and stay
+ * null until the structured schema-runner output ships (issue #282, stage 2).
+ */
+final readonly class ValidationIssue
+{
+    public function __construct(
+        public string $category,
+        public string $message,
+        public ?string $instancePath = null,
+        public ?string $keyword = null,
+        public ?string $method = null,
+        public ?string $path = null,
+        public ?string $statusCode = null,
+        public ?string $contentType = null,
+    ) {}
+}

--- a/tests/Unit/Compatibility/PublicApiBaselineTest.php
+++ b/tests/Unit/Compatibility/PublicApiBaselineTest.php
@@ -23,6 +23,7 @@ use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
 use Studio\Gesso\Fuzz\ExploredCase;
 use Studio\Gesso\Laravel\Commands\OpenApiRoutesCommand;
 use Studio\Gesso\OpenApiResponseValidator;
+use Studio\Gesso\OpenApiValidationResult;
 use Studio\Gesso\Pest\Expectations;
 use Studio\Gesso\PHPUnit\ConsoleOutput;
 use Studio\Gesso\PHPUnit\InvalidStrictRequiredConfigurationException;
@@ -36,6 +37,7 @@ use Studio\Gesso\Tests\Unit\Compatibility\Fixture\PublicApiReturnTypeFixture;
 use Studio\Gesso\Tests\Unit\Compatibility\Fixture\PublicApiTraitSurfaceConsumerFixture;
 use Studio\Gesso\Tests\Unit\Compatibility\Fixture\PublicApiTraitSurfaceFixture;
 use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
+use Studio\Gesso\ValidationIssue;
 
 use function array_keys;
 use function dirname;
@@ -250,6 +252,104 @@ final class PublicApiBaselineTest extends TestCase
             $maxErrors,
             $skipResponseCodes,
         ];
+
+        $expected[OpenApiValidationResult::class]['methods']['failure']['parameters'][] = [
+            'name' => 'issues',
+            'type' => 'array',
+            'optional' => true,
+            'variadic' => false,
+            'by_reference' => false,
+            'default' => [],
+            'attributes' => [],
+        ];
+        $expected[OpenApiValidationResult::class]['methods']['issues'] = [
+            'static' => false,
+            'final' => false,
+            'abstract' => false,
+            'returns_reference' => false,
+            'return_type' => 'array',
+            'attributes' => [],
+            'parameters' => [],
+        ];
+        ksort($expected[OpenApiValidationResult::class]['methods']);
+
+        // New public class in v2.x (#282 stage 1): structured issue DTO.
+        $issueStringProperty = static fn(): array => [
+            'type' => 'string',
+            'static' => false,
+            'readonly' => true,
+            'default' => ['unavailable' => true],
+        ];
+        $issueNullableProperty = static fn(): array => [
+            'type' => '?string',
+            'static' => false,
+            'readonly' => true,
+            'default' => ['unavailable' => true],
+        ];
+        $issueRequiredParam = static fn(string $name): array => [
+            'name' => $name,
+            'type' => 'string',
+            'optional' => false,
+            'variadic' => false,
+            'by_reference' => false,
+            'default' => ['unavailable' => true],
+            'attributes' => [],
+        ];
+        $issueOptionalParam = static fn(string $name): array => [
+            'name' => $name,
+            'type' => '?string',
+            'optional' => true,
+            'variadic' => false,
+            'by_reference' => false,
+            'default' => null,
+            'attributes' => [],
+        ];
+        $expected[ValidationIssue::class] = [
+            'kind' => 'class',
+            'final' => true,
+            'abstract' => false,
+            'readonly' => true,
+            'instantiable' => true,
+            'constructor' => ['kind' => 'declared', 'visibility' => 'public'],
+            'parent' => null,
+            'interfaces' => [],
+            'traits' => [],
+            'attributes' => [],
+            'backing_type' => null,
+            'cases' => [],
+            'constants' => [],
+            'properties' => [
+                'category' => $issueStringProperty(),
+                'contentType' => $issueNullableProperty(),
+                'instancePath' => $issueNullableProperty(),
+                'keyword' => $issueNullableProperty(),
+                'message' => $issueStringProperty(),
+                'method' => $issueNullableProperty(),
+                'path' => $issueNullableProperty(),
+                'statusCode' => $issueNullableProperty(),
+            ],
+            'methods' => [
+                '__construct' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => null,
+                    'attributes' => [],
+                    'parameters' => [
+                        $issueRequiredParam('category'),
+                        $issueRequiredParam('message'),
+                        $issueOptionalParam('instancePath'),
+                        $issueOptionalParam('keyword'),
+                        $issueOptionalParam('method'),
+                        $issueOptionalParam('path'),
+                        $issueOptionalParam('statusCode'),
+                        $issueOptionalParam('contentType'),
+                    ],
+                ],
+            ],
+        ];
+        ksort($expected);
 
         foreach ([
             ConsoleCoverageRenderer::class,

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -209,6 +209,11 @@ class OpenApiRequestValidatorTest extends TestCase
 
         $this->assertFalse($result->isValid());
         $this->assertNotEmpty($result->errors());
+        $this->assertSame(
+            'application/json',
+            $result->matchedContentType(),
+            'a failed request result must expose the media-type key the body was checked against',
+        );
     }
 
     #[Test]

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -3448,6 +3448,15 @@ class OpenApiRequestValidatorTest extends TestCase
         $this->assertStringContainsString('[path.id]', $joined, 'path-param error must survive body throw');
         $this->assertStringContainsString('[request-body]', $joined, 'body throw must surface as boundary error');
         $this->assertStringContainsString('InvalidKeywordException', $joined, 'exception class name preserved for diagnostics');
+
+        // The synthetic boundary error is still a body issue: it must carry
+        // the media-type key the validator had resolved before it threw.
+        $bodyIssues = array_values(array_filter(
+            $result->issues(),
+            static fn($issue) => $issue->category === 'request.body',
+        ));
+        $this->assertNotEmpty($bodyIssues);
+        $this->assertSame('application/json', $bodyIssues[0]->contentType);
     }
 
     // ========================================

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -3490,6 +3490,11 @@ class OpenApiRequestValidatorTest extends TestCase
         $this->assertTrue($result->isSkipped(), 'documented-4xx downgrade must produce a Skipped outcome');
         $this->assertSame('/exact-422', $result->matchedPath());
         $this->assertSame('422', $result->matchedStatusCode(), 'matchedStatusCode must reflect the spec key the response resolved to');
+        $this->assertSame(
+            'application/json',
+            $result->matchedContentType(),
+            'the media-type key resolved before the downgrade must survive on the Skipped result',
+        );
         $this->assertNotNull($result->skipReason());
         $this->assertStringContainsString('422', (string) $result->skipReason());
     }

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -18,6 +18,7 @@ use Studio\Gesso\Validation\Request\SecurityValidator;
 
 use function array_filter;
 use function array_map;
+use function array_values;
 use function fclose;
 use function fopen;
 use function implode;
@@ -240,6 +241,53 @@ class OpenApiRequestValidatorTest extends TestCase
             'request.parameter.query',
             array_map(static fn($issue) => $issue->category, $query->issues()),
         );
+    }
+
+    #[Test]
+    public function request_body_issues_carry_the_matched_content_type(): void
+    {
+        $schemaError = $this->validator->validate(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            [],
+            [],
+            ['tag' => 'dog'],
+            'application/json',
+        );
+
+        $bodyIssues = array_values(array_filter(
+            $schemaError->issues(),
+            static fn($issue) => $issue->category === 'request.body',
+        ));
+        $this->assertNotEmpty($bodyIssues);
+        $this->assertSame('application/json', $bodyIssues[0]->contentType);
+
+        $missingBody = $this->validator->validate(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            [],
+            [],
+            null,
+            'application/json',
+        );
+
+        $missingBodyIssues = array_values(array_filter(
+            $missingBody->issues(),
+            static fn($issue) => $issue->category === 'request.body',
+        ));
+        $this->assertNotEmpty($missingBodyIssues);
+        $this->assertSame('application/json', $missingBodyIssues[0]->contentType);
+
+        // Parameter issues have no resolved media type — contentType stays null.
+        $query = $this->validator->validate('openapi-3.2', 'GET', '/v1/filter', ['limit' => '0'], [], null);
+        $queryIssues = array_values(array_filter(
+            $query->issues(),
+            static fn($issue) => $issue->category === 'request.parameter.query',
+        ));
+        $this->assertNotEmpty($queryIssues);
+        $this->assertNull($queryIssues[0]->contentType);
     }
 
     #[Test]

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -17,6 +17,7 @@ use Studio\Gesso\Spec\OpenApiSpecLoader;
 use Studio\Gesso\Validation\Request\SecurityValidator;
 
 use function array_filter;
+use function array_map;
 use function fclose;
 use function fopen;
 use function implode;
@@ -202,6 +203,66 @@ class OpenApiRequestValidatorTest extends TestCase
 
         $this->assertFalse($result->isValid());
         $this->assertNotEmpty($result->errors());
+    }
+
+    #[Test]
+    public function issues_carry_categories_and_operation_context(): void
+    {
+        $body = $this->validator->validate(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            [],
+            [],
+            ['tag' => 'dog'],
+            'application/json',
+        );
+
+        $this->assertFalse($body->isValid());
+        $bodyIssues = $body->issues();
+        $this->assertNotEmpty($bodyIssues);
+        $this->assertContains('request.body', array_map(static fn($issue) => $issue->category, $bodyIssues));
+        $this->assertSame('POST', $bodyIssues[0]->method);
+        $this->assertSame('/v1/pets', $bodyIssues[0]->path);
+        $this->assertSame(
+            $body->errors(),
+            array_map(static fn($issue) => $issue->message, $bodyIssues),
+        );
+
+        $security = $this->validator->validate('petstore-3.0', 'GET', '/v1/secure/bearer', [], [], null);
+        $this->assertContains(
+            'request.security',
+            array_map(static fn($issue) => $issue->category, $security->issues()),
+        );
+
+        $query = $this->validator->validate('openapi-3.2', 'GET', '/v1/filter', ['limit' => '0'], [], null);
+        $this->assertContains(
+            'request.parameter.query',
+            array_map(static fn($issue) => $issue->category, $query->issues()),
+        );
+    }
+
+    #[Test]
+    public function path_not_found_issue_is_categorized(): void
+    {
+        $result = $this->validator->validate('petstore-3.0', 'GET', '/v1/does-not-exist', [], [], null);
+
+        $issues = $result->issues();
+        $this->assertCount(1, $issues);
+        $this->assertSame('request.path_match', $issues[0]->category);
+        $this->assertSame('GET', $issues[0]->method);
+        $this->assertNull($issues[0]->path);
+    }
+
+    #[Test]
+    public function method_not_defined_issue_is_categorized(): void
+    {
+        $result = $this->validator->validate('petstore-3.0', 'DELETE', '/v1/pets', [], [], null);
+
+        $issues = $result->issues();
+        $this->assertCount(1, $issues);
+        $this->assertSame('request.method', $issues[0]->category);
+        $this->assertSame('/v1/pets', $issues[0]->path);
     }
 
     #[Test]

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -187,6 +187,11 @@ class OpenApiRequestValidatorTest extends TestCase
 
         $this->assertTrue($result->isValid());
         $this->assertSame('/v1/pets', $result->matchedPath());
+        $this->assertSame(
+            'application/json',
+            $result->matchedContentType(),
+            'a successful request result must expose the media-type key the body was checked against',
+        );
     }
 
     #[Test]

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -65,6 +65,60 @@ class OpenApiResponseValidatorTest extends TestCase
         yield '4XX matches 499' => [499, '4XX'];
     }
 
+    #[Test]
+    public function issues_carry_categories_and_operation_context(): void
+    {
+        // psr7 spec: POST /widgets/{id} 201 requires header X-Trace and an
+        // object body with integer `id` — wrong body type + missing header
+        // yields one issue from each source.
+        $result = $this->validator->validate(
+            'psr7',
+            'POST',
+            '/widgets/42',
+            201,
+            ['id' => 'not-an-integer'],
+            'application/json',
+            [],
+        );
+
+        $this->assertFalse($result->isValid());
+        $issues = $result->issues();
+        $categories = array_map(static fn($issue) => $issue->category, $issues);
+        $this->assertContains('response.body', $categories);
+        $this->assertContains('response.header', $categories);
+        $this->assertSame('POST', $issues[0]->method);
+        $this->assertSame('/widgets/{id}', $issues[0]->path);
+        $this->assertSame('201', $issues[0]->statusCode);
+        $this->assertSame('application/json', $issues[0]->contentType);
+        $this->assertSame(
+            $result->errors(),
+            array_map(static fn($issue) => $issue->message, $issues),
+        );
+    }
+
+    #[Test]
+    public function undefined_status_issue_is_categorized_with_status(): void
+    {
+        $result = $this->validator->validate('psr7', 'GET', '/body/scalar', 418, 5, 'application/json');
+
+        $issues = $result->issues();
+        $this->assertCount(1, $issues);
+        $this->assertSame('response.status', $issues[0]->category);
+        $this->assertSame('418', $issues[0]->statusCode);
+        $this->assertSame('/body/scalar', $issues[0]->path);
+    }
+
+    #[Test]
+    public function response_path_not_found_issue_is_categorized(): void
+    {
+        $result = $this->validator->validate('psr7', 'GET', '/does-not-exist', 200, null);
+
+        $issues = $result->issues();
+        $this->assertCount(1, $issues);
+        $this->assertSame('response.request_context', $issues[0]->category);
+        $this->assertSame('GET', $issues[0]->method);
+    }
+
     // ========================================
     // OAS 3.0 tests
     // ========================================

--- a/tests/Unit/OpenApiValidationResultTest.php
+++ b/tests/Unit/OpenApiValidationResultTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\Gesso\OpenApiValidationOutcome;
 use Studio\Gesso\OpenApiValidationResult;
+use Studio\Gesso\ValidationIssue;
 
 class OpenApiValidationResultTest extends TestCase
 {
@@ -47,6 +48,70 @@ class OpenApiValidationResultTest extends TestCase
         $this->assertFalse($result->isSkipped());
         $this->assertSame($errors, $result->errors());
         $this->assertNull($result->matchedPath());
+    }
+
+    #[Test]
+    public function failure_with_tagged_issues_returns_them(): void
+    {
+        $issues = [
+            new ValidationIssue('request.parameter.query', 'Error 1', method: 'GET', path: '/v1/pets'),
+            new ValidationIssue('request.security', 'Error 2', method: 'GET', path: '/v1/pets'),
+        ];
+        $result = OpenApiValidationResult::failure(['Error 1', 'Error 2'], '/v1/pets', issues: $issues);
+
+        $this->assertSame($issues, $result->issues());
+    }
+
+    #[Test]
+    public function failure_without_issues_derives_unknown_issues_with_result_context(): void
+    {
+        $result = OpenApiValidationResult::failure(
+            ['Error 1', 'Error 2'],
+            '/v1/pets',
+            '200',
+            'application/json',
+        );
+
+        $issues = $result->issues();
+        $this->assertCount(2, $issues);
+        $this->assertSame('unknown', $issues[0]->category);
+        $this->assertSame('Error 1', $issues[0]->message);
+        $this->assertSame('/v1/pets', $issues[0]->path);
+        $this->assertSame('200', $issues[0]->statusCode);
+        $this->assertSame('application/json', $issues[0]->contentType);
+        $this->assertNull($issues[0]->method);
+        $this->assertSame('Error 2', $issues[1]->message);
+    }
+
+    #[Test]
+    public function failure_with_mismatched_issue_count_throws(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('must mirror');
+
+        OpenApiValidationResult::failure(
+            ['Error 1', 'Error 2'],
+            issues: [new ValidationIssue('request.spec', 'Error 1')],
+        );
+    }
+
+    #[Test]
+    public function failure_with_mismatched_issue_message_throws(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('must mirror');
+
+        OpenApiValidationResult::failure(
+            ['Error 1'],
+            issues: [new ValidationIssue('request.spec', 'Different message')],
+        );
+    }
+
+    #[Test]
+    public function success_and_skipped_have_no_issues(): void
+    {
+        $this->assertSame([], OpenApiValidationResult::success('/v1/pets')->issues());
+        $this->assertSame([], OpenApiValidationResult::skipped('/v1/pets', 'reason')->issues());
     }
 
     #[Test]

--- a/tests/Unit/Psr7/OpenApiPsr7ValidatorTest.php
+++ b/tests/Unit/Psr7/OpenApiPsr7ValidatorTest.php
@@ -278,6 +278,8 @@ final class OpenApiPsr7ValidatorTest extends TestCase
         );
         $this->assertSame('response.body', $issues[0]->category);
         $this->assertSame('POST', $issues[0]->method);
+        $this->assertSame('201', $issues[0]->statusCode);
+        $this->assertSame('application/json', $issues[0]->contentType);
         $this->assertStringContainsString('could not be parsed as JSON', $issues[0]->message);
         $this->assertNotContains(
             'unknown',
@@ -307,10 +309,40 @@ final class OpenApiPsr7ValidatorTest extends TestCase
         );
         $this->assertSame('request.body', $issues[0]->category);
         $this->assertSame('POST', $issues[0]->method);
+        $this->assertNull($issues[0]->statusCode, 'request issues never carry a statusCode');
+        $this->assertSame(
+            'application/json',
+            $issues[0]->contentType,
+            'adapter body issue must share the media-type key its sibling body issues resolved',
+        );
         $this->assertStringContainsString('could not be parsed as JSON', $issues[0]->message);
         $this->assertNotContains(
             'unknown',
             array_map(static fn($issue) => $issue->category, $issues),
         );
+    }
+
+    #[Test]
+    public function request_adapter_issue_context_stays_request_side_after_downgrade(): void
+    {
+        // Invalid JSON + a documented 422 response: the inner request result
+        // is downgraded to Skipped carrying matchedStatusCode '422'. The
+        // adapter error rebuilds it as a Failure — the request-side issue
+        // must not inherit that response status.
+        $validator = new OpenApiPsr7Validator('request-validation-skip');
+        $request = new ServerRequest(
+            'POST',
+            'https://example.test/exact-422',
+            ['Content-Type' => 'application/json'],
+            '{invalid',
+        );
+
+        $result = $validator->validateRequest($request, 422);
+
+        $this->assertFalse($result->isValid());
+        $issues = $result->issues();
+        $this->assertCount(1, $issues);
+        $this->assertSame('request.body', $issues[0]->category);
+        $this->assertNull($issues[0]->statusCode, 'request issues never carry a statusCode');
     }
 }

--- a/tests/Unit/Psr7/OpenApiPsr7ValidatorTest.php
+++ b/tests/Unit/Psr7/OpenApiPsr7ValidatorTest.php
@@ -377,4 +377,30 @@ final class OpenApiPsr7ValidatorTest extends TestCase
         $this->assertNull($issues[0]->statusCode, 'request issues never carry a statusCode');
         $this->assertSame('application/json', $issues[0]->contentType);
     }
+
+    #[Test]
+    public function request_adapter_issue_keeps_content_type_alongside_non_body_sibling_errors(): void
+    {
+        // Optional body + unreadable stream + a path-parameter error: the
+        // inner result is a Failure whose issues contain no request.body
+        // entry, so the media-type key must come from the Failure's
+        // result-level matchedContentType.
+        $stream = new NoSeekStream(Utils::streamFor('{"text":"hi"}'));
+        $request = new ServerRequest(
+            'POST',
+            'https://example.test/notes/abc',
+            ['Content-Type' => 'application/json'],
+            $stream,
+        );
+
+        $result = $this->validator->validateRequest($request);
+
+        $this->assertFalse($result->isValid());
+        $issues = $result->issues();
+        $categories = array_map(static fn($issue) => $issue->category, $issues);
+        $this->assertContains('request.parameter.path', $categories, 'the sibling path error must surface');
+        $this->assertSame('request.body', $issues[0]->category);
+        $this->assertStringContainsString('not seekable', $issues[0]->message);
+        $this->assertSame('application/json', $issues[0]->contentType);
+    }
 }

--- a/tests/Unit/Psr7/OpenApiPsr7ValidatorTest.php
+++ b/tests/Unit/Psr7/OpenApiPsr7ValidatorTest.php
@@ -19,6 +19,8 @@ use Studio\Gesso\Coverage\OpenApiCoverageTracker;
 use Studio\Gesso\Psr7\OpenApiPsr7Validator;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 
+use function array_map;
+
 final class OpenApiPsr7ValidatorTest extends TestCase
 {
     private OpenApiPsr7Validator $validator;
@@ -255,5 +257,60 @@ final class OpenApiPsr7ValidatorTest extends TestCase
         $this->assertFalse($result->isValid());
         $this->assertStringContainsString('could not be parsed as JSON', $result->errorMessage());
         $this->assertSame('/widgets/{id}', $result->matchedPath());
+    }
+
+    #[Test]
+    public function response_adapter_errors_preserve_structured_issues(): void
+    {
+        $response = new Response(
+            201,
+            ['Content-Type' => 'application/json', 'X-Trace' => 'trace-1'],
+            '{invalid',
+        );
+
+        $result = $this->validator->validateResponseForOperation('POST', '/widgets/42', $response);
+
+        $this->assertFalse($result->isValid());
+        $issues = $result->issues();
+        $this->assertSame(
+            $result->errors(),
+            array_map(static fn($issue) => $issue->message, $issues),
+        );
+        $this->assertSame('response.body', $issues[0]->category);
+        $this->assertSame('POST', $issues[0]->method);
+        $this->assertStringContainsString('could not be parsed as JSON', $issues[0]->message);
+        $this->assertNotContains(
+            'unknown',
+            array_map(static fn($issue) => $issue->category, $issues),
+        );
+    }
+
+    #[Test]
+    public function request_adapter_errors_preserve_structured_issues(): void
+    {
+        $request = (new ServerRequest(
+            'POST',
+            'https://example.test/widgets/42?q=blue',
+            ['Content-Type' => 'application/json', 'X-Token' => 'secret'],
+            '{invalid',
+        ))
+            ->withQueryParams(['q' => 'blue'])
+            ->withCookieParams(['session' => 'abc']);
+
+        $result = $this->validator->validateRequest($request);
+
+        $this->assertFalse($result->isValid());
+        $issues = $result->issues();
+        $this->assertSame(
+            $result->errors(),
+            array_map(static fn($issue) => $issue->message, $issues),
+        );
+        $this->assertSame('request.body', $issues[0]->category);
+        $this->assertSame('POST', $issues[0]->method);
+        $this->assertStringContainsString('could not be parsed as JSON', $issues[0]->message);
+        $this->assertNotContains(
+            'unknown',
+            array_map(static fn($issue) => $issue->category, $issues),
+        );
     }
 }

--- a/tests/Unit/Psr7/OpenApiPsr7ValidatorTest.php
+++ b/tests/Unit/Psr7/OpenApiPsr7ValidatorTest.php
@@ -344,5 +344,10 @@ final class OpenApiPsr7ValidatorTest extends TestCase
         $this->assertCount(1, $issues);
         $this->assertSame('request.body', $issues[0]->category);
         $this->assertNull($issues[0]->statusCode, 'request issues never carry a statusCode');
+        $this->assertSame(
+            'application/json',
+            $issues[0]->contentType,
+            'the media-type key resolved before the downgrade must survive into the adapter issue',
+        );
     }
 }

--- a/tests/Unit/Psr7/OpenApiPsr7ValidatorTest.php
+++ b/tests/Unit/Psr7/OpenApiPsr7ValidatorTest.php
@@ -350,4 +350,31 @@ final class OpenApiPsr7ValidatorTest extends TestCase
             'the media-type key resolved before the downgrade must survive into the adapter issue',
         );
     }
+
+    #[Test]
+    public function request_adapter_issue_keeps_content_type_when_inner_result_succeeds(): void
+    {
+        // Optional request body + a non-seekable stream: the adapter refuses
+        // to read the body, the inner validator sees an absent optional body
+        // and succeeds — so there is no sibling body issue to borrow the
+        // media-type key from. The Success result must carry the key the
+        // body validator resolved.
+        $stream = new NoSeekStream(Utils::streamFor('{"text":"hi"}'));
+        $request = new ServerRequest(
+            'POST',
+            'https://example.test/notes',
+            ['Content-Type' => 'application/json'],
+            $stream,
+        );
+
+        $result = $this->validator->validateRequest($request);
+
+        $this->assertFalse($result->isValid());
+        $issues = $result->issues();
+        $this->assertCount(1, $issues);
+        $this->assertSame('request.body', $issues[0]->category);
+        $this->assertStringContainsString('not seekable', $issues[0]->message);
+        $this->assertNull($issues[0]->statusCode, 'request issues never carry a statusCode');
+        $this->assertSame('application/json', $issues[0]->contentType);
+    }
 }

--- a/tests/Unit/ValidationIssueTest.php
+++ b/tests/Unit/ValidationIssueTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\Gesso\ValidationIssue;
+
+final class ValidationIssueTest extends TestCase
+{
+    #[Test]
+    public function exposes_all_constructor_properties(): void
+    {
+        $issue = new ValidationIssue(
+            'response.body',
+            'Response body does not match the schema',
+            instancePath: '/data/0/name',
+            keyword: 'type',
+            method: 'GET',
+            path: '/v1/pets/{petId}',
+            statusCode: '200',
+            contentType: 'application/json',
+        );
+
+        $this->assertSame('response.body', $issue->category);
+        $this->assertSame('Response body does not match the schema', $issue->message);
+        $this->assertSame('/data/0/name', $issue->instancePath);
+        $this->assertSame('type', $issue->keyword);
+        $this->assertSame('GET', $issue->method);
+        $this->assertSame('/v1/pets/{petId}', $issue->path);
+        $this->assertSame('200', $issue->statusCode);
+        $this->assertSame('application/json', $issue->contentType);
+    }
+
+    #[Test]
+    public function context_fields_default_to_null(): void
+    {
+        $issue = new ValidationIssue('request.security', 'Authorization header is missing');
+
+        $this->assertNull($issue->instancePath);
+        $this->assertNull($issue->keyword);
+        $this->assertNull($issue->method);
+        $this->assertNull($issue->path);
+        $this->assertNull($issue->statusCode);
+        $this->assertNull($issue->contentType);
+    }
+}

--- a/tests/fixtures/compatibility/v2-public-api.json
+++ b/tests/fixtures/compatibility/v2-public-api.json
@@ -5365,6 +5365,15 @@
                         "by_reference": false,
                         "default": null,
                         "attributes": []
+                    },
+                    {
+                        "name": "issues",
+                        "type": "array",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": [],
+                        "attributes": []
                     }
                 ]
             },
@@ -5383,6 +5392,15 @@
                 "abstract": false,
                 "returns_reference": false,
                 "return_type": "bool",
+                "attributes": [],
+                "parameters": []
+            },
+            "issues": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
                 "attributes": [],
                 "parameters": []
             },
@@ -7419,6 +7437,178 @@
                     "attributes": [],
                     "parameters": []
                 }
+            }
+        }
+    },
+    "Studio\\Gesso\\ValidationIssue": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": true,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": {
+            "category": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "contentType": {
+                "type": "?string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "instancePath": {
+                "type": "?string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "keyword": {
+                "type": "?string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "message": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "method": {
+                "type": "?string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "path": {
+                "type": "?string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "statusCode": {
+                "type": "?string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "category",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "message",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "instancePath",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "keyword",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "method",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "path",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "statusCode",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "contentType",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
             }
         }
     },

--- a/tests/fixtures/specs/psr7.json
+++ b/tests/fixtures/specs/psr7.json
@@ -142,6 +142,36 @@
         }
       }
     },
+    "/notes/{id}": {
+      "post": {
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "text": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          }
+        }
+      }
+    },
     "/search": {
       "get": {
         "parameters": [

--- a/tests/fixtures/specs/psr7.json
+++ b/tests/fixtures/specs/psr7.json
@@ -120,6 +120,28 @@
         }
       }
     },
+    "/notes": {
+      "post": {
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "text": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          }
+        }
+      }
+    },
     "/search": {
       "get": {
         "parameters": [


### PR DESCRIPTION
## Summary

Adds a public `Studio\Gesso\ValidationIssue` readonly DTO and `OpenApiValidationResult::issues()`. Every failure from the request/response orchestrators now carries a structured view of its errors — a stable `category` slug (`request.security`, `response.body`, …) plus the resolved operation context (`method`, `path`, `statusCode`, `contentType`) — while `errors()` / `errorMessage()` and all error prose stay byte-identical.

Stage 1 of 3 for #282 (agreed split): this PR ships the DTO and tagging; stage 2 adds structured schema-runner output (`instancePath` / `keyword`, reserved-null here) and the versioned JSON renderer; stage 3 adds adapter output-mode selection.

## Why

`OpenApiValidationResult` exposes only `string[]`, which blocks stable assertions, CI ingestion, and JSON output (#282). Tagging at the orchestrator composition points gets structured categories into every failure without touching the eight sub-validators or changing any message — the lowest-risk first slice that later stages build on.

Design notes:
- `failure()` gains an optional `$issues` list with a hard invariant (same count, `issues[$i]->message === errors[$i]`) so the two views cannot drift; legacy callers derive `unknown`-category issues, keeping `count(issues()) === count(errors())` universally.
- Category slugs are a new documented compatibility surface (docs/versioning.md); message prose remains explicitly outside the contract.

## Verification

- [x] `composer test` passes (2,197 tests / 8,156 assertions, Unit + Integration)
- [x] `composer stan` passes (0 errors)
- [x] `composer cs-check` passes (both configs)

New coverage: DTO property exposure, issues↔errors invariant (count/message mismatch throws), legacy derivation, per-category tagging tests for both orchestrators (multi-source failures, path-not-found, method-not-defined, undefined status with statusCode context). Public API baseline regenerated and the v1→v2 contract-change test extended with the new class, method, and parameter.

## Notes for reviewers

- `instancePath` / `keyword` are intentionally always `null` in this PR — populating them requires structured `SchemaValidatorRunner` output, which is stage 2 alongside the JSON schema so the wire format and the data land together.
- The response-side `content_type`-mismatch and security-scheme messages currently tag as `response.body` / `request.security` respectively (they originate inside those sub-validators); finer categories can be added in a minor release since category additions are documented as non-breaking.

Refs #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqWR5DigRbDnzvSkMEXaLi