### PR TITLE
feat(output): populate body issue schema context and add versioned json output

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ To validate every response automatically, set `'auto_assert' => true` and drop t
 | Coverage report modes & threshold gate | [`docs/coverage.md`](docs/coverage.md) |
 | HTML coverage output | [`docs/coverage-html-output.md`](docs/coverage-html-output.md) |
 | JSON coverage output schema | [`docs/coverage-json-schema.md`](docs/coverage-json-schema.md) |
+| JSON validation result output schema | [`docs/validation-json-schema.md`](docs/validation-json-schema.md) |
 | Parallel test runners (paratest / Pest `--parallel`) | [`docs/parallel.md`](docs/parallel.md) |
 | CI integration (GitHub Actions, PR comments, output formats, partial-run handling) | [`docs/ci.md`](docs/ci.md) |
 | API reference (`OpenApiResponseValidator`, `OpenApiSpecLoader`, `OpenApiCoverageTracker`) | [`docs/api-reference.md`](docs/api-reference.md) |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -49,10 +49,27 @@ context the validator resolved (`method`, `path`, `statusCode`,
 or was not resolved — request-side issues never carry a `statusCode`, and
 `contentType` is set only on body issues (the resolved spec media-type key).
 Assert on `category` and context instead of message wording —
-the prose is not a compatibility surface. `instancePath` and `keyword` are
-reserved for body-schema errors and are always `null` today (issue #282,
-stage 2). Results built by code that predates the structured API derive
+the prose is not a compatibility surface. On body-schema violations
+(`request.body` / `response.body` issues produced by schema validation),
+`instancePath` carries the JSON Pointer into the validated body and `keyword`
+the failing JSON Schema keyword (`type`, `required`, …); both stay `null` for
+every other error source, including non-schema body errors such as a missing
+required body. Results built by code that predates the structured API derive
 issues with category `unknown`.
+
+To hand the full result to machine consumers (CI ingestion, IDE annotations),
+render it as a versioned JSON document:
+
+```php
+use Studio\Gesso\JsonValidationResultRenderer;
+
+$json = JsonValidationResultRenderer::render($result);
+// Optionally embed a (pre-redacted) reproduction command:
+$json = JsonValidationResultRenderer::render($result, $curlCommand);
+```
+
+The document shape (`schema_version` 1) is a compatibility surface — see
+[validation-json-schema.md](validation-json-schema.md).
 
 Prefer `outcome()` when you need to distinguish all three states explicitly — PHPStan enforces `match` exhaustiveness, so adding a future outcome cannot silently slip past a caller:
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -51,10 +51,11 @@ or was not resolved — request-side issues never carry a `statusCode`, and
 Assert on `category` and context instead of message wording —
 the prose is not a compatibility surface. On body-schema violations
 (`request.body` / `response.body` issues produced by schema validation),
-`instancePath` carries the JSON Pointer into the validated body and `keyword`
-the failing JSON Schema keyword (`type`, `required`, …); both stay `null` for
-every other error source, including non-schema body errors such as a missing
-required body. Results built by code that predates the structured API derive
+`instancePath` carries the RFC 6901 JSON Pointer into the validated body
+(`''` = document root — the `message` prefix renders it as `[/]` for
+historical reasons) and `keyword` the failing JSON Schema keyword (`type`,
+`required`, …); both stay `null` for every other error source, including
+non-schema body errors such as a missing required body. Results built by code that predates the structured API derive
 issues with category `unknown`.
 
 To hand the full result to machine consumers (CI ingestion, IDE annotations),

--- a/docs/samples/validation.json
+++ b/docs/samples/validation.json
@@ -1,0 +1,37 @@
+{
+    "schema_version": 1,
+    "tool": {
+        "name": "studio-design/gesso",
+        "version": "dev-main"
+    },
+    "outcome": "failure",
+    "matched": {
+        "path": "/v1/pets",
+        "status_code": null,
+        "content_type": "application/json"
+    },
+    "skip_reason": null,
+    "reproduce_command": "curl -X POST 'https://api.example.test/v1/pets' -H 'Authorization: <redacted>' -H 'Content-Type: application/json' --data '{\"name\":42}'",
+    "issues": [
+        {
+            "category": "request.body",
+            "message": "[/name] The data (integer) must match the type: string",
+            "instance_path": "/name",
+            "keyword": "type",
+            "method": "POST",
+            "path": "/v1/pets",
+            "status_code": null,
+            "content_type": "application/json"
+        },
+        {
+            "category": "request.parameter.query",
+            "message": "Required query parameter 'limit' is missing for GET /v1/pets in 'petstore' spec.",
+            "instance_path": null,
+            "keyword": null,
+            "method": "POST",
+            "path": "/v1/pets",
+            "status_code": null,
+            "content_type": null
+        }
+    ]
+}

--- a/docs/validation-json-schema.md
+++ b/docs/validation-json-schema.md
@@ -52,7 +52,7 @@ Each entry serialises one `ValidationIssue` field-for-field (snake_case). The
 |-------|------|-------------|
 | `category` | `string` | Stable slug naming the producing validator (`request.body`, `response.header`, …). Results built by code that predates the structured API derive `"unknown"`. |
 | `message` | `string` | Exact human-readable error text. **Not** a compatibility surface — assert on `category` and context instead. |
-| `instance_path` | `string \| null` | JSON Pointer into the validated body (`/` = document root). Set only on body-schema violations; `null` for every other error source. |
+| `instance_path` | `string \| null` | RFC 6901 JSON Pointer into the validated body: `""` is the document root and `"/"` is the property whose name is the empty string. (The human-readable `message` prefix renders the root as `[/]` for historical reasons; `instance_path` is the unambiguous form.) Set only on body-schema violations; `null` for every other error source. |
 | `keyword` | `string \| null` | JSON Schema keyword that failed (`type`, `required`, `enum`, …). Set together with `instance_path`; `null` otherwise. |
 | `method` | `string \| null` | HTTP method of the validated operation. |
 | `path` | `string \| null` | Matched spec path template. |
@@ -71,8 +71,11 @@ The document shape is covered by the [versioning policy](versioning.md):
 
 ## Security notes
 
-- No absolute filesystem paths are emitted.
-- `message` values can embed fragments of the request/response under test;
-  treat the document with the same sensitivity as your test payloads.
+- The renderer itself adds no filesystem paths or environment details — every
+  field is derived from the validation result plus the caller-supplied
+  `reproduce_command`. `message` and `reproduce_command` are emitted verbatim,
+  so anything they embed (request/response fragments, absolute paths in test
+  payloads or commands) passes through: treat the document with the same
+  sensitivity as your test payloads and redact before rendering if needed.
 - Invalid UTF-8 byte sequences inside messages are replaced with U+FFFD so the
   document always renders instead of masking the original validation failure.

--- a/docs/validation-json-schema.md
+++ b/docs/validation-json-schema.md
@@ -1,0 +1,78 @@
+# Validation JSON Schema
+
+`Studio\Gesso\JsonValidationResultRenderer::render()` turns any
+`OpenApiValidationResult` into a machine-readable JSON document for consumers
+that need more than the flat assertion text — CI ingestion, IDE annotations,
+scripted triage, or AI-assisted remediation. This page documents the schema so
+downstream consumers can rely on a stable shape.
+
+A sample document is committed at [`samples/validation.json`](samples/validation.json).
+
+```php
+use Studio\Gesso\JsonValidationResultRenderer;
+
+$json = JsonValidationResultRenderer::render($result);
+// Optionally embed a reproduction command (redact secrets first — the
+// built-in curl reproduction output is already redacted by default):
+$json = JsonValidationResultRenderer::render($result, $curlCommand);
+```
+
+The document is deliberately timestamp-free: rendering the same result twice
+produces byte-identical output, so snapshot tests and CI diffing work without
+masking.
+
+## Top level
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `schema_version` | `integer` | Bumped on incompatible contract changes. The current version is `1`. Consumers SHOULD reject unknown values. |
+| `tool` | `object` | `{ "name": "studio-design/gesso", "version": "<composer version or 'unknown'>" }`. `"unknown"` is emitted when Composer's `InstalledVersions` metadata is unavailable; the field is always a string. |
+| `outcome` | `string` | One of `"success"`, `"failure"`, `"skipped"` — the result's `outcome()` enum value. |
+| `matched` | `object` | Operation context the validator resolved. See [matched fields](#matched-fields). |
+| `skip_reason` | `string \| null` | Human-readable reason for `"skipped"` outcomes; `null` otherwise. |
+| `reproduce_command` | `string \| null` | The command passed as the second `render()` argument, verbatim; `null` when omitted. The renderer performs no redaction of its own — pass a pre-redacted command (the built-in curl formatter redacts sensitive headers, cookies, and query values by default). |
+| `issues` | `array` | One entry per structured issue, in the same order as `errors()`. Empty for `"success"` and `"skipped"` outcomes. See [Issue](#issue). |
+
+## Matched fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `path` | `string \| null` | Matched spec path template (e.g. `/v1/pets/{petId}`), or `null` when no path matched. |
+| `status_code` | `string \| null` | Spec response key (`"200"`, `"5XX"`, `"default"`) or the literal status for skipped responses; `null` for request-side results and unresolved lookups. |
+| `content_type` | `string \| null` | Spec media-type key (spec author's casing) the body was checked against; `null` when no body lookup occurred. |
+
+## Issue
+
+Each entry serialises one `ValidationIssue` field-for-field (snake_case). The
+`category` slugs and null-ness semantics are the same as the PHP API — see
+[api-reference.md](api-reference.md#openapivalidationresult) and
+[versioning.md](versioning.md#whats-covered-by-semver).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `category` | `string` | Stable slug naming the producing validator (`request.body`, `response.header`, …). Results built by code that predates the structured API derive `"unknown"`. |
+| `message` | `string` | Exact human-readable error text. **Not** a compatibility surface — assert on `category` and context instead. |
+| `instance_path` | `string \| null` | JSON Pointer into the validated body (`/` = document root). Set only on body-schema violations; `null` for every other error source. |
+| `keyword` | `string \| null` | JSON Schema keyword that failed (`type`, `required`, `enum`, …). Set together with `instance_path`; `null` otherwise. |
+| `method` | `string \| null` | HTTP method of the validated operation. |
+| `path` | `string \| null` | Matched spec path template. |
+| `status_code` | `string \| null` | Spec response key. Always `null` on request-side issues. |
+| `content_type` | `string \| null` | Resolved spec media-type key. Set only on body issues. |
+
+## Versioning
+
+The document shape is covered by the [versioning policy](versioning.md):
+
+- Adding a new field is a minor change — consumers MUST ignore fields they do
+  not recognise.
+- Removing or renaming a field, changing a field's type, or changing the
+  meaning of an existing value is a major change and bumps `schema_version`.
+- New `category` slugs and new `keyword` values may appear in minor releases.
+
+## Security notes
+
+- No absolute filesystem paths are emitted.
+- `message` values can embed fragments of the request/response under test;
+  treat the document with the same sensitivity as your test payloads.
+- Invalid UTF-8 byte sequences inside messages are replaced with U+FFFD so the
+  document always renders instead of masking the original validation failure.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -23,9 +23,15 @@ This library follows [Semantic Versioning 2.0](https://semver.org/). v1.0.0 is t
   `request.body`, `response.spec`, `response.request_context`,
   `response.status`, `response.body`, `response.header`, and the legacy
   fallback `unknown`). New categories may be added in minor releases;
-  renaming or removing one is major. `instancePath` / `keyword` are reserved
-  and currently always `null` (issue #282, stage 2). `message` remains
+  renaming or removing one is major. `instancePath` / `keyword` are populated
+  on body-schema violations and `null` for every other error source; new
+  `keyword` values may appear in minor releases. `message` remains
   explicitly outside the contract (see below).
+- The validation JSON document rendered by `JsonValidationResultRenderer`
+  (`schema_version` 1) — see
+  [validation-json-schema.md](validation-json-schema.md) for the field-level
+  rules (additions are minor, removals/renames/type changes are major and
+  bump `schema_version`).
 - CLI surfaces by major (commands, flags, exit codes, and versioned inputs and
   output where applicable):
   - v1.x: `bin/openapi-contract`, `bin/openapi-coverage-merge`, and the v1.10

--- a/src/JsonValidationResultRenderer.php
+++ b/src/JsonValidationResultRenderer.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso;
+
+use const JSON_INVALID_UTF8_SUBSTITUTE;
+use const JSON_PRETTY_PRINT;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+
+use Composer\InstalledVersions;
+use RuntimeException;
+use Studio\Gesso\Coverage\JsonCoverageRenderer;
+use Throwable;
+
+use function json_encode;
+use function json_last_error_msg;
+use function sprintf;
+
+/**
+ * Render an {@see OpenApiValidationResult} as a versioned JSON document for
+ * machine consumers (CI ingestion, IDE annotations, AI-assisted remediation)
+ * that need more than the flat assertion text (issue #282).
+ *
+ * Top-level shape (see `docs/validation-json-schema.md` for the full field
+ * reference — the document is a documented compatibility surface):
+ *  - `schema_version`: int, bumped on incompatible structural changes
+ *  - `tool`: `{ name, version }` for downstream consumers diagnosing drift
+ *  - `outcome`: `success` | `failure` | `skipped`
+ *  - `matched`: `{ path, status_code, content_type }` operation context
+ *  - `skip_reason`: string reason for skipped outcomes, else null
+ *  - `reproduce_command`: caller-supplied reproduction command, else null
+ *  - `issues`: one entry per {@see ValidationIssue}, snake_case fields
+ *
+ * The document is deliberately timestamp-free so per-assertion output stays
+ * deterministic for snapshot tests and CI diffing. `reproduce_command` is
+ * embedded verbatim — callers are responsible for redacting secrets before
+ * passing it in (the built-in curl formatter redacts by default, issue #404).
+ */
+final class JsonValidationResultRenderer
+{
+    public const SCHEMA_VERSION = 1;
+    private const COMPOSER_PACKAGE_NAME = 'studio-design/gesso';
+    private const TOOL_NAME = 'studio-design/gesso';
+
+    /**
+     * @return string A pretty-printed JSON document terminated by a single
+     *                `"\n"`. Error messages may embed request/response
+     *                fragments, so invalid UTF-8 byte sequences are replaced
+     *                with U+FFFD instead of aborting the render — a diagnostic
+     *                document that loses one byte beats an exception that
+     *                masks the original validation failure.
+     *
+     * @throws RuntimeException when the payload cannot be encoded as JSON
+     */
+    public static function render(OpenApiValidationResult $result, ?string $reproduceCommand = null): string
+    {
+        $issues = [];
+        foreach ($result->issues() as $issue) {
+            $issues[] = [
+                'category' => $issue->category,
+                'message' => $issue->message,
+                'instance_path' => $issue->instancePath,
+                'keyword' => $issue->keyword,
+                'method' => $issue->method,
+                'path' => $issue->path,
+                'status_code' => $issue->statusCode,
+                'content_type' => $issue->contentType,
+            ];
+        }
+
+        $payload = [
+            'schema_version' => self::SCHEMA_VERSION,
+            'tool' => [
+                'name' => self::TOOL_NAME,
+                'version' => self::resolveToolVersion(),
+            ],
+            'outcome' => $result->outcome()->value,
+            'matched' => [
+                'path' => $result->matchedPath(),
+                'status_code' => $result->matchedStatusCode(),
+                'content_type' => $result->matchedContentType(),
+            ],
+            'skip_reason' => $result->skipReason(),
+            'reproduce_command' => $reproduceCommand,
+            'issues' => $issues,
+        ];
+
+        $encoded = json_encode(
+            $payload,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE,
+        );
+        if ($encoded === false) {
+            // Practically unreachable (strings are UTF-8-substituted, no
+            // resources, no NAN) but surface a clear error instead of an
+            // empty document if the payload shape changes unexpectedly.
+            throw new RuntimeException(sprintf(
+                'Failed to encode the validation result as JSON: %s',
+                json_last_error_msg(),
+            ));
+        }
+
+        return $encoded . "\n";
+    }
+
+    /**
+     * Resolve the running tool version. The field is cosmetic — any failure
+     * here must never abort the document, so the catch is intentionally broad
+     * (mirrors {@see JsonCoverageRenderer}): corrupted
+     * Composer metadata or stripped vendor directories surface as `'unknown'`
+     * rather than an exception.
+     */
+    private static function resolveToolVersion(): string
+    {
+        try {
+            $version = InstalledVersions::getVersion(self::COMPOSER_PACKAGE_NAME);
+        } catch (Throwable) {
+            return 'unknown';
+        }
+
+        return $version ?? 'unknown';
+    }
+}

--- a/src/OpenApiRequestValidator.php
+++ b/src/OpenApiRequestValidator.php
@@ -29,6 +29,8 @@ use Studio\Gesso\Validation\Support\ValidatorErrorBoundary;
 use function array_key_exists;
 use function array_keys;
 use function array_map;
+use function array_values;
+use function count;
 use function is_array;
 use function sprintf;
 
@@ -275,20 +277,33 @@ final class OpenApiRequestValidator
         // Category tags mirror the sub-validator that produced each message so
         // issues() can expose a structured view without touching the
         // sub-validators themselves (#282, stage 1). Only body issues have a
-        // resolved spec media-type key; parameter/security issues carry null.
+        // resolved spec media-type key and (on the schema-error path) a
+        // structured violation twin; parameter/security issues carry null.
         $issueGroups = [
-            ['request.spec', $collected->specErrors, null],
-            ['request.parameter.path', ValidatorErrorBoundary::safely('path', $specName, $method, $matchedPath, fn(): array => $this->pathValidator->validate($method, $matchedPath, $collected->parameters, $pathVariables, $version, $jsonSchemaDialect)), null],
-            ['request.parameter.query', ValidatorErrorBoundary::safely('query', $specName, $method, $matchedPath, fn(): array => $this->queryValidator->validate($method, $matchedPath, $collected->parameters, $queryParams, $version, $jsonSchemaDialect)), null],
-            ['request.parameter.header', ValidatorErrorBoundary::safely('header', $specName, $method, $matchedPath, fn(): array => $this->headerValidator->validate($method, $matchedPath, $collected->parameters, $headers, $version, $jsonSchemaDialect)), null],
-            ['request.security', ValidatorErrorBoundary::safely('security', $specName, $method, $matchedPath, fn(): array => $this->securityValidator->validate($method, $matchedPath, $spec, $operation, $headers, $queryParams, $cookies)), null],
-            ['request.body', $bodyResult->errors, $bodyResult->matchedContentType],
+            ['request.spec', $collected->specErrors, null, []],
+            ['request.parameter.path', ValidatorErrorBoundary::safely('path', $specName, $method, $matchedPath, fn(): array => $this->pathValidator->validate($method, $matchedPath, $collected->parameters, $pathVariables, $version, $jsonSchemaDialect)), null, []],
+            ['request.parameter.query', ValidatorErrorBoundary::safely('query', $specName, $method, $matchedPath, fn(): array => $this->queryValidator->validate($method, $matchedPath, $collected->parameters, $queryParams, $version, $jsonSchemaDialect)), null, []],
+            ['request.parameter.header', ValidatorErrorBoundary::safely('header', $specName, $method, $matchedPath, fn(): array => $this->headerValidator->validate($method, $matchedPath, $collected->parameters, $headers, $version, $jsonSchemaDialect)), null, []],
+            ['request.security', ValidatorErrorBoundary::safely('security', $specName, $method, $matchedPath, fn(): array => $this->securityValidator->validate($method, $matchedPath, $spec, $operation, $headers, $queryParams, $cookies)), null, []],
+            ['request.body', $bodyResult->errors, $bodyResult->matchedContentType, $bodyResult->violations],
         ];
 
         $issues = [];
-        foreach ($issueGroups as [$category, $messages, $issueContentType]) {
-            foreach ($messages as $message) {
-                $issues[] = new ValidationIssue($category, $message, method: $method, path: $matchedPath, contentType: $issueContentType);
+        foreach ($issueGroups as [$category, $messages, $issueContentType, $violations]) {
+            // The violation list mirrors the messages index-for-index only on
+            // the schema-error path; non-schema body errors ship an empty
+            // list, so gate on the counts before pairing the two.
+            $aligned = $violations !== [] && count($violations) === count($messages);
+            foreach (array_values($messages) as $index => $message) {
+                $issues[] = new ValidationIssue(
+                    $category,
+                    $message,
+                    instancePath: $aligned ? $violations[$index]->instancePath : null,
+                    keyword: $aligned ? $violations[$index]->keyword : null,
+                    method: $method,
+                    path: $matchedPath,
+                    contentType: $issueContentType,
+                );
             }
         }
         $errors = array_map(static fn(ValidationIssue $issue): string => $issue->message, $issues);

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -29,6 +29,8 @@ use Studio\Gesso\Validation\Support\ValidatorErrorBoundary;
 use function array_key_exists;
 use function array_keys;
 use function array_merge;
+use function array_values;
+use function count;
 use function get_debug_type;
 use function is_array;
 use function sprintf;
@@ -410,8 +412,21 @@ final class OpenApiResponseValidator
         // change diagnostic flow without breaking behaviour. Category tags
         // mirror the producing sub-validator (#282, stage 1).
         $issues = [];
-        foreach ($bodyResult->errors as $message) {
-            $issues[] = new ValidationIssue('response.body', $message, method: $method, path: $matchedPath, statusCode: $statusCodeStr, contentType: $bodyResult->matchedContentType);
+        // The violation list mirrors the body errors index-for-index only on
+        // the schema-error path; non-schema body errors (empty body, decode
+        // failures) ship an empty list, so gate on the counts before pairing.
+        $aligned = $bodyResult->violations !== [] && count($bodyResult->violations) === count($bodyResult->errors);
+        foreach (array_values($bodyResult->errors) as $index => $message) {
+            $issues[] = new ValidationIssue(
+                'response.body',
+                $message,
+                instancePath: $aligned ? $bodyResult->violations[$index]->instancePath : null,
+                keyword: $aligned ? $bodyResult->violations[$index]->keyword : null,
+                method: $method,
+                path: $matchedPath,
+                statusCode: $statusCodeStr,
+                contentType: $bodyResult->matchedContentType,
+            );
         }
         foreach ($headerErrors as $message) {
             $issues[] = new ValidationIssue('response.header', $message, method: $method, path: $matchedPath, statusCode: $statusCodeStr, contentType: $bodyResult->matchedContentType);

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -429,7 +429,10 @@ final class OpenApiResponseValidator
             );
         }
         foreach ($headerErrors as $message) {
-            $issues[] = new ValidationIssue('response.header', $message, method: $method, path: $matchedPath, statusCode: $statusCodeStr, contentType: $bodyResult->matchedContentType);
+            // No contentType: header validation is independent of the response
+            // media type, and the documented contract reserves that context
+            // field for body issues.
+            $issues[] = new ValidationIssue('response.header', $message, method: $method, path: $matchedPath, statusCode: $statusCodeStr);
         }
         $errors = array_merge($bodyResult->errors, $headerErrors);
 

--- a/src/Validation/Request/RequestBodyValidationResult.php
+++ b/src/Validation/Request/RequestBodyValidationResult.php
@@ -39,8 +39,9 @@ use Studio\Gesso\ValidationIssue;
  *
  * `violations` carries the structured twin of `errors` on the schema-error
  * path only: index-aligned, with `errors[$i]` always equal to
- * `"[{$violations[$i]->instancePath}] {$violations[$i]->message}"`. Every
- * non-schema error site (missing required body, unknown content type,
+ * `"[{$violations[$i]->displayPath()}] {$violations[$i]->message}"` (the
+ * display path renders the RFC 6901 root pointer `''` as the legacy `/`).
+ * Every non-schema error site (missing required body, unknown content type,
  * exception boundary) leaves it empty — consumers must check the counts
  * align before pairing the two lists.
  *

--- a/src/Validation/Request/RequestBodyValidationResult.php
+++ b/src/Validation/Request/RequestBodyValidationResult.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use Studio\Gesso\OpenApiRequestValidator;
 use Studio\Gesso\OpenApiValidationResult;
 use Studio\Gesso\Validation\Response\ResponseBodyValidationResult;
+use Studio\Gesso\Validation\Support\SchemaViolation;
 use Studio\Gesso\ValidationIssue;
 
 /**
@@ -36,12 +37,20 @@ use Studio\Gesso\ValidationIssue;
  * carried so the orchestrator can attach it to `request.body`
  * {@see ValidationIssue}s (issue #282).
  *
+ * `violations` carries the structured twin of `errors` on the schema-error
+ * path only: index-aligned, with `errors[$i]` always equal to
+ * `"[{$violations[$i]->instancePath}] {$violations[$i]->message}"`. Every
+ * non-schema error site (missing required body, unknown content type,
+ * exception boundary) leaves it empty — consumers must check the counts
+ * align before pairing the two lists.
+ *
  * @internal Not part of the package's public API. Do not use from user code.
  */
 final readonly class RequestBodyValidationResult
 {
     /**
      * @param string[] $errors
+     * @param list<SchemaViolation> $violations
      *
      * @throws InvalidArgumentException when `skipReason` is set alongside a
      *                                  non-empty `errors` list — a skip means the body was deliberately
@@ -52,6 +61,7 @@ final readonly class RequestBodyValidationResult
         public array $errors,
         public ?string $skipReason = null,
         public ?string $matchedContentType = null,
+        public array $violations = [],
     ) {
         if ($skipReason !== null && $errors !== []) {
             throw new InvalidArgumentException(

--- a/src/Validation/Request/RequestBodyValidator.php
+++ b/src/Validation/Request/RequestBodyValidator.php
@@ -283,16 +283,18 @@ final class RequestBodyValidator
         $schemaObject = ObjectConverter::convert($jsonSchema);
         $dataObject = ObjectConverter::convert($bodyValue);
 
-        $formatted = $this->runner->validate($schemaObject, $dataObject);
+        $violations = $this->runner->validateStructured($schemaObject, $dataObject);
 
         $errors = [];
-        foreach ($formatted as $path => $messages) {
-            foreach ($messages as $message) {
-                $errors[] = "[{$path}] {$message}";
-            }
+        foreach ($violations as $violation) {
+            $errors[] = "[{$violation->instancePath}] {$violation->message}";
         }
 
-        return new RequestBodyValidationResult($errors, matchedContentType: $jsonContentType);
+        return new RequestBodyValidationResult(
+            $errors,
+            matchedContentType: $jsonContentType,
+            violations: $violations,
+        );
     }
 
     private static function missingRequiredBodyResult(

--- a/src/Validation/Request/RequestBodyValidator.php
+++ b/src/Validation/Request/RequestBodyValidator.php
@@ -287,7 +287,7 @@ final class RequestBodyValidator
 
         $errors = [];
         foreach ($violations as $violation) {
-            $errors[] = "[{$violation->instancePath}] {$violation->message}";
+            $errors[] = "[{$violation->displayPath()}] {$violation->message}";
         }
 
         return new RequestBodyValidationResult(

--- a/src/Validation/Response/ResponseBodyValidationResult.php
+++ b/src/Validation/Response/ResponseBodyValidationResult.php
@@ -31,8 +31,9 @@ use Studio\Gesso\Validation\Support\SchemaViolation;
  *
  * `violations` carries the structured twin of `errors` on the schema-error
  * path only: index-aligned, with `errors[$i]` always equal to
- * `"[{$violations[$i]->instancePath}] {$violations[$i]->message}"`. Every
- * non-schema error site (empty body, decode failure) leaves it empty —
+ * `"[{$violations[$i]->displayPath()}] {$violations[$i]->message}"` (the
+ * display path renders the RFC 6901 root pointer `''` as the legacy `/`).
+ * Every non-schema error site (empty body, decode failure) leaves it empty —
  * consumers must check the counts align before pairing the two lists.
  *
  * @internal Not part of the package's public API. Do not use from user code.

--- a/src/Validation/Response/ResponseBodyValidationResult.php
+++ b/src/Validation/Response/ResponseBodyValidationResult.php
@@ -6,6 +6,7 @@ namespace Studio\Gesso\Validation\Response;
 
 use InvalidArgumentException;
 use Studio\Gesso\OpenApiValidationResult;
+use Studio\Gesso\Validation\Support\SchemaViolation;
 
 /**
  * Outcome of {@see ResponseBodyValidator::validate()}.
@@ -28,12 +29,19 @@ use Studio\Gesso\OpenApiValidationResult;
  * Coverage tracking uses `matchedContentType` to record per-(status, media-type)
  * granularity instead of treating the whole endpoint as a single bucket.
  *
+ * `violations` carries the structured twin of `errors` on the schema-error
+ * path only: index-aligned, with `errors[$i]` always equal to
+ * `"[{$violations[$i]->instancePath}] {$violations[$i]->message}"`. Every
+ * non-schema error site (empty body, decode failure) leaves it empty —
+ * consumers must check the counts align before pairing the two lists.
+ *
  * @internal Not part of the package's public API. Do not use from user code.
  */
 final readonly class ResponseBodyValidationResult
 {
     /**
      * @param string[] $errors
+     * @param list<SchemaViolation> $violations
      *
      * @throws InvalidArgumentException when `skipReason` is set alongside a
      *                                  non-empty `errors` list (a skip is mutually exclusive with
@@ -45,6 +53,7 @@ final readonly class ResponseBodyValidationResult
         public array $errors,
         public ?string $matchedContentType,
         public ?string $skipReason = null,
+        public array $violations = [],
     ) {
         if ($skipReason !== null && $errors !== []) {
             throw new InvalidArgumentException(

--- a/src/Validation/Response/ResponseBodyValidator.php
+++ b/src/Validation/Response/ResponseBodyValidator.php
@@ -253,16 +253,14 @@ final class ResponseBodyValidator
         $schemaObject = ObjectConverter::convert($jsonSchema);
         $dataObject = ObjectConverter::convert($bodyValue);
 
-        $formatted = $this->runner->validate($schemaObject, $dataObject);
+        $violations = $this->runner->validateStructured($schemaObject, $dataObject);
 
         $errors = [];
-        foreach ($formatted as $path => $messages) {
-            foreach ($messages as $message) {
-                $errors[] = "[{$path}] {$message}";
-            }
+        foreach ($violations as $violation) {
+            $errors[] = "[{$violation->instancePath}] {$violation->message}";
         }
 
-        return new ResponseBodyValidationResult($errors, $jsonContentType);
+        return new ResponseBodyValidationResult($errors, $jsonContentType, violations: $violations);
     }
 
     private static function unsupportedItemSchemaResult(string $matchedKey, string $actualMediaType): ResponseBodyValidationResult

--- a/src/Validation/Response/ResponseBodyValidator.php
+++ b/src/Validation/Response/ResponseBodyValidator.php
@@ -257,7 +257,7 @@ final class ResponseBodyValidator
 
         $errors = [];
         foreach ($violations as $violation) {
-            $errors[] = "[{$violation->instancePath}] {$violation->message}";
+            $errors[] = "[{$violation->displayPath()}] {$violation->message}";
         }
 
         return new ResponseBodyValidationResult($errors, $jsonContentType, violations: $violations);

--- a/src/Validation/Support/SchemaValidatorRunner.php
+++ b/src/Validation/Support/SchemaValidatorRunner.php
@@ -93,6 +93,26 @@ final class SchemaValidatorRunner
      */
     public function validate(mixed $jsonSchema, mixed $data): array
     {
+        $grouped = [];
+        foreach ($this->validateStructured($jsonSchema, $data) as $violation) {
+            $grouped[$violation->instancePath][] = $violation->message;
+        }
+
+        return $grouped;
+    }
+
+    /**
+     * Structured variant of {@see self::validate()}: same violations, same
+     * order (the pointer-keyed map above is derived from this list, so the
+     * two views can never drift), but each entry keeps the instance pointer
+     * and failing keyword as fields instead of baking the pointer into a
+     * `[{pointer}] {message}` prefix. Runs through the same cascade-dedup
+     * pipeline (issue #159).
+     *
+     * @return list<SchemaViolation>
+     */
+    public function validateStructured(mixed $jsonSchema, mixed $data): array
+    {
         $jsonSchema = $this->canonicalSchema($jsonSchema);
         $result = $this->opisValidator->validate($data, $jsonSchema);
 
@@ -108,15 +128,33 @@ final class SchemaValidatorRunner
             // ErrorFormatter::format() and producing a TypeError, so the
             // validator still surfaces *something* if the opis invariant
             // ever changes.
-            return ['/' => ['Schema validation failed but opis reported no error detail.']];
+            return [new SchemaViolation('/', null, 'Schema validation failed but opis reported no error detail.')];
         }
 
         $cascadeActions = self::computeCascadeActions($error, $jsonSchema);
 
-        return self::applyCascadeActions(
-            $this->errorFormatter->format($error),
-            $cascadeActions,
+        // Custom formatter callable so each entry keeps its keyword next to
+        // the interpolated message; the default key formatter still renders
+        // the instance pointer, preserving the grouping/order `validate()`
+        // has always produced.
+        /** @var array<string, list<array{message: string, keyword: string}>> $formatted */
+        $formatted = $this->errorFormatter->format(
+            $error,
+            true,
+            fn(ValidationError $entryError, ?string $message = null): array => [
+                'message' => $this->errorFormatter->formatErrorMessage($entryError, $message),
+                'keyword' => $entryError->keyword(),
+            ],
         );
+
+        $violations = [];
+        foreach (self::applyCascadeActions($formatted, $cascadeActions) as $path => $entries) {
+            foreach ($entries as $entry) {
+                $violations[] = new SchemaViolation($path, $entry['keyword'], $entry['message']);
+            }
+        }
+
+        return $violations;
     }
 
     /**
@@ -200,18 +238,19 @@ final class SchemaValidatorRunner
      * genuinely-additional names. Sibling messages at the same path (e.g. a
      * `required` failure that fired in the same object) are preserved.
      *
-     * The detection of which message line is the cascade target uses a regex
-     * against opis's English template (`Additional object properties are not
-     * allowed: ...`). If opis ever rewords this template, the regex stops
-     * matching and we leave the messages unchanged — fail-safe in the noisy
-     * direction (no silent suppression of real violations). This is the only
-     * string-based step in the pipeline; the property-name comparison itself
-     * is fully structural.
+     * The cascade target is identified structurally (`keyword ===
+     * 'additionalProperties'`) AND by opis's English template (`Additional
+     * object properties are not allowed: ...`) — the rewrite re-renders that
+     * template, so it must not fire on a message whose wording it cannot
+     * reproduce. If opis ever rewords the template, the regex stops matching
+     * and the messages are left unchanged — fail-safe in the noisy direction
+     * (no silent suppression of real violations). The property-name
+     * comparison itself is fully structural.
      *
-     * @param array<string, string[]> $errors
+     * @param array<string, list<array{message: string, keyword: string}>> $errors
      * @param array<string, list<string>> $actions
      *
-     * @return array<string, string[]>
+     * @return array<string, list<array{message: string, keyword: string}>>
      */
     private static function applyCascadeActions(array $errors, array $actions): array
     {
@@ -219,16 +258,18 @@ final class SchemaValidatorRunner
             return $errors;
         }
 
-        foreach ($errors as $path => $messages) {
+        foreach ($errors as $path => $entries) {
             if (!array_key_exists($path, $actions)) {
                 continue;
             }
 
             $real = $actions[$path];
             $kept = [];
-            foreach ($messages as $message) {
-                if (preg_match('/^Additional object properties are not allowed: /', $message) !== 1) {
-                    $kept[] = $message;
+            foreach ($entries as $entry) {
+                if ($entry['keyword'] !== 'additionalProperties'
+                    || preg_match('/^Additional object properties are not allowed: /', $entry['message']) !== 1
+                ) {
+                    $kept[] = $entry;
 
                     continue;
                 }
@@ -238,10 +279,13 @@ final class SchemaValidatorRunner
                     continue;
                 }
 
-                $kept[] = sprintf(
-                    'Additional object properties are not allowed: %s',
-                    implode(', ', $real),
-                );
+                $kept[] = [
+                    'message' => sprintf(
+                        'Additional object properties are not allowed: %s',
+                        implode(', ', $real),
+                    ),
+                    'keyword' => $entry['keyword'],
+                ];
             }
 
             if ($kept === []) {

--- a/src/Validation/Support/SchemaValidatorRunner.php
+++ b/src/Validation/Support/SchemaValidatorRunner.php
@@ -266,8 +266,8 @@ final class SchemaValidatorRunner
             $real = $actions[$path];
             $kept = [];
             foreach ($entries as $entry) {
-                if ($entry['keyword'] !== 'additionalProperties'
-                    || preg_match('/^Additional object properties are not allowed: /', $entry['message']) !== 1
+                if ($entry['keyword'] !== 'additionalProperties' ||
+                    preg_match('/^Additional object properties are not allowed: /', $entry['message']) !== 1
                 ) {
                     $kept[] = $entry;
 

--- a/src/Validation/Support/SchemaValidatorRunner.php
+++ b/src/Validation/Support/SchemaValidatorRunner.php
@@ -95,7 +95,7 @@ final class SchemaValidatorRunner
     {
         $grouped = [];
         foreach ($this->validateStructured($jsonSchema, $data) as $violation) {
-            $grouped[$violation->instancePath][] = $violation->message;
+            $grouped[$violation->displayPath()][] = $violation->message;
         }
 
         return $grouped;
@@ -108,6 +108,10 @@ final class SchemaValidatorRunner
      * and failing keyword as fields instead of baking the pointer into a
      * `[{pointer}] {message}` prefix. Runs through the same cascade-dedup
      * pipeline (issue #159).
+     *
+     * Pointers here are RFC 6901 (`''` = document root, `'/'` = the
+     * empty-string key) — unlike the map view, which keeps opis's legacy
+     * rendering of both as `'/'` ({@see SchemaViolation::displayPath()}).
      *
      * @return list<SchemaViolation>
      */
@@ -128,15 +132,16 @@ final class SchemaValidatorRunner
             // ErrorFormatter::format() and producing a TypeError, so the
             // validator still surfaces *something* if the opis invariant
             // ever changes.
-            return [new SchemaViolation('/', null, 'Schema validation failed but opis reported no error detail.')];
+            return [new SchemaViolation('', null, 'Schema validation failed but opis reported no error detail.')];
         }
 
         $cascadeActions = self::computeCascadeActions($error, $jsonSchema);
 
         // Custom formatter callable so each entry keeps its keyword next to
-        // the interpolated message; the default key formatter still renders
-        // the instance pointer, preserving the grouping/order `validate()`
-        // has always produced.
+        // the interpolated message; the custom key formatter produces RFC
+        // 6901 pointers (root = '') instead of opis's default, which renders
+        // the root and the empty-string key identically as '/'. Grouping and
+        // order are otherwise exactly what `validate()` has always produced.
         /** @var array<string, list<array{message: string, keyword: string}>> $formatted */
         $formatted = $this->errorFormatter->format(
             $error,
@@ -145,6 +150,7 @@ final class SchemaValidatorRunner
                 'message' => $this->errorFormatter->formatErrorMessage($entryError, $message),
                 'keyword' => $entryError->keyword(),
             ],
+            static fn(ValidationError $entryError): string => self::instancePointer($entryError->data()->fullPath()),
         );
 
         $violations = [];
@@ -155,6 +161,20 @@ final class SchemaValidatorRunner
         }
 
         return $violations;
+    }
+
+    /**
+     * Render raw data-path segments as an RFC 6901 JSON Pointer. Non-empty
+     * paths match opis's `JsonPointer::pathToString()` byte-for-byte; the
+     * empty path becomes `''` (the RFC root pointer) where opis would return
+     * `'/'` — which is also what it returns for the empty-string key, an
+     * ambiguity the structured output must not inherit.
+     *
+     * @param array<int, mixed> $segments
+     */
+    private static function instancePointer(array $segments): string
+    {
+        return $segments === [] ? '' : JsonPointer::pathToString($segments);
     }
 
     /**
@@ -220,7 +240,7 @@ final class SchemaValidatorRunner
                     // unchanged so we don't pay the format-pass cost or
                     // risk re-encoding the message.
                     if (count($real) < count($listed)) {
-                        $actions[JsonPointer::pathToString($segments)] = $real;
+                        $actions[self::instancePointer($segments)] = $real;
                     }
                 }
             }

--- a/src/Validation/Support/SchemaViolation.php
+++ b/src/Validation/Support/SchemaViolation.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Validation\Support;
+
+/**
+ * One JSON Schema violation reported by {@see SchemaValidatorRunner}, keeping
+ * the structured fields (instance pointer, failing keyword) that the flat
+ * `[{pointer}] {message}` string rendering discards (issue #282, stage 2).
+ *
+ * `instancePath` is the JSON Pointer into the validated instance exactly as
+ * opis's ErrorFormatter renders it (`/` = document root). `keyword` is the
+ * JSON Schema keyword that failed (`type`, `required`, …); it is null only
+ * for the runner's defensive "no error detail" synthetic entry. `message` is
+ * the human-readable prose without the pointer prefix.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+final readonly class SchemaViolation
+{
+    public function __construct(
+        public string $instancePath,
+        public ?string $keyword,
+        public string $message,
+    ) {}
+}

--- a/src/Validation/Support/SchemaViolation.php
+++ b/src/Validation/Support/SchemaViolation.php
@@ -9,11 +9,15 @@ namespace Studio\Gesso\Validation\Support;
  * the structured fields (instance pointer, failing keyword) that the flat
  * `[{pointer}] {message}` string rendering discards (issue #282, stage 2).
  *
- * `instancePath` is the JSON Pointer into the validated instance exactly as
- * opis's ErrorFormatter renders it (`/` = document root). `keyword` is the
- * JSON Schema keyword that failed (`type`, `required`, …); it is null only
- * for the runner's defensive "no error detail" synthetic entry. `message` is
- * the human-readable prose without the pointer prefix.
+ * `instancePath` is an RFC 6901 JSON Pointer into the validated instance:
+ * `''` (empty string) is the document root and `'/'` is the property whose
+ * name is the empty string. This deliberately diverges from opis's
+ * `JsonPointer::pathToString()`, which renders both as `'/'` and cannot
+ * distinguish them — {@see self::displayPath()} reproduces that legacy
+ * rendering for the human-readable views. `keyword` is the JSON Schema
+ * keyword that failed (`type`, `required`, …); it is null only for the
+ * runner's defensive "no error detail" synthetic entry. `message` is the
+ * human-readable prose without the pointer prefix.
  *
  * @internal Not part of the package's public API. Do not use from user code.
  */
@@ -24,4 +28,16 @@ final readonly class SchemaViolation
         public ?string $keyword,
         public string $message,
     ) {}
+
+    /**
+     * The pointer as historically rendered in error strings and in
+     * {@see SchemaValidatorRunner::validate()} map keys: the document root
+     * shows as `'/'` (collapsing the RFC distinction with the empty-string
+     * key, which also renders `'/'`). Kept so the flat error prose stays
+     * byte-identical while `instancePath` itself is unambiguous.
+     */
+    public function displayPath(): string
+    {
+        return $this->instancePath === '' ? '/' : $this->instancePath;
+    }
 }

--- a/src/ValidationIssue.php
+++ b/src/ValidationIssue.php
@@ -11,9 +11,10 @@ namespace Studio\Gesso;
  * `category` is a stable slug and part of the documented compatibility
  * surface (see docs/versioning.md); `message` is the exact human-readable
  * error text and remains explicitly outside the compatibility contract.
- * `instancePath` (JSON Pointer into the validated body) and `keyword` (the
- * failing JSON Schema keyword) are populated on body-schema violations and
- * stay null for every other error source (issue #282, stage 2).
+ * `instancePath` (RFC 6901 JSON Pointer into the validated body, `''` =
+ * document root) and `keyword` (the failing JSON Schema keyword) are
+ * populated on body-schema violations and stay null for every other error
+ * source (issue #282, stage 2).
  */
 final readonly class ValidationIssue
 {

--- a/src/ValidationIssue.php
+++ b/src/ValidationIssue.php
@@ -11,8 +11,9 @@ namespace Studio\Gesso;
  * `category` is a stable slug and part of the documented compatibility
  * surface (see docs/versioning.md); `message` is the exact human-readable
  * error text and remains explicitly outside the compatibility contract.
- * `instancePath` and `keyword` are reserved for body-schema errors and stay
- * null until the structured schema-runner output ships (issue #282, stage 2).
+ * `instancePath` (JSON Pointer into the validated body) and `keyword` (the
+ * failing JSON Schema keyword) are populated on body-schema violations and
+ * stay null for every other error source (issue #282, stage 2).
  */
 final readonly class ValidationIssue
 {

--- a/tests/Unit/Compatibility/PublicApiBaselineTest.php
+++ b/tests/Unit/Compatibility/PublicApiBaselineTest.php
@@ -21,6 +21,7 @@ use Studio\Gesso\Coverage\JUnitCoverageRenderer;
 use Studio\Gesso\Coverage\MarkdownCoverageRenderer;
 use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
 use Studio\Gesso\Fuzz\ExploredCase;
+use Studio\Gesso\JsonValidationResultRenderer;
 use Studio\Gesso\Laravel\Commands\OpenApiRoutesCommand;
 use Studio\Gesso\OpenApiResponseValidator;
 use Studio\Gesso\OpenApiValidationResult;
@@ -354,6 +355,54 @@ final class PublicApiBaselineTest extends TestCase
                         $issueOptionalParam('path'),
                         $issueOptionalParam('statusCode'),
                         $issueOptionalParam('contentType'),
+                    ],
+                ],
+            ],
+        ];
+        // New public class in v2.x (#282 stage 2): versioned JSON output for
+        // validation results.
+        $expected[JsonValidationResultRenderer::class] = [
+            'kind' => 'class',
+            'final' => true,
+            'abstract' => false,
+            'readonly' => false,
+            'instantiable' => true,
+            'constructor' => ['kind' => 'implicit', 'visibility' => 'public'],
+            'parent' => null,
+            'interfaces' => [],
+            'traits' => [],
+            'attributes' => [],
+            'backing_type' => null,
+            'cases' => [],
+            'constants' => ['SCHEMA_VERSION' => 1],
+            'properties' => [],
+            'methods' => [
+                'render' => [
+                    'static' => true,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'string',
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'result',
+                            'type' => 'Studio\Gesso\OpenApiValidationResult',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => ['unavailable' => true],
+                            'attributes' => [],
+                        ],
+                        [
+                            'name' => 'reproduceCommand',
+                            'type' => '?string',
+                            'optional' => true,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => null,
+                            'attributes' => [],
+                        ],
                     ],
                 ],
             ],

--- a/tests/Unit/JsonValidationResultRendererTest.php
+++ b/tests/Unit/JsonValidationResultRendererTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit;
+
+use const JSON_THROW_ON_ERROR;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\Gesso\JsonValidationResultRenderer;
+use Studio\Gesso\OpenApiValidationResult;
+use Studio\Gesso\ValidationIssue;
+
+use function json_decode;
+
+class JsonValidationResultRendererTest extends TestCase
+{
+    #[Test]
+    public function failure_serialises_issues_with_all_fields(): void
+    {
+        $result = OpenApiValidationResult::failure(
+            ['[/name] The data (integer) must match the type: string', 'query error'],
+            '/v1/pets',
+            matchedContentType: 'application/json',
+            issues: [
+                new ValidationIssue(
+                    'request.body',
+                    '[/name] The data (integer) must match the type: string',
+                    instancePath: '/name',
+                    keyword: 'type',
+                    method: 'POST',
+                    path: '/v1/pets',
+                    contentType: 'application/json',
+                ),
+                new ValidationIssue(
+                    'request.parameter.query',
+                    'query error',
+                    method: 'POST',
+                    path: '/v1/pets',
+                ),
+            ],
+        );
+
+        $decoded = self::decode(JsonValidationResultRenderer::render($result));
+
+        $this->assertSame(1, $decoded['schema_version']);
+        $this->assertSame('studio-design/gesso', $decoded['tool']['name']);
+        $this->assertIsString($decoded['tool']['version']);
+        $this->assertSame('failure', $decoded['outcome']);
+        $this->assertSame(
+            ['path' => '/v1/pets', 'status_code' => null, 'content_type' => 'application/json'],
+            $decoded['matched'],
+        );
+        $this->assertNull($decoded['skip_reason']);
+        $this->assertNull($decoded['reproduce_command']);
+        $this->assertSame(
+            [
+                [
+                    'category' => 'request.body',
+                    'message' => '[/name] The data (integer) must match the type: string',
+                    'instance_path' => '/name',
+                    'keyword' => 'type',
+                    'method' => 'POST',
+                    'path' => '/v1/pets',
+                    'status_code' => null,
+                    'content_type' => 'application/json',
+                ],
+                [
+                    'category' => 'request.parameter.query',
+                    'message' => 'query error',
+                    'instance_path' => null,
+                    'keyword' => null,
+                    'method' => 'POST',
+                    'path' => '/v1/pets',
+                    'status_code' => null,
+                    'content_type' => null,
+                ],
+            ],
+            $decoded['issues'],
+        );
+    }
+
+    #[Test]
+    public function success_serialises_with_empty_issues(): void
+    {
+        $result = OpenApiValidationResult::success('/v1/pets', '200', 'application/json');
+
+        $decoded = self::decode(JsonValidationResultRenderer::render($result));
+
+        $this->assertSame('success', $decoded['outcome']);
+        $this->assertSame(
+            ['path' => '/v1/pets', 'status_code' => '200', 'content_type' => 'application/json'],
+            $decoded['matched'],
+        );
+        $this->assertNull($decoded['skip_reason']);
+        $this->assertSame([], $decoded['issues']);
+    }
+
+    #[Test]
+    public function skipped_serialises_the_reason(): void
+    {
+        $result = OpenApiValidationResult::skipped('/v1/pets', 'undocumented 5xx', '503');
+
+        $decoded = self::decode(JsonValidationResultRenderer::render($result));
+
+        $this->assertSame('skipped', $decoded['outcome']);
+        $this->assertSame('undocumented 5xx', $decoded['skip_reason']);
+        $this->assertSame('503', $decoded['matched']['status_code']);
+        $this->assertSame([], $decoded['issues']);
+    }
+
+    #[Test]
+    public function legacy_failure_serialises_derived_unknown_issues(): void
+    {
+        // Results built without tagged issues derive one `unknown` issue per
+        // error string; the JSON view must serialise those the same way.
+        $result = OpenApiValidationResult::failure(['some error'], '/v1/pets', '404');
+
+        $decoded = self::decode(JsonValidationResultRenderer::render($result));
+
+        $this->assertCount(1, $decoded['issues']);
+        $this->assertSame('unknown', $decoded['issues'][0]['category']);
+        $this->assertSame('some error', $decoded['issues'][0]['message']);
+        $this->assertSame('404', $decoded['issues'][0]['status_code']);
+    }
+
+    #[Test]
+    public function reproduce_command_is_embedded_verbatim(): void
+    {
+        $result = OpenApiValidationResult::failure(['boom']);
+        $command = "curl -X POST 'https://api.test/v1/pets' -H 'Authorization: <redacted>'";
+
+        $decoded = self::decode(JsonValidationResultRenderer::render($result, $command));
+
+        $this->assertSame($command, $decoded['reproduce_command']);
+    }
+
+    #[Test]
+    public function document_is_pretty_printed_with_trailing_newline(): void
+    {
+        $document = JsonValidationResultRenderer::render(OpenApiValidationResult::success());
+
+        $this->assertStringEndsWith("}\n", $document);
+        $this->assertStringContainsString("\n    \"schema_version\": 1", $document);
+        // Unescaped slashes keep categories and pointers readable.
+        $this->assertStringNotContainsString('\\/', $document);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function decode(string $document): array
+    {
+        /** @var array<string, mixed> */
+        return json_decode($document, true, flags: JSON_THROW_ON_ERROR);
+    }
+}

--- a/tests/Unit/OpenApiRequestValidatorTest.php
+++ b/tests/Unit/OpenApiRequestValidatorTest.php
@@ -301,6 +301,66 @@ class OpenApiRequestValidatorTest extends TestCase
     }
 
     #[Test]
+    public function request_body_issues_carry_instance_path_and_keyword(): void
+    {
+        // Issue #282 stage 2: schema-produced request.body issues expose the
+        // structured pointer and failing keyword; every other error source
+        // keeps both fields null.
+        $result = $this->validator->validate(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            [],
+            [],
+            ['name' => 42, 'tag' => 7],
+            'application/json',
+        );
+
+        $bodyIssues = array_values(array_filter(
+            $result->issues(),
+            static fn($issue) => $issue->category === 'request.body',
+        ));
+        $this->assertCount(2, $bodyIssues);
+        $byPointer = [];
+        foreach ($bodyIssues as $issue) {
+            $byPointer[$issue->instancePath] = $issue;
+            $this->assertStringStartsWith("[{$issue->instancePath}] ", $issue->message);
+        }
+        $this->assertArrayHasKey('/name', $byPointer);
+        $this->assertSame('type', $byPointer['/name']->keyword);
+        $this->assertArrayHasKey('/tag', $byPointer);
+        $this->assertSame('type', $byPointer['/tag']->keyword);
+
+        // Non-schema body error (missing required body) stays null/null.
+        $missingBody = $this->validator->validate(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            [],
+            [],
+            null,
+            'application/json',
+        );
+        $missingBodyIssues = array_values(array_filter(
+            $missingBody->issues(),
+            static fn($issue) => $issue->category === 'request.body',
+        ));
+        $this->assertNotEmpty($missingBodyIssues);
+        $this->assertNull($missingBodyIssues[0]->instancePath);
+        $this->assertNull($missingBodyIssues[0]->keyword);
+
+        // Parameter issues never carry schema context.
+        $query = $this->validator->validate('openapi-3.2', 'GET', '/v1/filter', ['limit' => '0'], [], null);
+        $queryIssues = array_values(array_filter(
+            $query->issues(),
+            static fn($issue) => $issue->category === 'request.parameter.query',
+        ));
+        $this->assertNotEmpty($queryIssues);
+        $this->assertNull($queryIssues[0]->instancePath);
+        $this->assertNull($queryIssues[0]->keyword);
+    }
+
+    #[Test]
     public function path_not_found_issue_is_categorized(): void
     {
         $result = $this->validator->validate('petstore-3.0', 'GET', '/v1/does-not-exist', [], [], null);

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -15,7 +15,9 @@ use Studio\Gesso\OpenApiResponseValidator;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
 
+use function array_filter;
 use function array_map;
+use function array_values;
 use function count;
 use function implode;
 use function range;
@@ -94,6 +96,49 @@ class OpenApiResponseValidatorTest extends TestCase
             $result->errors(),
             array_map(static fn($issue) => $issue->message, $issues),
         );
+    }
+
+    #[Test]
+    public function response_body_issues_carry_instance_path_and_keyword(): void
+    {
+        // Issue #282 stage 2: schema-produced response.body issues expose the
+        // structured pointer and failing keyword.
+        $result = $this->validator->validate(
+            'psr7',
+            'POST',
+            '/widgets/42',
+            201,
+            ['id' => 'not-an-integer'],
+            'application/json',
+            ['X-Trace' => 'abc'],
+        );
+
+        $bodyIssues = array_values(array_filter(
+            $result->issues(),
+            static fn($issue) => $issue->category === 'response.body',
+        ));
+        $this->assertNotEmpty($bodyIssues);
+        $this->assertSame('/id', $bodyIssues[0]->instancePath);
+        $this->assertSame('type', $bodyIssues[0]->keyword);
+        $this->assertStringStartsWith('[/id] ', $bodyIssues[0]->message);
+
+        // Header issues are not schema violations — both fields stay null.
+        $headerFailure = $this->validator->validate(
+            'psr7',
+            'POST',
+            '/widgets/42',
+            201,
+            ['id' => 1],
+            'application/json',
+            [],
+        );
+        $headerIssues = array_values(array_filter(
+            $headerFailure->issues(),
+            static fn($issue) => $issue->category === 'response.header',
+        ));
+        $this->assertNotEmpty($headerIssues);
+        $this->assertNull($headerIssues[0]->instancePath);
+        $this->assertNull($headerIssues[0]->keyword);
     }
 
     #[Test]

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -139,6 +139,9 @@ class OpenApiResponseValidatorTest extends TestCase
         $this->assertNotEmpty($headerIssues);
         $this->assertNull($headerIssues[0]->instancePath);
         $this->assertNull($headerIssues[0]->keyword);
+        // Header validation is independent of the response media type —
+        // contentType is documented as body-issue-only context.
+        $this->assertNull($headerIssues[0]->contentType);
     }
 
     #[Test]

--- a/tests/Unit/Validation/Request/RequestBodyValidatorTest.php
+++ b/tests/Unit/Validation/Request/RequestBodyValidatorTest.php
@@ -413,6 +413,72 @@ class RequestBodyValidatorTest extends TestCase
     }
 
     #[Test]
+    public function validate_carries_structured_violations_aligned_with_errors(): void
+    {
+        // Issue #282 stage 2: schema errors keep their structured twin so the
+        // orchestrator can attach instancePath/keyword to request.body issues.
+        $operation = [
+            'requestBody' => [
+                'content' => [
+                    'application/json' => [
+                        'schema' => [
+                            'type' => 'object',
+                            'properties' => ['name' => ['type' => 'string']],
+                            'required' => ['name', 'age'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->validator->validate(
+            'spec',
+            'POST',
+            '/pets',
+            $operation,
+            DecodedBody::present(['name' => 42]),
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertCount(2, $result->errors);
+        $this->assertCount(2, $result->violations);
+        foreach ($result->violations as $index => $violation) {
+            $this->assertSame(
+                "[{$violation->instancePath}] {$violation->message}",
+                $result->errors[$index],
+            );
+            $this->assertNotNull($violation->keyword);
+        }
+    }
+
+    #[Test]
+    public function validate_reports_no_violations_for_non_schema_errors(): void
+    {
+        $operation = [
+            'requestBody' => [
+                'required' => true,
+                'content' => [
+                    'application/json' => ['schema' => ['type' => 'object']],
+                ],
+            ],
+        ];
+
+        $result = $this->validator->validate(
+            'spec',
+            'POST',
+            '/pets',
+            $operation,
+            DecodedBody::absent(),
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertNotSame([], $result->errors);
+        $this->assertSame([], $result->violations);
+    }
+
+    #[Test]
     public function validate_accepts_empty_object_body_against_type_object(): void
     {
         // PHP's `json_decode('{}', true) === []` — the Laravel adapter's

--- a/tests/Unit/Validation/Request/RequestBodyValidatorTest.php
+++ b/tests/Unit/Validation/Request/RequestBodyValidatorTest.php
@@ -445,7 +445,7 @@ class RequestBodyValidatorTest extends TestCase
         $this->assertCount(2, $result->violations);
         foreach ($result->violations as $index => $violation) {
             $this->assertSame(
-                "[{$violation->instancePath}] {$violation->message}",
+                "[{$violation->displayPath()}] {$violation->message}",
                 $result->errors[$index],
             );
             $this->assertNotNull($violation->keyword);

--- a/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
+++ b/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
@@ -75,6 +75,65 @@ class ResponseBodyValidatorTest extends TestCase
     }
 
     #[Test]
+    public function validate_carries_structured_violations_aligned_with_errors(): void
+    {
+        // Issue #282 stage 2: schema errors keep their structured twin so the
+        // orchestrator can attach instancePath/keyword to response.body issues.
+        $content = [
+            'application/json' => [
+                'schema' => [
+                    'type' => 'object',
+                    'properties' => ['id' => ['type' => 'integer']],
+                    'required' => ['id', 'name'],
+                ],
+            ],
+        ];
+
+        $result = $this->validator->validate(
+            'spec',
+            'GET',
+            '/pets',
+            200,
+            $content,
+            DecodedBody::present(['id' => 'not-an-int']),
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertCount(2, $result->errors);
+        $this->assertCount(2, $result->violations);
+        foreach ($result->violations as $index => $violation) {
+            $this->assertSame(
+                "[{$violation->instancePath}] {$violation->message}",
+                $result->errors[$index],
+            );
+            $this->assertNotNull($violation->keyword);
+        }
+    }
+
+    #[Test]
+    public function validate_reports_no_violations_for_non_schema_errors(): void
+    {
+        $content = [
+            'application/json' => ['schema' => ['type' => 'object']],
+        ];
+
+        $result = $this->validator->validate(
+            'spec',
+            'GET',
+            '/pets',
+            200,
+            $content,
+            DecodedBody::absent(),
+            'application/json',
+            OpenApiVersion::V3_0,
+        );
+
+        $this->assertNotSame([], $result->errors);
+        $this->assertSame([], $result->violations);
+    }
+
+    #[Test]
     public function validate_type_checks_present_literal_null_body_against_object_schema(): void
     {
         // Issue #246: a response body of the literal JSON `null` (the four

--- a/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
+++ b/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
@@ -104,7 +104,7 @@ class ResponseBodyValidatorTest extends TestCase
         $this->assertCount(2, $result->violations);
         foreach ($result->violations as $index => $violation) {
             $this->assertSame(
-                "[{$violation->instancePath}] {$violation->message}",
+                "[{$violation->displayPath()}] {$violation->message}",
                 $result->errors[$index],
             );
             $this->assertNotNull($violation->keyword);

--- a/tests/Unit/Validation/Support/SchemaValidatorRunnerTest.php
+++ b/tests/Unit/Validation/Support/SchemaValidatorRunnerTest.php
@@ -1161,6 +1161,138 @@ class SchemaValidatorRunnerTest extends TestCase
         );
     }
 
+    // ============================================================
+    // Structured output (issue #282, stage 2)
+    //
+    // validateStructured() is the source of truth; validate() derives
+    // its pointer-keyed map from it. These tests pin the structured
+    // entries (pointer + keyword + unprefixed message) and the
+    // equivalence between the two views, including through the
+    // cascade-dedup pipeline above.
+    // ============================================================
+
+    #[Test]
+    public function validate_structured_returns_empty_list_for_valid_data(): void
+    {
+        $runner = new SchemaValidatorRunner(20);
+        $schema = ObjectConverter::convert(['type' => 'integer']);
+
+        $this->assertSame([], $runner->validateStructured($schema, 42));
+    }
+
+    #[Test]
+    public function validate_structured_carries_pointer_and_keyword_per_violation(): void
+    {
+        $runner = new SchemaValidatorRunner(0);
+        $schema = ObjectConverter::convert([
+            'type' => 'object',
+            'properties' => [
+                'count' => ['type' => 'integer'],
+            ],
+            'required' => ['count', 'name'],
+        ]);
+        $data = ObjectConverter::convert(['count' => 'not-an-int']);
+
+        $violations = $runner->validateStructured($schema, $data);
+
+        $byPath = [];
+        foreach ($violations as $violation) {
+            $byPath[$violation->instancePath][] = $violation;
+        }
+
+        $this->assertArrayHasKey('/count', $byPath);
+        $this->assertSame('type', $byPath['/count'][0]->keyword);
+        $this->assertStringContainsString('integer', $byPath['/count'][0]->message);
+
+        $this->assertArrayHasKey('/', $byPath);
+        $this->assertSame('required', $byPath['/'][0]->keyword);
+    }
+
+    #[Test]
+    public function validate_structured_flattening_matches_validate_output(): void
+    {
+        $schema = ObjectConverter::convert([
+            'type' => 'object',
+            'properties' => [
+                'a' => ['type' => 'integer'],
+                'b' => ['type' => 'string', 'enum' => ['ok']],
+            ],
+            'required' => ['a', 'b', 'missing'],
+        ]);
+        $data = ObjectConverter::convert(['a' => 'not-int', 'b' => 'not-ok']);
+
+        $mapView = (new SchemaValidatorRunner(0))->validate($schema, $data);
+        $structured = (new SchemaValidatorRunner(0))->validateStructured($schema, $data);
+
+        $flattenedMap = [];
+        foreach ($mapView as $path => $messages) {
+            foreach ($messages as $message) {
+                $flattenedMap[] = [$path, $message];
+            }
+        }
+        $flattenedStructured = [];
+        foreach ($structured as $violation) {
+            $flattenedStructured[] = [$violation->instancePath, $violation->message];
+        }
+
+        $this->assertNotSame([], $flattenedStructured);
+        $this->assertSame($flattenedMap, $flattenedStructured);
+    }
+
+    #[Test]
+    public function validate_structured_applies_cascade_suppression(): void
+    {
+        // Issue #159 repro through the structured view: the cascading
+        // additionalProperties artifact at `/` must be suppressed, leaving
+        // only the real enum violation with its keyword.
+        $schema = ObjectConverter::convert([
+            'type' => 'object',
+            'required' => ['message', 'code'],
+            'properties' => [
+                'message' => ['type' => 'string'],
+                'code' => ['type' => 'string', 'enum' => ['allowedCode']],
+            ],
+            'additionalProperties' => false,
+        ]);
+        $data = ObjectConverter::convert(['message' => 'oops', 'code' => 'notInEnum']);
+
+        $violations = (new SchemaValidatorRunner(0))->validateStructured($schema, $data);
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('/code', $violations[0]->instancePath);
+        $this->assertSame('enum', $violations[0]->keyword);
+    }
+
+    #[Test]
+    public function validate_structured_rewrites_partial_cascade_message(): void
+    {
+        // Mixed cascade: declared `code` is stripped from the
+        // additionalProperties message while the genuinely-undeclared
+        // `extra` survives, and the rewritten entry keeps its keyword.
+        $schema = ObjectConverter::convert([
+            'type' => 'object',
+            'required' => ['code'],
+            'properties' => [
+                'code' => ['type' => 'string', 'enum' => ['allowedCode']],
+            ],
+            'additionalProperties' => false,
+        ]);
+        $data = ObjectConverter::convert(['code' => 'notInEnum', 'extra' => 'nope']);
+
+        $violations = (new SchemaValidatorRunner(0))->validateStructured($schema, $data);
+
+        $rewritten = null;
+        foreach ($violations as $violation) {
+            if ($violation->instancePath === '/') {
+                $rewritten = $violation;
+            }
+        }
+
+        $this->assertNotNull($rewritten);
+        $this->assertSame('additionalProperties', $rewritten->keyword);
+        $this->assertSame('Additional object properties are not allowed: extra', $rewritten->message);
+    }
+
     /**
      * @param array<string, string[]> $errors
      */

--- a/tests/Unit/Validation/Support/SchemaValidatorRunnerTest.php
+++ b/tests/Unit/Validation/Support/SchemaValidatorRunnerTest.php
@@ -1204,8 +1204,40 @@ class SchemaValidatorRunnerTest extends TestCase
         $this->assertSame('type', $byPath['/count'][0]->keyword);
         $this->assertStringContainsString('integer', $byPath['/count'][0]->message);
 
-        $this->assertArrayHasKey('/', $byPath);
-        $this->assertSame('required', $byPath['/'][0]->keyword);
+        // RFC 6901: the document root is the empty pointer, NOT '/'.
+        $this->assertArrayHasKey('', $byPath);
+        $this->assertSame('required', $byPath[''][0]->keyword);
+    }
+
+    #[Test]
+    public function validate_structured_distinguishes_root_from_empty_string_key(): void
+    {
+        // RFC 6901 pins '' = document root and '/' = the property whose name
+        // is the empty string. opis's pathToString() renders both as '/';
+        // the structured view must not inherit that ambiguity (the JSON
+        // output's instance_path is a frozen compatibility surface), while
+        // the legacy pointer-keyed map keeps rendering both as '/'.
+        $runner = new SchemaValidatorRunner(0);
+
+        $rootViolationSchema = ObjectConverter::convert(['type' => 'object']);
+        $rootViolations = $runner->validateStructured($rootViolationSchema, 'not-an-object');
+        $this->assertCount(1, $rootViolations);
+        $this->assertSame('', $rootViolations[0]->instancePath);
+        $this->assertSame('/', $rootViolations[0]->displayPath());
+        $this->assertArrayHasKey('/', $runner->validate($rootViolationSchema, 'not-an-object'));
+
+        $emptyKeySchema = ObjectConverter::convert([
+            'type' => 'object',
+            'properties' => [
+                '' => ['type' => 'integer'],
+            ],
+        ]);
+        $emptyKeyData = ObjectConverter::convert(['' => 'not-an-int']);
+        $emptyKeyViolations = $runner->validateStructured($emptyKeySchema, $emptyKeyData);
+        $this->assertCount(1, $emptyKeyViolations);
+        $this->assertSame('/', $emptyKeyViolations[0]->instancePath);
+        $this->assertSame('/', $emptyKeyViolations[0]->displayPath());
+        $this->assertArrayHasKey('/', $runner->validate($emptyKeySchema, $emptyKeyData));
     }
 
     #[Test]
@@ -1230,9 +1262,11 @@ class SchemaValidatorRunnerTest extends TestCase
                 $flattenedMap[] = [$path, $message];
             }
         }
+        // displayPath() bridges the one deliberate divergence: the map view
+        // renders the RFC-6901 root pointer '' as the legacy '/'.
         $flattenedStructured = [];
         foreach ($structured as $violation) {
-            $flattenedStructured[] = [$violation->instancePath, $violation->message];
+            $flattenedStructured[] = [$violation->displayPath(), $violation->message];
         }
 
         $this->assertNotSame([], $flattenedStructured);
@@ -1283,7 +1317,7 @@ class SchemaValidatorRunnerTest extends TestCase
 
         $rewritten = null;
         foreach ($violations as $violation) {
-            if ($violation->instancePath === '/') {
+            if ($violation->instancePath === '') {
                 $rewritten = $violation;
             }
         }

--- a/tests/fixtures/compatibility/v2-public-api.json
+++ b/tests/fixtures/compatibility/v2-public-api.json
@@ -3395,6 +3395,59 @@
             }
         }
     },
+    "Studio\\Gesso\\JsonValidationResultRenderer": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "implicit",
+            "visibility": "public"
+        },
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": {
+            "SCHEMA_VERSION": 1
+        },
+        "properties": [],
+        "methods": {
+            "render": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "string",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "result",
+                        "type": "Studio\\Gesso\\OpenApiValidationResult",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "reproduceCommand",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
     "Studio\\Gesso\\Laravel\\ExploresOpenApiEndpoint": {
         "kind": "trait",
         "final": false,


### PR DESCRIPTION
## Summary

Populates `instancePath` / `keyword` on body-schema `ValidationIssue`s (reserved-null since #413) and adds a public `Studio\Gesso\JsonValidationResultRenderer` that renders any `OpenApiValidationResult` as a versioned JSON document (`schema_version` 1) with a `reproduce_command` slot for the #410 curl output.

Stage 2 of 3 for #282 (agreed split): stage 3 adds adapter/extension output-mode selection.

## Why

Structured issues without the instance pointer and failing keyword cannot drive IDE annotations or precise CI triage, and there was no machine-readable rendering of a validation result at all (#282).

Design notes:
- `SchemaValidatorRunner` gains `validateStructured(): list<SchemaViolation>` (pointer / keyword / unprefixed message); `validate()` is now a thin wrapper deriving the pointer-keyed map from it, so the two views cannot drift and the other four call sites are byte-for-byte unchanged. The #159 cascade dedup now identifies its target structurally (`keyword === 'additionalProperties'`) with the English-template regex kept as a guard for the rewrite.
- Body result DTOs carry the violation list index-aligned with `errors`; orchestrators attach `instancePath` / `keyword` only when the counts align, so non-schema body errors (missing required body, decode failures, exception boundary) keep both fields `null` as documented.
- The JSON document mirrors the coverage-JSON conventions (`schema_version` int, snake_case, `tool` block) but is deliberately timestamp-free so per-assertion output stays deterministic for snapshot tests. `reproduce_command` is embedded verbatim — redaction stays with the curl formatter (#404), and adapters wire it in stage 3.

## Verification

- [x] `composer test` passes (2,245 tests / 8,361 assertions, Unit + Integration)
- [x] `composer stan` passes (0 errors)
- [x] `composer cs-check` passes (both configs)

TDD per stage: structured-runner entries + ordering equivalence + cascade suppression/rewrite through the structured view; violations↔errors alignment on both body validators; orchestrator pointer/keyword tagging (schema vs non-schema vs parameter sources); renderer output for failure / success / skipped / legacy-derived / reproduce_command cases. Public API baseline regenerated and the v1→v2 contract-change test extended with the new class.

## Notes for reviewers

- Documented compatibility surfaces added: the JSON document (docs/validation-json-schema.md, sample at docs/samples/validation.json) and the populated-field semantics in docs/versioning.md.
- `instancePath` / `keyword` stay `null` for parameter/header schema errors — their pointers are scoped inside a single parameter value and need a parameter-name context field to be useful; deferred beyond stage 3 unless requested.

Refs #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqWR5DigRbDnzvSkMEXaLi