### PR TITLE
fix(compat): omit @internal traits from the public-api baseline

### DIFF
--- a/tests/Helpers/PublicApiInventory.php
+++ b/tests/Helpers/PublicApiInventory.php
@@ -25,6 +25,7 @@ use RuntimeException;
 use UnitEnum;
 
 use function array_diff;
+use function array_filter;
 use function array_map;
 use function array_values;
 use function class_exists;
@@ -112,6 +113,13 @@ final class PublicApiInventory
         if ($parent !== false) {
             $traits = array_values(array_diff($traits, $parent->getTraitNames()));
         }
+        // Trait composition is an implementation detail unless the trait is
+        // itself public API: renaming or splitting an @internal trait must not
+        // read as a baseline change (#420).
+        $traits = array_values(array_filter(
+            $traits,
+            static fn(string $trait): bool => !self::isInternal((new ReflectionClass($trait))->getDocComment()),
+        ));
         sort($traits);
 
         $methods = [];

--- a/tests/Unit/Compatibility/Fixture/PublicApiInternalTraitConsumerFixture.php
+++ b/tests/Unit/Compatibility/Fixture/PublicApiInternalTraitConsumerFixture.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Compatibility\Fixture;
+
+final class PublicApiInternalTraitConsumerFixture
+{
+    use PublicApiInternalTraitFixture;
+    use PublicApiTraitSurfaceFixture;
+}

--- a/tests/Unit/Compatibility/Fixture/PublicApiInternalTraitFixture.php
+++ b/tests/Unit/Compatibility/Fixture/PublicApiInternalTraitFixture.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Compatibility\Fixture;
+
+/**
+ * @internal Fixture trait excluded from the recorded trait list of consumers.
+ */
+trait PublicApiInternalTraitFixture
+{
+    private function internalHelper(): void {}
+}

--- a/tests/Unit/Compatibility/PublicApiBaselineTest.php
+++ b/tests/Unit/Compatibility/PublicApiBaselineTest.php
@@ -27,9 +27,10 @@ use Studio\Gesso\Fuzz\ContractCheckSkip;
 use Studio\Gesso\Fuzz\ContractCheckSummary;
 use Studio\Gesso\Fuzz\ExploredCase;
 use Studio\Gesso\Fuzz\OpenApiContractChecks;
-use Studio\Gesso\Fuzz\OpenApiSpecExploration;
 use Studio\Gesso\JsonValidationResultRenderer;
 use Studio\Gesso\Laravel\Commands\OpenApiRoutesCommand;
+use Studio\Gesso\Laravel\ExploresOpenApiEndpoint;
+use Studio\Gesso\Laravel\ValidatesOpenApiSchema;
 use Studio\Gesso\OpenApiResponseValidator;
 use Studio\Gesso\OpenApiValidationResult;
 use Studio\Gesso\Pest\Expectations;
@@ -40,6 +41,7 @@ use Studio\Gesso\SkipOpenApiResolver;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 use Studio\Gesso\Tests\Helpers\PublicApiInventory;
 use Studio\Gesso\Tests\Unit\Compatibility\Fixture\PublicApiImplicitConstructorFixture;
+use Studio\Gesso\Tests\Unit\Compatibility\Fixture\PublicApiInternalTraitConsumerFixture;
 use Studio\Gesso\Tests\Unit\Compatibility\Fixture\PublicApiPrivateConstructorFixture;
 use Studio\Gesso\Tests\Unit\Compatibility\Fixture\PublicApiReturnTypeFixture;
 use Studio\Gesso\Tests\Unit\Compatibility\Fixture\PublicApiTraitSurfaceConsumerFixture;
@@ -93,6 +95,20 @@ final class PublicApiBaselineTest extends TestCase
         $this->assertFalse($privateConstructor['instantiable']);
         $this->assertSame('declared', $privateConstructor['constructor']['kind']);
         $this->assertSame('private', $privateConstructor['constructor']['visibility']);
+    }
+
+    #[Test]
+    public function inventory_omits_internal_traits_from_the_traits_list(): void
+    {
+        $inventory = PublicApiInventory::capture(
+            __DIR__ . '/Fixture',
+            'Studio\\Gesso\\Tests\\Unit\\Compatibility\\Fixture\\',
+        );
+
+        $this->assertSame(
+            [PublicApiTraitSurfaceFixture::class],
+            $inventory[PublicApiInternalTraitConsumerFixture::class]['traits'],
+        );
     }
 
     #[Test]
@@ -555,11 +571,11 @@ final class PublicApiBaselineTest extends TestCase
                 ],
             ],
         ];
-        // Shared operation selection was extracted from OpenApiSpecExploration
-        // into the @internal SelectsExploredOperations trait; the method
-        // surface is unchanged, but the composing class's trait list gains
-        // the trait name.
-        $expected[OpenApiSpecExploration::class]['traits'] = ['Studio\\Gesso\\Fuzz\\SelectsExploredOperations'];
+        // #420: @internal traits are an implementation detail and are no
+        // longer recorded in a consuming class's trait list. The v1.9 baseline
+        // still names them, so drop them from the expectation.
+        $expected[ExploresOpenApiEndpoint::class]['traits'] = [];
+        $expected[ValidatesOpenApiSchema::class]['traits'] = [];
 
         // New public symbols in v2.x (named contract checks): the
         // ContractCheck enum, its ContractCheckFailure/ContractCheckSkip
@@ -853,9 +869,7 @@ final class PublicApiBaselineTest extends TestCase
             ],
             'parent' => null,
             'interfaces' => [],
-            'traits' => [
-                'Studio\\Gesso\\Fuzz\\SelectsExploredOperations',
-            ],
+            'traits' => [],
             'attributes' => [],
             'backing_type' => null,
             'cases' => [],

--- a/tests/fixtures/compatibility/v2-public-api.json
+++ b/tests/fixtures/compatibility/v2-public-api.json
@@ -1887,9 +1887,7 @@
         },
         "parent": null,
         "interfaces": [],
-        "traits": [
-            "Studio\\Gesso\\Fuzz\\SelectsExploredOperations"
-        ],
+        "traits": [],
         "attributes": [],
         "backing_type": null,
         "cases": [],
@@ -3683,9 +3681,7 @@
         },
         "parent": null,
         "interfaces": [],
-        "traits": [
-            "Studio\\Gesso\\Fuzz\\SelectsExploredOperations"
-        ],
+        "traits": [],
         "attributes": [],
         "backing_type": null,
         "cases": [],
@@ -4415,9 +4411,7 @@
         "constructor": null,
         "parent": null,
         "interfaces": [],
-        "traits": [
-            "Studio\\Gesso\\Laravel\\ResolvesOpenApiSpec"
-        ],
+        "traits": [],
         "attributes": [],
         "backing_type": null,
         "cases": [],
@@ -4822,10 +4816,7 @@
         "constructor": null,
         "parent": null,
         "interfaces": [],
-        "traits": [
-            "Studio\\Gesso\\Laravel\\ResolvesOpenApiSpec",
-            "Studio\\Gesso\\SkipOpenApiResolver"
-        ],
+        "traits": [],
         "attributes": [],
         "backing_type": null,
         "cases": [],


### PR DESCRIPTION
## Summary

`PublicApiInventory` now filters traits marked `@internal` out of the recorded `traits` list of public classes, keeping non-internal traits (e.g. `Spec\OpenApiSpecResolver`). `v2-public-api.json` is regenerated once, and the v1.9 → v2 contract test drops the `@internal` trait names the old baselines carried.

## Why

Fixes #420

Trait composition of a public class is an implementation detail under the versioning policy unless the trait is itself public API. Recording `@internal` trait names (e.g. `SelectsExploredOperations`) in the baseline made a future rename/split of such a trait trip `PublicApiBaselineTest` as a false positive, turning hand-edits of the baseline into routine noise.

## Verification

Failing-test-then-fix: added `inventory_omits_internal_traits_from_the_traits_list` with a fixture class composing one `@internal` and one public trait, watched it fail (both traits recorded), then implemented the filter.

- [x] `composer test` passes (2416 tests)
- [x] `composer stan` passes (run with `--memory-limit=1G`; default 128M crashed the worker locally, unrelated to this change)
- [x] `composer cs-check` passes

## Notes for reviewers

- Only directly-used traits are recorded (`ReflectionClass::getTraitNames()`), so `ValidatesOpenApiSchema` now reports `traits: []` even though its `@internal` `ResolvesOpenApiSpec` trait transitively composes the public `OpenApiSpecResolver`. The public trait's own surface is still tracked as its own baseline symbol.
- `interfaces` are left untouched: implementing an interface is part of a class's type identity, unlike trait composition.