### PR TITLE
docs: close v2.1 documentation gaps for shipped features

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ when upgrading from `studio-design/openapi-contract-testing` v1.10.
 - **Endpoint coverage tracking** — Unique PHPUnit extension that reports which spec endpoints are covered by tests, at `(method, path, status, content-type)` granularity
 - **Laravel route/spec parity** — `openapi:routes` finds documented operations without routes and registered routes without OpenAPI operations, with filters, stable JSON, and independent CI gates
 - **Schema-driven request fuzzing** — Valid boundaries, composition branches, targeted negative cases with explicit expected status classes, deterministic replay/reduction, whole-spec filters, lifecycle/auth hooks, and explicit skip reasons
+- **Named negative contract checks** — Opt-in `unsupported_method` probes that dispatch an undocumented HTTP method per documented path and expect 405, with deterministic replay and collect-then-assert reporting. See [`docs/fuzzing.md`](docs/fuzzing.md#named-contract-checks).
 - **Enum drift detection** — Static comparison between PHP backed enums and their `enum:` spec arrays, with PHPUnit-extension auto-discovery
 - **Schema under-description detection** — Optional strict mode that flags response fields the implementation always returns but the spec marks as optional, catching the spec gaps that conformance checks alone can't. See [`docs/strict-required.md`](docs/strict-required.md) for current scope and limitations.
 - **Skip-by-status-code** — Configurable regex list of status codes whose bodies are not validated (default: every `5xx`); per-request via `skipResponseCode()`
@@ -59,7 +60,7 @@ Choose based on the workflow you need rather than on a single yes/no feature cou
 | Parallel coverage merge | [Sidecar + merge CLI](docs/parallel.md) | Not documented | — | — | — |
 | Route/spec parity | [`openapi:routes`](docs/laravel-route-parity.md) with text/JSON and CI gates | [`spectator:routes`][spectator-cli] | — | — | — |
 | CLI diagnostics / scaffolding | [`doctor`](docs/doctor.md), [`openapi:routes`](docs/laravel-route-parity.md), coverage merge; no scaffolding | [`validate`, `coverage`, `routes`, `stubs`][spectator-cli] | — | — | — |
-| Structured validation failures | Text messages; JSON planned ([#282](https://github.com/studio-design/gesso/issues/282)) | [JSON `{errors: [...]}`][spectator-errors] | [PHP exception hierarchy][league-errors] | [Wrapper exception][osteel-readme] | [PHPUnit failure text][kirschbaum-failure-source] |
+| Structured validation failures | [`issues()` + versioned JSON failure output](docs/validation-json-schema.md) | [JSON `{errors: [...]}`][spectator-errors] | [PHP exception hierarchy][league-errors] | [Wrapper exception][osteel-readme] | [PHPUnit failure text][kirschbaum-failure-source] |
 | Schema-driven exploration | [Deterministic endpoint + whole-spec generation](docs/fuzzing.md) | — | — | — | — |
 | Drift / under-description checks | [Enum drift](docs/enum-drift.md), [strict required](docs/strict-required.md) | — | — | — | — |
 | First-class integration | [PSR-7](docs/psr7.md), [Laravel, Symfony, Pest](docs/setup.md) | [Laravel][spectator] | [PSR-7, PSR-15 middleware][league-middleware] | [HttpFoundation, PSR-7][osteel-readme] | [Laravel auto-validation][kirschbaum-readme] |
@@ -227,7 +228,7 @@ To validate every response automatically, set `'auto_assert' => true` and drop t
 | Pre-test compatibility diagnostics (`gesso doctor`) | [`docs/doctor.md`](docs/doctor.md) |
 | Laravel route/spec parity (`openapi:routes`) | [`docs/laravel-route-parity.md`](docs/laravel-route-parity.md) |
 | Pest plugin: `expect()->toMatchOpenApiResponseSchema()` and friends | [`docs/pest-plugin.md`](docs/pest-plugin.md) |
-| Schema-driven request fuzzing | [`docs/fuzzing.md`](docs/fuzzing.md) |
+| Schema-driven request fuzzing & named contract checks | [`docs/fuzzing.md`](docs/fuzzing.md) |
 | Enum drift detection | [`docs/enum-drift.md`](docs/enum-drift.md) |
 | Schema under-description detection (`strict_required`) | [`docs/strict-required.md`](docs/strict-required.md) |
 | Violation baseline: adopt on a legacy API, fail only on new violations | [`docs/baseline.md`](docs/baseline.md) |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -3,6 +3,7 @@
 - [`OpenApiResponseValidator`](#openapiresponsevalidator)
 - [`OpenApiPsr7Validator`](#openapipsr7validator)
 - [`OpenApiSpecExplorer`](#openapispecexplorer)
+- [`OpenApiContractChecks`](#openapicontractchecks)
 - [`OpenApiSpecLoader`](#openapispecloader)
 - [`OpenApiCoverageTracker`](#openapicoveragetracker)
 
@@ -155,6 +156,36 @@ For one operation, use
 `OpenApiEndpointExplorer::exploreInvalid(..., expectedStatusClasses: [4])` or
 Laravel's `exploreInvalidEndpoint()`. `FailureReducer::reduce()` minimizes a
 failing body while preserving a caller-defined failure classification.
+
+## `OpenApiContractChecks`
+
+Builds a plan of named negative contract checks — probes for protocol-level
+holes schema validation cannot see. The first check, `unsupported_method`,
+dispatches one deterministically chosen undocumented HTTP method per
+documented path and expects 405 by default:
+
+```php
+use Studio\Gesso\Fuzz\ContractCheck;
+use Studio\Gesso\Fuzz\OpenApiContractChecks;
+
+$summary = OpenApiContractChecks::run('front', seed: 7)
+    ->checks([ContractCheck::UnsupportedMethod])
+    ->includeTags(['public'])
+    ->expectedStatuses(ContractCheck::UnsupportedMethod, [405, 404]) // optional override
+    ->dispatchUsing(fn ($case) => dispatch_request($case))
+    ->report();
+
+self::assertSame([], $summary->failures, $summary->describeFailures());
+```
+
+The plan shares the exploration filter set (tags, methods, paths, operation
+IDs, deprecated) and the `authenticateUsing()` / `setUpUsing()` /
+`tearDownUsing()` hooks. `dispatchUsing()` may return an `int`, a PSR-7
+response, or any object exposing `getStatusCode(): int`. Probes never throw
+on a status mismatch — the returned `ContractCheckSummary` collects every
+`ContractCheckFailure` (with a replayable curl command) and every explained
+`ContractCheckSkip`, plus `probedPaths` / `dispatchedProbes` counts. See
+[named contract checks](fuzzing.md#named-contract-checks).
 
 ## `OpenApiSpecLoader`
 

--- a/docs/psr7.md
+++ b/docs/psr7.md
@@ -87,6 +87,13 @@ $this->assertPsr7ResponseMatchesOpenApiSchema($request, $response);
 $this->assertPsr7ResponseForOperationMatchesOpenApiSchema('POST', '/v1/pets', $response);
 ```
 
+Assertion failures end with a redacted `Reproduce: curl …` line (for the
+exchange assertion, one line for the whole exchange, with each error prefixed
+by its `[request]` / `[response]` side). In the JSON failure output mode the
+exchange failure instead emits one labelled JSON document per failing side.
+See [reproduction commands](setup.md#reproduction-commands-in-failure-output)
+and [validation-json-schema.md](validation-json-schema.md).
+
 ## PSR-15 test integration
 
 Keep contract validation in tests rather than placing validation middleware on

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -13,6 +13,7 @@
 ## Guides
 
 - [Doctor command](https://studio-design.github.io/gesso/doctor): preflight a local spec for load and enforcement problems before tests run.
+- [Violation baseline](https://studio-design.github.io/gesso/baseline): adopt contract testing on a legacy API by baselining existing violations and failing only on new ones.
 - [PSR-7 validation](https://studio-design.github.io/gesso/psr7): validate PSR-7 requests and responses from any HTTP client or middleware.
 - [Laravel route parity](https://studio-design.github.io/gesso/laravel-route-parity): compare registered Laravel routes with spec operations to catch undocumented drift.
 - [Schema-driven fuzzing](https://studio-design.github.io/gesso/fuzzing): generate deterministic valid and invalid request cases from schemas, with replay tokens.

--- a/docs/samples/validation.json
+++ b/docs/samples/validation.json
@@ -11,27 +11,29 @@
         "content_type": "application/json"
     },
     "skip_reason": null,
-    "reproduce_command": "curl -X POST 'https://api.example.test/v1/pets' -H 'Authorization: <redacted>' -H 'Content-Type: application/json' --data '{\"name\":42}'",
+    "reproduce_command": "curl -X POST 'https://api.example.test/v1/pets?dryRun=maybe' -H 'Authorization: <redacted>' -H 'Content-Type: application/json' --data '{\"name\":42}'",
     "issues": [
+        {
+            "category": "request.parameter.query",
+            "message": "[query.dryRun] The data (string) must match the type: boolean",
+            "instance_path": "",
+            "keyword": "type",
+            "parameter": "dryRun",
+            "method": "POST",
+            "path": "/v1/pets",
+            "status_code": null,
+            "content_type": null
+        },
         {
             "category": "request.body",
             "message": "[/name] The data (integer) must match the type: string",
             "instance_path": "/name",
             "keyword": "type",
+            "parameter": null,
             "method": "POST",
             "path": "/v1/pets",
             "status_code": null,
             "content_type": "application/json"
-        },
-        {
-            "category": "request.parameter.query",
-            "message": "Required query parameter 'limit' is missing for GET /v1/pets in 'petstore' spec.",
-            "instance_path": null,
-            "keyword": null,
-            "method": "POST",
-            "path": "/v1/pets",
-            "status_code": null,
-            "content_type": null
         }
     ]
 }

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -370,8 +370,8 @@ exchange. In the JSON failure output mode the same command is carried in the
 document's `reproduce_command` field instead of a trailing line — see
 [validation-json-schema.md](validation-json-schema.md).
 
-Sensitive values are redacted before the command is rendered, so it is safe
-to print into CI logs:
+Header and query values that look sensitive are redacted before the command
+is rendered:
 
 - `Authorization`, `Proxy-Authorization`, and `Cookie` header values, plus
   any header whose name contains `api-key` / `api_key` / `apikey`, `token`,
@@ -379,12 +379,17 @@ to print into CI logs:
 - Query-string values whose parameter name matches the same pattern are
   redacted too (OpenAPI supports `apiKey` security in query parameters).
 - The request body is rendered only for JSON content types and is **not**
-  redacted — the body is test data the failing test constructed.
+  redacted. A body can itself carry credentials (a login password, a token
+  refresh payload), so treat the failure output as sensitive as a whole —
+  the redaction keeps header and query secrets out of CI logs, it does not
+  make the output safe to share.
 
 Redaction in adapter failure output cannot be disabled. Only the fuzzing
 API's `ExploredCase::curlSnippet(redactSensitiveHeaders: false)` opts out,
-for local debugging ([fuzzing.md](fuzzing.md)). The command is built lazily:
-a passing assertion never reads the request body stream.
+for local debugging ([fuzzing.md](fuzzing.md)). The command is rendered only
+when an assertion actually fails, so a passing PSR-7 assertion never
+re-reads the body stream for output — validation itself still decodes
+seekable streams (and restores the cursor) either way.
 
 ## Skipping responses by status code
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -353,6 +353,39 @@ $validator = new OpenApiResponseValidator($tracker, maxErrors: 1);
 
 For Laravel, set the `max_errors` key in `config/gesso.php`.
 
+## Reproduction commands in failure output
+
+Every adapter assertion failure (Laravel, Symfony, Pest, PSR-7) ends with a
+one-line curl command that reproduces the validated request:
+
+```text
+OpenAPI schema validation failed for POST /v1/pets (spec: front):
+[/name] The data (integer) must match the type: string
+Reproduce: curl -X POST 'https://api.example.test/v1/pets' -H 'Authorization: <redacted>' -H 'Content-Type: application/json' --data '{"name":42}'
+```
+
+The PSR-7 exchange assertion prefixes each error line with its `[request]` /
+`[response]` side label and ends with one `Reproduce:` line for the whole
+exchange. In the JSON failure output mode the same command is carried in the
+document's `reproduce_command` field instead of a trailing line — see
+[validation-json-schema.md](validation-json-schema.md).
+
+Sensitive values are redacted before the command is rendered, so it is safe
+to print into CI logs:
+
+- `Authorization`, `Proxy-Authorization`, and `Cookie` header values, plus
+  any header whose name contains `api-key` / `api_key` / `apikey`, `token`,
+  or `secret` (case-insensitive), become `<redacted>`.
+- Query-string values whose parameter name matches the same pattern are
+  redacted too (OpenAPI supports `apiKey` security in query parameters).
+- The request body is rendered only for JSON content types and is **not**
+  redacted — the body is test data the failing test constructed.
+
+Redaction in adapter failure output cannot be disabled. Only the fuzzing
+API's `ExploredCase::curlSnippet(redactSensitiveHeaders: false)` opts out,
+for local debugging ([fuzzing.md](fuzzing.md)). The command is built lazily:
+a passing assertion never reads the request body stream.
+
 ## Skipping responses by status code
 
 Production error responses (typically `5xx`) are often deliberately left out of the OpenAPI spec. Without special handling, a test that hits a `500` would fail twice: once from the underlying bug, and again from "Status code 500 not defined". To avoid that noise, every `5xx` response is **skipped by default** — body validation is not performed, the assertion passes, and the endpoint is still recorded as covered.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -116,6 +116,10 @@ written by `json_output` has its own `schema_version` contract documented in
 
 - Anything marked `@internal` — including the `Internal\` and `Validation\Support\` namespaces, the per-validator helpers under `Validation\Request\` / `Validation\Response\`, `Spec\OpenApiSchemaConverter` / `Spec\OpenApiPathMatcher` / `Spec\OpenApiRefResolver` / `Spec\OpenApiPathSuggester`, the PHPUnit `CoverageReportSubscriber`, `Cli\DoctorCommand`, `Coverage\CoverageMergeCommand` (the `gesso doctor` and `gesso coverage:merge` CLI surfaces remain covered — these classes are their implementation details), and test seams (`*::resetWarningStateForTesting()`, `OpenApiSpecLoader::reset()`, `OpenApiCoverageTracker::reset()` / `exportState()` / `importState()`).
 - Validator error message wording (we may improve them; assert on presence/category, not on exact strings).
+- The text-mode assertion failure layout — the header line, the error list,
+  and the trailing `Reproduce:` curl line (including its redaction details).
+  Machine consumers should select the json output mode, whose failure shape
+  and document schema are covered above.
 - The set of `format` keywords delegated to opis — we follow opis upstream, so a new format is added when opis adds it.
 - Behaviour of bug-fix releases that close a documented silent-pass case. A test that passed only because of the silent pass may start failing — that's the fix doing its job, not a SemVer break.
 

--- a/tests/Unit/JsonValidationResultRendererTest.php
+++ b/tests/Unit/JsonValidationResultRendererTest.php
@@ -8,10 +8,14 @@ use const JSON_THROW_ON_ERROR;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\Gesso\DecodedBody;
 use Studio\Gesso\JsonValidationResultRenderer;
+use Studio\Gesso\OpenApiRequestValidator;
 use Studio\Gesso\OpenApiValidationResult;
+use Studio\Gesso\Spec\OpenApiSpecLoader;
 use Studio\Gesso\ValidationIssue;
 
+use function file_get_contents;
 use function json_decode;
 
 class JsonValidationResultRendererTest extends TestCase
@@ -148,6 +152,42 @@ class JsonValidationResultRendererTest extends TestCase
         $this->assertStringContainsString("\n    \"schema_version\": 1", $document);
         // Unescaped slashes keep categories and pointers readable.
         $this->assertStringNotContainsString('\\/', $document);
+    }
+
+    #[Test]
+    public function the_documented_sample_is_real_renderer_output(): void
+    {
+        // docs/samples/validation.json is the only committed example of the
+        // schema_version 1 document; regenerate it from this exact scenario
+        // when the renderer or validator output changes.
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs');
+
+        try {
+            $result = (new OpenApiRequestValidator())->validate(
+                'petstore-3.0',
+                'POST',
+                '/v1/pets',
+                ['dryRun' => 'maybe'],
+                ['Content-Type' => ['application/json']],
+                DecodedBody::present(['name' => 42]),
+                'application/json',
+            );
+            $document = JsonValidationResultRenderer::render(
+                $result,
+                "curl -X POST 'https://api.example.test/v1/pets?dryRun=maybe' -H 'Authorization: <redacted>' -H 'Content-Type: application/json' --data '{\"name\":42}'",
+            );
+        } finally {
+            OpenApiSpecLoader::reset();
+        }
+
+        $expected = self::decode((string) file_get_contents(__DIR__ . '/../../docs/samples/validation.json'));
+        $actual = self::decode($document);
+        // The running tool version depends on the checkout (branch, tag);
+        // the committed sample pins the main-branch rendering.
+        $actual['tool']['version'] = $expected['tool']['version'];
+
+        $this->assertSame($expected, $actual);
     }
 
     /**

--- a/tests/Unit/JsonValidationResultRendererTest.php
+++ b/tests/Unit/JsonValidationResultRendererTest.php
@@ -187,7 +187,14 @@ class JsonValidationResultRendererTest extends TestCase
         // the committed sample pins the main-branch rendering.
         $actual['tool']['version'] = $expected['tool']['version'];
 
-        $this->assertSame($expected, $actual);
+        // Validator message prose is explicitly outside the compatibility
+        // surface (docs/versioning.md), so an allowed opis wording change
+        // must not fail this pin — compare the stable structure and context
+        // and only require that every message is a non-empty string.
+        $this->assertSame(
+            $this->withNormalizedMessages($expected),
+            $this->withNormalizedMessages($actual),
+        );
     }
 
     /**
@@ -197,5 +204,25 @@ class JsonValidationResultRendererTest extends TestCase
     {
         /** @var array<string, mixed> */
         return json_decode($document, true, flags: JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @param array<string, mixed> $document
+     *
+     * @return array<string, mixed>
+     */
+    private function withNormalizedMessages(array $document): array
+    {
+        $this->assertIsArray($document['issues']);
+        foreach ($document['issues'] as $index => $issue) {
+            $this->assertIsArray($issue);
+            $this->assertArrayHasKey('message', $issue);
+            $this->assertIsString($issue['message']);
+            $this->assertNotSame('', $issue['message']);
+            $issue['message'] = '<any non-empty string>';
+            $document['issues'][$index] = $issue;
+        }
+
+        return $document;
     }
 }


### PR DESCRIPTION
## Summary

Fixes the documentation gaps found by a pre-release audit of everything shipping in v2.1.0: content that contradicted the shipped behavior, and two shipped features with no user-facing documentation surface.

## Factually wrong content fixed

- **README comparison table** still listed structured validation failures as "Text messages; JSON planned (#282)" — #413/#414/#415 shipped `issues()` and the versioned JSON failure output. The row now links to docs/validation-json-schema.md.
- **docs/samples/validation.json** (the only committed example of the `schema_version` 1 document) contradicted the shipped renderer: missing `parameter` field, `keyword: null` where the code emits `required`, a message the codebase never produces, and a `POST` method on a `GET` description. The sample is now **real `OpenApiRequestValidator` output** (body type violation + query type violation on `POST /v1/pets` in the petstore fixture), and a new regression test regenerates the scenario and asserts the sample matches — it can no longer drift silently (`tool.version` is normalized; it depends on the checkout).
- **docs/public/llms.txt** was missing the `/baseline` guide entry that #419 added to the vitepress sidebar (the only sidebar/llms.txt divergence).

## Missing documentation added

- **Failure reproduction commands (#410)** had no adapter-side documentation. New `docs/setup.md` section covers the `Reproduce: curl …` line on every adapter assertion failure, the PSR-7 exchange form, the full redaction rules (sensitive headers, `api-key`/`token`/`secret` name pattern, query values; body not redacted), the absence of an adapter opt-out, and the json-mode `reproduce_command` equivalent. Cross-linked from docs/psr7.md; docs/versioning.md now explicitly places the text-mode failure layout outside SemVer (json mode remains the covered machine surface).
- **Named contract checks (#421)** had no README or API-reference surface. Added a README features bullet, extended the docs-table row, and added an `OpenApiContractChecks` section (+ index entry) to docs/api-reference.md.

## Verification

- [x] `composer ci` passes (2,409 tests / 8,817 assertions) — includes the new sample pin test
- Documented behavior verified against `src/Internal/CurlCommandFormatter.php`, `src/Internal/FailureOutput.php`, and the `src/Fuzz` contract-check API.