### PR TITLE
feat(baseline): support baseline generation under parallel test runners

### DIFF
--- a/docs/baseline.md
+++ b/docs/baseline.md
@@ -20,7 +20,7 @@ one reviewable file and can be ratcheted down entry by entry.
    </extensions>
    ```
 
-2. Generate the baseline (full suite, no parallelism, no `--filter`):
+2. Generate the baseline (full suite, no `--filter`):
 
    ```bash
    OPENAPI_BASELINE_GENERATE=1 vendor/bin/phpunit
@@ -69,6 +69,45 @@ Body-decode failures (unparseable JSON, an unreadable or non-seekable PSR-7
 stream) carry the synthetic `parse` keyword, so a baselined decode failure
 never absorbs a genuinely empty body on the same operation — and vice
 versa.
+
+## Generating under parallel runners
+
+Under paratest or Pest `--parallel`, each worker sees only its slice of the
+suite, so no single worker may write the baseline file. Generation instead
+follows the same two-step workflow as [parallel coverage](parallel.md): each
+worker stages its collected fingerprints in its sidecar (envelope v3), and
+the merge step unions them into the committed file:
+
+```bash
+# 1. Run the parallel suite in generation mode — failures are demoted,
+#    fingerprints ride the worker sidecars.
+OPENAPI_BASELINE_GENERATE=1 vendor/bin/paratest --processes=4
+
+# 2. Union the worker halves and write the baseline.
+vendor/bin/gesso coverage:merge \
+    --spec-base-path=openapi/bundled \
+    --baseline-file=gesso-baseline.json
+```
+
+The union is deterministic — the same contract debt produces a byte-identical
+file regardless of how tests were distributed across workers.
+
+The merge fails loudly (exit 1, sidecars preserved for a retry) instead of
+writing a wrong or missing baseline when:
+
+- sidecars carry baseline data but `--baseline-file` was not given —
+  discarding it would silently hide the violations the workers demoted;
+- `--baseline-file` was given but some sidecar carries no baseline data
+  (a worker ran without generation mode, or on a pre-2.2 library version) —
+  the union would be an incomplete baseline;
+- `--baseline-file` was given but no sidecars exist at all.
+
+Because generation demotes failures per worker, the merge step is what makes
+the run trustworthy — wire both steps into the same CI job so a forgotten
+merge cannot leave a green run with no baseline written. As with sequential
+generation, run the full suite: per-worker slices are expected, but a
+`--filter`ed parallel run cannot be detected and would bake an incomplete
+baseline.
 
 ## Enforcement semantics
 
@@ -138,12 +177,10 @@ in two cases:
 
 ## Limitations
 
-- **Parallel runners:** baseline generation is refused under paratest
-  (`TEST_TOKEN`) — every worker would demote failures and none would write
-  the file. Enforcement (suppression) works per worker, but the stale
-  summary is not aggregated across workers. Sidecar-based parallel
-  generation is tracked in
-  [#417](https://github.com/studio-design/gesso/issues/417).
+- **Parallel runners:** enforcement (suppression) works per worker, but the
+  stale summary is not aggregated across workers — ratchet-down evaluation
+  needs a sequential full run. Generation is supported via the sidecar merge
+  (see [Generating under parallel runners](#generating-under-parallel-runners)).
 - Suppression is per assertion, not per test: an assertion mixing baselined
   and new violations fails as a whole (by design — see enforcement
   semantics).

--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -50,6 +50,7 @@ vendor/bin/gesso coverage:merge \
 | `--min-response-coverage=<pct>` | — | Threshold gate at `(method, path, status, content-type)` granularity |
 | `--min-coverage-strict` | `false` (warn-only) | Treat threshold misses as exit non-zero |
 | `--strict-required=<mode>` | `off` | `off` / `warn` / `fail`. Assert no schema under-description drift across worker observations. See [`strict-required.md`](strict-required.md#paratest) |
+| `--baseline-file=<path>` | — | Union the violation-baseline halves staged by an `OPENAPI_BASELINE_GENERATE=1` parallel run and write the merged baseline. See [`baseline.md`](baseline.md#generating-under-parallel-runners) |
 | `--no-cleanup` | (cleanup is on by default) | Keep sidecar files after merge |
 
 Sidecar dir defaults are deliberately stable — workers and the merge CLI
@@ -73,10 +74,15 @@ itself; the default already does this.
 Sidecars are a versioned worker-to-merge protocol, separate from the coverage
 report produced by `json_output`. The current writer emits an
 `envelopeVersion: 2` envelope containing coverage state `version: 1` and
-strict-required state `version: 2`. The merge reader also accepts the older
-bare coverage state `version: 1`, so coverage can still be combined while a
-worker fleet is being upgraded. That legacy payload has no strict-required
-observations, so a strict-required gate cannot be evaluated from it.
+strict-required state `version: 2`; a baseline-generation run
+(`OPENAPI_BASELINE_GENERATE=1`) upgrades the envelope to `envelopeVersion: 3`,
+adding the violation-baseline document (`baseline_version: 1`). The merge
+reader also accepts the older bare coverage state `version: 1`, so coverage
+can still be combined while a worker fleet is being upgraded. That legacy
+payload has no strict-required observations, so a strict-required gate cannot
+be evaluated from it — and neither the legacy payload nor a v2 envelope
+carries baseline data, so `--baseline-file` requires every worker on the
+v3-capable version.
 
 Unknown envelope or tracker versions fail the merge rather than being guessed.
 Strict-required state `version: 1` is also rejected because merging it with the
@@ -100,6 +106,10 @@ changing a sidecar shape or filename pattern.
   `--strict-required` flag decides whether to assert the gate; the
   `strict_required` parameter on the PHPUnit extension does not propagate
   to the merge step. See [`strict-required.md`](strict-required.md#paratest).
+- **Baseline generation aggregates across workers too.** An
+  `OPENAPI_BASELINE_GENERATE=1` parallel run stages fingerprints in the
+  sidecars; pass `--baseline-file=<path>` to the merge to write the union.
+  See [`baseline.md`](baseline.md#generating-under-parallel-runners).
 - **Worker counts are not exposed by paratest.** A child cannot reliably
   tell how many siblings it has, so the merge has to run as a separate
   step rather than auto-firing from "the last worker." This matches how

--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -118,7 +118,11 @@ changing a sidecar shape or filename pattern.
   want to inspect the per-worker JSON for debugging.
 - **A failed sidecar write does not fail the test run.** Workers log a
   warning to `STDERR` and let the suite finish — your contract assertions
-  already passed; sidecar I/O is a CI artifact concern.
+  already passed; sidecar I/O is a CI artifact concern. The exception is a
+  baseline-generation run (`OPENAPI_BASELINE_GENERATE=1`): the worker
+  demoted its failures on the promise that the merge unions its sidecar, so
+  losing the sidecar fails the worker — otherwise the merge could write an
+  incomplete baseline from the remaining workers.
 - **Stale sidecars across runs.** Cleanup-on-success removes sidecars after
   every successful merge. If a previous run crashed before the merge step,
   any leftover sidecars in the dir will be picked up by the next merge —

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -92,6 +92,16 @@ coverage state `version: 1` and strict-required state `version: 2`. The v1.9
 reader accepts that envelope and the legacy bare coverage state `version: 1`.
 It recognises `part-*.json` sidecars and `failed-*.json` failure markers.
 
+The v2.2 writer additionally emits `envelopeVersion: 3` — the v2 shape plus a
+`baseline` key holding the violation-baseline document (`baseline_version: 1`)
+— but only when the worker ran under `OPENAPI_BASELINE_GENERATE`; plain runs
+keep writing `envelopeVersion: 2` so an older merge reader stays usable for
+coverage-only fleets. The v2.2 reader accepts `envelopeVersion` 2 and 3 plus
+the legacy bare coverage state; a v2 envelope carrying a `baseline` key and a
+v3 envelope missing one are rejected as malformed, and `coverage:merge
+--baseline-file` refuses to write a union when any sidecar lacks the baseline
+half.
+
 The compatibility rules are:
 
 - A newer merge reader keeps support for the explicitly documented older

--- a/src/Baseline/ViolationBaselineFile.php
+++ b/src/Baseline/ViolationBaselineFile.php
@@ -58,18 +58,28 @@ final class ViolationBaselineFile
 
     private function __construct() {}
 
-    public static function render(ViolationBaseline $baseline): string
+    /**
+     * The baseline document as a plain array — the shape {@see render()}
+     * serializes and the shape the v3 sidecar envelope embeds verbatim
+     * (issue #417), so both carriers share one versioned format.
+     *
+     * @return array{baseline_version: int, violations: list<array<string, null|string>>}
+     */
+    public static function toDocument(ViolationBaseline $baseline): array
     {
-        $document = [
+        return [
             'baseline_version' => self::BASELINE_VERSION,
             'violations' => array_map(
                 static fn(ViolationFingerprint $fingerprint): array => $fingerprint->toArray(),
                 $baseline->sorted(),
             ),
         ];
+    }
 
+    public static function render(ViolationBaseline $baseline): string
+    {
         return json_encode(
-            $document,
+            self::toDocument($baseline),
             JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
         ) . "\n";
     }
@@ -93,6 +103,21 @@ final class ViolationBaselineFile
             throw new InvalidArgumentException('Baseline file must decode to a JSON object.');
         }
 
+        return self::parseDocument($decoded);
+    }
+
+    /**
+     * Validate an already-decoded baseline document — the merge CLI parses
+     * documents embedded in sidecar envelopes (issue #417), where the JSON
+     * decode already happened at the envelope layer.
+     *
+     * @param array<mixed, mixed> $decoded
+     *
+     * @throws InvalidArgumentException on an unknown baseline_version or an
+     *                                  invalid entry
+     */
+    public static function parseDocument(array $decoded): ViolationBaseline
+    {
         $version = $decoded['baseline_version'] ?? null;
         if (!is_int($version) || $version !== self::BASELINE_VERSION) {
             throw new InvalidArgumentException(sprintf(

--- a/src/Coverage/CoverageMergeCommand.php
+++ b/src/Coverage/CoverageMergeCommand.php
@@ -8,6 +8,8 @@ use const FILE_APPEND;
 
 use InvalidArgumentException;
 use RuntimeException;
+use Studio\Gesso\Baseline\ViolationBaseline;
+use Studio\Gesso\Baseline\ViolationBaselineFile;
 use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\Exception\SpecFileNotFoundException;
 use Studio\Gesso\PHPUnit\ConsoleOutput;
@@ -68,6 +70,7 @@ use function unlink;
  *     min_response_coverage?: float|string,
  *     min_coverage_strict?: bool,
  *     strict_required?: string,
+ *     baseline_file?: string,
  *     help?: bool,
  * }
  *
@@ -189,6 +192,9 @@ final class CoverageMergeCommand
               --strict-required=<mode>      off | warn | fail. Aggregate worker observations
                                             and assert no schema under-description drift
                                             (Issue #224 / #226). Defaults to off.
+              --baseline-file=<path>        Union the violation-baseline halves staged by a
+                                            parallel `OPENAPI_BASELINE_GENERATE=1` run and
+                                            write the merged baseline here (Issue #417).
               --no-cleanup                  Keep sidecar files after merge (default: cleanup).
               --help                        Show this message.
 
@@ -260,6 +266,10 @@ final class CoverageMergeCommand
             return 2;
         }
 
+        $baselineFile = isset($options['baseline_file']) && $options['baseline_file'] !== ''
+            ? $this->absolutise($options['baseline_file'])
+            : null;
+
         if ($specBasePath === null) {
             $this->writeStderr("[OpenAPI Coverage] FATAL: --spec-base-path is required\n");
 
@@ -290,6 +300,18 @@ final class CoverageMergeCommand
         }
 
         if ($payloads === []) {
+            // Issue #417: a generation run that produced no sidecars cannot
+            // yield a baseline — but the workers already demoted every
+            // failure, so returning 0 without a file would hide all of them.
+            if ($baselineFile !== null) {
+                $this->writeStderr(sprintf(
+                    "[Gesso] FATAL: --baseline-file requested but no sidecars were found in %s; no baseline was written. Run the parallel suite with OPENAPI_BASELINE_GENERATE=1 first.\n",
+                    $sidecarDir,
+                ));
+
+                return 1;
+            }
+
             // Strict-mode gate must fail-fast even before sidecars exist —
             // otherwise a misconfigured paratest dir or zero workers would
             // silently pass an opt-in CI gate (issue #135 review C2).
@@ -324,6 +346,8 @@ final class CoverageMergeCommand
         StrictRequiredTracker::resetCurrent();
         OpenApiCoverageTracker::setCurrent($coverageTracker);
         StrictRequiredTracker::setCurrent($strictRequiredTracker);
+        $mergedBaseline = new ViolationBaseline();
+        $sidecarsWithoutBaseline = 0;
         foreach ($payloads as $payload) {
             try {
                 $parsed = CoverageSidecarEnvelope::parse($payload);
@@ -331,11 +355,25 @@ final class CoverageMergeCommand
                 if ($parsed['strictRequired'] !== null) {
                     $strictRequiredTracker->importStateOn($parsed['strictRequired']);
                 }
+                if ($parsed['baseline'] !== null) {
+                    // parseDocument re-validates the embedded document
+                    // (unknown baseline_version fails loudly — the
+                    // mixed-fleet contract of issue #417).
+                    foreach (ViolationBaselineFile::parseDocument($parsed['baseline'])->sorted() as $fingerprint) {
+                        $mergedBaseline->add($fingerprint);
+                    }
+                } else {
+                    $sidecarsWithoutBaseline++;
+                }
             } catch (InvalidArgumentException $e) {
                 $this->writeStderr(sprintf("[OpenAPI Coverage] FATAL: invalid sidecar payload: %s\n", $e->getMessage()));
 
                 return 1;
             }
+        }
+
+        if (!$this->handleBaseline($baselineFile, $mergedBaseline, $sidecarsWithoutBaseline, count($payloads))) {
+            return 1;
         }
 
         $results = $this->computeResults($specs, $coverageTracker);
@@ -371,6 +409,69 @@ final class CoverageMergeCommand
         $cleanupFailure = $cleanup && !$this->cleanupSafely($sidecarDir);
 
         return $writeFailures > 0 || $thresholdFailure || $strictFailure || $cleanupFailure ? 1 : 0;
+    }
+
+    /**
+     * Issue #417: union the violation-baseline halves staged by
+     * generation-mode workers and write the merged file. Returns `false`
+     * when the merge must exit non-zero; every failure path runs before
+     * sidecar cleanup so the staged data survives for a corrected retry.
+     *
+     * Fail-loud cases mirror the sequential generation contract:
+     *  - baseline data present but no `--baseline-file`: discarding it
+     *    would silently hide the violations the workers demoted.
+     *  - `--baseline-file` given but some sidecar carries no baseline half
+     *    (a non-generation or pre-#417 worker): the union would be a
+     *    partial baseline — the exact incomplete-file hazard the
+     *    sequential path refuses partial runs for.
+     */
+    private function handleBaseline(
+        ?string $baselineFile,
+        ViolationBaseline $merged,
+        int $sidecarsWithoutBaseline,
+        int $sidecarCount,
+    ): bool {
+        $sidecarsWithBaseline = $sidecarCount - $sidecarsWithoutBaseline;
+
+        if ($baselineFile === null) {
+            if ($sidecarsWithBaseline === 0) {
+                return true;
+            }
+
+            $this->writeStderr(sprintf(
+                "[Gesso] FATAL: %d of %d sidecar(s) carry violation-baseline data from an OPENAPI_BASELINE_GENERATE run, but --baseline-file was not given; discarding it would silently hide the demoted violations. Re-run the merge with --baseline-file=<path>.\n",
+                $sidecarsWithBaseline,
+                $sidecarCount,
+            ));
+
+            return false;
+        }
+
+        if ($sidecarsWithoutBaseline > 0) {
+            $this->writeStderr(sprintf(
+                "[Gesso] FATAL: --baseline-file requested but %d of %d sidecar(s) carry no baseline data; the union would be an incomplete baseline. Ensure every worker ran with OPENAPI_BASELINE_GENERATE=1 on a library version that stages baseline sidecars. No baseline was written.\n",
+                $sidecarsWithoutBaseline,
+                $sidecarCount,
+            ));
+
+            return false;
+        }
+
+        try {
+            ViolationBaselineFile::write($baselineFile, $merged);
+        } catch (RuntimeException $e) {
+            $this->writeStderr("[Gesso] FATAL: {$e->getMessage()}\n");
+
+            return false;
+        }
+
+        $this->writeStderr(sprintf(
+            "[Gesso] Baseline written: %d violation(s) → %s\n",
+            $merged->count(),
+            $baselineFile,
+        ));
+
+        return true;
     }
 
     /**

--- a/src/Coverage/CoverageSidecarEnvelope.php
+++ b/src/Coverage/CoverageSidecarEnvelope.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Studio\Gesso\Coverage;
 
 use InvalidArgumentException;
+use Studio\Gesso\Baseline\ViolationBaselineFile;
 use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
 
 use function array_key_exists;
 use function get_debug_type;
+use function in_array;
 use function is_array;
 use function is_int;
 use function sprintf;
@@ -30,6 +32,23 @@ use function sprintf;
  *   "strictRequired": { "version": 2, "observations": { ... } }
  * }
  * ```
+ *
+ * Wire shape (v3, issue #417) adds the violation-baseline half collected
+ * during a parallel generation run (`OPENAPI_BASELINE_GENERATE` under
+ * paratest). Its value is the baseline-file document verbatim
+ * ({@see ViolationBaselineFile}), so the inner
+ * `baseline_version` stays owned by the baseline format:
+ * ```json
+ * {
+ *   "envelopeVersion": 3,
+ *   "coverage":       { "version": 1, "specs":        { ... } },
+ *   "strictRequired": { "version": 2, "observations": { ... } },
+ *   "baseline":       { "baseline_version": 1, "violations": [ ... ] }
+ * }
+ * ```
+ * v3 is emitted only when a generation run has a baseline to hand off;
+ * plain runs keep writing v2 so an older merge CLI stays compatible with
+ * coverage-only fleets during an upgrade.
  *
  * Backwards compatibility: workers running an older library version write
  * a bare v1 coverage payload (`{ "version": 1, "specs": { ... } }`) with no
@@ -54,39 +73,67 @@ use function sprintf;
  *     envelopeVersion: int,
  *     coverage: CoverageStatePayload,
  *     strictRequired: StrictRequiredStatePayload,
+ *     baseline?: array<string, mixed>,
  * }
  * @phpstan-type ParsedEnvelope array{
  *     coverage: array<string, mixed>,
  *     strictRequired: array<string, mixed>|null,
+ *     baseline: array<string, mixed>|null,
  * }
  */
 final class CoverageSidecarEnvelope
 {
     /**
      * Envelope wire-format version. Importers reject unknown values rather
-     * than guessing — a future v3 worker writing into an older merge CLI
-     * must fail loudly so partial-upgrade silos surface immediately.
+     * than guessing — a future writer's version landing in an older merge
+     * CLI must fail loudly so partial-upgrade silos surface immediately.
      */
     public const ENVELOPE_VERSION = 2;
+
+    /**
+     * Envelope version carrying the violation-baseline half (issue #417).
+     * Written only by generation-mode workers; see the class doc for why
+     * plain runs stay on {@see self::ENVELOPE_VERSION}.
+     */
+    public const ENVELOPE_VERSION_WITH_BASELINE = 3;
 
     private function __construct() {}
 
     /**
-     * Compose a v2 envelope from the two tracker `exportState()` payloads.
+     * Compose an envelope from the two tracker `exportState()` payloads.
      * Typed `@phpstan-param`s flow the tracker shapes through so PHPStan
      * catches a tracker-side `exportState()` regression at this boundary.
+     *
+     * `$baselineDocument` (the baseline-file document from
+     * {@see ViolationBaselineFile::toDocument()})
+     * upgrades the envelope to v3; `null` keeps the v2 shape byte-compatible
+     * with pre-#417 writers.
+     *
+     * @param null|array<string, mixed> $baselineDocument
      *
      * @phpstan-param CoverageStatePayload $coverageState
      * @phpstan-param StrictRequiredStatePayload $strictRequiredState
      *
      * @return SidecarEnvelopePayload
      */
-    public static function build(array $coverageState, array $strictRequiredState): array
-    {
+    public static function build(
+        array $coverageState,
+        array $strictRequiredState,
+        ?array $baselineDocument = null,
+    ): array {
+        if ($baselineDocument === null) {
+            return [
+                'envelopeVersion' => self::ENVELOPE_VERSION,
+                'coverage' => $coverageState,
+                'strictRequired' => $strictRequiredState,
+            ];
+        }
+
         return [
-            'envelopeVersion' => self::ENVELOPE_VERSION,
+            'envelopeVersion' => self::ENVELOPE_VERSION_WITH_BASELINE,
             'coverage' => $coverageState,
             'strictRequired' => $strictRequiredState,
+            'baseline' => $baselineDocument,
         ];
     }
 
@@ -94,7 +141,7 @@ final class CoverageSidecarEnvelope
      * Route a sidecar payload into its tracker-shaped parts.
      *
      * Discriminator priority:
-     *  1. `envelopeVersion` present → v2 path. Unknown values are rejected.
+     *  1. `envelopeVersion` present → v2/v3 path. Unknown values are rejected.
      *  2. `version` + `specs` keys → legacy v1 bare coverage payload;
      *     returns `strictRequired => null`.
      *  3. Otherwise reject (unrecognised shape).
@@ -133,6 +180,7 @@ final class CoverageSidecarEnvelope
             return [
                 'coverage' => $payload,
                 'strictRequired' => null,
+                'baseline' => null,
             ];
         }
 
@@ -149,11 +197,15 @@ final class CoverageSidecarEnvelope
     private static function parseEnvelope(array $payload): array
     {
         $version = $payload['envelopeVersion'] ?? null;
-        if (!is_int($version) || $version !== self::ENVELOPE_VERSION) {
+        if (
+            !is_int($version) ||
+            !in_array($version, [self::ENVELOPE_VERSION, self::ENVELOPE_VERSION_WITH_BASELINE], true)
+        ) {
             throw new InvalidArgumentException(sprintf(
-                'Unsupported sidecar envelope version: got %s, expected %d.',
+                'Unsupported sidecar envelope version: got %s, expected %d or %d.',
                 is_int($version) ? (string) $version : get_debug_type($version),
                 self::ENVELOPE_VERSION,
+                self::ENVELOPE_VERSION_WITH_BASELINE,
             ));
         }
 
@@ -173,9 +225,31 @@ final class CoverageSidecarEnvelope
             ));
         }
 
+        $baseline = $payload['baseline'] ?? null;
+        if ($version === self::ENVELOPE_VERSION) {
+            // A v2 envelope must not smuggle a baseline half: accepting it
+            // would silently drop generation data whenever a future writer
+            // (or a hand-edited sidecar) forgets the version bump — mirror
+            // the v1 `strictRequired` guard in parse().
+            if (array_key_exists('baseline', $payload)) {
+                throw new InvalidArgumentException(
+                    'Sidecar envelope v2 must not contain a "baseline" key; '
+                    . 'expected envelopeVersion=3 when baseline data is present.',
+                );
+            }
+        } elseif (!is_array($baseline)) {
+            // v3 exists solely to carry the baseline half — a v3 envelope
+            // without it is malformed, not "generation off".
+            throw new InvalidArgumentException(sprintf(
+                'Sidecar envelope v3 "baseline" must be an array; got %s.',
+                get_debug_type($baseline),
+            ));
+        }
+
         return [
             'coverage' => $coverage,
             'strictRequired' => $strictRequired,
+            'baseline' => $baseline,
         ];
     }
 }

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -415,6 +415,21 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
             // worker's worth of data.
             $this->writeStderr("[OpenAPI Coverage] WARNING: failed to write sidecar (token={$token}): {$e->getMessage()}\n");
             CoverageSidecarWriter::writeFailureMarker($dir, $token, $e->getMessage());
+
+            // Issue #417: a generation worker demoted its failures on the
+            // promise that the merge unions this sidecar; a lost sidecar
+            // cannot be recovered by the marker alone — the marker write is
+            // itself best-effort, and when it also fails (full disk,
+            // revoked permissions) the merge would see N-1 complete
+            // baseline halves and write an incomplete baseline. Fail the
+            // worker so the parallel run cannot end green with staged
+            // violations silently dropped.
+            if ($baselineDocument !== null) {
+                $this->writeStderr(
+                    "[Gesso] FATAL: baseline generation could not stage this worker's violations in the sidecar; failing the worker so the parallel run does not produce an incomplete baseline.\n",
+                );
+                $this->exitNonZero();
+            }
         }
     }
 

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -79,8 +79,9 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
      * @param null|string $baselineGeneratePath Issue #402: destination of a violation-baseline generation run
      *                                          (`OPENAPI_BASELINE_GENERATE`). When non-null the subscriber writes the
      *                                          collected fingerprints here at run end; partial runs refuse the write
-     *                                          (an incomplete baseline would hide violations) and worker mode warns
-     *                                          (parallel generation is not supported yet).
+     *                                          (an incomplete baseline would hide violations). Worker mode instead
+     *                                          stages the fingerprints in the sidecar envelope for
+     *                                          `gesso coverage:merge --baseline-file` to union (issue #417).
      * @param null|TestRunCompletionTracer $baselineCompletionTracer Issue #402: registered by the extension for
      *                                                               enforcement runs. Unless it can prove every
      *                                                               planned test finished with no defects, stale
@@ -133,26 +134,10 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
     {
         $workerToken = self::resolveWorkerToken();
         if ($workerToken !== null) {
-            // Issue #402: normally unreachable — the extension refuses
-            // generation at bootstrap when TEST_TOKEN is set — but a token
-            // appearing only after bootstrap must not let a generation run
-            // demote every failure and still exit green. Warn, keep the
-            // coverage sidecar for debuggability, and exit non-zero.
-            if ($this->baselineGeneratePath !== null) {
-                $this->writeStderr(
-                    '[Gesso] WARNING: baseline generation is not supported under parallel test runners yet; no baseline file was written. '
-                    . "Run the suite without parallelism to generate the baseline.\n",
-                );
-            }
-
             $this->writeWorkerSidecar($workerToken);
 
             // Free cached spec data; the merge CLI re-loads on its own.
             OpenApiSpecLoader::clearCache();
-
-            if ($this->baselineGeneratePath !== null) {
-                $this->exitNonZero();
-            }
 
             return;
         }
@@ -391,14 +376,32 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
     {
         $dir = $this->sidecarDir ?? OpenApiCoverageExtension::defaultSidecarDir();
 
-        // Sidecar envelope (v2) carries both coverage and strict_required
-        // observations so the merge CLI can aggregate the gate across all
-        // paratest workers. The strict_required half is always exported,
-        // independent of the worker's `strict_required` mode — the merge
-        // CLI decides whether to assert (Issue #226).
+        // Issue #417: a generation-mode worker hands its collected
+        // fingerprints to the merge CLI through the envelope's baseline
+        // half — the per-worker view is a subset, so only the merged union
+        // may reach ViolationBaselineFile::write(). One guidance line per
+        // worker keeps a forgotten merge step from silently discarding the
+        // demoted failures.
+        $baselineDocument = null;
+        $collector = $this->baselineGeneratePath === null ? null : ViolationBaselineCollector::current();
+        if ($collector !== null) {
+            $baselineDocument = ViolationBaselineFile::toDocument($collector->baseline());
+            $this->writeStderr(sprintf(
+                "[Gesso] baseline: %d violation(s) staged in this worker's sidecar. Run `gesso coverage:merge --baseline-file=%s` after the parallel run to write the merged baseline.\n",
+                $collector->baseline()->count(),
+                $this->baselineGeneratePath,
+            ));
+        }
+
+        // Sidecar envelope carries coverage and strict_required observations
+        // so the merge CLI can aggregate the gate across all paratest
+        // workers. The strict_required half is always exported, independent
+        // of the worker's `strict_required` mode — the merge CLI decides
+        // whether to assert (Issue #226).
         $envelope = CoverageSidecarEnvelope::build(
             $this->coverageTracker->exportStateOn(),
             $this->strictRequiredTracker->exportStateOn(),
+            $baselineDocument,
         );
 
         try {

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -357,24 +357,11 @@ final class OpenApiCoverageExtension implements Extension
         ViolationBaselineEnforcer::resetCurrent();
         $baselineGeneratePath = null;
         if (self::baselineGenerationRequested()) {
-            // Refuse generation in paratest workers up front: every worker
-            // would demote its failures and none would write a baseline, so
-            // the run would end green while hiding every violation. Failing
-            // each worker's bootstrap makes the parallel runner exit
-            // non-zero before any test is silently demoted (issue #402;
-            // per-worker merge support is tracked in #417).
-            $workerToken = getenv('TEST_TOKEN');
-            if ($workerToken !== false && trim($workerToken) !== '') {
-                self::writeStderr(
-                    '[Gesso] FATAL: OPENAPI_BASELINE_GENERATE is not supported under parallel test runners yet (TEST_TOKEN is set). '
-                    . "Run the suite without parallelism to generate the baseline.\n",
-                );
-
-                throw new InvalidBaselineConfigurationException(
-                    'OPENAPI_BASELINE_GENERATE is not supported under parallel test runners.',
-                );
-            }
-
+            // Issue #417: paratest workers (TEST_TOKEN set) run generation
+            // like a sequential run — the collector demotes failures and the
+            // subscriber's worker branch stages the fingerprints in the
+            // sidecar envelope for `gesso coverage:merge --baseline-file`
+            // to union into the committed file.
             if ($baselineFile === null) {
                 // A generation run with nowhere to write would complete
                 // "green" (all failures demoted) and then drop every

--- a/tests/Integration/CoverageMergeCliIntegrationTest.php
+++ b/tests/Integration/CoverageMergeCliIntegrationTest.php
@@ -6,6 +6,7 @@ namespace Studio\Gesso\Tests\Integration;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Coverage\CoverageMergeCommand;
 use Studio\Gesso\Coverage\CoverageSidecarEnvelope;
 use Studio\Gesso\Coverage\CoverageSidecarWriter;
 use Studio\Gesso\Coverage\OpenApiCoverageTracker;
@@ -14,6 +15,7 @@ use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
 
 use function dirname;
 use function escapeshellarg;
+use function explode;
 use function fclose;
 use function file_exists;
 use function file_get_contents;
@@ -29,6 +31,7 @@ use function sprintf;
 use function str_replace;
 use function stream_get_contents;
 use function sys_get_temp_dir;
+use function trim;
 use function uniqid;
 use function unlink;
 
@@ -140,14 +143,22 @@ class CoverageMergeCliIntegrationTest extends TestCase
 
         $this->assertSame(0, $exit);
         $this->assertSame('', $stderr);
-        $this->assertSame(
-            str_replace(
-                'openapi-coverage-merge',
-                'gesso coverage:merge',
-                (string) file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v1.9-openapi-coverage-merge-help.txt'),
-            ),
-            $stdout,
+        // The bin shim must route --help to the canonical usage text …
+        $this->assertSame(CoverageMergeCommand::usage(), $stdout);
+        // … and the v1.x CLI compatibility policy requires every v1.9 help
+        // line (flags, wording) to survive. New flags may be appended, so
+        // this is containment, not equality, against the frozen capture.
+        $v19Help = str_replace(
+            'openapi-coverage-merge',
+            'gesso coverage:merge',
+            (string) file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v1.9-openapi-coverage-merge-help.txt'),
         );
+        foreach (explode("\n", $v19Help) as $line) {
+            if (trim($line) === '') {
+                continue;
+            }
+            $this->assertStringContainsString($line, $stdout, 'v1.9 help line must be retained');
+        }
     }
 
     #[Test]

--- a/tests/Integration/GessoCliIntegrationTest.php
+++ b/tests/Integration/GessoCliIntegrationTest.php
@@ -7,9 +7,11 @@ namespace Studio\Gesso\Tests\Integration;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Coverage\CoverageMergeCommand;
 
 use function dirname;
 use function escapeshellarg;
+use function explode;
 use function fclose;
 use function file_get_contents;
 use function is_resource;
@@ -19,6 +21,7 @@ use function realpath;
 use function sprintf;
 use function str_replace;
 use function stream_get_contents;
+use function trim;
 
 final class GessoCliIntegrationTest extends TestCase
 {
@@ -85,14 +88,23 @@ final class GessoCliIntegrationTest extends TestCase
 
         $this->assertSame(0, $helpExit);
         $this->assertSame('', $helpStderr);
-        $this->assertSame(
-            str_replace(
-                'openapi-coverage-merge',
-                'gesso coverage:merge',
-                (string) file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v1.9-openapi-coverage-merge-help.txt'),
-            ),
-            $helpStdout,
+        // The subcommand must route --help to the canonical usage text under
+        // the `gesso coverage:merge` invocation …
+        $this->assertSame(CoverageMergeCommand::usage(), $helpStdout);
+        // … and every v1.9 help line must survive per the v1.x CLI
+        // compatibility policy. New flags may be appended, so this is
+        // containment, not equality, against the frozen capture.
+        $v19Help = str_replace(
+            'openapi-coverage-merge',
+            'gesso coverage:merge',
+            (string) file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v1.9-openapi-coverage-merge-help.txt'),
         );
+        foreach (explode("\n", $v19Help) as $line) {
+            if (trim($line) === '') {
+                continue;
+            }
+            $this->assertStringContainsString($line, $helpStdout, 'v1.9 help line must be retained');
+        }
         $this->assertSame(2, $errorExit);
         $this->assertSame('', $errorStdout);
         $this->assertSame(

--- a/tests/Unit/Baseline/ViolationBaselineFileTest.php
+++ b/tests/Unit/Baseline/ViolationBaselineFileTest.php
@@ -58,6 +58,32 @@ class ViolationBaselineFileTest extends TestCase
     }
 
     #[Test]
+    public function to_document_round_trips_through_parse_document(): void
+    {
+        // Issue #417: the v3 sidecar envelope embeds toDocument() verbatim
+        // and the merge CLI re-validates it via parseDocument() — the pair
+        // must round-trip without loss, including entry normalization.
+        $baseline = new ViolationBaseline();
+        $baseline->add(new ViolationFingerprint('front', 'GET', '/v1/pets', '200', 'application/json', 'response.body', '/data/*/id', 'type'));
+        $baseline->add(new ViolationFingerprint('front', 'POST', '/v1/pets', null, null, 'request.body', '/name', 'type'));
+
+        $document = ViolationBaselineFile::toDocument($baseline);
+        $reparsed = ViolationBaselineFile::parseDocument($document);
+
+        $this->assertSame(2, $reparsed->count());
+        $this->assertSame($document, ViolationBaselineFile::toDocument($reparsed));
+    }
+
+    #[Test]
+    public function parse_document_rejects_unknown_baseline_version(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('baseline_version');
+
+        ViolationBaselineFile::parseDocument(['baseline_version' => 99, 'violations' => []]);
+    }
+
+    #[Test]
     public function render_is_deterministic_regardless_of_insertion_order(): void
     {
         $a = new ViolationBaseline();

--- a/tests/Unit/Coverage/CoverageMergeCommandTest.php
+++ b/tests/Unit/Coverage/CoverageMergeCommandTest.php
@@ -8,6 +8,9 @@ use const DIRECTORY_SEPARATOR;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Baseline\ViolationBaseline;
+use Studio\Gesso\Baseline\ViolationBaselineFile;
+use Studio\Gesso\Baseline\ViolationFingerprint;
 use Studio\Gesso\Coverage\CoverageMergeCommand;
 use Studio\Gesso\Coverage\CoverageSidecarEnvelope;
 use Studio\Gesso\Coverage\CoverageSidecarWriter;
@@ -1598,6 +1601,218 @@ class CoverageMergeCommandTest extends TestCase
     }
 
     #[Test]
+    public function parse_argv_accepts_baseline_file_flag(): void
+    {
+        $opts = CoverageMergeCommand::parseArgv(['--baseline-file=gesso-baseline.json']);
+        $this->assertSame('gesso-baseline.json', $opts['baseline_file'] ?? null);
+    }
+
+    #[Test]
+    public function merges_baseline_halves_across_workers_and_writes_the_union(): void
+    {
+        // Issue #417: two generation-mode workers stage overlapping
+        // fingerprint sets; the merge must write their union exactly once,
+        // deterministically (presence-only collapse + sorted render).
+        $shared = $this->baselineFingerprint('POST', '/v1/pets', '/name');
+        $this->writeBaselineWorkerSidecar('1', [
+            $this->baselineFingerprint('GET', '/v1/pets', '/data/*/id'),
+            $shared,
+        ]);
+        $this->writeBaselineWorkerSidecar('2', [
+            $shared,
+            $this->baselineFingerprint('GET', '/v1/pets/{petId}', '/tag'),
+        ]);
+
+        $baselinePath = dirname($this->sidecarDir) . '/gesso-baseline.json';
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stdoutWriter: static fn(string $msg): null => null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'baseline_file' => $baselinePath,
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('Baseline written: 3 violation(s)', $stderr);
+        $merged = ViolationBaselineFile::read($baselinePath);
+        $this->assertSame(3, $merged->count());
+        $this->assertTrue($merged->contains($shared));
+        $this->assertSame([], $this->sidecars(), 'successful merge must still clean up sidecars');
+
+        @unlink($baselinePath);
+    }
+
+    #[Test]
+    public function empty_baseline_union_still_writes_a_baseline_file(): void
+    {
+        // A clean contract legitimately produces zero fingerprints; the
+        // merge must still write the (empty) file so enforcement config
+        // pointing at baseline_file keeps loading.
+        $this->writeBaselineWorkerSidecar('1', []);
+
+        $baselinePath = dirname($this->sidecarDir) . '/gesso-baseline.json';
+        $command = new CoverageMergeCommand(
+            stdoutWriter: static fn(string $msg): null => null,
+            stderrWriter: static fn(string $msg): null => null,
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'baseline_file' => $baselinePath,
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(0, $exit);
+        $this->assertSame(0, ViolationBaselineFile::read($baselinePath)->count());
+
+        @unlink($baselinePath);
+    }
+
+    #[Test]
+    public function exits_one_when_baseline_file_requested_but_a_sidecar_lacks_baseline_data(): void
+    {
+        // Worker 1 staged baseline data, worker 2 did not (non-generation
+        // or pre-#417 library). The union would be an incomplete baseline —
+        // exactly the hazard the sequential path refuses partial runs for —
+        // so the merge must fail loudly and keep the sidecars for a retry.
+        $this->writeBaselineWorkerSidecar('1', [
+            $this->baselineFingerprint('GET', '/v1/pets', '/data/*/id'),
+        ]);
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'POST',
+            '/v1/pets',
+            '201',
+            'application/json',
+            schemaValidated: true,
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, '2', OpenApiCoverageTracker::exportState());
+        OpenApiCoverageTracker::reset();
+
+        $baselinePath = dirname($this->sidecarDir) . '/gesso-baseline.json';
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stdoutWriter: static fn(string $msg): null => null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'baseline_file' => $baselinePath,
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('[Gesso] FATAL', $stderr);
+        $this->assertStringContainsString('1 of 2 sidecar(s) carry no baseline data', $stderr);
+        $this->assertFileDoesNotExist($baselinePath, 'an incomplete union must never be written');
+        $this->assertCount(2, $this->sidecars(), 'failure must preserve sidecars for a corrected retry');
+    }
+
+    #[Test]
+    public function exits_one_when_baseline_data_present_but_baseline_file_flag_missing(): void
+    {
+        // The workers demoted their failures on the promise that the merge
+        // writes the baseline; dropping the staged data because the flag
+        // was forgotten would hide every violation silently.
+        $this->writeBaselineWorkerSidecar('1', [
+            $this->baselineFingerprint('GET', '/v1/pets', '/data/*/id'),
+        ]);
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stdoutWriter: static fn(string $msg): null => null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'cleanup' => true,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('--baseline-file was not given', $stderr);
+        $this->assertCount(1, $this->sidecars(), 'failure must preserve sidecars for a corrected retry');
+    }
+
+    #[Test]
+    public function exits_one_when_baseline_file_requested_but_no_sidecars_exist(): void
+    {
+        $baselinePath = dirname($this->sidecarDir) . '/gesso-baseline.json';
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stdoutWriter: static fn(string $msg): null => null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'baseline_file' => $baselinePath,
+        ]);
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('no sidecars were found', $stderr);
+        $this->assertFileDoesNotExist($baselinePath);
+    }
+
+    #[Test]
+    public function exits_one_when_merged_baseline_write_fails(): void
+    {
+        $this->writeBaselineWorkerSidecar('1', [
+            $this->baselineFingerprint('GET', '/v1/pets', '/data/*/id'),
+        ]);
+
+        // A directory at the destination path makes the write fail.
+        $baselinePath = dirname($this->sidecarDir) . '/baseline-as-dir';
+        mkdir($baselinePath, 0o755, recursive: true);
+
+        $stderr = '';
+        $command = new CoverageMergeCommand(
+            stdoutWriter: static fn(string $msg): null => null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+        );
+
+        $exit = $command->run([
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'baseline_file' => $baselinePath,
+            'cleanup' => true,
+        ]);
+
+        @rmdir($baselinePath);
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('[Gesso] FATAL', $stderr);
+        $this->assertStringContainsString('Could not write baseline file', $stderr);
+        $this->assertCount(1, $this->sidecars(), 'failure must preserve sidecars for a corrected retry');
+    }
+
+    #[Test]
     public function run_isolates_from_a_pre_installed_locator_instance(): void
     {
         // Issue #229: the merge command constructs its own tracker
@@ -1708,6 +1923,55 @@ class CoverageMergeCommandTest extends TestCase
         CoverageSidecarWriter::write($this->sidecarDir, $token, $envelope);
         OpenApiCoverageTracker::reset();
         StrictRequiredTracker::reset();
+    }
+
+    /**
+     * Write a v3 worker sidecar staging baseline fingerprints (issue #417),
+     * with a minimal coverage recording so the merged report stays
+     * representative of a real generation-mode worker.
+     *
+     * @param list<ViolationFingerprint> $fingerprints
+     */
+    private function writeBaselineWorkerSidecar(string $token, array $fingerprints): void
+    {
+        OpenApiCoverageTracker::reset();
+        StrictRequiredTracker::reset();
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        $baseline = new ViolationBaseline();
+        foreach ($fingerprints as $fingerprint) {
+            $baseline->add($fingerprint);
+        }
+
+        $envelope = CoverageSidecarEnvelope::build(
+            OpenApiCoverageTracker::exportState(),
+            StrictRequiredTracker::exportState(),
+            ViolationBaselineFile::toDocument($baseline),
+        );
+        CoverageSidecarWriter::write($this->sidecarDir, $token, $envelope);
+        OpenApiCoverageTracker::reset();
+        StrictRequiredTracker::reset();
+    }
+
+    private function baselineFingerprint(string $method, string $path, ?string $instancePath): ViolationFingerprint
+    {
+        return new ViolationFingerprint(
+            'petstore-3.0',
+            $method,
+            $path,
+            '200',
+            'application/json',
+            'response.body',
+            $instancePath,
+            'type',
+        );
     }
 
     /** @return list<string> */

--- a/tests/Unit/Coverage/CoverageSidecarEnvelopeTest.php
+++ b/tests/Unit/Coverage/CoverageSidecarEnvelopeTest.php
@@ -10,9 +10,10 @@ use PHPUnit\Framework\TestCase;
 use Studio\Gesso\Coverage\CoverageSidecarEnvelope;
 
 /**
- * Pins the v2 sidecar envelope wire format and the v1 ↔ v2 compatibility
- * routing. The merge CLI relies on this discriminator to keep working when
- * a worker still on an older library version contributes a bare v1 payload.
+ * Pins the v2/v3 sidecar envelope wire formats and the v1 ↔ v2 ↔ v3
+ * compatibility routing. The merge CLI relies on this discriminator to keep
+ * working when a worker still on an older library version contributes a
+ * bare v1 payload — and to fail loudly on shapes it cannot represent.
  */
 class CoverageSidecarEnvelopeTest extends TestCase
 {
@@ -42,6 +43,86 @@ class CoverageSidecarEnvelopeTest extends TestCase
 
         $this->assertSame($payload['coverage'], $parsed['coverage']);
         $this->assertSame($payload['strictRequired'], $parsed['strictRequired']);
+    }
+
+    #[Test]
+    public function build_with_a_baseline_document_emits_v3_shape(): void
+    {
+        // Issue #417: the baseline half upgrades the envelope to v3. Plain
+        // runs must keep the exact v2 shape (previous test) so pre-#417
+        // merge CLIs stay compatible with coverage-only fleets.
+        $coverage = ['version' => 1, 'specs' => ['petstore' => []]];
+        $strictRequired = ['version' => 1, 'observations' => ['petstore' => []]];
+        $baseline = ['baseline_version' => 1, 'violations' => []];
+
+        $envelope = CoverageSidecarEnvelope::build($coverage, $strictRequired, $baseline);
+
+        $this->assertSame(3, $envelope['envelopeVersion']);
+        $this->assertSame($coverage, $envelope['coverage']);
+        $this->assertSame($strictRequired, $envelope['strictRequired']);
+        $this->assertSame($baseline, $envelope['baseline']);
+    }
+
+    #[Test]
+    public function parse_accepts_v3_payload_and_returns_the_baseline_half(): void
+    {
+        $payload = [
+            'envelopeVersion' => 3,
+            'coverage' => ['version' => 1, 'specs' => ['petstore' => []]],
+            'strictRequired' => ['version' => 1, 'observations' => ['petstore' => []]],
+            'baseline' => ['baseline_version' => 1, 'violations' => []],
+        ];
+
+        $parsed = CoverageSidecarEnvelope::parse($payload);
+
+        $this->assertSame($payload['coverage'], $parsed['coverage']);
+        $this->assertSame($payload['strictRequired'], $parsed['strictRequired']);
+        $this->assertSame($payload['baseline'], $parsed['baseline']);
+    }
+
+    #[Test]
+    public function parse_returns_null_baseline_for_v2_payload(): void
+    {
+        $parsed = CoverageSidecarEnvelope::parse([
+            'envelopeVersion' => 2,
+            'coverage' => ['version' => 1, 'specs' => []],
+            'strictRequired' => ['version' => 1, 'observations' => []],
+        ]);
+
+        $this->assertNull($parsed['baseline']);
+    }
+
+    #[Test]
+    public function parse_rejects_v2_payload_carrying_a_baseline_key(): void
+    {
+        // A v2 envelope smuggling a baseline half is ambiguous — either the
+        // writer forgot the version bump or the payload was hand-edited.
+        // Accepting it would silently drop generation data on older readers
+        // that ignore unknown keys, so the v3-aware reader rejects it.
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('baseline');
+
+        CoverageSidecarEnvelope::parse([
+            'envelopeVersion' => 2,
+            'coverage' => ['version' => 1, 'specs' => []],
+            'strictRequired' => ['version' => 1, 'observations' => []],
+            'baseline' => ['baseline_version' => 1, 'violations' => []],
+        ]);
+    }
+
+    #[Test]
+    public function parse_rejects_v3_payload_without_a_baseline_half(): void
+    {
+        // v3 exists solely to carry the baseline half; a v3 envelope without
+        // it is malformed, not "generation off" (that shape is v2).
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('baseline');
+
+        CoverageSidecarEnvelope::parse([
+            'envelopeVersion' => 3,
+            'coverage' => ['version' => 1, 'specs' => []],
+            'strictRequired' => ['version' => 1, 'observations' => []],
+        ]);
     }
 
     #[Test]

--- a/tests/Unit/PHPUnit/CoverageReportSubscriberBaselineTest.php
+++ b/tests/Unit/PHPUnit/CoverageReportSubscriberBaselineTest.php
@@ -18,6 +18,7 @@ use Studio\Gesso\PHPUnit\CoverageReportSubscriber;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 
 use function file_get_contents;
+use function file_put_contents;
 use function getenv;
 use function glob;
 use function is_dir;
@@ -167,6 +168,50 @@ class CoverageReportSubscriberBaselineTest extends TestCase
         $this->assertSame(ViolationBaselineFile::BASELINE_VERSION, $envelope['baseline']['baseline_version']);
         $this->assertCount(1, $envelope['baseline']['violations']);
         $this->assertSame('/data/*/id', $envelope['baseline']['violations'][0]['instance_path']);
+    }
+
+    #[Test]
+    public function a_generation_worker_exits_non_zero_when_the_sidecar_write_fails(): void
+    {
+        // Worst case of issue #417: the sidecar write fails AND the failure
+        // marker cannot be dropped either (here: the sidecar dir path is an
+        // existing file, so ensureDir fails for both). The merge would then
+        // see only the other workers' complete baseline halves and write an
+        // incomplete baseline — the worker itself must fail the parallel
+        // run. Contrast with coverage-only workers, which stay green on
+        // sidecar I/O errors (pinned in CoverageReportSubscriberWorkerModeTest).
+        $this->installCollectorWithOneViolation();
+        putenv('TEST_TOKEN=5');
+        $baselinePath = $this->tmpDir . '/gesso-baseline.json';
+
+        $blocker = $this->tmpDir . '/not-a-dir';
+        file_put_contents($blocker, 'blocks the sidecar dir');
+
+        $stderr = '';
+        $exitCode = null;
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            sidecarDir: $blocker,
+            exitHandler: static function (int $code) use (&$exitCode): void {
+                $exitCode = $code;
+            },
+            baselineGeneratePath: $baselinePath,
+        );
+
+        ob_start();
+        $subscriber->notify($this->fakeExecutionFinished());
+        ob_get_clean();
+
+        $this->assertFileDoesNotExist($baselinePath);
+        $this->assertStringContainsString('[Gesso] FATAL', $stderr);
+        $this->assertStringContainsString('incomplete baseline', $stderr);
+        $this->assertSame(1, $exitCode, 'a generation worker that lost its sidecar must fail the run');
     }
 
     #[Test]

--- a/tests/Unit/PHPUnit/CoverageReportSubscriberBaselineTest.php
+++ b/tests/Unit/PHPUnit/CoverageReportSubscriberBaselineTest.php
@@ -17,9 +17,11 @@ use Studio\Gesso\PHPUnit\ConsoleOutput;
 use Studio\Gesso\PHPUnit\CoverageReportSubscriber;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 
+use function file_get_contents;
 use function getenv;
 use function glob;
 use function is_dir;
+use function json_decode;
 use function mkdir;
 use function ob_get_clean;
 use function ob_start;
@@ -135,8 +137,12 @@ class CoverageReportSubscriberBaselineTest extends TestCase
     }
 
     #[Test]
-    public function a_paratest_worker_warns_and_exits_non_zero_without_writing_a_baseline(): void
+    public function a_paratest_worker_stages_the_baseline_in_the_sidecar_envelope(): void
     {
+        // Issue #417: worker mode does NOT write the baseline file — the
+        // per-worker view is a subset. Instead the fingerprints ride the v3
+        // sidecar envelope for `gesso coverage:merge --baseline-file` to
+        // union, and the worker exits normally.
         $this->installCollectorWithOneViolation();
         putenv('TEST_TOKEN=3');
         $baselinePath = $this->tmpDir . '/gesso-baseline.json';
@@ -149,15 +155,18 @@ class CoverageReportSubscriberBaselineTest extends TestCase
         $subscriber->notify($this->fakeExecutionFinished());
         ob_get_clean();
 
-        $this->assertFileDoesNotExist($baselinePath);
-        $this->assertStringContainsString('[Gesso] WARNING', $stderr);
-        $this->assertStringContainsString('parallel', $stderr);
-        $this->assertCount(
-            1,
-            glob($this->tmpDir . '/part-3-*.json') ?: [],
-            'the coverage sidecar must still be written in worker mode',
-        );
-        $this->assertSame(1, $exitCode, 'a refused parallel generation run must not look successful');
+        $this->assertFileDoesNotExist($baselinePath, 'workers must never write the baseline file themselves');
+        $this->assertStringContainsString('coverage:merge --baseline-file=', $stderr);
+        $this->assertStringContainsString($baselinePath, $stderr);
+        $this->assertNull($exitCode, 'a staged parallel generation run must not exit non-zero');
+
+        $sidecars = glob($this->tmpDir . '/part-3-*.json') ?: [];
+        $this->assertCount(1, $sidecars, 'the sidecar must still be written in worker mode');
+        $envelope = json_decode((string) file_get_contents($sidecars[0]), true);
+        $this->assertSame(3, $envelope['envelopeVersion']);
+        $this->assertSame(ViolationBaselineFile::BASELINE_VERSION, $envelope['baseline']['baseline_version']);
+        $this->assertCount(1, $envelope['baseline']['violations']);
+        $this->assertSame('/data/*/id', $envelope['baseline']['violations'][0]['instance_path']);
     }
 
     #[Test]

--- a/tests/Unit/PHPUnit/OpenApiCoverageExtensionBaselineTest.php
+++ b/tests/Unit/PHPUnit/OpenApiCoverageExtensionBaselineTest.php
@@ -123,18 +123,18 @@ class OpenApiCoverageExtensionBaselineTest extends TestCase
     }
 
     #[Test]
-    public function generation_under_a_parallel_worker_is_fatal_at_bootstrap(): void
+    public function generation_under_a_parallel_worker_installs_the_collector(): void
     {
+        // Issue #417: paratest workers bootstrap generation exactly like a
+        // sequential run — the subscriber's worker branch stages the
+        // collected fingerprints in the sidecar envelope for
+        // `gesso coverage:merge --baseline-file` instead of writing a file.
         putenv('OPENAPI_BASELINE_GENERATE=1');
         putenv('TEST_TOKEN=3');
 
         try {
             $this->setupExtension(['baseline_file' => 'gesso-baseline.json']);
-            $this->fail('Expected an InvalidBaselineConfigurationException.');
-        } catch (InvalidBaselineConfigurationException) {
-            $this->assertStringContainsString('[Gesso] FATAL', $this->capturedStderr());
-            $this->assertStringContainsString('parallel', $this->capturedStderr());
-            $this->assertNull(ViolationBaselineCollector::current());
+            $this->assertNotNull(ViolationBaselineCollector::current());
         } finally {
             putenv('TEST_TOKEN');
         }

--- a/tests/fixtures/compatibility/v2-diagnostic-prefixes.json
+++ b/tests/fixtures/compatibility/v2-diagnostic-prefixes.json
@@ -1,9 +1,10 @@
 {
     "[Gesso]": {
+        "src/Coverage/CoverageMergeCommand.php": 5,
         "src/Fuzz/SchemaDataGenerator.php": 1,
         "src/Laravel/ValidatesOpenApiSchema.php": 1,
         "src/PHPUnit/CoverageReportSubscriber.php": 9,
-        "src/PHPUnit/OpenApiCoverageExtension.php": 7,
+        "src/PHPUnit/OpenApiCoverageExtension.php": 6,
         "src/ValidationOutput.php": 1
     },
     "[OpenAPI 3.2 $self]": {

--- a/tests/fixtures/compatibility/v2-diagnostic-prefixes.json
+++ b/tests/fixtures/compatibility/v2-diagnostic-prefixes.json
@@ -3,7 +3,7 @@
         "src/Coverage/CoverageMergeCommand.php": 5,
         "src/Fuzz/SchemaDataGenerator.php": 1,
         "src/Laravel/ValidatesOpenApiSchema.php": 1,
-        "src/PHPUnit/CoverageReportSubscriber.php": 9,
+        "src/PHPUnit/CoverageReportSubscriber.php": 10,
         "src/PHPUnit/OpenApiCoverageExtension.php": 6,
         "src/ValidationOutput.php": 1
     },


### PR DESCRIPTION
## Summary

Supports `OPENAPI_BASELINE_GENERATE=1` under paratest / Pest `--parallel`. Workers now run generation like a sequential run and stage their collected fingerprints in the sidecar envelope (new `envelopeVersion: 3` — the v2 shape plus a `baseline` key holding the baseline-file document verbatim). `gesso coverage:merge` gains `--baseline-file=<path>`, which unions the worker halves and writes the merged baseline deterministically via `ViolationBaselineFile::write()`.

## Why

Fixes #417. Stage 1 of #402 (PR #416) refused generation in workers at bootstrap and the subscriber's worker branch warned and exited non-zero, so parallel suites could not generate a baseline at all — even though the collector was already demoting failures and recording fingerprints per worker.

Design points:

- **v3 is opt-in per run**: plain (non-generation) runs keep emitting the byte-identical v2 envelope, so an older merge CLI stays usable for coverage-only fleets during an upgrade. Mixed-version safety is loud: unknown envelope versions, a v2 envelope smuggling a `baseline` key, and a v3 envelope missing one are all rejected; the embedded document is re-validated with the existing `baseline_version` check.
- **The merge is the trust boundary**: it fails with exit 1 (sidecars preserved for a retry) when baseline data is present but `--baseline-file` was not given (silent drop would hide the demoted violations), when the flag is given but some sidecar lacks the baseline half (incomplete union), when no sidecars exist, or when the write fails. The old per-worker WARNING is replaced by a per-worker guidance line pointing at the merge flag.
- The union is deterministic (presence-only collapse + sorted render), so worker distribution never changes the committed file.

Docs: `baseline.md` gains a "Generating under parallel runners" section, `parallel.md` documents the flag and the v3 envelope, and `versioning.md`'s sidecar-compatibility section records the v2.2 writer/reader rules.

## Verification

- [x] `composer test` passes (2430 tests)
- [x] `composer stan` passes
- [x] `composer cs-check` passes

New regression tests: envelope v3 build/parse and reject cases; worker-mode staging (v3 sidecar, exit 0, no baseline file written); bootstrap under `TEST_TOKEN` installs the collector; merge union across workers, empty-union write, and each fail-loud path; `toDocument()`/`parseDocument()` round-trip.

## Notes for reviewers

- The two CLI help-snapshot tests previously asserted byte-equality against the frozen v1.9 capture, which cannot hold once a flag is added. They now pin `CoverageMergeCommand::usage()` exactly and assert every v1.9 help line is retained (containment), keeping the fixture frozen as the historical record.
- `v2-diagnostic-prefixes.json` counts updated for the moved/added `[Gesso]` messages (branded prefix — not covered by the ADR 0001 identity-neutral parity check, which still passes untouched).
- Per-worker partial runs are inherently undetectable as user `--filter`s; like parallel coverage, generation trusts that the full suite ran and the doc says so explicitly. Stale-entry aggregation across workers remains out of scope (unchanged limitation).