### PR TITLE
feat(fuzz): named contract checks with unsupported_method

### DIFF
--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -232,6 +232,56 @@ members only while the callback returns the original non-empty classification.
 Use a stable value such as `status:500` or an exception class. Reduction is
 deliberately classification-preserving; it never equates every failure.
 
+## Named contract checks
+
+Schema validation cannot see protocol-level contract holes. Named checks probe
+them directly, mirroring [Schemathesis check names][schemathesis-checks] where
+behavior matches. The pipeline is opt-in per check, deterministic under
+`seed`, and collects every result before you assert — one run reports all
+holes, not just the first:
+
+```php
+use Studio\Gesso\Fuzz\ContractCheck;
+use Studio\Gesso\Fuzz\ExploredCase;
+use Studio\Gesso\Fuzz\OpenApiContractChecks;
+
+$summary = OpenApiContractChecks::run('petstore', seed: 7)
+    ->checks([ContractCheck::UnsupportedMethod])
+    ->dispatchUsing(fn (ExploredCase $case): int => $this->send($case)->getStatusCode())
+    ->report();
+
+self::assertSame([], $summary->failures, $summary->describeFailures());
+```
+
+| Check | Probe | Default pass statuses |
+|---|---|---|
+| `unsupported_method` | one deterministically chosen undocumented method per documented path | `405` |
+
+`dispatchUsing()` may return an `int` status, a PSR-7 response, or any object
+exposing `getStatusCode(): int` (Symfony `Response`, Laravel `TestResponse`).
+The same `includeTags()`/`excludePaths()`/… filters and
+`setUpUsing()`/`authenticateUsing()`/`tearDownUsing()` hooks as whole-spec
+exploration apply; a path is probed when at least one of its documented
+operations passes the filters. Override the pass statuses per check with
+`expectedStatuses(ContractCheck::UnsupportedMethod, [405, 404])` for
+frameworks that answer unknown methods with 404.
+
+Probe construction: candidates are the explorer-supported methods (`GET`,
+`POST`, `PUT`, `PATCH`, `DELETE`, `QUERY`) minus the path's documented fixed
+methods; OpenAPI 3.2 `additionalOperations` are never probed (case-sensitive
+custom methods). Concrete path parameters are generated from a documented
+operation of the same path. Paths where every explorable method is documented,
+or where no documented operation's values can be generated, appear in
+`$summary->skips` with a reason. `ContractCheckFailure::describe()` names the
+check, operation, expected/actual status, and a replayable curl command.
+
+Two caveats: `HEAD`/`OPTIONS`/`TRACE` are outside the explorer's method set
+and are not probed, and a probe response cannot pass normal response
+validation (its method is undocumented by definition) — disable Laravel's
+`auto_assert` in contract-check tests or dispatch outside the trait's helpers.
+
+[schemathesis-checks]: https://schemathesis.readthedocs.io/en/stable/reference/checks/
+
 ## Remaining gaps
 
 - Arbitrary ECMA-262 regex synthesis and recursive/reference-cycle generation.

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -267,9 +267,13 @@ operations passes the filters. Override the pass statuses per check with
 frameworks that answer unknown methods with 404.
 
 Probe construction: candidates are the explorer-supported methods (`GET`,
-`POST`, `PUT`, `PATCH`, `DELETE`, `QUERY`) minus the path's documented fixed
-methods; OpenAPI 3.2 `additionalOperations` are never probed (case-sensitive
-custom methods). Concrete path parameters are generated from a documented
+`POST`, `PUT`, `PATCH`, `DELETE`, `QUERY`) minus every method the path
+documents — fixed fields and `additionalOperations` keys, matched
+case-sensitively, so a (spec-invalid but runtime-honored) `"PUT"` entry
+under `additionalOperations` removes `PUT` from the candidates while a
+custom `"copy"` entry removes nothing. OpenAPI 3.2 `additionalOperations`
+are never probed themselves (case-sensitive custom methods). Concrete path
+parameters are generated from a documented
 operation of the same path. Paths where every explorable method is documented,
 or where no documented operation's values can be generated, appear in
 `$summary->skips` with a reason. `ContractCheckFailure::describe()` names the

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -62,6 +62,10 @@ This library follows [Semantic Versioning 2.0](https://semver.org/). v1.0.0 is t
   baselined, and entries that no longer occur during a full run are reported
   as stale per `baseline_stale`. Unknown `baseline_version` values are
   rejected.
+- Named contract checks: `ContractCheck` names and default expected statuses,
+  the `OpenApiContractChecks`/`ContractCheckPlan` fluent surface, and the
+  `ContractCheckSummary`/`ContractCheckFailure`/`ContractCheckSkip` shapes.
+  Failure/skip prose is not a contract.
 - CLI surfaces by major (commands, flags, exit codes, and versioned inputs and
   output where applicable):
   - v1.x: `bin/openapi-contract`, `bin/openapi-coverage-merge`, and the v1.10

--- a/src/Fuzz/ContractCheck.php
+++ b/src/Fuzz/ContractCheck.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Fuzz;
+
+/**
+ * Named negative contract checks. Values match the Schemathesis check names
+ * so cross-tool documentation and CI dashboards line up.
+ */
+enum ContractCheck: string
+{
+    case UnsupportedMethod = 'unsupported_method';
+
+    /**
+     * Default pass statuses; override per plan via
+     * {@see ContractCheckPlan::expectedStatuses()}.
+     *
+     * @return list<int>
+     */
+    public function defaultExpectedStatuses(): array
+    {
+        return match ($this) {
+            self::UnsupportedMethod => [405],
+        };
+    }
+}

--- a/src/Fuzz/ContractCheckFailure.php
+++ b/src/Fuzz/ContractCheckFailure.php
@@ -21,6 +21,11 @@ final readonly class ContractCheckFailure
         public ContractCheck $check,
         public string $method,
         public string $path,
+        /**
+         * Null for unsupported_method (the probe's method has no documented
+         * operation by definition); populated by per-operation checks
+         * (planned: ignored_auth, missing_required_header).
+         */
         public ?string $operationId,
         public array $expectedStatuses,
         public int $actualStatus,

--- a/src/Fuzz/ContractCheckFailure.php
+++ b/src/Fuzz/ContractCheckFailure.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Fuzz;
+
+use function array_map;
+use function implode;
+use function sprintf;
+use function strval;
+
+/**
+ * Contract check detected a failure (probe received unexpected status).
+ */
+final readonly class ContractCheckFailure
+{
+    /**
+     * @param list<int> $expectedStatuses
+     */
+    public function __construct(
+        public ContractCheck $check,
+        public string $method,
+        public string $path,
+        public ?string $operationId,
+        public array $expectedStatuses,
+        public int $actualStatus,
+        public ExploredCase $case,
+    ) {}
+
+    public function describe(): string
+    {
+        return sprintf(
+            "%s: %s %s — expected %s, got %d\n  Curl: %s",
+            $this->check->value,
+            $this->method,
+            $this->path,
+            implode(' or ', array_map(strval(...), $this->expectedStatuses)),
+            $this->actualStatus,
+            $this->case->curlSnippet(),
+        );
+    }
+}

--- a/src/Fuzz/ContractCheckPlan.php
+++ b/src/Fuzz/ContractCheckPlan.php
@@ -1,0 +1,322 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Fuzz;
+
+use InvalidArgumentException;
+use RuntimeException;
+use Studio\Gesso\HttpMethod;
+use Studio\Gesso\Spec\OpenApiOperationResolver;
+use Studio\Gesso\Spec\OpenApiSpecLoader;
+use Throwable;
+
+use function array_key_exists;
+use function array_values;
+use function count;
+use function crc32;
+use function implode;
+use function in_array;
+use function sprintf;
+use function strtoupper;
+
+/**
+ * Fluent, process-local plan that dispatches named negative contract checks
+ * ({@see ContractCheck}) and collects every result into one
+ * {@see ContractCheckSummary} instead of failing on the first probe.
+ */
+final class ContractCheckPlan
+{
+    use SelectsExploredOperations;
+
+    /** @var list<ContractCheck> */
+    private array $checks = [];
+
+    /** @var array<string, list<int>> keyed by ContractCheck value */
+    private array $expectedStatusOverrides = [];
+
+    /** @var null|callable(ExploredOperation): void */
+    private $authenticate;
+
+    /** @var null|callable(ExploredOperation): void */
+    private $setUp;
+
+    /** @var null|callable(ExploredOperation): void */
+    private $tearDown;
+
+    /** @var null|callable(ExploredCase): mixed */
+    private $dispatch;
+
+    public function __construct(
+        private readonly string $specName,
+        private readonly int $seed,
+    ) {}
+
+    /** @param list<ContractCheck> $checks */
+    public function checks(array $checks): self
+    {
+        if ($checks === []) {
+            throw new InvalidArgumentException('checks() requires at least one ContractCheck.');
+        }
+
+        $deduplicated = [];
+        foreach ($checks as $check) {
+            $deduplicated[$check->value] = $check;
+        }
+        $this->checks = array_values($deduplicated);
+
+        return $this;
+    }
+
+    /**
+     * Replace the default pass statuses for one check
+     * ({@see ContractCheck::defaultExpectedStatuses()}) with an exact list.
+     *
+     * @param list<int> $statuses
+     */
+    public function expectedStatuses(ContractCheck $check, array $statuses): self
+    {
+        if ($statuses === []) {
+            throw new InvalidArgumentException('expectedStatuses() requires at least one HTTP status.');
+        }
+        foreach ($statuses as $status) {
+            if ($status < 100 || $status > 599) {
+                throw new InvalidArgumentException(sprintf('Expected HTTP status must be between 100 and 599, got %d.', $status));
+            }
+        }
+        $this->expectedStatusOverrides[$check->value] = $statuses;
+
+        return $this;
+    }
+
+    /** @param callable(ExploredOperation): void $callback */
+    public function authenticateUsing(callable $callback): self
+    {
+        $this->authenticate = $callback;
+
+        return $this;
+    }
+
+    /** @param callable(ExploredOperation): void $callback */
+    public function setUpUsing(callable $callback): self
+    {
+        $this->setUp = $callback;
+
+        return $this;
+    }
+
+    /** @param callable(ExploredOperation): void $callback */
+    public function tearDownUsing(callable $callback): self
+    {
+        $this->tearDown = $callback;
+
+        return $this;
+    }
+
+    /** @param callable(ExploredCase): mixed $callback */
+    public function dispatchUsing(callable $callback): self
+    {
+        $this->dispatch = $callback;
+
+        return $this;
+    }
+
+    public function report(): ContractCheckSummary
+    {
+        if ($this->dispatch === null) {
+            throw new InvalidArgumentException('Contract checks requires dispatchUsing() before report().');
+        }
+        if ($this->checks === []) {
+            throw new InvalidArgumentException('Contract checks requires checks() with at least one check before report().');
+        }
+
+        $spec = OpenApiSpecLoader::load($this->specName);
+        $paths = SpecPathsPreflight::validatedPaths($this->specName, $spec);
+
+        $failures = [];
+        $skips = [];
+        $probedPaths = 0;
+        $dispatchedProbes = 0;
+        $selected = 0;
+
+        foreach ($paths as $path => $pathItem) {
+            foreach ($this->checks as $check) {
+                $derivedSeed = $this->derivedSeed($check, $path);
+                $matching = [];
+                foreach (OpenApiOperationResolver::declaredOperations($pathItem) as $declared) {
+                    $operation = ExploredOperation::fromDeclaration(
+                        $this->specName,
+                        $path,
+                        $declared['method'],
+                        $declared['operation'],
+                        $derivedSeed,
+                    );
+                    if ($this->matchesFilters($operation)) {
+                        $matching[] = $operation;
+                    }
+                }
+                if ($matching === []) {
+                    continue;
+                }
+                $selected += count($matching);
+
+                $probe = $this->buildUnsupportedMethodProbe($check, $path, $pathItem, $matching, $derivedSeed, $skips);
+                if ($probe === null) {
+                    continue;
+                }
+                [$case, $sourceOperation] = $probe;
+                $probedPaths++;
+
+                $actualStatus = $this->dispatchProbe($check, $case, $sourceOperation);
+                $dispatchedProbes++;
+
+                $expected = $this->expectedStatusOverrides[$check->value] ?? $check->defaultExpectedStatuses();
+                if (!in_array($actualStatus, $expected, true)) {
+                    $failures[] = new ContractCheckFailure(
+                        $check,
+                        $case->method->value,
+                        $path,
+                        null,
+                        $expected,
+                        $actualStatus,
+                        $case,
+                    );
+                }
+            }
+        }
+
+        if ($selected === 0) {
+            throw new InvalidArgumentException(sprintf(
+                "Contract checks matched no operations in spec '%s'.",
+                $this->specName,
+            ));
+        }
+
+        return new ContractCheckSummary($probedPaths, $dispatchedProbes, $failures, $skips);
+    }
+
+    private function derivedSeed(ContractCheck $check, string $path): int
+    {
+        return crc32(implode("\0", [$this->specName, $check->value, $path, (string) $this->seed])) & 0x7fffffff;
+    }
+
+    /**
+     * Choose one undocumented explorable method for the path and build the
+     * probe case from a generatable documented operation's concrete values.
+     * `additionalOperations` names are never probe candidates: they are
+     * case-sensitive custom methods outside the fixed HTTP set.
+     *
+     * @param array<string, mixed> $pathItem
+     * @param non-empty-list<ExploredOperation> $matching
+     * @param list<ContractCheckSkip> $skips
+     *
+     * @return null|array{ExploredCase, ExploredOperation}
+     */
+    private function buildUnsupportedMethodProbe(
+        ContractCheck $check,
+        string $path,
+        array $pathItem,
+        array $matching,
+        int $derivedSeed,
+        array &$skips,
+    ): ?array {
+        $documented = [];
+        foreach (OpenApiOperationResolver::FIXED_OPERATION_FIELDS as $field) {
+            if (array_key_exists($field, $pathItem)) {
+                $documented[] = strtoupper($field);
+            }
+        }
+
+        $candidates = [];
+        foreach (HttpMethod::cases() as $method) {
+            if (!in_array($method->value, $documented, true)) {
+                $candidates[] = $method;
+            }
+        }
+        if ($candidates === []) {
+            $skips[] = new ContractCheckSkip(
+                $check,
+                $path,
+                null,
+                'Every explorable HTTP method is documented for this path; no undocumented method to probe.',
+            );
+
+            return null;
+        }
+
+        $probeMethod = $candidates[$derivedSeed % count($candidates)];
+
+        $lastReason = null;
+        foreach ($matching as $operation) {
+            if (HttpMethod::tryFrom($operation->method) === null) {
+                $lastReason ??= sprintf(
+                    'No documented operation with an explorer-supported method (%s) is available to generate concrete request values.',
+                    HttpMethod::listOfValues(),
+                );
+
+                continue;
+            }
+
+            try {
+                $cases = OpenApiEndpointExplorer::explore($this->specName, $operation->method, $operation->path, 1, $derivedSeed);
+            } catch (InvalidArgumentException $e) {
+                $lastReason = $e->getMessage();
+
+                continue;
+            }
+
+            foreach ($cases as $sourceCase) {
+                return [
+                    new ExploredCase(
+                        null,
+                        [],
+                        [],
+                        $sourceCase->pathParams,
+                        $probeMethod,
+                        $path,
+                        seed: $derivedSeed,
+                        caseIndex: 0,
+                    ),
+                    $operation,
+                ];
+            }
+        }
+
+        $skips[] = new ContractCheckSkip($check, $path, null, $lastReason ?? 'No documented operation could generate concrete request values.');
+
+        return null;
+    }
+
+    private function dispatchProbe(ContractCheck $check, ExploredCase $case, ExploredOperation $operation): int
+    {
+        try {
+            if ($this->setUp !== null) {
+                ($this->setUp)($operation);
+            }
+            if ($this->authenticate !== null) {
+                ($this->authenticate)($operation);
+            }
+
+            try {
+                $response = ($this->dispatch)($case);
+
+                return ResponseStatusExtractor::extract($response);
+            } catch (Throwable $e) {
+                throw new RuntimeException(sprintf(
+                    "Contract check dispatch failed.\nCheck: %s\nSpec: %s\nMethod/path: %s %s\nGlobal seed: %d\nDerived seed: %d\nCurl: %s",
+                    $check->value,
+                    $this->specName,
+                    $case->method->value,
+                    $case->matchedPath,
+                    $this->seed,
+                    $case->seed ?? 0,
+                    $case->curlSnippet(),
+                ), 0, $e);
+            }
+        } finally {
+            if ($this->tearDown !== null) {
+                ($this->tearDown)($operation);
+            }
+        }
+    }
+}

--- a/src/Fuzz/ContractCheckPlan.php
+++ b/src/Fuzz/ContractCheckPlan.php
@@ -124,10 +124,10 @@ final class ContractCheckPlan
     public function report(): ContractCheckSummary
     {
         if ($this->dispatch === null) {
-            throw new InvalidArgumentException('Contract checks requires dispatchUsing() before report().');
+            throw new InvalidArgumentException('The contract check plan requires dispatchUsing() before report().');
         }
         if ($this->checks === []) {
-            throw new InvalidArgumentException('Contract checks requires checks() with at least one check before report().');
+            throw new InvalidArgumentException('The contract check plan requires checks() with at least one check before report().');
         }
 
         $spec = OpenApiSpecLoader::load($this->specName);
@@ -135,7 +135,8 @@ final class ContractCheckPlan
 
         $failures = [];
         $skips = [];
-        $probedPaths = 0;
+        /** @var array<string, true> */
+        $probedPathSet = [];
         $dispatchedProbes = 0;
         $selected = 0;
 
@@ -160,14 +161,16 @@ final class ContractCheckPlan
                 }
                 $selected += count($matching);
 
-                $probe = $this->buildUnsupportedMethodProbe($check, $path, $pathItem, $matching, $derivedSeed, $skips);
+                $probe = match ($check) {
+                    ContractCheck::UnsupportedMethod => $this->buildUnsupportedMethodProbe($check, $path, $pathItem, $matching, $derivedSeed, $skips),
+                };
                 if ($probe === null) {
                     continue;
                 }
                 [$case, $sourceOperation] = $probe;
-                $probedPaths++;
+                $probedPathSet[$path] = true;
 
-                $actualStatus = $this->dispatchProbe($check, $case, $sourceOperation);
+                $actualStatus = $this->dispatchProbe($check, $case, $sourceOperation, $derivedSeed);
                 $dispatchedProbes++;
 
                 $expected = $this->expectedStatusOverrides[$check->value] ?? $check->defaultExpectedStatuses();
@@ -192,7 +195,7 @@ final class ContractCheckPlan
             ));
         }
 
-        return new ContractCheckSummary($probedPaths, $dispatchedProbes, $failures, $skips);
+        return new ContractCheckSummary(count($probedPathSet), $dispatchedProbes, $failures, $skips);
     }
 
     private function derivedSeed(ContractCheck $check, string $path): int
@@ -263,6 +266,8 @@ final class ContractCheckPlan
                 $lastReason = $e->getMessage();
 
                 continue;
+            } catch (Throwable $e) {
+                throw new RuntimeException($this->generationFailureMessage($check, $operation, $derivedSeed, $e), 0, $e);
             }
 
             foreach ($cases as $sourceCase) {
@@ -287,7 +292,26 @@ final class ContractCheckPlan
         return null;
     }
 
-    private function dispatchProbe(ContractCheck $check, ExploredCase $case, ExploredOperation $operation): int
+    private function generationFailureMessage(
+        ContractCheck $check,
+        ExploredOperation $operation,
+        int $derivedSeed,
+        Throwable $failure,
+    ): string {
+        return sprintf(
+            "Contract check input generation failed.\nCheck: %s\nSpec: %s\nOperation: %s\nMethod/path: %s %s\nGlobal seed: %d\nDerived seed: %d\nMessage: %s",
+            $check->value,
+            $this->specName,
+            $operation->operationId ?? '(none)',
+            $operation->method,
+            $operation->path,
+            $this->seed,
+            $derivedSeed,
+            $failure->getMessage(),
+        );
+    }
+
+    private function dispatchProbe(ContractCheck $check, ExploredCase $case, ExploredOperation $operation, int $derivedSeed): int
     {
         try {
             if ($this->setUp !== null) {
@@ -309,7 +333,7 @@ final class ContractCheckPlan
                     $case->method->value,
                     $case->matchedPath,
                     $this->seed,
-                    $case->seed ?? 0,
+                    $derivedSeed,
                     $case->curlSnippet(),
                 ), 0, $e);
             }

--- a/src/Fuzz/ContractCheckPlan.php
+++ b/src/Fuzz/ContractCheckPlan.php
@@ -11,14 +11,12 @@ use Studio\Gesso\Spec\OpenApiOperationResolver;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 use Throwable;
 
-use function array_key_exists;
 use function array_values;
 use function count;
 use function crc32;
 use function implode;
 use function in_array;
 use function sprintf;
-use function strtoupper;
 
 /**
  * Fluent, process-local plan that dispatches named negative contract checks
@@ -206,8 +204,9 @@ final class ContractCheckPlan
     /**
      * Choose one undocumented explorable method for the path and build the
      * probe case from a generatable documented operation's concrete values.
-     * `additionalOperations` names are never probe candidates: they are
-     * case-sensitive custom methods outside the fixed HTTP set.
+     * `additionalOperations` names are never probed themselves (case-sensitive
+     * custom methods), but every declared name counts as documented and is
+     * excluded from the candidates.
      *
      * @param array<string, mixed> $pathItem
      * @param non-empty-list<ExploredOperation> $matching
@@ -223,11 +222,15 @@ final class ContractCheckPlan
         int $derivedSeed,
         array &$skips,
     ): ?array {
+        // Every declared method name counts as documented: fixed fields under
+        // their canonical uppercase key, additionalOperations entries verbatim.
+        // OAS 3.2 forbids additionalOperations entries that spell a fixed
+        // method ("PUT"), but the runtime resolver honors them case-sensitively,
+        // so the probe must too — otherwise a documented method would be
+        // reported as an unsupported-method contract failure.
         $documented = [];
-        foreach (OpenApiOperationResolver::FIXED_OPERATION_FIELDS as $field) {
-            if (array_key_exists($field, $pathItem)) {
-                $documented[] = strtoupper($field);
-            }
+        foreach (OpenApiOperationResolver::declaredOperations($pathItem) as $declared) {
+            $documented[] = $declared['method'];
         }
 
         $candidates = [];

--- a/src/Fuzz/ContractCheckSkip.php
+++ b/src/Fuzz/ContractCheckSkip.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Fuzz;
+
+/**
+ * Contract check skipped (not probed) for a path or method.
+ */
+final readonly class ContractCheckSkip
+{
+    /**
+     * @param null|string $method null for path-level skips (e.g. every explorable method documented)
+     */
+    public function __construct(
+        public ContractCheck $check,
+        public string $path,
+        public ?string $method,
+        public string $reason,
+    ) {}
+}

--- a/src/Fuzz/ContractCheckSummary.php
+++ b/src/Fuzz/ContractCheckSummary.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Fuzz;
+
+use function array_map;
+use function implode;
+
+/**
+ * Summary of contract check results across all probed paths and methods.
+ */
+final readonly class ContractCheckSummary
+{
+    /**
+     * @param list<ContractCheckFailure> $failures
+     * @param list<ContractCheckSkip> $skips
+     */
+    public function __construct(
+        public int $probedPaths,
+        public int $dispatchedProbes,
+        public array $failures,
+        public array $skips,
+    ) {}
+
+    public function hasFailures(): bool
+    {
+        return $this->failures !== [];
+    }
+
+    public function hasSkips(): bool
+    {
+        return $this->skips !== [];
+    }
+
+    public function describeFailures(): string
+    {
+        return implode("\n", array_map(static fn(ContractCheckFailure $f): string => $f->describe(), $this->failures));
+    }
+}

--- a/src/Fuzz/ContractCheckSummary.php
+++ b/src/Fuzz/ContractCheckSummary.php
@@ -13,6 +13,7 @@ use function implode;
 final readonly class ContractCheckSummary
 {
     /**
+     * @param int $probedPaths unique paths for which at least one probe was dispatched
      * @param list<ContractCheckFailure> $failures
      * @param list<ContractCheckSkip> $skips
      */

--- a/src/Fuzz/ExploredOperation.php
+++ b/src/Fuzz/ExploredOperation.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace Studio\Gesso\Fuzz;
 
+use Studio\Gesso\Spec\OpenApiOperationResolver;
+
+use function array_filter;
+use function array_values;
 use function implode;
+use function is_array;
+use function is_string;
 use function sprintf;
 use function var_export;
 
@@ -25,6 +31,36 @@ final readonly class ExploredOperation
         public bool $deprecated,
         public int $seed,
     ) {}
+
+    /**
+     * Build the operation DTO from a raw Path Item declaration.
+     *
+     * @internal shared factory for the exploration and contract-check plans.
+     */
+    public static function fromDeclaration(
+        string $specName,
+        string $path,
+        string $method,
+        mixed $rawOperation,
+        int $derivedSeed,
+    ): self {
+        $normalizedMethod = OpenApiOperationResolver::normalizeMethodForKey($method);
+        $operation = is_array($rawOperation) ? $rawOperation : [];
+        $operationId = is_string($operation['operationId'] ?? null) ? $operation['operationId'] : null;
+        $tags = is_array($operation['tags'] ?? null)
+            ? array_values(array_filter($operation['tags'], is_string(...)))
+            : [];
+
+        return new self(
+            $specName,
+            $normalizedMethod,
+            $path,
+            $operationId,
+            $tags,
+            ($operation['deprecated'] ?? false) === true,
+            $derivedSeed,
+        );
+    }
 
     /**
      * Return a minimal expression that regenerates the exact input case.

--- a/src/Fuzz/OpenApiContractChecks.php
+++ b/src/Fuzz/OpenApiContractChecks.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Fuzz;
+
+use InvalidArgumentException;
+
+/**
+ * Entry point for deterministic named contract checks
+ * ({@see ContractCheck}) over a whole spec.
+ */
+final class OpenApiContractChecks
+{
+    public static function run(string $specName, int $seed = 1): ContractCheckPlan
+    {
+        if ($specName === '') {
+            throw new InvalidArgumentException('OpenApiContractChecks::run() requires a non-empty spec name.');
+        }
+
+        return new ContractCheckPlan($specName, $seed);
+    }
+}

--- a/src/Fuzz/OpenApiSpecExploration.php
+++ b/src/Fuzz/OpenApiSpecExploration.php
@@ -9,19 +9,10 @@ use RuntimeException;
 use Studio\Gesso\HttpMethod;
 use Studio\Gesso\Spec\OpenApiOperationResolver;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
-use Studio\Gesso\Validation\Support\MalformedSpecNode;
 use Throwable;
 
-use function array_filter;
-use function array_intersect;
-use function array_key_exists;
-use function array_map;
-use function array_values;
 use function crc32;
 use function implode;
-use function in_array;
-use function is_array;
-use function is_string;
 use function sprintf;
 
 /**
@@ -33,30 +24,7 @@ use function sprintf;
  */
 final class OpenApiSpecExploration
 {
-    /** @var list<string> */
-    private array $includedTags = [];
-
-    /** @var list<string> */
-    private array $excludedTags = [];
-
-    /** @var list<string> */
-    private array $includedMethods = [];
-
-    /** @var list<string> */
-    private array $excludedMethods = [];
-
-    /** @var list<string> */
-    private array $includedPaths = [];
-
-    /** @var list<string> */
-    private array $excludedPaths = [];
-
-    /** @var list<string> */
-    private array $includedOperationIds = [];
-
-    /** @var list<string> */
-    private array $excludedOperationIds = [];
-    private bool $includeDeprecated = false;
+    use SelectsExploredOperations;
 
     /** @var null|list<int> */
     private ?array $negativeExpectedStatusClasses = null;
@@ -84,77 +52,6 @@ final class OpenApiSpecExploration
         private readonly int $casesPerOperation,
         private readonly int $seed,
     ) {}
-
-    /** @param list<string> $tags */
-    public function includeTags(array $tags): self
-    {
-        $this->includedTags = $tags;
-
-        return $this;
-    }
-
-    /** @param list<string> $tags */
-    public function excludeTags(array $tags): self
-    {
-        $this->excludedTags = $tags;
-
-        return $this;
-    }
-
-    /** @param list<string> $methods */
-    public function includeMethods(array $methods): self
-    {
-        $this->includedMethods = array_map(self::normalizeFilterMethod(...), $methods);
-
-        return $this;
-    }
-
-    /** @param list<string> $methods */
-    public function excludeMethods(array $methods): self
-    {
-        $this->excludedMethods = array_map(self::normalizeFilterMethod(...), $methods);
-
-        return $this;
-    }
-
-    /** @param list<string> $paths */
-    public function includePaths(array $paths): self
-    {
-        $this->includedPaths = $paths;
-
-        return $this;
-    }
-
-    /** @param list<string> $paths */
-    public function excludePaths(array $paths): self
-    {
-        $this->excludedPaths = $paths;
-
-        return $this;
-    }
-
-    /** @param list<string> $operationIds */
-    public function includeOperations(array $operationIds): self
-    {
-        $this->includedOperationIds = $operationIds;
-
-        return $this;
-    }
-
-    /** @param list<string> $operationIds */
-    public function excludeOperations(array $operationIds): self
-    {
-        $this->excludedOperationIds = $operationIds;
-
-        return $this;
-    }
-
-    public function includeDeprecated(bool $include = true): self
-    {
-        $this->includeDeprecated = $include;
-
-        return $this;
-    }
 
     /**
      * Switch the plan to single-constraint invalid cases. The expected status
@@ -235,7 +132,7 @@ final class OpenApiSpecExploration
         }
 
         $spec = OpenApiSpecLoader::load($this->specName);
-        $paths = $this->validatedPaths($spec);
+        $paths = SpecPathsPreflight::validatedPaths($this->specName, $spec);
         $selected = 0;
         $executedOperations = 0;
         $executedCases = 0;
@@ -300,128 +197,12 @@ final class OpenApiSpecExploration
         return new SpecExplorationSummary($executedOperations, $executedCases, $operations, $skips);
     }
 
-    private static function normalizeFilterMethod(string $method): string
-    {
-        return OpenApiOperationResolver::normalizeMethodForKey($method);
-    }
-
-    /**
-     * Validate every structural node required to enumerate the spec before
-     * dispatching any request. A mixed valid/malformed document must fail
-     * atomically instead of executing the valid prefix and silently omitting
-     * the malformed remainder.
-     *
-     * @param array<string, mixed> $spec
-     *
-     * @return array<string, array<string, mixed>>
-     */
-    private function validatedPaths(array $spec): array
-    {
-        $paths = array_key_exists('paths', $spec) ? $spec['paths'] : [];
-        if (MalformedSpecNode::isMalformed($paths)) {
-            throw new InvalidArgumentException(sprintf(
-                "Malformed 'paths' in '%s' spec: expected object, got %s.",
-                $this->specName,
-                MalformedSpecNode::describe($paths),
-            ));
-        }
-
-        foreach ($paths as $path => $pathItem) {
-            if (!is_string($path)) {
-                throw new InvalidArgumentException(sprintf(
-                    "Malformed 'paths' in '%s' spec: expected string path key.",
-                    $this->specName,
-                ));
-            }
-
-            if (MalformedSpecNode::isMalformed($pathItem)) {
-                throw new InvalidArgumentException(sprintf(
-                    "Malformed 'paths[\"%s\"]' in '%s' spec: expected object, got %s.",
-                    $path,
-                    $this->specName,
-                    MalformedSpecNode::describe($pathItem),
-                ));
-            }
-
-            if (array_key_exists('additionalOperations', $pathItem) &&
-                MalformedSpecNode::isMalformed($pathItem['additionalOperations'])) {
-                throw new InvalidArgumentException(sprintf(
-                    "Malformed 'paths[\"%s\"].additionalOperations' in '%s' spec: expected object, got %s.",
-                    $path,
-                    $this->specName,
-                    MalformedSpecNode::describe($pathItem['additionalOperations']),
-                ));
-            }
-
-            foreach (OpenApiOperationResolver::declaredOperations($pathItem) as $declared) {
-                if (!MalformedSpecNode::isMalformed($declared['operation'])) {
-                    continue;
-                }
-
-                throw new InvalidArgumentException(sprintf(
-                    "Malformed 'paths[\"%s\"].%s' for %s %s in '%s' spec: expected object, got %s.",
-                    $path,
-                    $declared['location'],
-                    $declared['method'],
-                    $path,
-                    $this->specName,
-                    MalformedSpecNode::describe($declared['operation']),
-                ));
-            }
-        }
-
-        return $paths;
-    }
-
     private function operationFromDeclaration(string $path, string $method, mixed $rawOperation): ExploredOperation
     {
         $normalizedMethod = OpenApiOperationResolver::normalizeMethodForKey($method);
-        $operation = is_array($rawOperation) ? $rawOperation : [];
-        $operationId = is_string($operation['operationId'] ?? null) ? $operation['operationId'] : null;
-        $tags = is_array($operation['tags'] ?? null)
-            ? array_values(array_filter($operation['tags'], is_string(...)))
-            : [];
         $derivedSeed = crc32(implode("\0", [$this->specName, $normalizedMethod, $path, (string) $this->seed])) & 0x7fffffff;
 
-        return new ExploredOperation(
-            $this->specName,
-            $normalizedMethod,
-            $path,
-            $operationId,
-            $tags,
-            ($operation['deprecated'] ?? false) === true,
-            $derivedSeed,
-        );
-    }
-
-    private function matchesFilters(ExploredOperation $operation): bool
-    {
-        if (!$this->includeDeprecated && $operation->deprecated) {
-            return false;
-        }
-        if ($this->includedTags !== [] && array_intersect($this->includedTags, $operation->tags) === []) {
-            return false;
-        }
-        if (array_intersect($this->excludedTags, $operation->tags) !== []) {
-            return false;
-        }
-        if ($this->includedMethods !== [] && !in_array($operation->method, $this->includedMethods, true)) {
-            return false;
-        }
-        if (in_array($operation->method, $this->excludedMethods, true)) {
-            return false;
-        }
-        if ($this->includedPaths !== [] && !in_array($operation->path, $this->includedPaths, true)) {
-            return false;
-        }
-        if (in_array($operation->path, $this->excludedPaths, true)) {
-            return false;
-        }
-        if ($this->includedOperationIds !== [] && !in_array($operation->operationId, $this->includedOperationIds, true)) {
-            return false;
-        }
-
-        return !in_array($operation->operationId, $this->excludedOperationIds, true);
+        return ExploredOperation::fromDeclaration($this->specName, $path, $method, $rawOperation, $derivedSeed);
     }
 
     private function runOperation(

--- a/src/Fuzz/ResponseStatusExtractor.php
+++ b/src/Fuzz/ResponseStatusExtractor.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Fuzz;
+
+use InvalidArgumentException;
+
+use function get_debug_type;
+use function is_callable;
+use function is_int;
+use function is_object;
+use function sprintf;
+
+/**
+ * Turn a contract-check dispatch return value into an HTTP status code.
+ * Duck-typing `getStatusCode()` covers PSR-7 responses, Symfony's Response,
+ * and Laravel's TestResponse (a `__call` proxy) without a framework
+ * dependency.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+final class ResponseStatusExtractor
+{
+    public static function extract(mixed $response): int
+    {
+        if (is_int($response)) {
+            return $response;
+        }
+
+        if (is_object($response) && is_callable([$response, 'getStatusCode'])) {
+            $status = $response->getStatusCode();
+            if (is_int($status)) {
+                return $status;
+            }
+        }
+
+        throw new InvalidArgumentException(sprintf(
+            'Contract check dispatchUsing() must return an int status code, a PSR-7 response, or an object exposing getStatusCode(): int — got %s.',
+            get_debug_type($response),
+        ));
+    }
+}

--- a/src/Fuzz/SelectsExploredOperations.php
+++ b/src/Fuzz/SelectsExploredOperations.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Fuzz;
+
+use Studio\Gesso\Spec\OpenApiOperationResolver;
+
+use function array_intersect;
+use function array_map;
+use function in_array;
+
+/**
+ * Fluent include/exclude operation selection shared by the whole-spec
+ * exploration plan and the contract-check plan. Extracted so the two builders
+ * cannot drift apart on filter semantics.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+trait SelectsExploredOperations
+{
+    /** @var list<string> */
+    private array $includedTags = [];
+
+    /** @var list<string> */
+    private array $excludedTags = [];
+
+    /** @var list<string> */
+    private array $includedMethods = [];
+
+    /** @var list<string> */
+    private array $excludedMethods = [];
+
+    /** @var list<string> */
+    private array $includedPaths = [];
+
+    /** @var list<string> */
+    private array $excludedPaths = [];
+
+    /** @var list<string> */
+    private array $includedOperationIds = [];
+
+    /** @var list<string> */
+    private array $excludedOperationIds = [];
+    private bool $includeDeprecated = false;
+
+    /** @param list<string> $tags */
+    public function includeTags(array $tags): self
+    {
+        $this->includedTags = $tags;
+
+        return $this;
+    }
+
+    /** @param list<string> $tags */
+    public function excludeTags(array $tags): self
+    {
+        $this->excludedTags = $tags;
+
+        return $this;
+    }
+
+    /** @param list<string> $methods */
+    public function includeMethods(array $methods): self
+    {
+        $this->includedMethods = array_map(self::normalizeFilterMethod(...), $methods);
+
+        return $this;
+    }
+
+    /** @param list<string> $methods */
+    public function excludeMethods(array $methods): self
+    {
+        $this->excludedMethods = array_map(self::normalizeFilterMethod(...), $methods);
+
+        return $this;
+    }
+
+    /** @param list<string> $paths */
+    public function includePaths(array $paths): self
+    {
+        $this->includedPaths = $paths;
+
+        return $this;
+    }
+
+    /** @param list<string> $paths */
+    public function excludePaths(array $paths): self
+    {
+        $this->excludedPaths = $paths;
+
+        return $this;
+    }
+
+    /** @param list<string> $operationIds */
+    public function includeOperations(array $operationIds): self
+    {
+        $this->includedOperationIds = $operationIds;
+
+        return $this;
+    }
+
+    /** @param list<string> $operationIds */
+    public function excludeOperations(array $operationIds): self
+    {
+        $this->excludedOperationIds = $operationIds;
+
+        return $this;
+    }
+
+    public function includeDeprecated(bool $include = true): self
+    {
+        $this->includeDeprecated = $include;
+
+        return $this;
+    }
+
+    private static function normalizeFilterMethod(string $method): string
+    {
+        return OpenApiOperationResolver::normalizeMethodForKey($method);
+    }
+
+    private function matchesFilters(ExploredOperation $operation): bool
+    {
+        if (!$this->includeDeprecated && $operation->deprecated) {
+            return false;
+        }
+        if ($this->includedTags !== [] && array_intersect($this->includedTags, $operation->tags) === []) {
+            return false;
+        }
+        if (array_intersect($this->excludedTags, $operation->tags) !== []) {
+            return false;
+        }
+        if ($this->includedMethods !== [] && !in_array($operation->method, $this->includedMethods, true)) {
+            return false;
+        }
+        if (in_array($operation->method, $this->excludedMethods, true)) {
+            return false;
+        }
+        if ($this->includedPaths !== [] && !in_array($operation->path, $this->includedPaths, true)) {
+            return false;
+        }
+        if (in_array($operation->path, $this->excludedPaths, true)) {
+            return false;
+        }
+        if ($this->includedOperationIds !== [] && !in_array($operation->operationId, $this->includedOperationIds, true)) {
+            return false;
+        }
+
+        return !in_array($operation->operationId, $this->excludedOperationIds, true);
+    }
+}

--- a/src/Fuzz/SpecPathsPreflight.php
+++ b/src/Fuzz/SpecPathsPreflight.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Fuzz;
+
+use InvalidArgumentException;
+use Studio\Gesso\Spec\OpenApiOperationResolver;
+use Studio\Gesso\Validation\Support\MalformedSpecNode;
+
+use function array_key_exists;
+use function is_string;
+use function sprintf;
+
+/**
+ * Structural preflight over a spec's `paths` shared by the whole-spec
+ * exploration plan and the contract-check plan: a mixed valid/malformed
+ * document must fail atomically before any request is dispatched.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+final class SpecPathsPreflight
+{
+    /**
+     * Validate every structural node required to enumerate the spec before
+     * dispatching any request. A mixed valid/malformed document must fail
+     * atomically instead of executing the valid prefix and silently omitting
+     * the malformed remainder.
+     *
+     * @param array<string, mixed> $spec
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public static function validatedPaths(string $specName, array $spec): array
+    {
+        $paths = array_key_exists('paths', $spec) ? $spec['paths'] : [];
+        if (MalformedSpecNode::isMalformed($paths)) {
+            throw new InvalidArgumentException(sprintf(
+                "Malformed 'paths' in '%s' spec: expected object, got %s.",
+                $specName,
+                MalformedSpecNode::describe($paths),
+            ));
+        }
+
+        foreach ($paths as $path => $pathItem) {
+            if (!is_string($path)) {
+                throw new InvalidArgumentException(sprintf(
+                    "Malformed 'paths' in '%s' spec: expected string path key.",
+                    $specName,
+                ));
+            }
+
+            if (MalformedSpecNode::isMalformed($pathItem)) {
+                throw new InvalidArgumentException(sprintf(
+                    "Malformed 'paths[\"%s\"]' in '%s' spec: expected object, got %s.",
+                    $path,
+                    $specName,
+                    MalformedSpecNode::describe($pathItem),
+                ));
+            }
+
+            if (array_key_exists('additionalOperations', $pathItem) &&
+                MalformedSpecNode::isMalformed($pathItem['additionalOperations'])) {
+                throw new InvalidArgumentException(sprintf(
+                    "Malformed 'paths[\"%s\"].additionalOperations' in '%s' spec: expected object, got %s.",
+                    $path,
+                    $specName,
+                    MalformedSpecNode::describe($pathItem['additionalOperations']),
+                ));
+            }
+
+            foreach (OpenApiOperationResolver::declaredOperations($pathItem) as $declared) {
+                if (!MalformedSpecNode::isMalformed($declared['operation'])) {
+                    continue;
+                }
+
+                throw new InvalidArgumentException(sprintf(
+                    "Malformed 'paths[\"%s\"].%s' for %s %s in '%s' spec: expected object, got %s.",
+                    $path,
+                    $declared['location'],
+                    $declared['method'],
+                    $path,
+                    $specName,
+                    MalformedSpecNode::describe($declared['operation']),
+                ));
+            }
+        }
+
+        return $paths;
+    }
+}

--- a/tests/Unit/Compatibility/PublicApiBaselineTest.php
+++ b/tests/Unit/Compatibility/PublicApiBaselineTest.php
@@ -20,7 +20,14 @@ use Studio\Gesso\Coverage\JsonCoverageRenderer;
 use Studio\Gesso\Coverage\JUnitCoverageRenderer;
 use Studio\Gesso\Coverage\MarkdownCoverageRenderer;
 use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
+use Studio\Gesso\Fuzz\ContractCheck;
+use Studio\Gesso\Fuzz\ContractCheckFailure;
+use Studio\Gesso\Fuzz\ContractCheckPlan;
+use Studio\Gesso\Fuzz\ContractCheckSkip;
+use Studio\Gesso\Fuzz\ContractCheckSummary;
 use Studio\Gesso\Fuzz\ExploredCase;
+use Studio\Gesso\Fuzz\OpenApiContractChecks;
+use Studio\Gesso\Fuzz\OpenApiSpecExploration;
 use Studio\Gesso\JsonValidationResultRenderer;
 use Studio\Gesso\Laravel\Commands\OpenApiRoutesCommand;
 use Studio\Gesso\OpenApiResponseValidator;
@@ -542,6 +549,977 @@ final class PublicApiBaselineTest extends TestCase
                             'variadic' => false,
                             'by_reference' => false,
                             'default' => ['unavailable' => true],
+                            'attributes' => [],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        // Shared operation selection was extracted from OpenApiSpecExploration
+        // into the @internal SelectsExploredOperations trait; the method
+        // surface is unchanged, but the composing class's trait list gains
+        // the trait name.
+        $expected[OpenApiSpecExploration::class]['traits'] = ['Studio\\Gesso\\Fuzz\\SelectsExploredOperations'];
+
+        // New public symbols in v2.x (named contract checks): the
+        // ContractCheck enum, its ContractCheckFailure/ContractCheckSkip
+        // result DTOs, ContractCheckSummary, and the
+        // OpenApiContractChecks/ContractCheckPlan fluent entry point.
+        $expected[ContractCheck::class] = [
+            'kind' => 'enum',
+            'final' => true,
+            'abstract' => false,
+            'readonly' => false,
+            'instantiable' => false,
+            'constructor' => null,
+            'parent' => null,
+            'interfaces' => [
+                'BackedEnum',
+                'UnitEnum',
+            ],
+            'traits' => [],
+            'attributes' => [],
+            'backing_type' => 'string',
+            'cases' => [
+                'UnsupportedMethod' => 'unsupported_method',
+            ],
+            'constants' => [],
+            'properties' => [
+                'name' => [
+                    'type' => 'string',
+                    'static' => false,
+                    'readonly' => true,
+                    'default' => [
+                        'unavailable' => true,
+                    ],
+                ],
+                'value' => [
+                    'type' => 'string',
+                    'static' => false,
+                    'readonly' => true,
+                    'default' => [
+                        'unavailable' => true,
+                    ],
+                ],
+            ],
+            'methods' => [
+                'cases' => [
+                    'static' => true,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'array',
+                    'attributes' => [],
+                    'parameters' => [],
+                ],
+                'defaultExpectedStatuses' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'array',
+                    'attributes' => [],
+                    'parameters' => [],
+                ],
+                'from' => [
+                    'static' => true,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'static',
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'value',
+                            'type' => 'string|int',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                    ],
+                ],
+                'tryFrom' => [
+                    'static' => true,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => '?static',
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'value',
+                            'type' => 'string|int',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $expected[ContractCheckFailure::class] = [
+            'kind' => 'class',
+            'final' => true,
+            'abstract' => false,
+            'readonly' => true,
+            'instantiable' => true,
+            'constructor' => [
+                'kind' => 'declared',
+                'visibility' => 'public',
+            ],
+            'parent' => null,
+            'interfaces' => [],
+            'traits' => [],
+            'attributes' => [],
+            'backing_type' => null,
+            'cases' => [],
+            'constants' => [],
+            'properties' => [
+                'actualStatus' => [
+                    'type' => 'int',
+                    'static' => false,
+                    'readonly' => true,
+                    'default' => [
+                        'unavailable' => true,
+                    ],
+                ],
+                'case' => [
+                    'type' => 'Studio\\Gesso\\Fuzz\\ExploredCase',
+                    'static' => false,
+                    'readonly' => true,
+                    'default' => [
+                        'unavailable' => true,
+                    ],
+                ],
+                'check' => [
+                    'type' => 'Studio\\Gesso\\Fuzz\\ContractCheck',
+                    'static' => false,
+                    'readonly' => true,
+                    'default' => [
+                        'unavailable' => true,
+                    ],
+                ],
+                'expectedStatuses' => [
+                    'type' => 'array',
+                    'static' => false,
+                    'readonly' => true,
+                    'default' => [
+                        'unavailable' => true,
+                    ],
+                ],
+                'method' => [
+                    'type' => 'string',
+                    'static' => false,
+                    'readonly' => true,
+                    'default' => [
+                        'unavailable' => true,
+                    ],
+                ],
+                'operationId' => [
+                    'type' => '?string',
+                    'static' => false,
+                    'readonly' => true,
+                    'default' => [
+                        'unavailable' => true,
+                    ],
+                ],
+                'path' => [
+                    'type' => 'string',
+                    'static' => false,
+                    'readonly' => true,
+                    'default' => [
+                        'unavailable' => true,
+                    ],
+                ],
+            ],
+            'methods' => [
+                '__construct' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => null,
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'check',
+                            'type' => 'Studio\\Gesso\\Fuzz\\ContractCheck',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                        [
+                            'name' => 'method',
+                            'type' => 'string',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                        [
+                            'name' => 'path',
+                            'type' => 'string',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                        [
+                            'name' => 'operationId',
+                            'type' => '?string',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                        [
+                            'name' => 'expectedStatuses',
+                            'type' => 'array',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                        [
+                            'name' => 'actualStatus',
+                            'type' => 'int',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                        [
+                            'name' => 'case',
+                            'type' => 'Studio\\Gesso\\Fuzz\\ExploredCase',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                    ],
+                ],
+                'describe' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'string',
+                    'attributes' => [],
+                    'parameters' => [],
+                ],
+            ],
+        ];
+
+        $expected[ContractCheckPlan::class] = [
+            'kind' => 'class',
+            'final' => true,
+            'abstract' => false,
+            'readonly' => false,
+            'instantiable' => true,
+            'constructor' => [
+                'kind' => 'declared',
+                'visibility' => 'public',
+            ],
+            'parent' => null,
+            'interfaces' => [],
+            'traits' => [
+                'Studio\\Gesso\\Fuzz\\SelectsExploredOperations',
+            ],
+            'attributes' => [],
+            'backing_type' => null,
+            'cases' => [],
+            'constants' => [],
+            'properties' => [],
+            'methods' => [
+                '__construct' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => null,
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'specName',
+                            'type' => 'string',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                        [
+                            'name' => 'seed',
+                            'type' => 'int',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                    ],
+                ],
+                'authenticateUsing' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'self',
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'callback',
+                            'type' => 'callable',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                    ],
+                ],
+                'checks' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'self',
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'checks',
+                            'type' => 'array',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                    ],
+                ],
+                'dispatchUsing' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'self',
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'callback',
+                            'type' => 'callable',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                    ],
+                ],
+                'excludeMethods' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'self',
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'methods',
+                            'type' => 'array',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                    ],
+                ],
+                'excludeOperations' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'self',
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'operationIds',
+                            'type' => 'array',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                    ],
+                ],
+                'excludePaths' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'self',
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'paths',
+                            'type' => 'array',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                    ],
+                ],
+                'excludeTags' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'self',
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'tags',
+                            'type' => 'array',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                    ],
+                ],
+                'expectedStatuses' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'self',
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'check',
+                            'type' => 'Studio\\Gesso\\Fuzz\\ContractCheck',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                        [
+                            'name' => 'statuses',
+                            'type' => 'array',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                    ],
+                ],
+                'includeDeprecated' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'self',
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'include',
+                            'type' => 'bool',
+                            'optional' => true,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => true,
+                            'attributes' => [],
+                        ],
+                    ],
+                ],
+                'includeMethods' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'self',
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'methods',
+                            'type' => 'array',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                    ],
+                ],
+                'includeOperations' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'self',
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'operationIds',
+                            'type' => 'array',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                    ],
+                ],
+                'includePaths' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'self',
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'paths',
+                            'type' => 'array',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                    ],
+                ],
+                'includeTags' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'self',
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'tags',
+                            'type' => 'array',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                    ],
+                ],
+                'report' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'Studio\\Gesso\\Fuzz\\ContractCheckSummary',
+                    'attributes' => [],
+                    'parameters' => [],
+                ],
+                'setUpUsing' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'self',
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'callback',
+                            'type' => 'callable',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                    ],
+                ],
+                'tearDownUsing' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'self',
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'callback',
+                            'type' => 'callable',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $expected[ContractCheckSkip::class] = [
+            'kind' => 'class',
+            'final' => true,
+            'abstract' => false,
+            'readonly' => true,
+            'instantiable' => true,
+            'constructor' => [
+                'kind' => 'declared',
+                'visibility' => 'public',
+            ],
+            'parent' => null,
+            'interfaces' => [],
+            'traits' => [],
+            'attributes' => [],
+            'backing_type' => null,
+            'cases' => [],
+            'constants' => [],
+            'properties' => [
+                'check' => [
+                    'type' => 'Studio\\Gesso\\Fuzz\\ContractCheck',
+                    'static' => false,
+                    'readonly' => true,
+                    'default' => [
+                        'unavailable' => true,
+                    ],
+                ],
+                'method' => [
+                    'type' => '?string',
+                    'static' => false,
+                    'readonly' => true,
+                    'default' => [
+                        'unavailable' => true,
+                    ],
+                ],
+                'path' => [
+                    'type' => 'string',
+                    'static' => false,
+                    'readonly' => true,
+                    'default' => [
+                        'unavailable' => true,
+                    ],
+                ],
+                'reason' => [
+                    'type' => 'string',
+                    'static' => false,
+                    'readonly' => true,
+                    'default' => [
+                        'unavailable' => true,
+                    ],
+                ],
+            ],
+            'methods' => [
+                '__construct' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => null,
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'check',
+                            'type' => 'Studio\\Gesso\\Fuzz\\ContractCheck',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                        [
+                            'name' => 'path',
+                            'type' => 'string',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                        [
+                            'name' => 'method',
+                            'type' => '?string',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                        [
+                            'name' => 'reason',
+                            'type' => 'string',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $expected[ContractCheckSummary::class] = [
+            'kind' => 'class',
+            'final' => true,
+            'abstract' => false,
+            'readonly' => true,
+            'instantiable' => true,
+            'constructor' => [
+                'kind' => 'declared',
+                'visibility' => 'public',
+            ],
+            'parent' => null,
+            'interfaces' => [],
+            'traits' => [],
+            'attributes' => [],
+            'backing_type' => null,
+            'cases' => [],
+            'constants' => [],
+            'properties' => [
+                'dispatchedProbes' => [
+                    'type' => 'int',
+                    'static' => false,
+                    'readonly' => true,
+                    'default' => [
+                        'unavailable' => true,
+                    ],
+                ],
+                'failures' => [
+                    'type' => 'array',
+                    'static' => false,
+                    'readonly' => true,
+                    'default' => [
+                        'unavailable' => true,
+                    ],
+                ],
+                'probedPaths' => [
+                    'type' => 'int',
+                    'static' => false,
+                    'readonly' => true,
+                    'default' => [
+                        'unavailable' => true,
+                    ],
+                ],
+                'skips' => [
+                    'type' => 'array',
+                    'static' => false,
+                    'readonly' => true,
+                    'default' => [
+                        'unavailable' => true,
+                    ],
+                ],
+            ],
+            'methods' => [
+                '__construct' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => null,
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'probedPaths',
+                            'type' => 'int',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                        [
+                            'name' => 'dispatchedProbes',
+                            'type' => 'int',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                        [
+                            'name' => 'failures',
+                            'type' => 'array',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                        [
+                            'name' => 'skips',
+                            'type' => 'array',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                    ],
+                ],
+                'describeFailures' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'string',
+                    'attributes' => [],
+                    'parameters' => [],
+                ],
+                'hasFailures' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'bool',
+                    'attributes' => [],
+                    'parameters' => [],
+                ],
+                'hasSkips' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'bool',
+                    'attributes' => [],
+                    'parameters' => [],
+                ],
+            ],
+        ];
+
+        $expected[OpenApiContractChecks::class] = [
+            'kind' => 'class',
+            'final' => true,
+            'abstract' => false,
+            'readonly' => false,
+            'instantiable' => true,
+            'constructor' => [
+                'kind' => 'implicit',
+                'visibility' => 'public',
+            ],
+            'parent' => null,
+            'interfaces' => [],
+            'traits' => [],
+            'attributes' => [],
+            'backing_type' => null,
+            'cases' => [],
+            'constants' => [],
+            'properties' => [],
+            'methods' => [
+                'run' => [
+                    'static' => true,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => 'Studio\\Gesso\\Fuzz\\ContractCheckPlan',
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'specName',
+                            'type' => 'string',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => [
+                                'unavailable' => true,
+                            ],
+                            'attributes' => [],
+                        ],
+                        [
+                            'name' => 'seed',
+                            'type' => 'int',
+                            'optional' => true,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => 1,
                             'attributes' => [],
                         ],
                     ],

--- a/tests/Unit/Fuzz/ContractCheckSummaryTest.php
+++ b/tests/Unit/Fuzz/ContractCheckSummaryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Fuzz;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Fuzz\ContractCheck;
+use Studio\Gesso\Fuzz\ContractCheckFailure;
+use Studio\Gesso\Fuzz\ContractCheckSkip;
+use Studio\Gesso\Fuzz\ContractCheckSummary;
+use Studio\Gesso\Fuzz\ExploredCase;
+use Studio\Gesso\HttpMethod;
+
+class ContractCheckSummaryTest extends TestCase
+{
+    #[Test]
+    public function check_names_match_schemathesis(): void
+    {
+        $this->assertSame('unsupported_method', ContractCheck::UnsupportedMethod->value);
+        $this->assertSame([405], ContractCheck::UnsupportedMethod->defaultExpectedStatuses());
+    }
+
+    #[Test]
+    public function failure_describe_names_check_operation_and_mutation(): void
+    {
+        $failure = new ContractCheckFailure(
+            ContractCheck::UnsupportedMethod,
+            'PATCH',
+            '/v1/pets/{petId}',
+            null,
+            [405],
+            200,
+            new ExploredCase(null, [], [], ['petId' => 7], HttpMethod::PATCH, '/v1/pets/{petId}'),
+        );
+
+        $described = $failure->describe();
+        $this->assertStringContainsString('unsupported_method: PATCH /v1/pets/{petId}', $described);
+        $this->assertStringContainsString('expected 405, got 200', $described);
+        $this->assertStringContainsString('curl -X PATCH', $described);
+    }
+
+    #[Test]
+    public function summary_reports_and_describes_failures(): void
+    {
+        $failure = new ContractCheckFailure(
+            ContractCheck::UnsupportedMethod,
+            'DELETE',
+            '/pets',
+            null,
+            [405, 404],
+            204,
+            new ExploredCase(null, [], [], [], HttpMethod::DELETE, '/pets'),
+        );
+        $skip = new ContractCheckSkip(ContractCheck::UnsupportedMethod, '/full', null, 'documented');
+
+        $summary = new ContractCheckSummary(2, 2, [$failure], [$skip]);
+
+        $this->assertTrue($summary->hasFailures());
+        $this->assertTrue($summary->hasSkips());
+        $this->assertStringContainsString('expected 405 or 404, got 204', $summary->describeFailures());
+
+        $empty = new ContractCheckSummary(1, 1, [], []);
+        $this->assertFalse($empty->hasFailures());
+        $this->assertFalse($empty->hasSkips());
+        $this->assertSame('', $empty->describeFailures());
+    }
+}

--- a/tests/Unit/Fuzz/OpenApiContractChecksTest.php
+++ b/tests/Unit/Fuzz/OpenApiContractChecksTest.php
@@ -193,4 +193,65 @@ class OpenApiContractChecksTest extends TestCase
             ->dispatchUsing(static fn(ExploredCase $case): int => 405)
             ->report();
     }
+
+    #[Test]
+    public function a_fully_documented_path_is_skipped_with_a_reason(): void
+    {
+        $dispatched = 0;
+
+        $summary = OpenApiContractChecks::run('contract-checks', seed: 7)
+            ->checks([ContractCheck::UnsupportedMethod])
+            ->includePaths(['/saturated'])
+            ->dispatchUsing(static function (ExploredCase $case) use (&$dispatched): int {
+                $dispatched++;
+
+                return 405;
+            })
+            ->report();
+
+        $this->assertSame(0, $dispatched);
+        $this->assertCount(1, $summary->skips);
+        $this->assertSame('/saturated', $summary->skips[0]->path);
+        $this->assertNull($summary->skips[0]->method);
+        $this->assertStringContainsString('Every explorable HTTP method is documented', $summary->skips[0]->reason);
+    }
+
+    #[Test]
+    public function a_custom_method_only_path_is_skipped_not_probed(): void
+    {
+        $summary = OpenApiContractChecks::run('contract-checks', seed: 7)
+            ->checks([ContractCheck::UnsupportedMethod])
+            ->includePaths(['/custom-only'])
+            ->dispatchUsing(static fn(ExploredCase $case): int => 405)
+            ->report();
+
+        $this->assertSame(0, $summary->dispatchedProbes);
+        $this->assertCount(1, $summary->skips);
+        $this->assertStringContainsString('explorer-supported method', $summary->skips[0]->reason);
+    }
+
+    #[Test]
+    public function probe_method_is_deterministic_for_a_seed_and_undocumented(): void
+    {
+        $probeFor = static function (int $seed): string {
+            $method = null;
+            OpenApiContractChecks::run('contract-checks', seed: $seed)
+                ->checks([ContractCheck::UnsupportedMethod])
+                ->includePaths(['/pets'])
+                ->dispatchUsing(static function (ExploredCase $case) use (&$method): int {
+                    $method = $case->method->value;
+
+                    return 405;
+                })
+                ->report();
+
+            return $method ?? self::fail('probe did not dispatch');
+        };
+
+        $first = $probeFor(7);
+        $this->assertSame($first, $probeFor(7), 'same seed must choose the same probe method');
+        $this->assertContains($first, ['PUT', 'PATCH', 'DELETE', 'QUERY']);
+        // Pinned regression: fill in the literal observed on first green run.
+        $this->assertSame('PUT', $first);
+    }
 }

--- a/tests/Unit/Fuzz/OpenApiContractChecksTest.php
+++ b/tests/Unit/Fuzz/OpenApiContractChecksTest.php
@@ -14,6 +14,8 @@ use Studio\Gesso\Fuzz\ExploredOperation;
 use Studio\Gesso\Fuzz\OpenApiContractChecks;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 
+use function range;
+
 class OpenApiContractChecksTest extends TestCase
 {
     protected function setUp(): void
@@ -235,6 +237,29 @@ class OpenApiContractChecksTest extends TestCase
         $this->assertSame(0, $summary->dispatchedProbes);
         $this->assertCount(1, $summary->skips);
         $this->assertStringContainsString('explorer-supported method', $summary->skips[0]->reason);
+    }
+
+    #[Test]
+    public function an_additional_operations_entry_spelling_a_fixed_method_is_documented_not_probed(): void
+    {
+        $methods = [];
+        foreach (range(1, 10) as $seed) {
+            OpenApiContractChecks::run('contract-checks', seed: $seed)
+                ->checks([ContractCheck::UnsupportedMethod])
+                ->includePaths(['/mixed'])
+                ->dispatchUsing(static function (ExploredCase $case) use (&$methods): int {
+                    $methods[] = $case->method->value;
+
+                    return 405;
+                })
+                ->report();
+        }
+
+        // /mixed documents GET (fixed field) and PUT (additionalOperations
+        // "PUT" — the wire method PUT, resolved case-sensitively at runtime).
+        $this->assertNotContains('PUT', $methods);
+        $this->assertNotContains('GET', $methods);
+        $this->assertNotSame([], $methods);
     }
 
     #[Test]

--- a/tests/Unit/Fuzz/OpenApiContractChecksTest.php
+++ b/tests/Unit/Fuzz/OpenApiContractChecksTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Fuzz;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Studio\Gesso\Fuzz\ContractCheck;
+use Studio\Gesso\Fuzz\ExploredCase;
+use Studio\Gesso\Fuzz\ExploredOperation;
+use Studio\Gesso\Fuzz\OpenApiContractChecks;
+use Studio\Gesso\Spec\OpenApiSpecLoader;
+
+class OpenApiContractChecksTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../../fixtures/specs');
+    }
+
+    protected function tearDown(): void
+    {
+        OpenApiSpecLoader::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function collects_a_failure_instead_of_throwing_when_the_probe_is_accepted(): void
+    {
+        $dispatched = [];
+
+        $summary = OpenApiContractChecks::run('contract-checks', seed: 7)
+            ->checks([ContractCheck::UnsupportedMethod])
+            ->includePaths(['/pets'])
+            ->dispatchUsing(static function (ExploredCase $case) use (&$dispatched): int {
+                $dispatched[] = $case;
+
+                return 200; // API wrongly accepts the undocumented method
+            })
+            ->report();
+
+        $this->assertCount(1, $dispatched);
+        $this->assertNotContains($dispatched[0]->method->value, ['GET', 'POST'], 'probe must use an undocumented method');
+        $this->assertNull($dispatched[0]->body);
+        $this->assertSame([], $dispatched[0]->query);
+        $this->assertSame('/pets', $dispatched[0]->matchedPath);
+
+        $this->assertCount(1, $summary->failures);
+        $failure = $summary->failures[0];
+        $this->assertSame(ContractCheck::UnsupportedMethod, $failure->check);
+        $this->assertSame('/pets', $failure->path);
+        $this->assertSame([405], $failure->expectedStatuses);
+        $this->assertSame(200, $failure->actualStatus);
+        $this->assertSame(1, $summary->probedPaths);
+        $this->assertSame(1, $summary->dispatchedProbes);
+    }
+
+    #[Test]
+    public function passes_when_the_probe_is_rejected_with_405(): void
+    {
+        $summary = OpenApiContractChecks::run('contract-checks', seed: 7)
+            ->checks([ContractCheck::UnsupportedMethod])
+            ->includePaths(['/pets'])
+            ->dispatchUsing(static fn(ExploredCase $case): int => 405)
+            ->report();
+
+        $this->assertFalse($summary->hasFailures());
+        $this->assertSame('', $summary->describeFailures());
+    }
+
+    #[Test]
+    public function expected_statuses_override_replaces_the_default(): void
+    {
+        $summary = OpenApiContractChecks::run('contract-checks', seed: 7)
+            ->checks([ContractCheck::UnsupportedMethod])
+            ->includePaths(['/pets'])
+            ->expectedStatuses(ContractCheck::UnsupportedMethod, [405, 404])
+            ->dispatchUsing(static fn(ExploredCase $case): int => 404)
+            ->report();
+
+        $this->assertFalse($summary->hasFailures());
+    }
+
+    #[Test]
+    public function substitutes_generated_path_parameters(): void
+    {
+        $uris = [];
+
+        OpenApiContractChecks::run('contract-checks', seed: 3)
+            ->checks([ContractCheck::UnsupportedMethod])
+            ->includePaths(['/pets/{petId}'])
+            ->dispatchUsing(static function (ExploredCase $case) use (&$uris): int {
+                $uris[] = $case->uri();
+
+                return 405;
+            })
+            ->report();
+
+        $this->assertCount(1, $uris);
+        $this->assertStringNotContainsString('{petId}', $uris[0]);
+    }
+
+    #[Test]
+    public function hooks_run_in_order_and_tear_down_runs_on_dispatch_failure(): void
+    {
+        $events = [];
+
+        try {
+            OpenApiContractChecks::run('contract-checks', seed: 7)
+                ->checks([ContractCheck::UnsupportedMethod])
+                ->includePaths(['/pets'])
+                ->setUpUsing(static function (ExploredOperation $operation) use (&$events): void {
+                    $events[] = 'setUp';
+                })
+                ->authenticateUsing(static function (ExploredOperation $operation) use (&$events): void {
+                    $events[] = 'auth';
+                })
+                ->tearDownUsing(static function (ExploredOperation $operation) use (&$events): void {
+                    $events[] = 'tearDown';
+                })
+                ->dispatchUsing(static function (ExploredCase $case) use (&$events): int {
+                    $events[] = 'dispatch';
+
+                    throw new RuntimeException('boom');
+                })
+                ->report();
+            $this->fail('Expected the dispatch failure to be rethrown.');
+        } catch (RuntimeException $e) {
+            $this->assertStringContainsString('Contract check dispatch failed.', $e->getMessage());
+            $this->assertStringContainsString('unsupported_method', $e->getMessage());
+            $this->assertStringContainsString('Curl:', $e->getMessage());
+        }
+
+        $this->assertSame(['setUp', 'auth', 'dispatch', 'tearDown'], $events);
+    }
+
+    #[Test]
+    public function loud_failures_for_missing_configuration(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/requires checks\(\)/');
+        OpenApiContractChecks::run('contract-checks')
+            ->dispatchUsing(static fn(ExploredCase $case): int => 405)
+            ->report();
+    }
+
+    #[Test]
+    public function checks_rejects_an_empty_list(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        OpenApiContractChecks::run('contract-checks')->checks([]);
+    }
+
+    #[Test]
+    public function report_requires_dispatch_using(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/requires dispatchUsing\(\)/');
+        OpenApiContractChecks::run('contract-checks')
+            ->checks([ContractCheck::UnsupportedMethod])
+            ->report();
+    }
+
+    #[Test]
+    public function expected_statuses_validates_range_and_emptiness(): void
+    {
+        $plan = OpenApiContractChecks::run('contract-checks');
+
+        $this->expectException(InvalidArgumentException::class);
+        $plan->expectedStatuses(ContractCheck::UnsupportedMethod, [99]);
+    }
+
+    #[Test]
+    public function run_rejects_an_empty_spec_name(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        OpenApiContractChecks::run('');
+    }
+
+    #[Test]
+    public function filters_matching_nothing_fail_loudly(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/matched no operations/');
+        OpenApiContractChecks::run('contract-checks')
+            ->checks([ContractCheck::UnsupportedMethod])
+            ->includeTags(['nope'])
+            ->dispatchUsing(static fn(ExploredCase $case): int => 405)
+            ->report();
+    }
+}

--- a/tests/Unit/Fuzz/OpenApiContractChecksTest.php
+++ b/tests/Unit/Fuzz/OpenApiContractChecksTest.php
@@ -176,6 +176,13 @@ class OpenApiContractChecksTest extends TestCase
     }
 
     #[Test]
+    public function expected_statuses_rejects_an_empty_list(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        OpenApiContractChecks::run('contract-checks')->expectedStatuses(ContractCheck::UnsupportedMethod, []);
+    }
+
+    #[Test]
     public function run_rejects_an_empty_spec_name(): void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -251,7 +258,7 @@ class OpenApiContractChecksTest extends TestCase
         $first = $probeFor(7);
         $this->assertSame($first, $probeFor(7), 'same seed must choose the same probe method');
         $this->assertContains($first, ['PUT', 'PATCH', 'DELETE', 'QUERY']);
-        // Pinned regression: fill in the literal observed on first green run.
+        // Pinned regression: seed 7 deterministically selects PUT for /pets.
         $this->assertSame('PUT', $first);
     }
 }

--- a/tests/Unit/Fuzz/ResponseStatusExtractorTest.php
+++ b/tests/Unit/Fuzz/ResponseStatusExtractorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Fuzz;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Fuzz\ResponseStatusExtractor;
+
+class ResponseStatusExtractorTest extends TestCase
+{
+    #[Test]
+    public function accepts_a_plain_int(): void
+    {
+        $this->assertSame(405, ResponseStatusExtractor::extract(405));
+    }
+
+    #[Test]
+    public function accepts_an_object_with_get_status_code(): void
+    {
+        $response = new class {
+            public function getStatusCode(): int
+            {
+                return 204;
+            }
+        };
+
+        $this->assertSame(204, ResponseStatusExtractor::extract($response));
+    }
+
+    #[Test]
+    public function accepts_a_magic_call_proxy(): void
+    {
+        $response = new class {
+            /** @param list<mixed> $arguments */
+            public function __call(string $name, array $arguments): int
+            {
+                return $name === 'getStatusCode' ? 418 : 0;
+            }
+        };
+
+        $this->assertSame(418, ResponseStatusExtractor::extract($response));
+    }
+
+    #[Test]
+    public function rejects_unsupported_return_values(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/int status code, a PSR-7 response, or an object exposing getStatusCode\(\)/');
+        ResponseStatusExtractor::extract(['status' => 200]);
+    }
+
+    #[Test]
+    public function rejects_a_non_int_status_from_the_object(): void
+    {
+        $response = new class {
+            public function getStatusCode(): string
+            {
+                return 'ok';
+            }
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        ResponseStatusExtractor::extract($response);
+    }
+}

--- a/tests/fixtures/compatibility/v2-public-api.json
+++ b/tests/fixtures/compatibility/v2-public-api.json
@@ -1601,6 +1601,911 @@
             }
         }
     },
+    "Studio\\Gesso\\Fuzz\\ContractCheck": {
+        "kind": "enum",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "instantiable": false,
+        "constructor": null,
+        "parent": null,
+        "interfaces": [
+            "BackedEnum",
+            "UnitEnum"
+        ],
+        "traits": [],
+        "attributes": [],
+        "backing_type": "string",
+        "cases": {
+            "UnsupportedMethod": "unsupported_method"
+        },
+        "constants": [],
+        "properties": {
+            "name": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "value": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "cases": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": []
+            },
+            "defaultExpectedStatuses": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "array",
+                "attributes": [],
+                "parameters": []
+            },
+            "from": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "static",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "string|int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "tryFrom": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "?static",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "value",
+                        "type": "string|int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\Gesso\\Fuzz\\ContractCheckFailure": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": true,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": {
+            "actualStatus": {
+                "type": "int",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "case": {
+                "type": "Studio\\Gesso\\Fuzz\\ExploredCase",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "check": {
+                "type": "Studio\\Gesso\\Fuzz\\ContractCheck",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "expectedStatuses": {
+                "type": "array",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "method": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "operationId": {
+                "type": "?string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "path": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "check",
+                        "type": "Studio\\Gesso\\Fuzz\\ContractCheck",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "method",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "operationId",
+                        "type": "?string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "expectedStatuses",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "actualStatus",
+                        "type": "int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "case",
+                        "type": "Studio\\Gesso\\Fuzz\\ExploredCase",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "describe": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "string",
+                "attributes": [],
+                "parameters": []
+            }
+        }
+    },
+    "Studio\\Gesso\\Fuzz\\ContractCheckPlan": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
+        "parent": null,
+        "interfaces": [],
+        "traits": [
+            "Studio\\Gesso\\Fuzz\\SelectsExploredOperations"
+        ],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "seed",
+                        "type": "int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "authenticateUsing": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "callback",
+                        "type": "callable",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "checks": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "checks",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "dispatchUsing": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "callback",
+                        "type": "callable",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "excludeMethods": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "methods",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "excludeOperations": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "operationIds",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "excludePaths": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "paths",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "excludeTags": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "tags",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "expectedStatuses": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "check",
+                        "type": "Studio\\Gesso\\Fuzz\\ContractCheck",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "statuses",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "includeDeprecated": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "include",
+                        "type": "bool",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": true,
+                        "attributes": []
+                    }
+                ]
+            },
+            "includeMethods": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "methods",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "includeOperations": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "operationIds",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "includePaths": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "paths",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "includeTags": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "tags",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "report": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "Studio\\Gesso\\Fuzz\\ContractCheckSummary",
+                "attributes": [],
+                "parameters": []
+            },
+            "setUpUsing": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "callback",
+                        "type": "callable",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "tearDownUsing": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "self",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "callback",
+                        "type": "callable",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\Gesso\\Fuzz\\ContractCheckSkip": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": true,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": {
+            "check": {
+                "type": "Studio\\Gesso\\Fuzz\\ContractCheck",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "method": {
+                "type": "?string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "path": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "reason": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "check",
+                        "type": "Studio\\Gesso\\Fuzz\\ContractCheck",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "method",
+                        "type": "?string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "reason",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
+    "Studio\\Gesso\\Fuzz\\ContractCheckSummary": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": true,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": {
+            "dispatchedProbes": {
+                "type": "int",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "failures": {
+                "type": "array",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "probedPaths": {
+                "type": "int",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "skips": {
+                "type": "array",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "probedPaths",
+                        "type": "int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "dispatchedProbes",
+                        "type": "int",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "failures",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "skips",
+                        "type": "array",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    }
+                ]
+            },
+            "describeFailures": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "string",
+                "attributes": [],
+                "parameters": []
+            },
+            "hasFailures": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "bool",
+                "attributes": [],
+                "parameters": []
+            },
+            "hasSkips": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "bool",
+                "attributes": [],
+                "parameters": []
+            }
+        }
+    },
     "Studio\\Gesso\\Fuzz\\ExplorationCaseKind": {
         "kind": "enum",
         "final": true,
@@ -2561,6 +3466,57 @@
             }
         }
     },
+    "Studio\\Gesso\\Fuzz\\OpenApiContractChecks": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": false,
+        "instantiable": true,
+        "constructor": {
+            "kind": "implicit",
+            "visibility": "public"
+        },
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": [],
+        "methods": {
+            "run": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "Studio\\Gesso\\Fuzz\\ContractCheckPlan",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "seed",
+                        "type": "int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": 1,
+                        "attributes": []
+                    }
+                ]
+            }
+        }
+    },
     "Studio\\Gesso\\Fuzz\\OpenApiEndpointExplorer": {
         "kind": "class",
         "final": true,
@@ -2727,7 +3683,9 @@
         },
         "parent": null,
         "interfaces": [],
-        "traits": [],
+        "traits": [
+            "Studio\\Gesso\\Fuzz\\SelectsExploredOperations"
+        ],
         "attributes": [],
         "backing_type": null,
         "cases": [],

--- a/tests/fixtures/specs/contract-checks.json
+++ b/tests/fixtures/specs/contract-checks.json
@@ -1,0 +1,52 @@
+{
+    "openapi": "3.1.0",
+    "info": { "title": "Contract checks fixture", "version": "1.0.0" },
+    "paths": {
+        "/pets": {
+            "get": {
+                "operationId": "listPets",
+                "tags": ["public"],
+                "responses": { "200": { "description": "ok" } }
+            },
+            "post": {
+                "operationId": "createPet",
+                "tags": ["public"],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "required": ["name"],
+                                "properties": { "name": { "type": "string", "minLength": 1 } }
+                            }
+                        }
+                    }
+                },
+                "responses": { "201": { "description": "created" } }
+            }
+        },
+        "/pets/{petId}": {
+            "get": {
+                "operationId": "showPet",
+                "tags": ["public"],
+                "parameters": [
+                    { "name": "petId", "in": "path", "required": true, "schema": { "type": "integer", "minimum": 1 } }
+                ],
+                "responses": { "200": { "description": "ok" } }
+            }
+        },
+        "/saturated": {
+            "get": { "operationId": "saturatedGet", "responses": { "200": { "description": "ok" } } },
+            "put": { "operationId": "saturatedPut", "responses": { "200": { "description": "ok" } } },
+            "post": { "operationId": "saturatedPost", "responses": { "200": { "description": "ok" } } },
+            "delete": { "operationId": "saturatedDelete", "responses": { "204": { "description": "gone" } } },
+            "patch": { "operationId": "saturatedPatch", "responses": { "200": { "description": "ok" } } },
+            "query": { "operationId": "saturatedQuery", "responses": { "200": { "description": "ok" } } }
+        },
+        "/custom-only": {
+            "additionalOperations": {
+                "COPY": { "operationId": "copyThing", "responses": { "200": { "description": "ok" } } }
+            }
+        }
+    }
+}

--- a/tests/fixtures/specs/contract-checks.json
+++ b/tests/fixtures/specs/contract-checks.json
@@ -1,51 +1,156 @@
 {
     "openapi": "3.1.0",
-    "info": { "title": "Contract checks fixture", "version": "1.0.0" },
+    "info": {
+        "title": "Contract checks fixture",
+        "version": "1.0.0"
+    },
     "paths": {
         "/pets": {
             "get": {
                 "operationId": "listPets",
-                "tags": ["public"],
-                "responses": { "200": { "description": "ok" } }
+                "tags": [
+                    "public"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ok"
+                    }
+                }
             },
             "post": {
                 "operationId": "createPet",
-                "tags": ["public"],
+                "tags": [
+                    "public"
+                ],
                 "requestBody": {
                     "content": {
                         "application/json": {
                             "schema": {
                                 "type": "object",
-                                "required": ["name"],
-                                "properties": { "name": { "type": "string", "minLength": 1 } }
+                                "required": [
+                                    "name"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    }
+                                }
                             }
                         }
                     }
                 },
-                "responses": { "201": { "description": "created" } }
+                "responses": {
+                    "201": {
+                        "description": "created"
+                    }
+                }
             }
         },
         "/pets/{petId}": {
             "get": {
                 "operationId": "showPet",
-                "tags": ["public"],
-                "parameters": [
-                    { "name": "petId", "in": "path", "required": true, "schema": { "type": "integer", "minimum": 1 } }
+                "tags": [
+                    "public"
                 ],
-                "responses": { "200": { "description": "ok" } }
+                "parameters": [
+                    {
+                        "name": "petId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ok"
+                    }
+                }
             }
         },
         "/saturated": {
-            "get": { "operationId": "saturatedGet", "responses": { "200": { "description": "ok" } } },
-            "put": { "operationId": "saturatedPut", "responses": { "200": { "description": "ok" } } },
-            "post": { "operationId": "saturatedPost", "responses": { "200": { "description": "ok" } } },
-            "delete": { "operationId": "saturatedDelete", "responses": { "204": { "description": "gone" } } },
-            "patch": { "operationId": "saturatedPatch", "responses": { "200": { "description": "ok" } } },
-            "query": { "operationId": "saturatedQuery", "responses": { "200": { "description": "ok" } } }
+            "get": {
+                "operationId": "saturatedGet",
+                "responses": {
+                    "200": {
+                        "description": "ok"
+                    }
+                }
+            },
+            "put": {
+                "operationId": "saturatedPut",
+                "responses": {
+                    "200": {
+                        "description": "ok"
+                    }
+                }
+            },
+            "post": {
+                "operationId": "saturatedPost",
+                "responses": {
+                    "200": {
+                        "description": "ok"
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "saturatedDelete",
+                "responses": {
+                    "204": {
+                        "description": "gone"
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "saturatedPatch",
+                "responses": {
+                    "200": {
+                        "description": "ok"
+                    }
+                }
+            },
+            "query": {
+                "operationId": "saturatedQuery",
+                "responses": {
+                    "200": {
+                        "description": "ok"
+                    }
+                }
+            }
         },
         "/custom-only": {
             "additionalOperations": {
-                "COPY": { "operationId": "copyThing", "responses": { "200": { "description": "ok" } } }
+                "COPY": {
+                    "operationId": "copyThing",
+                    "responses": {
+                        "200": {
+                            "description": "ok"
+                        }
+                    }
+                }
+            }
+        },
+        "/mixed": {
+            "get": {
+                "operationId": "mixedGet",
+                "responses": {
+                    "200": {
+                        "description": "ok"
+                    }
+                }
+            },
+            "additionalOperations": {
+                "PUT": {
+                    "operationId": "mixedPut",
+                    "responses": {
+                        "200": {
+                            "description": "ok"
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Adds opt-in named negative contract checks to the exploration pipeline: `OpenApiContractChecks::run()` returns a fluent `ContractCheckPlan` that probes protocol-level contract holes schema validation cannot see, collects every result, and reports one `ContractCheckSummary` to assert at the end. First check: `unsupported_method` (Schemathesis-compatible name) — dispatch one deterministically chosen undocumented HTTP method per documented path and expect 405 (override via `expectedStatuses()`, e.g. `[405, 404]`).

## Why

Green tests against requests the API should reject are a silent failure class for a contract-testing tool. No PHP library probes these holes today; this extends Gesso's drift-detection identity (enum drift, strict-required) to the protocol level. PR1 of 2 for #401 — infrastructure + `unsupported_method`; `ignored_auth` and `missing_required_header` follow in PR2.

Design decisions (approved in planning):

- **Dedicated builder**, not an extension of `OpenApiSpecExploration` — checks share the filter set and hooks but none of the case-generation knobs (`casesPerOperation`, `negativeCases`, …). Shared semantics are extracted (`SelectsExploredOperations` trait, `SpecPathsPreflight`, `ExploredOperation::fromDeclaration()`, all `@internal`) so the two plans cannot drift; exploration behavior is unchanged and its tests are untouched.
- **Collect-then-assert**: probes never throw on a status mismatch; `$summary->failures` lists every hole with expected/actual status and a replayable curl command.
- **Determinism**: probe method chosen via `crc32(spec \0 check \0 path \0 seed)` over the undocumented explorer methods; pinned by a regression test.
- OpenAPI 3.2 `additionalOperations` are never probed (case-sensitive custom methods); fully documented paths and non-generatable sources become explained skips, which still count toward the loud zero-match gate.
- `dispatchUsing()` may return an `int`, a PSR-7 response, or any object exposing `getStatusCode(): int` (covers Symfony `Response` and Laravel `TestResponse` without a framework dependency).

New public API (v1.x compat surface, documented in docs/versioning.md): `ContractCheck`, `OpenApiContractChecks`, `ContractCheckPlan`, `ContractCheckSummary`, `ContractCheckFailure`, `ContractCheckSkip`. Docs: new "Named contract checks" section in docs/fuzzing.md, including the Laravel `auto_assert` interaction caveat.

## Verification

- [x] `composer test` passes (2,407 tests / 8,813 assertions)
- [x] `composer stan` passes
- [x] `composer cs-check` passes

- TDD per component; RED runs captured before each implementation.
- Skip semantics: fully documented path (`/saturated`) and custom-method-only path (`/custom-only`) covered by fixture-backed tests.
- Determinism: same-seed probe choice pinned (`seed 7` → `PUT` for `/pets`).
- `v2-public-api.json` regenerated: exactly the six new public symbols; `@internal` helpers excluded. `v2-diagnostic-prefixes.json` untouched (no new `[Gesso]` messages).

## Notes for reviewers

- `unsupported_method` default is strict 405 (RFC 9110 / Schemathesis parity); frameworks answering 404 opt in via `expectedStatuses()`.
- HEAD/OPTIONS/TRACE are outside the explorer's `HttpMethod` set and are not probed (documented limitation).
- `PublicApiBaselineTest` gained expectations for the six new symbols; `OpenApiSpecExploration`'s `traits` entry now records the `@internal` trait — follow-up to exclude internal traits from the baseline: #420.

Part of #401 (PR1 of 2 — the issue stays open for `ignored_auth` + `missing_required_header`).
