### PR TITLE
feat(spec): authenticated remote spec sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ when upgrading from `studio-design/openapi-contract-testing` v1.10.
 Choose based on the workflow you need rather than on a single yes/no feature count:
 
 - Choose **this library** when you need response-level coverage at `(method, path, status, content-type)` granularity, several CI report formats, OpenAPI 3.1/3.2 JSON Schema semantics, schema-driven exploration, or drift detection across a framework-agnostic core and Laravel, Symfony, and Pest adapters.
-- Choose **[Spectator][spectator]** for a Laravel 12 application when generated test stubs, JSON assertion failures, or remote/private-GitHub spec sources matter more than response-level coverage granularity and broader framework support.
+- Choose **[Spectator][spectator]** for a Laravel 12 application when generated test stubs or JSON assertion failures matter more than response-level coverage granularity and broader framework support. (Remote and private-GitHub spec sources are supported here too via [`remoteSpecs`](docs/setup.md#remote-spec-sources-opt-in).)
 - Choose **[league/openapi-psr7-validator][league]** when you want a low-level PSR-7 validator or PSR-15 middleware and will build the test/reporting integration yourself.
 - Choose **[osteel/openapi-httpfoundation-testing][osteel]** when you want a small HttpFoundation-to-PSR-7 validation bridge, or **[laravel-openapi-validator][kirschbaum]** when automatic validation around Laravel HTTP tests is the main requirement.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -17,6 +17,7 @@ This guide walks through end-to-end setup, including the configuration knobs, op
 - [Skip request validation when the response is a documented 4xx](#skip-request-validation-when-the-response-is-a-documented-4xx)
 - [Auto-inject dummy bearer](#auto-inject-dummy-bearer)
 - [HTTP `$ref` resolution (opt-in)](#http-ref-resolution-opt-in)
+- [Remote spec sources (opt-in)](#remote-spec-sources-opt-in)
 
 ## 1. Provide your OpenAPI spec
 
@@ -711,3 +712,88 @@ Misconfiguration is caught early:
 Format detection prefers the URL's filename extension (`.json` / `.yaml` / `.yml`) and falls back to the response's `Content-Type` (`application/json`, `application/*+json`, `application/yaml`, `text/yaml`, etc.). URLs without a recognisable extension still work as long as the server sets a usable `Content-Type`.
 
 Inside an HTTP-loaded document, relative `$refs` resolve against the URL per RFC 3986: a `$ref: './pet.yaml'` inside `https://example.com/openapi.json` fetches `https://example.com/pet.yaml`.
+
+## Remote spec sources (opt-in)
+
+Normally a named spec resolves to a file under `basePath`. When the contract
+lives in a central registry or a separate spec repository (spec-first orgs,
+API gateways), `remoteSpecs` lets a name resolve to an HTTP(S) entry document
+instead — including a private GitHub repository — without vendoring the file
+into every service repo:
+
+```php
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\HttpFactory;
+use Studio\Gesso\Spec\OpenApiSpecLoader;
+use Studio\Gesso\Spec\RemoteSpecSource;
+
+OpenApiSpecLoader::configure(
+    basePath: 'openapi/',                    // still used for filesystem specs
+    httpClient: new Client(['allow_redirects' => false]),
+    requestFactory: new HttpFactory(),
+    allowRemoteRefs: true,
+    allowedRemoteRefHosts: ['raw.githubusercontent.com'],
+    remoteSpecs: [
+        // Private GitHub repo via a fine-grained PAT with contents:read.
+        'front' => new RemoteSpecSource(
+            'https://raw.githubusercontent.com/acme/api-specs/main/bundled/front.json',
+            authorizationEnv: 'GESSO_SPEC_TOKEN',
+        ),
+        // Unauthenticated internal registry: a plain URL works too.
+        'admin' => 'https://specs.internal.example.com/admin/openapi.yaml',
+    ],
+);
+```
+
+```bash
+# GitHub raw content accepts a PAT as a bearer token.
+export GESSO_SPEC_TOKEN='Bearer github_pat_…'
+```
+
+After that, `front` and `admin` behave like any other spec name — in
+`specs=` for coverage, in `#[OpenApiSpec(...)]` attributes, and in the direct
+validators. Call `configure()` from your PHPUnit bootstrap file and omit the
+extension's `spec_base_path` parameter (the extension would otherwise
+re-configure the loader without your HTTP client); keep `specs=` so remote
+documents are eagerly fetched and structurally validated at bootstrap.
+
+Rules and behavior:
+
+- **Same opt-in as HTTP `$ref`s.** `remoteSpecs` requires `allowRemoteRefs:
+  true`, the PSR-18/PSR-17 pair, and every URL's host in
+  `allowedRemoteRefHosts` — all enforced at `configure()` time. Redirect
+  rejection, the response-size limit, format detection, and URL redaction
+  apply exactly as described in the previous section.
+- **`authorizationEnv` is provider-agnostic.** The environment variable's
+  value is sent verbatim as the `Authorization` header (`Bearer …`,
+  `token …`, `Basic …` — whatever the registry expects). A missing or empty
+  variable fails loudly with reason `RemoteSpecAuthEnvMissing` before any
+  request is sent. The value itself never appears in diagnostics.
+- **Credentials are host-scoped.** The header is sent to the entry document's
+  host only: relative `$ref`s (which resolve against the entry URL per RFC
+  3986) and same-host absolute `$ref`s carry it; a cross-host `$ref` — even
+  to another allowlisted host — never does.
+- **A mapped name never touches the filesystem.** If `front` is in
+  `remoteSpecs`, `openapi/front.json` is ignored for that name.
+- **Fetched once per process.** The resolved document is cached under its
+  spec name like a local spec; parallel workers fetch once each.
+
+For CI predictability, pin the document to the exact bytes you reviewed:
+
+```php
+'front' => new RemoteSpecSource(
+    'https://raw.githubusercontent.com/acme/api-specs/main/bundled/front.json',
+    authorizationEnv: 'GESSO_SPEC_TOKEN',
+    expectedSha256: '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
+),
+```
+
+A mismatch fails with reason `RemoteSpecHashMismatch` (showing expected and
+actual digests) before the document is parsed, so an upstream edit — or a
+compromised registry — cannot silently change what your tests enforce.
+Compute the pin with `curl -s … | shasum -a 256` and commit it; update it
+deliberately when the upstream contract changes. If you prefer freshness over
+pinning, point the URL at an immutable ref (a commit SHA instead of a branch)
+or add ETag caching middleware to the injected PSR-18 client — Gesso
+deliberately performs plain conditional-free GETs and leaves transport
+caching to the client.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -769,10 +769,13 @@ Rules and behavior:
   `token …`, `Basic …` — whatever the registry expects). A missing or empty
   variable fails loudly with reason `RemoteSpecAuthEnvMissing` before any
   request is sent. The value itself never appears in diagnostics.
-- **Credentials are host-scoped.** The header is sent to the entry document's
-  host only: relative `$ref`s (which resolve against the entry URL per RFC
-  3986) and same-host absolute `$ref`s carry it; a cross-host `$ref` — even
-  to another allowlisted host — never does.
+- **Credentials are origin-scoped.** The header is sent to the entry
+  document's origin only — same scheme, host, and effective port (RFC 6454).
+  Relative `$ref`s (which resolve against the entry URL per RFC 3986) and
+  same-origin absolute `$ref`s carry it; anything else never does: not a
+  cross-host `$ref` (even to another allowlisted host), not another port on
+  the same host, and not an `http://` downgrade of an `https://` entry
+  document.
 - **A mapped name never touches the filesystem.** If `front` is in
   `remoteSpecs`, `openapi/front.json` is ignored for that name.
 - **Fetched once per process.** The resolved document is cached under its

--- a/src/Exception/InvalidOpenApiSpecReason.php
+++ b/src/Exception/InvalidOpenApiSpecReason.php
@@ -18,6 +18,8 @@ enum InvalidOpenApiSpecReason
     case RemoteRefDisallowed;
     case RemoteRefHostDisallowed;
     case RemoteRefFetchFailed;
+    case RemoteSpecAuthEnvMissing;
+    case RemoteSpecHashMismatch;
     case HttpClientNotConfigured;
     case FileSchemeNotSupported;
     case EmptyRef;

--- a/src/Internal/HttpRefLoader.php
+++ b/src/Internal/HttpRefLoader.php
@@ -67,8 +67,9 @@ final class HttpRefLoader
      *
      * @param array<string, array<string, mixed>> $documentCache by-ref cache keyed by canonical URL
      * @param list<string> $allowedRemoteRefHosts exact normalized or user-provided host allowlist
-     * @param null|RemoteAuthorization $authorization host-scoped `Authorization` header; only sent
-     *                                                when the request host matches its scope
+     * @param null|RemoteAuthorization $authorization origin-scoped `Authorization` header; only sent
+     *                                                when the request's scheme, host, and effective
+     *                                                port all match its scope
      * @param null|string $expectedSha256 lowercase hex SHA-256 pin verified against the raw
      *                                    response body before decoding
      *
@@ -99,7 +100,7 @@ final class HttpRefLoader
             return new LoadedDocument($canonicalUri, $documentCache[$canonicalUri]);
         }
 
-        if ($authorization !== null && $authorization->appliesToHost($request->getUri()->getHost())) {
+        if ($authorization !== null && $authorization->appliesToUri($request->getUri())) {
             $request = $request->withHeader('Authorization', $authorization->headerValue);
         }
 

--- a/src/Internal/HttpRefLoader.php
+++ b/src/Internal/HttpRefLoader.php
@@ -85,7 +85,7 @@ final class HttpRefLoader
         ?RemoteAuthorization $authorization = null,
         ?string $expectedSha256 = null,
     ): LoadedDocument {
-        $canonicalUri = self::canonicalizeUri($url);
+        $trimmedUri = trim($url);
         $safeUrl = self::redactSensitiveUrlData($url);
 
         // PHP may include live function arguments when stringifying an
@@ -93,7 +93,15 @@ final class HttpRefLoader
         // already captured for the request and cache key, so replace the
         // parameter slot before any downstream operation can throw.
         $url = $safeUrl;
-        $request = $requestFactory->createRequest('GET', $canonicalUri);
+        $request = $requestFactory->createRequest('GET', $trimmedUri);
+        // The cache / cycle-detection key is the PSR-7 URI's string form,
+        // not the raw ref spelling. UriInterface guarantees lowercase
+        // scheme + host and a null port when it equals the scheme default,
+        // so equivalent spellings (`HOST` vs `host`, explicit `:443` vs
+        // none) collapse to one key. Distinct keys here would let a
+        // differently-spelled ref to an already-verified document trigger
+        // a second, unverified fetch of the same wire URL.
+        $canonicalUri = (string) $request->getUri();
         self::assertHostAllowed($safeUrl, $request->getUri()->getHost(), $allowedRemoteRefHosts);
 
         if (isset($documentCache[$canonicalUri])) {
@@ -328,13 +336,6 @@ final class HttpRefLoader
             ),
             ref: $safeUrl,
         );
-    }
-
-    private static function canonicalizeUri(string $url): string
-    {
-        // Trim only — case-folding scheme/host or removing default ports
-        // could collapse URIs the server treats as distinct.
-        return trim($url);
     }
 
     /**

--- a/src/Internal/HttpRefLoader.php
+++ b/src/Internal/HttpRefLoader.php
@@ -94,6 +94,13 @@ final class HttpRefLoader
         // parameter slot before any downstream operation can throw.
         $url = $safeUrl;
         $request = $requestFactory->createRequest('GET', $trimmedUri);
+        // A fragment is client-side only (RFC 9110): it is never part of
+        // the wire request, so it must not distinguish cache entries either.
+        // Refs have their fragment split off before reaching this loader,
+        // but callers passing an entry URL directly must get the same key.
+        if ($request->getUri()->getFragment() !== '') {
+            $request = $request->withUri($request->getUri()->withFragment(''));
+        }
         // The cache / cycle-detection key is the PSR-7 URI's string form,
         // not the raw ref spelling. UriInterface guarantees lowercase
         // scheme + host and a null port when it equals the scheme default,

--- a/src/Internal/HttpRefLoader.php
+++ b/src/Internal/HttpRefLoader.php
@@ -15,6 +15,7 @@ use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
 
 use function ctype_digit;
+use function hash;
 use function ltrim;
 use function pathinfo;
 use function preg_replace;
@@ -66,6 +67,10 @@ final class HttpRefLoader
      *
      * @param array<string, array<string, mixed>> $documentCache by-ref cache keyed by canonical URL
      * @param list<string> $allowedRemoteRefHosts exact normalized or user-provided host allowlist
+     * @param null|RemoteAuthorization $authorization host-scoped `Authorization` header; only sent
+     *                                                when the request host matches its scope
+     * @param null|string $expectedSha256 lowercase hex SHA-256 pin verified against the raw
+     *                                    response body before decoding
      *
      * @throws InvalidOpenApiSpecException when the URL cannot be fetched, decoded, or has no detectable format
      */
@@ -76,6 +81,8 @@ final class HttpRefLoader
         array &$documentCache,
         array $allowedRemoteRefHosts,
         int $maxResponseBytes = self::DEFAULT_MAX_RESPONSE_BYTES,
+        ?RemoteAuthorization $authorization = null,
+        ?string $expectedSha256 = null,
     ): LoadedDocument {
         $canonicalUri = self::canonicalizeUri($url);
         $safeUrl = self::redactSensitiveUrlData($url);
@@ -90,6 +97,10 @@ final class HttpRefLoader
 
         if (isset($documentCache[$canonicalUri])) {
             return new LoadedDocument($canonicalUri, $documentCache[$canonicalUri]);
+        }
+
+        if ($authorization !== null && $authorization->appliesToHost($request->getUri()->getHost())) {
+            $request = $request->withHeader('Authorization', $authorization->headerValue);
         }
 
         try {
@@ -169,6 +180,24 @@ final class HttpRefLoader
                 // nested causes. Do not reconnect the raw chain to a public
                 // exception that is commonly rendered in CI logs.
             );
+        }
+
+        if ($expectedSha256 !== null) {
+            $actualSha256 = hash('sha256', $body);
+            if ($actualSha256 !== $expectedSha256) {
+                throw new InvalidOpenApiSpecException(
+                    InvalidOpenApiSpecReason::RemoteSpecHashMismatch,
+                    sprintf(
+                        'Remote spec document does not match its expectedSha256 pin: %s '
+                        . '(expected %s, got %s). Update the pin if the upstream document '
+                        . 'changed intentionally.',
+                        $safeUrl,
+                        $expectedSha256,
+                        $actualSha256,
+                    ),
+                    ref: $safeUrl,
+                );
+            }
         }
 
         $format = self::detectFormat($canonicalUri, $response->getHeaderLine('Content-Type'));

--- a/src/Internal/RemoteAuthorization.php
+++ b/src/Internal/RemoteAuthorization.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Internal;
+
+/**
+ * An `Authorization` header value scoped to a single host.
+ *
+ * Created when a remote spec source declares `authorizationEnv`. The scope
+ * is the entry document's host: nested `$ref` fetches to the same host
+ * (relative refs, same-host absolute refs) carry the credential, while a
+ * cross-host `$ref` — even to another allowlisted host — never does. This
+ * keeps a registry credential from leaking to unrelated servers.
+ *
+ * The header value is never embedded in diagnostics; exception messages
+ * carry only URLs (already redacted by {@see HttpRefLoader}).
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+final readonly class RemoteAuthorization
+{
+    /** @param string $normalizedHost pre-normalized via {@see HttpRefLoader::normalizeHost()} */
+    public function __construct(
+        public string $headerValue,
+        public string $normalizedHost,
+    ) {}
+
+    public function appliesToHost(string $host): bool
+    {
+        return HttpRefLoader::normalizeHost($host) === $this->normalizedHost;
+    }
+}

--- a/src/Internal/RemoteAuthorization.php
+++ b/src/Internal/RemoteAuthorization.php
@@ -4,14 +4,23 @@ declare(strict_types=1);
 
 namespace Studio\Gesso\Internal;
 
+use Psr\Http\Message\UriInterface;
+use Studio\Gesso\Spec\RemoteSpecSource;
+
+use function parse_url;
+use function strtolower;
+
 /**
- * An `Authorization` header value scoped to a single host.
+ * An `Authorization` header value scoped to a single web origin.
  *
  * Created when a remote spec source declares `authorizationEnv`. The scope
- * is the entry document's host: nested `$ref` fetches to the same host
- * (relative refs, same-host absolute refs) carry the credential, while a
- * cross-host `$ref` — even to another allowlisted host — never does. This
- * keeps a registry credential from leaking to unrelated servers.
+ * is the entry document's origin — scheme, host, and effective port per
+ * RFC 6454 — so nested `$ref` fetches back to the same origin (relative
+ * refs, same-origin absolute refs) carry the credential, while any other
+ * target never does: not a cross-host ref (even to an allowlisted host),
+ * not another port on the same host, and not an `http://` downgrade of an
+ * `https://` entry document, which would put the credential on the wire in
+ * plaintext.
  *
  * The header value is never embedded in diagnostics; exception messages
  * carry only URLs (already redacted by {@see HttpRefLoader}).
@@ -20,14 +29,42 @@ namespace Studio\Gesso\Internal;
  */
 final readonly class RemoteAuthorization
 {
-    /** @param string $normalizedHost pre-normalized via {@see HttpRefLoader::normalizeHost()} */
-    public function __construct(
+    private function __construct(
         public string $headerValue,
-        public string $normalizedHost,
+        private string $scheme,
+        private string $normalizedHost,
+        private int $effectivePort,
     ) {}
 
-    public function appliesToHost(string $host): bool
+    /**
+     * `$url` must be an absolute `http://` / `https://` URL with a host —
+     * {@see RemoteSpecSource} validates this before the
+     * loader constructs the scope.
+     */
+    public static function forUrl(string $headerValue, string $url): self
     {
-        return HttpRefLoader::normalizeHost($host) === $this->normalizedHost;
+        $parts = parse_url($url);
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+
+        return new self(
+            $headerValue,
+            $scheme,
+            HttpRefLoader::normalizeHost((string) ($parts['host'] ?? '')),
+            $parts['port'] ?? self::defaultPort($scheme),
+        );
+    }
+
+    public function appliesToUri(UriInterface $uri): bool
+    {
+        $scheme = strtolower($uri->getScheme());
+
+        return $scheme === $this->scheme &&
+            HttpRefLoader::normalizeHost($uri->getHost()) === $this->normalizedHost &&
+            ($uri->getPort() ?? self::defaultPort($scheme)) === $this->effectivePort;
+    }
+
+    private static function defaultPort(string $scheme): int
+    {
+        return $scheme === 'http' ? 80 : 443;
     }
 }

--- a/src/Spec/OpenApiRefResolver.php
+++ b/src/Spec/OpenApiRefResolver.php
@@ -138,6 +138,9 @@ final class OpenApiRefResolver
      * @param list<string> $allowedRemoteRefHosts exact hosts allowed for HTTP(S) refs
      * @param int $maxRemoteRefBytes maximum response bytes read per remote document; must be positive
      * @param list<string> $allowedLocalRefRoots canonical filesystem roots local refs may read from
+     * @param array<string, array<string, mixed>> $preloadedDocuments already-verified external
+     *                                                                documents keyed by canonical identifier; seeds the
+     *                                                                per-resolution cache so refs to them never refetch
      *
      * @return array<string, mixed>
      *
@@ -153,6 +156,7 @@ final class OpenApiRefResolver
         int $maxRemoteRefBytes = OpenApiSpecLoader::DEFAULT_MAX_REMOTE_REF_BYTES,
         array $allowedLocalRefRoots = [],
         ?RemoteAuthorization $remoteAuthorization = null,
+        array $preloadedDocuments = [],
     ): array {
         // OpenApiSpecLoader::configure() catches this earlier with an
         // InvalidArgumentException; this guard is for callers that
@@ -200,8 +204,11 @@ final class OpenApiRefResolver
         // copy-on-write keeps it untouched as we mutate $spec via $node refs.
         $root = $spec;
         // Per-resolution external file/URL cache, keyed by canonical absolute
-        // path or canonical URL. Sibling refs into the same target decode it once.
-        $documentCache = [];
+        // path or canonical URL. Sibling refs into the same target decode it
+        // once. Callers may seed it with already-verified documents (the
+        // remote entry document and its SHA-256 pin) so a ref back to a
+        // seeded identifier never triggers an unverified refetch.
+        $documentCache = $preloadedDocuments;
         self::walk($spec, $root, [], false, $context, $documentCache);
 
         return $spec;

--- a/src/Spec/OpenApiRefResolver.php
+++ b/src/Spec/OpenApiRefResolver.php
@@ -11,6 +11,7 @@ use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
 use Studio\Gesso\Internal\ExternalRefLoader;
 use Studio\Gesso\Internal\HttpRefLoader;
+use Studio\Gesso\Internal\RemoteAuthorization;
 
 use function array_is_list;
 use function array_key_exists;
@@ -151,6 +152,7 @@ final class OpenApiRefResolver
         array $allowedRemoteRefHosts = [],
         int $maxRemoteRefBytes = OpenApiSpecLoader::DEFAULT_MAX_REMOTE_REF_BYTES,
         array $allowedLocalRefRoots = [],
+        ?RemoteAuthorization $remoteAuthorization = null,
     ): array {
         // OpenApiSpecLoader::configure() catches this earlier with an
         // InvalidArgumentException; this guard is for callers that
@@ -190,6 +192,7 @@ final class OpenApiRefResolver
                 $sourceFile,
                 $maxRemoteRefBytes,
                 $allowedLocalRefRoots,
+                $remoteAuthorization,
             )
             : RefResolutionContext::filesystemOnly($sourceFile, $allowedLocalRefRoots);
 
@@ -805,6 +808,7 @@ final class OpenApiRefResolver
                 $documentCache,
                 $context->allowedRemoteRefHosts,
                 $context->maxRemoteRefBytes,
+                $context->remoteAuthorization,
             );
         } catch (InvalidOpenApiSpecException $e) {
             // Re-wrap remote-fetch failures with the resolution chain so

--- a/src/Spec/OpenApiSpecLoader.php
+++ b/src/Spec/OpenApiSpecLoader.php
@@ -7,6 +7,7 @@ namespace Studio\Gesso\Spec;
 use const DIRECTORY_SEPARATOR;
 use const E_USER_WARNING;
 use const JSON_THROW_ON_ERROR;
+use const PHP_URL_HOST;
 
 use InvalidArgumentException;
 use JsonException;
@@ -17,6 +18,7 @@ use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
 use Studio\Gesso\Exception\SpecFileNotFoundException;
 use Studio\Gesso\Internal\HttpRefLoader;
 use Studio\Gesso\Internal\OpenApiDocumentShapeNormalizer;
+use Studio\Gesso\Internal\RemoteAuthorization;
 use Studio\Gesso\Internal\SpecDocumentDecoder;
 use Studio\Gesso\Internal\YamlAvailability;
 use Studio\Gesso\OpenApiVersion;
@@ -28,10 +30,13 @@ use function explode;
 use function file_exists;
 use function file_get_contents;
 use function get_debug_type;
+use function getenv;
 use function implode;
 use function in_array;
 use function is_array;
+use function is_string;
 use function json_decode;
+use function parse_url;
 use function preg_match;
 use function realpath;
 use function rtrim;
@@ -78,6 +83,9 @@ final class OpenApiSpecLoader
     private static array $allowedRemoteRefHosts = [];
     private static int $maxRemoteRefBytes = self::DEFAULT_MAX_REMOTE_REF_BYTES;
 
+    /** @var array<string, RemoteSpecSource> */
+    private static array $remoteSpecs = [];
+
     /**
      * Configure the spec loader.
      *
@@ -107,6 +115,12 @@ final class OpenApiSpecLoader
      *                                            are not accepted. Matching is case-insensitive.
      * @param int $maxRemoteRefBytes Maximum HTTP response-body bytes read for each remote
      *                               document. Must be positive; the default is 10 MiB.
+     * @param array<string, RemoteSpecSource|string> $remoteSpecs Map of spec name to an HTTP(S)
+     *                                                            entry-document source (issue #407). A plain string is
+     *                                                            shorthand for `new RemoteSpecSource($url)`. A mapped
+     *                                                            name always loads from its URL and never consults the
+     *                                                            filesystem. Requires `$allowRemoteRefs: true`, and every
+     *                                                            URL's host must appear in `$allowedRemoteRefHosts`.
      *
      * @throws InvalidArgumentException for any misconfigured pair: `$allowRemoteRefs` true
      *                                  without client/factory, OR client provided without
@@ -122,6 +136,7 @@ final class OpenApiSpecLoader
         ?string $enumBasePath = null,
         array $allowedRemoteRefHosts = [],
         int $maxRemoteRefBytes = self::DEFAULT_MAX_REMOTE_REF_BYTES,
+        array $remoteSpecs = [],
     ): void {
         if ($allowRemoteRefs && ($httpClient === null || $requestFactory === null)) {
             throw new InvalidArgumentException(
@@ -164,7 +179,17 @@ final class OpenApiSpecLoader
             );
         }
 
+        if (!$allowRemoteRefs && $remoteSpecs !== []) {
+            throw new InvalidArgumentException(
+                'OpenApiSpecLoader::configure(): $remoteSpecs was provided but allowRemoteRefs '
+                . 'is false. Remote entry documents share the HTTP $ref opt-in; pass '
+                . 'allowRemoteRefs: true together with an HTTP client, request factory, and '
+                . 'host allowlist.',
+            );
+        }
+
         $allowedRemoteRefHosts = self::normalizeAllowedRemoteRefHosts($allowedRemoteRefHosts);
+        $remoteSpecs = self::normalizeRemoteSpecs($remoteSpecs, $allowedRemoteRefHosts);
 
         if ($enumBasePath !== null && trim($enumBasePath) === '') {
             // Empty / whitespace-only `enumBasePath` would otherwise survive
@@ -188,6 +213,7 @@ final class OpenApiSpecLoader
         self::$allowRemoteRefs = $allowRemoteRefs;
         self::$allowedRemoteRefHosts = $allowedRemoteRefHosts;
         self::$maxRemoteRefBytes = $maxRemoteRefBytes;
+        self::$remoteSpecs = $remoteSpecs;
         // A previous configure() call may have cached specs under a
         // different remote-refs policy. Evict so the next load() runs
         // with the new client/flag combination.
@@ -233,6 +259,10 @@ final class OpenApiSpecLoader
             return self::$cache[$specName];
         }
 
+        if (isset(self::$remoteSpecs[$specName])) {
+            return self::$cache[$specName] = self::loadRemoteSpec($specName, self::$remoteSpecs[$specName]);
+        }
+
         ['path' => $path, 'extension' => $extension] = self::resolveSpecFile($specName);
 
         $decoded = match ($extension) {
@@ -245,28 +275,7 @@ final class OpenApiSpecLoader
             ),
         };
 
-        // Version selection changes schema semantics, so reject an absent,
-        // malformed, or unsupported `openapi` value before resolving refs or
-        // running any endpoint assertions. This also makes PHPUnit extension
-        // bootstrap fail while eagerly loading its configured specs.
-        try {
-            $version = OpenApiVersion::fromSpec($decoded);
-            OpenApiSchemaDialect::fromSpec($decoded, $version);
-        } catch (InvalidOpenApiSpecException $e) {
-            throw $e->withSpecName($specName);
-        }
-
-        if ($version === OpenApiVersion::V3_2 && array_key_exists('$self', $decoded)) {
-            trigger_error(
-                sprintf(
-                    "[OpenAPI 3.2 \$self] spec '%s' declares a \$self base URI, but this loader still resolves "
-                    . 'relative references from the retrieved file path. Remove $self or pre-bundle the document '
-                    . 'until $self-aware resolution is implemented.',
-                    $specName,
-                ),
-                E_USER_WARNING,
-            );
-        }
+        self::assertSupportedDocument($decoded, $specName);
 
         // Canonicalize the source path so the resolver's cycle detection
         // sees the same key for this file whether it's reached as the
@@ -346,7 +355,175 @@ final class OpenApiSpecLoader
         self::$allowRemoteRefs = false;
         self::$allowedRemoteRefHosts = [];
         self::$maxRemoteRefBytes = self::DEFAULT_MAX_REMOTE_REF_BYTES;
+        self::$remoteSpecs = [];
         YamlAvailability::reset();
+    }
+
+    /**
+     * Reject an absent, malformed, or unsupported `openapi` value before
+     * resolving refs or running any endpoint assertions — version selection
+     * changes schema semantics. This also makes PHPUnit extension bootstrap
+     * fail while eagerly loading its configured specs. Shared by the
+     * filesystem and remote entry-document paths so both stay consistent.
+     *
+     * @param array<string, mixed> $decoded
+     */
+    private static function assertSupportedDocument(array $decoded, string $specName): void
+    {
+        try {
+            $version = OpenApiVersion::fromSpec($decoded);
+            OpenApiSchemaDialect::fromSpec($decoded, $version);
+        } catch (InvalidOpenApiSpecException $e) {
+            throw $e->withSpecName($specName);
+        }
+
+        if ($version === OpenApiVersion::V3_2 && array_key_exists('$self', $decoded)) {
+            trigger_error(
+                sprintf(
+                    "[OpenAPI 3.2 \$self] spec '%s' declares a \$self base URI, but this loader still resolves "
+                    . 'relative references from the retrieved file path. Remove $self or pre-bundle the document '
+                    . 'until $self-aware resolution is implemented.',
+                    $specName,
+                ),
+                E_USER_WARNING,
+            );
+        }
+    }
+
+    /**
+     * Load a spec whose entry document lives at an HTTP(S) URL (issue #407).
+     *
+     * The fetch goes through the same {@see HttpRefLoader} boundary as HTTP
+     * `$ref` targets: host allowlist, no redirects, response-size limit, and
+     * URL redaction all apply. Ref resolution then runs with the canonical
+     * URL as the base, so relative `$ref`s inside the document resolve
+     * against it per RFC 3986.
+     *
+     * @return array<string, mixed>
+     */
+    private static function loadRemoteSpec(string $specName, RemoteSpecSource $source): array
+    {
+        $client = self::$httpClient;
+        $requestFactory = self::$requestFactory;
+        if ($client === null || $requestFactory === null) {
+            // configure() guarantees the pairing; this guard keeps the
+            // invariant explicit for static analysis and direct state abuse.
+            throw new InvalidOpenApiSpecException(
+                InvalidOpenApiSpecReason::HttpClientNotConfigured,
+                sprintf(
+                    'Remote spec `%s` requires a PSR-18 ClientInterface and PSR-17 '
+                    . 'RequestFactoryInterface. Pass them to OpenApiSpecLoader::configure().',
+                    $specName,
+                ),
+                specName: $specName,
+            );
+        }
+
+        $authorization = null;
+        if ($source->authorizationEnv !== null) {
+            $headerValue = self::readEnvValue($source->authorizationEnv);
+            if ($headerValue === null || trim($headerValue) === '') {
+                throw new InvalidOpenApiSpecException(
+                    InvalidOpenApiSpecReason::RemoteSpecAuthEnvMissing,
+                    sprintf(
+                        'Remote spec `%s` sources its Authorization header from the environment '
+                        . 'variable %s, which is not set (or empty). Export it before running '
+                        . 'tests; its value is sent verbatim as the Authorization header.',
+                        $specName,
+                        $source->authorizationEnv,
+                    ),
+                    specName: $specName,
+                );
+            }
+
+            $host = (string) parse_url($source->url, PHP_URL_HOST);
+            $authorization = new RemoteAuthorization(trim($headerValue), HttpRefLoader::normalizeHost($host));
+        }
+
+        $documentCache = [];
+
+        try {
+            $document = HttpRefLoader::loadDocument(
+                $source->url,
+                $client,
+                $requestFactory,
+                $documentCache,
+                self::$allowedRemoteRefHosts,
+                self::$maxRemoteRefBytes,
+                $authorization,
+                $source->expectedSha256,
+            );
+        } catch (InvalidOpenApiSpecException $e) {
+            throw $e->withSpecName($specName);
+        }
+
+        self::assertSupportedDocument($document->decoded, $specName);
+
+        try {
+            return OpenApiDocumentShapeNormalizer::normalizeResolvedDocument(
+                OpenApiRefResolver::resolve(
+                    $document->decoded,
+                    $document->canonicalIdentifier,
+                    $client,
+                    $requestFactory,
+                    true,
+                    self::$allowedRemoteRefHosts,
+                    self::$maxRemoteRefBytes,
+                    [self::getBasePath()],
+                    $authorization,
+                ),
+            );
+        } catch (InvalidOpenApiSpecException $e) {
+            throw $e->withSpecName($specName);
+        }
+    }
+
+    private static function readEnvValue(string $name): ?string
+    {
+        $value = $_SERVER[$name] ?? $_ENV[$name] ?? getenv($name);
+        if ($value === false || !is_string($value)) {
+            return null;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, RemoteSpecSource|string> $remoteSpecs
+     * @param list<string> $normalizedAllowedHosts already-normalized host allowlist
+     *
+     * @return array<string, RemoteSpecSource>
+     */
+    private static function normalizeRemoteSpecs(array $remoteSpecs, array $normalizedAllowedHosts): array
+    {
+        $normalized = [];
+        foreach ($remoteSpecs as $specName => $source) {
+            if (trim((string) $specName) === '') {
+                throw new InvalidArgumentException(
+                    'OpenApiSpecLoader::configure(): $remoteSpecs contains an empty spec name.',
+                );
+            }
+
+            if (is_string($source)) {
+                $source = new RemoteSpecSource($source);
+            }
+
+            $host = HttpRefLoader::normalizeHost((string) parse_url($source->url, PHP_URL_HOST));
+            if (!in_array($host, $normalizedAllowedHosts, true)) {
+                throw new InvalidArgumentException(
+                    sprintf(
+                        'OpenApiSpecLoader::configure(): remote spec `%s` targets host `%s`, '
+                        . 'which is not in $allowedRemoteRefHosts. Add the exact host to the allowlist.',
+                        $specName,
+                        $host,
+                    ),
+                );
+            }
+
+            $normalized[(string) $specName] = $source;
+        }
+
+        return $normalized;
     }
 
     /**

--- a/src/Spec/OpenApiSpecLoader.php
+++ b/src/Spec/OpenApiSpecLoader.php
@@ -436,8 +436,7 @@ final class OpenApiSpecLoader
                 );
             }
 
-            $host = (string) parse_url($source->url, PHP_URL_HOST);
-            $authorization = new RemoteAuthorization(trim($headerValue), HttpRefLoader::normalizeHost($host));
+            $authorization = RemoteAuthorization::forUrl(trim($headerValue), $source->url);
         }
 
         $documentCache = [];
@@ -471,6 +470,11 @@ final class OpenApiSpecLoader
                     self::$maxRemoteRefBytes,
                     [self::getBasePath()],
                     $authorization,
+                    // Seed the resolver with the pin-verified entry bytes so a
+                    // $ref back to the entry URL reuses them instead of
+                    // refetching — a second response would bypass the
+                    // expectedSha256 check.
+                    $documentCache,
                 ),
             );
         } catch (InvalidOpenApiSpecException $e) {

--- a/src/Spec/RefResolutionContext.php
+++ b/src/Spec/RefResolutionContext.php
@@ -7,6 +7,7 @@ namespace Studio\Gesso\Spec;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Studio\Gesso\Internal\HttpRefLoader;
+use Studio\Gesso\Internal\RemoteAuthorization;
 
 /**
  * Carries the per-resolution state that `OpenApiRefResolver::walk()` needs
@@ -41,6 +42,7 @@ final class RefResolutionContext
         public readonly int $maxRemoteRefBytes,
         /** @var list<string> */
         public readonly array $allowedLocalRefRoots,
+        public readonly ?RemoteAuthorization $remoteAuthorization = null,
     ) {}
 
     /**
@@ -69,6 +71,7 @@ final class RefResolutionContext
         ?string $sourceFile = null,
         int $maxRemoteRefBytes = HttpRefLoader::DEFAULT_MAX_RESPONSE_BYTES,
         array $allowedLocalRefRoots = [],
+        ?RemoteAuthorization $remoteAuthorization = null,
     ): self {
         return new self(
             $sourceFile,
@@ -78,6 +81,7 @@ final class RefResolutionContext
             $allowedRemoteRefHosts,
             $maxRemoteRefBytes,
             $allowedLocalRefRoots,
+            $remoteAuthorization,
         );
     }
 
@@ -98,6 +102,7 @@ final class RefResolutionContext
             $this->allowedRemoteRefHosts,
             $this->maxRemoteRefBytes,
             $this->allowedLocalRefRoots,
+            $this->remoteAuthorization,
         );
     }
 }

--- a/src/Spec/RemoteSpecSource.php
+++ b/src/Spec/RemoteSpecSource.php
@@ -7,6 +7,7 @@ namespace Studio\Gesso\Spec;
 use const PHP_URL_HOST;
 
 use InvalidArgumentException;
+use Studio\Gesso\Internal\HttpRefLoader;
 
 use function parse_url;
 use function preg_match;
@@ -51,22 +52,32 @@ final readonly class RemoteSpecSource
         public ?string $authorizationEnv = null,
         ?string $expectedSha256 = null,
     ) {
-        if (!str_starts_with($url, 'http://') && !str_starts_with($url, 'https://')) {
+        // Configure-time rejections surface in CI logs, and a spec URL may
+        // carry signed-URL query tokens or userinfo. Diagnostics use the
+        // redacted form only; the raw URL also replaces the parameter slot
+        // so traces stay clean under zend.exception_ignore_args=Off. The
+        // promoted property keeps the raw value — the fetch needs it.
+        $isHttp = str_starts_with($url, 'http://') || str_starts_with($url, 'https://');
+        $host = parse_url($url, PHP_URL_HOST);
+        $hasFragment = str_contains($url, '#');
+        $safeUrl = HttpRefLoader::redactSensitiveUrlData($url);
+        $url = $safeUrl;
+
+        if (!$isHttp) {
             throw new InvalidArgumentException(sprintf(
                 'RemoteSpecSource: URL must start with http:// or https://, got `%s`.',
-                $url,
+                $safeUrl,
             ));
         }
 
-        $host = parse_url($url, PHP_URL_HOST);
         if ($host === false || $host === null || $host === '') {
             throw new InvalidArgumentException(sprintf(
                 'RemoteSpecSource: URL has no parseable host: `%s`.',
-                $url,
+                $safeUrl,
             ));
         }
 
-        if (str_contains($url, '#')) {
+        if ($hasFragment) {
             // A fragment is client-side only and never part of the wire
             // request, so it cannot select a different entry document —
             // but it would make the URL spelling diverge from the fetched
@@ -74,7 +85,7 @@ final readonly class RemoteSpecSource
             throw new InvalidArgumentException(sprintf(
                 'RemoteSpecSource: URL must not contain a fragment: `%s`. '
                 . 'The entry document is always loaded whole; remove the `#...` part.',
-                $url,
+                $safeUrl,
             ));
         }
 

--- a/src/Spec/RemoteSpecSource.php
+++ b/src/Spec/RemoteSpecSource.php
@@ -11,6 +11,7 @@ use InvalidArgumentException;
 use function parse_url;
 use function preg_match;
 use function sprintf;
+use function str_contains;
 use function str_starts_with;
 use function strtolower;
 use function trim;
@@ -61,6 +62,18 @@ final readonly class RemoteSpecSource
         if ($host === false || $host === null || $host === '') {
             throw new InvalidArgumentException(sprintf(
                 'RemoteSpecSource: URL has no parseable host: `%s`.',
+                $url,
+            ));
+        }
+
+        if (str_contains($url, '#')) {
+            // A fragment is client-side only and never part of the wire
+            // request, so it cannot select a different entry document —
+            // but it would make the URL spelling diverge from the fetched
+            // resource's identity. Reject loudly instead of stripping.
+            throw new InvalidArgumentException(sprintf(
+                'RemoteSpecSource: URL must not contain a fragment: `%s`. '
+                . 'The entry document is always loaded whole; remove the `#...` part.',
                 $url,
             ));
         }

--- a/src/Spec/RemoteSpecSource.php
+++ b/src/Spec/RemoteSpecSource.php
@@ -14,7 +14,9 @@ use function preg_match;
 use function sprintf;
 use function str_contains;
 use function str_starts_with;
+use function strpos;
 use function strtolower;
+use function substr;
 use function trim;
 
 /**
@@ -61,6 +63,14 @@ final readonly class RemoteSpecSource
         $host = parse_url($url, PHP_URL_HOST);
         $hasFragment = str_contains($url, '#');
         $safeUrl = HttpRefLoader::redactSensitiveUrlData($url);
+        // The shared redaction keeps fragments because $ref diagnostics
+        // need their JSON pointers, but an entry URL's fragment is rejected
+        // wholesale and may carry an OAuth-style token — hide its content
+        // and show only that one was present.
+        $fragmentStart = strpos($safeUrl, '#');
+        if ($fragmentStart !== false) {
+            $safeUrl = substr($safeUrl, 0, $fragmentStart) . '#[redacted]';
+        }
         $url = $safeUrl;
 
         if (!$isHttp) {

--- a/src/Spec/RemoteSpecSource.php
+++ b/src/Spec/RemoteSpecSource.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Spec;
+
+use const PHP_URL_HOST;
+
+use InvalidArgumentException;
+
+use function parse_url;
+use function preg_match;
+use function sprintf;
+use function str_starts_with;
+use function strtolower;
+use function trim;
+
+/**
+ * Declares an HTTP(S) entry document for a named spec (issue #407).
+ *
+ * Passed to {@see OpenApiSpecLoader::configure()} via `$remoteSpecs` so a
+ * spec hosted in a private GitHub repository or an internal registry can be
+ * used by name without vendoring the file into the repository. Sharing the
+ * HTTP `$ref` opt-in, a remote source only works together with
+ * `allowRemoteRefs: true`, an injected PSR-18 client + PSR-17 factory, and
+ * a host allowlist that contains the URL's host.
+ */
+final readonly class RemoteSpecSource
+{
+    /**
+     * Hex-encoded SHA-256 pin of the raw response body, normalized to
+     * lowercase. `null` when the document is not pinned.
+     */
+    public ?string $expectedSha256;
+
+    /**
+     * @param string $url absolute `http://` / `https://` URL of the entry document
+     * @param null|string $authorizationEnv name of an environment variable whose value is sent
+     *                                      verbatim as the `Authorization` header (e.g.
+     *                                      `Bearer <token>`). The header is only sent to the
+     *                                      URL's own host, never to cross-host `$ref` targets.
+     * @param null|string $expectedSha256 optional hex SHA-256 of the raw entry-document bytes;
+     *                                    a mismatch fails the load before parsing
+     *
+     * @throws InvalidArgumentException when the URL is not absolute HTTP(S), the env variable
+     *                                  name is empty, or the pin is not a 64-digit hex string
+     */
+    public function __construct(
+        public string $url,
+        public ?string $authorizationEnv = null,
+        ?string $expectedSha256 = null,
+    ) {
+        if (!str_starts_with($url, 'http://') && !str_starts_with($url, 'https://')) {
+            throw new InvalidArgumentException(sprintf(
+                'RemoteSpecSource: URL must start with http:// or https://, got `%s`.',
+                $url,
+            ));
+        }
+
+        $host = parse_url($url, PHP_URL_HOST);
+        if ($host === false || $host === null || $host === '') {
+            throw new InvalidArgumentException(sprintf(
+                'RemoteSpecSource: URL has no parseable host: `%s`.',
+                $url,
+            ));
+        }
+
+        if ($authorizationEnv !== null && trim($authorizationEnv) === '') {
+            throw new InvalidArgumentException(
+                'RemoteSpecSource: $authorizationEnv must be a non-empty environment variable name, or null.',
+            );
+        }
+
+        if ($expectedSha256 !== null && preg_match('/^[0-9a-fA-F]{64}$/', $expectedSha256) !== 1) {
+            throw new InvalidArgumentException(
+                'RemoteSpecSource: $expectedSha256 must be a 64-character hex SHA-256 digest, or null.',
+            );
+        }
+
+        $this->expectedSha256 = $expectedSha256 !== null ? strtolower($expectedSha256) : null;
+    }
+}

--- a/tests/Unit/Compatibility/PublicApiBaselineTest.php
+++ b/tests/Unit/Compatibility/PublicApiBaselineTest.php
@@ -39,6 +39,7 @@ use Studio\Gesso\PHPUnit\InvalidStrictRequiredConfigurationException;
 use Studio\Gesso\SchemaContext;
 use Studio\Gesso\SkipOpenApiResolver;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
+use Studio\Gesso\Spec\RemoteSpecSource;
 use Studio\Gesso\Tests\Helpers\PublicApiInventory;
 use Studio\Gesso\Tests\Unit\Compatibility\Fixture\PublicApiImplicitConstructorFixture;
 use Studio\Gesso\Tests\Unit\Compatibility\Fixture\PublicApiInternalTraitConsumerFixture;
@@ -209,6 +210,11 @@ final class PublicApiBaselineTest extends TestCase
             if ($name === 'RemoteRefDisallowed') {
                 $reasonCases['RemoteRefHostDisallowed'] = null;
             }
+            if ($name === 'RemoteRefFetchFailed') {
+                // #407: authenticated remote spec sources (minor additions).
+                $reasonCases['RemoteSpecAuthEnvMissing'] = null;
+                $reasonCases['RemoteSpecHashMismatch'] = null;
+            }
         }
         $expected[InvalidOpenApiSpecReason::class]['cases'] = $reasonCases;
         $expected[OpenApiSpecLoader::class]['constants']['DEFAULT_MAX_REMOTE_REF_BYTES'] = 10_485_760;
@@ -231,6 +237,16 @@ final class PublicApiBaselineTest extends TestCase
                 'constant' => 'self::DEFAULT_MAX_REMOTE_REF_BYTES',
                 'value' => 10_485_760,
             ],
+            'attributes' => [],
+        ];
+        // #407: named specs may resolve to HTTP(S) entry documents.
+        $expected[OpenApiSpecLoader::class]['methods']['configure']['parameters'][] = [
+            'name' => 'remoteSpecs',
+            'type' => 'array',
+            'optional' => true,
+            'variadic' => false,
+            'by_reference' => false,
+            'default' => [],
             'attributes' => [],
         ];
         $expected[JsonCoverageRenderer::class]['constants']['SCHEMA_VERSION'] = 2;
@@ -1534,6 +1550,77 @@ final class PublicApiBaselineTest extends TestCase
                             'variadic' => false,
                             'by_reference' => false,
                             'default' => 1,
+                            'attributes' => [],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        // New public class in v2.x (#407): remote entry-document source.
+        $remoteSpecNullableProperty = static fn(): array => [
+            'type' => '?string',
+            'static' => false,
+            'readonly' => true,
+            'default' => ['unavailable' => true],
+        ];
+        $expected[RemoteSpecSource::class] = [
+            'kind' => 'class',
+            'final' => true,
+            'abstract' => false,
+            'readonly' => true,
+            'instantiable' => true,
+            'constructor' => ['kind' => 'declared', 'visibility' => 'public'],
+            'parent' => null,
+            'interfaces' => [],
+            'traits' => [],
+            'attributes' => [],
+            'backing_type' => null,
+            'cases' => [],
+            'constants' => [],
+            'properties' => [
+                'authorizationEnv' => $remoteSpecNullableProperty(),
+                'expectedSha256' => $remoteSpecNullableProperty(),
+                'url' => [
+                    'type' => 'string',
+                    'static' => false,
+                    'readonly' => true,
+                    'default' => ['unavailable' => true],
+                ],
+            ],
+            'methods' => [
+                '__construct' => [
+                    'static' => false,
+                    'final' => false,
+                    'abstract' => false,
+                    'returns_reference' => false,
+                    'return_type' => null,
+                    'attributes' => [],
+                    'parameters' => [
+                        [
+                            'name' => 'url',
+                            'type' => 'string',
+                            'optional' => false,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => ['unavailable' => true],
+                            'attributes' => [],
+                        ],
+                        [
+                            'name' => 'authorizationEnv',
+                            'type' => '?string',
+                            'optional' => true,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => null,
+                            'attributes' => [],
+                        ],
+                        [
+                            'name' => 'expectedSha256',
+                            'type' => '?string',
+                            'optional' => true,
+                            'variadic' => false,
+                            'by_reference' => false,
+                            'default' => null,
                             'attributes' => [],
                         ],
                     ],

--- a/tests/Unit/Internal/HttpRefLoaderTest.php
+++ b/tests/Unit/Internal/HttpRefLoaderTest.php
@@ -47,6 +47,43 @@ class HttpRefLoaderTest extends TestCase
     }
 
     #[Test]
+    public function strips_the_fragment_from_the_request_and_cache_key(): void
+    {
+        // The fragment is client-side only (RFC 9110): it is never part of
+        // the wire request, so a fragment spelling must share the cache
+        // entry of the fragment-free URL — distinct keys would allow a
+        // second, unverified fetch of an already-verified document.
+        $fetches = 0;
+        $client = new FakeHttpClient([
+            'https://example.com/schemas/pet.json' => static function () use (&$fetches) {
+                $fetches++;
+
+                return FakeHttpClient::jsonResponse('{"type":"object"}');
+            },
+        ]);
+
+        $cache = [];
+        $withFragment = HttpRefLoader::loadDocument(
+            'https://example.com/schemas/pet.json#entry',
+            $client,
+            $this->factory,
+            $cache,
+            ['example.com'],
+        );
+        $withoutFragment = HttpRefLoader::loadDocument(
+            'https://example.com/schemas/pet.json',
+            $client,
+            $this->factory,
+            $cache,
+            ['example.com'],
+        );
+
+        $this->assertSame(1, $fetches);
+        $this->assertSame('https://example.com/schemas/pet.json', $withFragment->canonicalIdentifier);
+        $this->assertSame($withFragment->canonicalIdentifier, $withoutFragment->canonicalIdentifier);
+    }
+
+    #[Test]
     public function fetches_and_decodes_yaml_via_url_extension(): void
     {
         $url = 'https://example.com/schemas/pet.yaml';

--- a/tests/Unit/Spec/OpenApiSpecLoaderRemoteSpecsTest.php
+++ b/tests/Unit/Spec/OpenApiSpecLoaderRemoteSpecsTest.php
@@ -379,6 +379,47 @@ final class OpenApiSpecLoaderRemoteSpecsTest extends TestCase
     }
 
     #[Test]
+    public function load_reuses_the_verified_entry_document_for_equivalent_url_spellings(): void
+    {
+        // The entry URL spells out the default port; the self-ref omits it.
+        // Both normalize to the same wire URL, so the pin-verified bytes
+        // must be reused — a refetch would bypass the SHA-256 pin.
+        $entryUrl = 'https://specs.example.com:443/openapi.json';
+        $pinnedBody = (string) json_encode([
+            'openapi' => '3.1.0',
+            'info' => ['title' => 'Pinned API', 'version' => '1'],
+            'paths' => [],
+            'components' => ['schemas' => [
+                'Base' => ['type' => 'object'],
+                'Self' => ['$ref' => 'https://specs.example.com/openapi.json#/components/schemas/Base'],
+                'UpperHost' => ['$ref' => 'https://SPECS.EXAMPLE.COM/openapi.json#/components/schemas/Base'],
+            ]],
+        ], JSON_THROW_ON_ERROR);
+
+        $fetches = 0;
+        $client = new FakeHttpClient([
+            // PSR-7 normalizes the wire URI (default port dropped,
+            // lowercase host), so every spelling above hits this one key.
+            'https://specs.example.com/openapi.json' => static function () use (&$fetches, $pinnedBody) {
+                $fetches++;
+
+                return FakeHttpClient::jsonResponse(
+                    $fetches === 1 ? $pinnedBody : '{"type":"string","x-tampered":true}',
+                );
+            },
+        ]);
+        self::configureRemote($client, [
+            'api' => new RemoteSpecSource($entryUrl, expectedSha256: hash('sha256', $pinnedBody)),
+        ]);
+
+        $spec = OpenApiSpecLoader::load('api');
+
+        $this->assertSame(1, $fetches);
+        $this->assertSame(['type' => 'object'], $spec['components']['schemas']['Self']);
+        $this->assertSame(['type' => 'object'], $spec['components']['schemas']['UpperHost']);
+    }
+
+    #[Test]
     public function load_throws_when_authorization_env_is_missing(): void
     {
         $client = new FakeHttpClient();

--- a/tests/Unit/Spec/OpenApiSpecLoaderRemoteSpecsTest.php
+++ b/tests/Unit/Spec/OpenApiSpecLoaderRemoteSpecsTest.php
@@ -1,0 +1,373 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Spec;
+
+use const JSON_THROW_ON_ERROR;
+
+use GuzzleHttp\Psr7\HttpFactory;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Studio\Gesso\Exception\InvalidOpenApiSpecException;
+use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
+use Studio\Gesso\Exception\SpecFileNotFoundException;
+use Studio\Gesso\Spec\OpenApiSpecLoader;
+use Studio\Gesso\Spec\RemoteSpecSource;
+use Studio\Gesso\Tests\Helpers\FakeHttpClient;
+
+use function file_put_contents;
+use function hash;
+use function json_encode;
+use function mkdir;
+use function putenv;
+use function rmdir;
+use function str_repeat;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+final class OpenApiSpecLoaderRemoteSpecsTest extends TestCase
+{
+    private const ENTRY_URL = 'https://specs.example.com/openapi.json';
+    private const AUTH_ENV = 'GESSO_TEST_REMOTE_SPEC_TOKEN';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiSpecLoader::reset();
+        $this->clearAuthEnv();
+    }
+
+    protected function tearDown(): void
+    {
+        OpenApiSpecLoader::reset();
+        $this->clearAuthEnv();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function configure_rejects_remote_specs_without_allow_remote_refs(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('remoteSpecs');
+
+        OpenApiSpecLoader::configure(
+            '/path/to/specs',
+            remoteSpecs: ['api' => self::ENTRY_URL],
+        );
+    }
+
+    #[Test]
+    public function configure_rejects_remote_spec_url_host_outside_allowlist(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('allowedRemoteRefHosts');
+
+        OpenApiSpecLoader::configure(
+            '/path/to/specs',
+            httpClient: new FakeHttpClient(),
+            requestFactory: new HttpFactory(),
+            allowRemoteRefs: true,
+            allowedRemoteRefHosts: ['other.example.com'],
+            remoteSpecs: ['api' => self::ENTRY_URL],
+        );
+    }
+
+    #[Test]
+    public function configure_rejects_empty_remote_spec_name(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('spec name');
+
+        OpenApiSpecLoader::configure(
+            '/path/to/specs',
+            httpClient: new FakeHttpClient(),
+            requestFactory: new HttpFactory(),
+            allowRemoteRefs: true,
+            allowedRemoteRefHosts: ['specs.example.com'],
+            remoteSpecs: ['  ' => self::ENTRY_URL],
+        );
+    }
+
+    #[Test]
+    public function load_fetches_remote_entry_document(): void
+    {
+        $client = new FakeHttpClient([
+            self::ENTRY_URL => FakeHttpClient::jsonResponse(self::minimalSpecJson('Remote API')),
+        ]);
+        self::configureRemote($client, ['api' => self::ENTRY_URL]);
+
+        $spec = OpenApiSpecLoader::load('api');
+
+        $this->assertSame('Remote API', $spec['info']['title']);
+        $this->assertSame([self::ENTRY_URL], $client->sentUrls());
+    }
+
+    #[Test]
+    public function load_accepts_remote_spec_source_object(): void
+    {
+        $client = new FakeHttpClient([
+            self::ENTRY_URL => FakeHttpClient::jsonResponse(self::minimalSpecJson('Remote API')),
+        ]);
+        self::configureRemote($client, ['api' => new RemoteSpecSource(self::ENTRY_URL)]);
+
+        $spec = OpenApiSpecLoader::load('api');
+
+        $this->assertSame('Remote API', $spec['info']['title']);
+    }
+
+    #[Test]
+    public function load_prefers_remote_mapping_over_local_file(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/openapi-remote-spec-' . uniqid('', true);
+        mkdir($tempDir);
+        file_put_contents($tempDir . '/api.json', self::minimalSpecJson('Local API'));
+
+        try {
+            $client = new FakeHttpClient([
+                self::ENTRY_URL => FakeHttpClient::jsonResponse(self::minimalSpecJson('Remote API')),
+            ]);
+            self::configureRemote($client, ['api' => self::ENTRY_URL], basePath: $tempDir);
+
+            $spec = OpenApiSpecLoader::load('api');
+
+            $this->assertSame('Remote API', $spec['info']['title']);
+        } finally {
+            @unlink($tempDir . '/api.json');
+            @rmdir($tempDir);
+        }
+    }
+
+    #[Test]
+    public function load_caches_remote_spec_per_process(): void
+    {
+        $client = new FakeHttpClient([
+            self::ENTRY_URL => FakeHttpClient::jsonResponse(self::minimalSpecJson('Remote API')),
+        ]);
+        self::configureRemote($client, ['api' => self::ENTRY_URL]);
+
+        OpenApiSpecLoader::load('api');
+        OpenApiSpecLoader::load('api');
+
+        $this->assertCount(1, $client->sentUrls());
+    }
+
+    #[Test]
+    public function load_sends_authorization_header_from_env(): void
+    {
+        putenv(self::AUTH_ENV . '=Bearer secret-token');
+
+        $seenAuthorization = null;
+        $client = new FakeHttpClient([
+            self::ENTRY_URL => static function (RequestInterface $request) use (&$seenAuthorization) {
+                $seenAuthorization = $request->getHeaderLine('Authorization');
+
+                return FakeHttpClient::jsonResponse(self::minimalSpecJson('Remote API'));
+            },
+        ]);
+        self::configureRemote($client, [
+            'api' => new RemoteSpecSource(self::ENTRY_URL, authorizationEnv: self::AUTH_ENV),
+        ]);
+
+        OpenApiSpecLoader::load('api');
+
+        $this->assertSame('Bearer secret-token', $seenAuthorization);
+    }
+
+    #[Test]
+    public function load_sends_authorization_to_same_host_relative_ref(): void
+    {
+        putenv(self::AUTH_ENV . '=Bearer secret-token');
+
+        $entry = json_encode([
+            'openapi' => '3.1.0',
+            'info' => ['title' => 'Remote API', 'version' => '1'],
+            'paths' => [],
+            'components' => ['schemas' => ['Pet' => ['$ref' => './pet.json']]],
+        ], JSON_THROW_ON_ERROR);
+
+        $authorizations = [];
+        $record = static function (RequestInterface $request, string $body) use (&$authorizations) {
+            $authorizations[(string) $request->getUri()] = $request->getHeaderLine('Authorization');
+
+            return FakeHttpClient::jsonResponse($body);
+        };
+
+        $client = new FakeHttpClient([
+            self::ENTRY_URL => static fn(RequestInterface $r) => $record($r, $entry),
+            'https://specs.example.com/pet.json' => static fn(RequestInterface $r) => $record($r, '{"type":"object"}'),
+        ]);
+        self::configureRemote($client, [
+            'api' => new RemoteSpecSource(self::ENTRY_URL, authorizationEnv: self::AUTH_ENV),
+        ]);
+
+        OpenApiSpecLoader::load('api');
+
+        $this->assertSame(
+            [
+                self::ENTRY_URL => 'Bearer secret-token',
+                'https://specs.example.com/pet.json' => 'Bearer secret-token',
+            ],
+            $authorizations,
+        );
+    }
+
+    #[Test]
+    public function load_does_not_send_authorization_to_other_hosts(): void
+    {
+        putenv(self::AUTH_ENV . '=Bearer secret-token');
+
+        $crossHostUrl = 'https://shared.example.org/error.json';
+        $entry = json_encode([
+            'openapi' => '3.1.0',
+            'info' => ['title' => 'Remote API', 'version' => '1'],
+            'paths' => [],
+            'components' => ['schemas' => ['Error' => ['$ref' => $crossHostUrl]]],
+        ], JSON_THROW_ON_ERROR);
+
+        $crossHostAuthorization = null;
+        $client = new FakeHttpClient([
+            self::ENTRY_URL => FakeHttpClient::jsonResponse($entry),
+            $crossHostUrl => static function (RequestInterface $request) use (&$crossHostAuthorization) {
+                $crossHostAuthorization = $request->getHeaderLine('Authorization');
+
+                return FakeHttpClient::jsonResponse('{"type":"object"}');
+            },
+        ]);
+        self::configureRemote(
+            $client,
+            ['api' => new RemoteSpecSource(self::ENTRY_URL, authorizationEnv: self::AUTH_ENV)],
+            allowedHosts: ['specs.example.com', 'shared.example.org'],
+        );
+
+        OpenApiSpecLoader::load('api');
+
+        $this->assertSame('', $crossHostAuthorization);
+    }
+
+    #[Test]
+    public function load_throws_when_authorization_env_is_missing(): void
+    {
+        $client = new FakeHttpClient();
+        self::configureRemote($client, [
+            'api' => new RemoteSpecSource(self::ENTRY_URL, authorizationEnv: self::AUTH_ENV),
+        ]);
+
+        try {
+            OpenApiSpecLoader::load('api');
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::RemoteSpecAuthEnvMissing, $e->reason);
+            $this->assertStringContainsString(self::AUTH_ENV, $e->getMessage());
+            $this->assertSame('api', $e->specName);
+            // No request may leave the process without the credential.
+            $this->assertSame([], $client->sentUrls());
+        }
+    }
+
+    #[Test]
+    public function load_accepts_matching_expected_sha256(): void
+    {
+        $body = self::minimalSpecJson('Pinned API');
+        $client = new FakeHttpClient([
+            self::ENTRY_URL => FakeHttpClient::jsonResponse($body),
+        ]);
+        self::configureRemote($client, [
+            'api' => new RemoteSpecSource(self::ENTRY_URL, expectedSha256: hash('sha256', $body)),
+        ]);
+
+        $spec = OpenApiSpecLoader::load('api');
+
+        $this->assertSame('Pinned API', $spec['info']['title']);
+    }
+
+    #[Test]
+    public function load_rejects_expected_sha256_mismatch(): void
+    {
+        $client = new FakeHttpClient([
+            self::ENTRY_URL => FakeHttpClient::jsonResponse(self::minimalSpecJson('Remote API')),
+        ]);
+        self::configureRemote($client, [
+            'api' => new RemoteSpecSource(self::ENTRY_URL, expectedSha256: str_repeat('0', 64)),
+        ]);
+
+        try {
+            OpenApiSpecLoader::load('api');
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::RemoteSpecHashMismatch, $e->reason);
+            $this->assertStringContainsString(str_repeat('0', 64), $e->getMessage());
+            $this->assertSame('api', $e->specName);
+        }
+    }
+
+    #[Test]
+    public function load_validates_remote_document_version(): void
+    {
+        $client = new FakeHttpClient([
+            self::ENTRY_URL => FakeHttpClient::jsonResponse('{"info":{"title":"No version","version":"1"}}'),
+        ]);
+        self::configureRemote($client, ['api' => self::ENTRY_URL]);
+
+        try {
+            OpenApiSpecLoader::load('api');
+            $this->fail('expected InvalidOpenApiSpecException');
+        } catch (InvalidOpenApiSpecException $e) {
+            $this->assertSame(InvalidOpenApiSpecReason::UnsupportedVersion, $e->reason);
+            $this->assertSame('api', $e->specName);
+        }
+    }
+
+    #[Test]
+    public function reset_clears_remote_specs(): void
+    {
+        $client = new FakeHttpClient([
+            self::ENTRY_URL => FakeHttpClient::jsonResponse(self::minimalSpecJson('Remote API')),
+        ]);
+        self::configureRemote($client, ['api' => self::ENTRY_URL]);
+        OpenApiSpecLoader::reset();
+
+        OpenApiSpecLoader::configure('/path/to/nowhere');
+
+        $this->expectException(SpecFileNotFoundException::class);
+        OpenApiSpecLoader::load('api');
+    }
+
+    /**
+     * @param array<string, RemoteSpecSource|string> $remoteSpecs
+     * @param null|list<string> $allowedHosts
+     */
+    private static function configureRemote(
+        FakeHttpClient $client,
+        array $remoteSpecs,
+        string $basePath = '/path/to/specs',
+        ?array $allowedHosts = null,
+    ): void {
+        OpenApiSpecLoader::configure(
+            $basePath,
+            httpClient: $client,
+            requestFactory: new HttpFactory(),
+            allowRemoteRefs: true,
+            allowedRemoteRefHosts: $allowedHosts ?? ['specs.example.com'],
+            remoteSpecs: $remoteSpecs,
+        );
+    }
+
+    private static function minimalSpecJson(string $title): string
+    {
+        return (string) json_encode([
+            'openapi' => '3.1.0',
+            'info' => ['title' => $title, 'version' => '1'],
+            'paths' => [],
+        ], JSON_THROW_ON_ERROR);
+    }
+
+    private function clearAuthEnv(): void
+    {
+        putenv(self::AUTH_ENV);
+        unset($_ENV[self::AUTH_ENV], $_SERVER[self::AUTH_ENV]);
+    }
+}

--- a/tests/Unit/Spec/OpenApiSpecLoaderRemoteSpecsTest.php
+++ b/tests/Unit/Spec/OpenApiSpecLoaderRemoteSpecsTest.php
@@ -249,6 +249,136 @@ final class OpenApiSpecLoaderRemoteSpecsTest extends TestCase
     }
 
     #[Test]
+    public function load_does_not_send_authorization_on_scheme_downgrade(): void
+    {
+        putenv(self::AUTH_ENV . '=Bearer secret-token');
+
+        $downgradeUrl = 'http://specs.example.com/private.json';
+        $entry = json_encode([
+            'openapi' => '3.1.0',
+            'info' => ['title' => 'Remote API', 'version' => '1'],
+            'paths' => [],
+            'components' => ['schemas' => ['Private' => ['$ref' => $downgradeUrl]]],
+        ], JSON_THROW_ON_ERROR);
+
+        $downgradeAuthorization = null;
+        $client = new FakeHttpClient([
+            self::ENTRY_URL => FakeHttpClient::jsonResponse($entry),
+            $downgradeUrl => static function (RequestInterface $request) use (&$downgradeAuthorization) {
+                $downgradeAuthorization = $request->getHeaderLine('Authorization');
+
+                return FakeHttpClient::jsonResponse('{"type":"object"}');
+            },
+        ]);
+        self::configureRemote($client, [
+            'api' => new RemoteSpecSource(self::ENTRY_URL, authorizationEnv: self::AUTH_ENV),
+        ]);
+
+        OpenApiSpecLoader::load('api');
+
+        $this->assertSame('', $downgradeAuthorization);
+    }
+
+    #[Test]
+    public function load_does_not_send_authorization_to_other_ports(): void
+    {
+        putenv(self::AUTH_ENV . '=Bearer secret-token');
+
+        $otherPortUrl = 'https://specs.example.com:8443/private.json';
+        $entry = json_encode([
+            'openapi' => '3.1.0',
+            'info' => ['title' => 'Remote API', 'version' => '1'],
+            'paths' => [],
+            'components' => ['schemas' => ['Private' => ['$ref' => $otherPortUrl]]],
+        ], JSON_THROW_ON_ERROR);
+
+        $otherPortAuthorization = null;
+        $client = new FakeHttpClient([
+            self::ENTRY_URL => FakeHttpClient::jsonResponse($entry),
+            $otherPortUrl => static function (RequestInterface $request) use (&$otherPortAuthorization) {
+                $otherPortAuthorization = $request->getHeaderLine('Authorization');
+
+                return FakeHttpClient::jsonResponse('{"type":"object"}');
+            },
+        ]);
+        self::configureRemote($client, [
+            'api' => new RemoteSpecSource(self::ENTRY_URL, authorizationEnv: self::AUTH_ENV),
+        ]);
+
+        OpenApiSpecLoader::load('api');
+
+        $this->assertSame('', $otherPortAuthorization);
+    }
+
+    #[Test]
+    public function load_sends_authorization_when_ref_spells_out_the_default_port(): void
+    {
+        putenv(self::AUTH_ENV . '=Bearer secret-token');
+
+        $explicitPortUrl = 'https://specs.example.com:443/pet.json';
+        $entry = json_encode([
+            'openapi' => '3.1.0',
+            'info' => ['title' => 'Remote API', 'version' => '1'],
+            'paths' => [],
+            'components' => ['schemas' => ['Pet' => ['$ref' => $explicitPortUrl]]],
+        ], JSON_THROW_ON_ERROR);
+
+        $explicitPortAuthorization = null;
+        $client = new FakeHttpClient([
+            self::ENTRY_URL => FakeHttpClient::jsonResponse($entry),
+            // PSR-7 URI normalization drops the default port from the wire
+            // request, so the mock is keyed on the normalized form.
+            'https://specs.example.com/pet.json' => static function (RequestInterface $request) use (&$explicitPortAuthorization) {
+                $explicitPortAuthorization = $request->getHeaderLine('Authorization');
+
+                return FakeHttpClient::jsonResponse('{"type":"object"}');
+            },
+        ]);
+        self::configureRemote($client, [
+            'api' => new RemoteSpecSource(self::ENTRY_URL, authorizationEnv: self::AUTH_ENV),
+        ]);
+
+        OpenApiSpecLoader::load('api');
+
+        $this->assertSame('Bearer secret-token', $explicitPortAuthorization);
+    }
+
+    #[Test]
+    public function load_reuses_the_verified_entry_document_for_self_refs(): void
+    {
+        $pinnedBody = (string) json_encode([
+            'openapi' => '3.1.0',
+            'info' => ['title' => 'Pinned API', 'version' => '1'],
+            'paths' => [],
+            'components' => ['schemas' => [
+                'Base' => ['type' => 'object'],
+                'Self' => ['$ref' => self::ENTRY_URL . '#/components/schemas/Base'],
+            ]],
+        ], JSON_THROW_ON_ERROR);
+
+        $fetches = 0;
+        $client = new FakeHttpClient([
+            self::ENTRY_URL => static function () use (&$fetches, $pinnedBody) {
+                $fetches++;
+
+                // A second fetch would bypass the SHA-256 pin: serve
+                // different bytes so a refetch cannot pass unnoticed.
+                return FakeHttpClient::jsonResponse(
+                    $fetches === 1 ? $pinnedBody : '{"type":"string","x-tampered":true}',
+                );
+            },
+        ]);
+        self::configureRemote($client, [
+            'api' => new RemoteSpecSource(self::ENTRY_URL, expectedSha256: hash('sha256', $pinnedBody)),
+        ]);
+
+        $spec = OpenApiSpecLoader::load('api');
+
+        $this->assertSame(1, $fetches);
+        $this->assertSame(['type' => 'object'], $spec['components']['schemas']['Self']);
+    }
+
+    #[Test]
     public function load_throws_when_authorization_env_is_missing(): void
     {
         $client = new FakeHttpClient();

--- a/tests/Unit/Spec/RemoteSpecSourceTest.php
+++ b/tests/Unit/Spec/RemoteSpecSourceTest.php
@@ -83,6 +83,29 @@ final class RemoteSpecSourceTest extends TestCase
     }
 
     #[Test]
+    public function redacts_fragment_contents_in_rejection_messages(): void
+    {
+        try {
+            new RemoteSpecSource('https://specs.example.com/openapi.json#access_token=top-secret');
+            $this->fail('expected InvalidArgumentException');
+        } catch (InvalidArgumentException $e) {
+            $this->assertStringNotContainsString('top-secret', $e->getMessage());
+            $this->assertStringContainsString('https://specs.example.com/openapi.json#[redacted]', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function redacts_fragment_contents_in_non_http_rejection_messages(): void
+    {
+        try {
+            new RemoteSpecSource('ftp://specs.example.com/openapi.json#access_token=top-secret');
+            $this->fail('expected InvalidArgumentException');
+        } catch (InvalidArgumentException $e) {
+            $this->assertStringNotContainsString('top-secret', $e->getMessage());
+        }
+    }
+
+    #[Test]
     public function rejects_empty_authorization_env_name(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Unit/Spec/RemoteSpecSourceTest.php
+++ b/tests/Unit/Spec/RemoteSpecSourceTest.php
@@ -51,6 +51,15 @@ final class RemoteSpecSourceTest extends TestCase
     }
 
     #[Test]
+    public function rejects_url_with_fragment(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('fragment');
+
+        new RemoteSpecSource('https://specs.example.com/openapi.json#entry');
+    }
+
+    #[Test]
     public function rejects_empty_authorization_env_name(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Unit/Spec/RemoteSpecSourceTest.php
+++ b/tests/Unit/Spec/RemoteSpecSourceTest.php
@@ -60,6 +60,29 @@ final class RemoteSpecSourceTest extends TestCase
     }
 
     #[Test]
+    public function redacts_query_values_in_rejection_messages(): void
+    {
+        try {
+            new RemoteSpecSource('https://specs.example.com/openapi.json?token=top-secret#entry');
+            $this->fail('expected InvalidArgumentException');
+        } catch (InvalidArgumentException $e) {
+            $this->assertStringNotContainsString('top-secret', $e->getMessage());
+            $this->assertStringContainsString('token=[redacted]', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function redacts_userinfo_in_rejection_messages(): void
+    {
+        try {
+            new RemoteSpecSource('ftp://user:hunter2@specs.example.com/openapi.json');
+            $this->fail('expected InvalidArgumentException');
+        } catch (InvalidArgumentException $e) {
+            $this->assertStringNotContainsString('hunter2', $e->getMessage());
+        }
+    }
+
+    #[Test]
     public function rejects_empty_authorization_env_name(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/Unit/Spec/RemoteSpecSourceTest.php
+++ b/tests/Unit/Spec/RemoteSpecSourceTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Spec;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Spec\RemoteSpecSource;
+
+use function str_repeat;
+
+final class RemoteSpecSourceTest extends TestCase
+{
+    #[Test]
+    public function constructs_with_url_only(): void
+    {
+        $source = new RemoteSpecSource('https://specs.example.com/openapi.json');
+
+        $this->assertSame('https://specs.example.com/openapi.json', $source->url);
+        $this->assertNull($source->authorizationEnv);
+        $this->assertNull($source->expectedSha256);
+    }
+
+    #[Test]
+    public function rejects_non_http_url(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('http:// or https://');
+
+        new RemoteSpecSource('file:///etc/openapi.json');
+    }
+
+    #[Test]
+    public function rejects_relative_url(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('http:// or https://');
+
+        new RemoteSpecSource('openapi/front.json');
+    }
+
+    #[Test]
+    public function rejects_url_without_host(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('host');
+
+        new RemoteSpecSource('https:///openapi.json');
+    }
+
+    #[Test]
+    public function rejects_empty_authorization_env_name(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('authorizationEnv');
+
+        new RemoteSpecSource('https://specs.example.com/openapi.json', authorizationEnv: '  ');
+    }
+
+    #[Test]
+    public function rejects_malformed_expected_sha256(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('expectedSha256');
+
+        new RemoteSpecSource('https://specs.example.com/openapi.json', expectedSha256: 'abc123');
+    }
+
+    #[Test]
+    public function normalizes_expected_sha256_to_lowercase(): void
+    {
+        $digest = str_repeat('AB', 32);
+        $source = new RemoteSpecSource('https://specs.example.com/openapi.json', expectedSha256: $digest);
+
+        $this->assertSame(str_repeat('ab', 32), $source->expectedSha256);
+    }
+}

--- a/tests/fixtures/compatibility/v2-public-api.json
+++ b/tests/fixtures/compatibility/v2-public-api.json
@@ -1408,6 +1408,8 @@
             "RemoteRefDisallowed": null,
             "RemoteRefHostDisallowed": null,
             "RemoteRefFetchFailed": null,
+            "RemoteSpecAuthEnvMissing": null,
+            "RemoteSpecHashMismatch": null,
             "HttpClientNotConfigured": null,
             "FileSchemeNotSupported": null,
             "EmptyRef": null,
@@ -8172,6 +8174,15 @@
                             "value": 10485760
                         },
                         "attributes": []
+                    },
+                    {
+                        "name": "remoteSpecs",
+                        "type": "array",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": [],
+                        "attributes": []
                     }
                 ]
             },
@@ -8274,6 +8285,91 @@
                     "attributes": [],
                     "parameters": []
                 }
+            }
+        }
+    },
+    "Studio\\Gesso\\Spec\\RemoteSpecSource": {
+        "kind": "class",
+        "final": true,
+        "abstract": false,
+        "readonly": true,
+        "instantiable": true,
+        "constructor": {
+            "kind": "declared",
+            "visibility": "public"
+        },
+        "parent": null,
+        "interfaces": [],
+        "traits": [],
+        "attributes": [],
+        "backing_type": null,
+        "cases": [],
+        "constants": [],
+        "properties": {
+            "authorizationEnv": {
+                "type": "?string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "expectedSha256": {
+                "type": "?string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            },
+            "url": {
+                "type": "string",
+                "static": false,
+                "readonly": true,
+                "default": {
+                    "unavailable": true
+                }
+            }
+        },
+        "methods": {
+            "__construct": {
+                "static": false,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": null,
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "url",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "authorizationEnv",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "expectedSha256",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    }
+                ]
             }
         }
     },


### PR DESCRIPTION
## Summary

Adds a `remoteSpecs` parameter to `OpenApiSpecLoader::configure()` so a named spec can resolve to an HTTP(S) entry document — including a private GitHub repository — instead of a local file. The new public `Spec\RemoteSpecSource` DTO optionally sources the `Authorization` header from an environment variable and pins the document with an expected SHA-256.

## Why

Teams with a central spec registry or a separate spec repository don't vendor the spec into every service repo; until now the entry document had to be a local file even with remote $refs enabled. Fixes #407.

Design notes:

- **Same opt-in as HTTP $refs**: `remoteSpecs` requires `allowRemoteRefs: true`, the PSR-18/PSR-17 pair, and every URL's host in `allowedRemoteRefHosts` (all enforced loudly at `configure()` time). Redirect rejection, size limits, and URL redaction reuse the existing `HttpRefLoader` boundary; no new runtime dependencies.
- **Provider-agnostic auth**: the env variable's value is sent verbatim as the `Authorization` header (covers GitHub PATs and generic bearer registries). Missing/empty env fails with the new `RemoteSpecAuthEnvMissing` reason before any request is sent; the value never appears in diagnostics.
- **Origin-scoped credentials**: the header is sent only to the entry document's origin — scheme, host, and effective port (RFC 6454). A cross-host $ref (even allowlisted), another port on the same host, or an http:// downgrade never carries it.
- **Pinning**: optional `expectedSha256` verifies the raw bytes before parsing (`RemoteSpecHashMismatch`), making the docs' caching/pinning recommendation actionable.
- Default behavior (local files only) is unchanged; a remote-mapped name deterministically never consults the filesystem.

## Verification

- [x] `composer test` passes (2495 tests, incl. 22 new: source validation, configure pairing, precedence, per-process caching, auth-header scoping, missing-env, sha256 pin, remote version validation, reset)
- [x] `composer stan` passes
- [x] `composer cs-check` passes
- Public-API baseline regenerated via `scripts/export-public-api.php --write`; the v1→v2 contract-change test documents the three additions (2 enum cases, 1 parameter, 1 class).

## Notes for reviewers

- Relative $refs inside a remote entry document already resolved against the URL per RFC 3986; this PR only adds the entry-document fetch and header injection on that existing path.
- `configure()` must be called from the PHPUnit bootstrap when using `remoteSpecs` (the extension's `spec_base_path` parameter would re-configure the loader without the HTTP client) — documented in `docs/setup.md`.
- The env value is `trim()`ed before use so trailing newlines from CI secret stores don't produce an invalid header.


---

Review follow-up (pushed as `fix(spec): scope remote spec credentials to the entry origin`):

- Authorization scope tightened from host to origin (scheme + host + effective port); regression tests cover the http:// downgrade, the alternate port, and the explicit-`:443`-still-sends cases.
- The pin-verified entry document is now seeded into the ref resolver's document cache, so an absolute $ref back to the entry URL reuses the verified bytes instead of refetching past the SHA-256 pin; regression test serves tampered bytes on a second fetch and asserts a single fetch.


Second review follow-up (`fix(spec): key the remote document cache by the normalized wire uri`):

- The remote document cache / cycle-detection key is now the PSR-7 request URI's string form instead of the trimmed raw ref. `UriInterface` contracts (lowercase scheme/host, `getPort()` null for the scheme default) collapse equivalent spellings — explicit `:443` vs none, host case — into one key, so a differently-spelled ref to the pin-verified entry document can no longer trigger a second, unverified fetch. This is RFC 3986 §6.2.3 semantics-preserving normalization, and matches what PSR-7 clients already send on the wire. Regression test covers both spellings against a tampering second response.


Third review follow-up (`fix(spec): reject fragments in remote entry urls and cache keys`):

- A `RemoteSpecSource` URL now rejects fragments at configure time (`#...` is client-side only; the entry document is always loaded whole), and `HttpRefLoader` strips any fragment from the request URI and cache key as defence in depth — a fragment spelling can no longer produce a second cache key for the same wire resource and refetch past the SHA-256 pin. Regression tests cover both layers.


Fourth review follow-up (`fix(spec): redact remote spec urls in configure-time diagnostics`):

- `RemoteSpecSource` rejection messages now pass the URL through the same `redactSensitiveUrlData()` boundary as remote $ref diagnostics (userinfo removed, query values `[redacted]`), and the raw-URL parameter slot is replaced before throwing so stack traces stay clean under `zend.exception_ignore_args=Off`. Regression tests assert the secret never appears for both query-token and userinfo spellings.


Fifth review follow-up (`fix(spec): hide fragment contents in remote spec diagnostics`):

- `RemoteSpecSource` rejection messages now replace the URL fragment with `#[redacted]` — the shared redaction keeps fragments for $ref JSON-pointer diagnostics, but an entry URL's fragment is rejected wholesale and may carry an OAuth-style token, so only its presence is shown. Regression tests cover the fragment-rejection and non-http paths.
