### PR TITLE
feat(coverage): create the parent directory for coverage output paths instead of hard-failing

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -73,7 +73,7 @@ Add the coverage extension to your `phpunit.xml`:
 | `strip_prefixes` | No | `[]` | Comma-separated prefixes to strip from request paths (e.g., `/api`) |
 | `specs` | No | `front` | Comma-separated spec names for coverage tracking |
 | `output_file` | No | — | File path to write Markdown coverage report (relative paths resolve from `getcwd()`). Skipped on partial runs — see [Partial test runs](ci.md#partial-test-runs-filter-testsuite-path-args-) |
-| `junit_output` | No | — | File path to write JUnit XML coverage report (for CI dashboards — GitLab CI, Jenkins, SonarQube, Bitrise). Empty value or unwritable parent directory is FATAL at bootstrap. See [Coverage output formats](ci.md#coverage-output-formats) |
+| `junit_output` | No | — | File path to write JUnit XML coverage report (for CI dashboards — GitLab CI, Jenkins, SonarQube, Bitrise). A missing parent directory is created automatically at bootstrap (applies to `json_output` / `html_output` too); an empty value, a failed creation, or an unwritable parent directory is FATAL at bootstrap. See [Coverage output formats](ci.md#coverage-output-formats) |
 | `json_output` | No | — | File path to write machine-readable JSON coverage report (custom dashboards, analytics, scripted gating). Schema: [`coverage-json-schema.md`](coverage-json-schema.md) |
 | `html_output` | No | — | File path to write self-contained HTML coverage report (PR comments, CI artifact preview, offline review). See [`coverage-html-output.md`](coverage-html-output.md) |
 | `console_output` | No | `default` | Console output mode: `default`, `all`, `uncovered_only`, or `active_only` (overridden by `OPENAPI_CONSOLE_OUTPUT` env var) |

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -63,6 +63,7 @@ use function is_string;
 use function is_writable;
 use function mb_strtolower;
 use function method_exists;
+use function mkdir;
 use function sprintf;
 use function str_starts_with;
 use function sys_get_temp_dir;
@@ -813,6 +814,13 @@ final class OpenApiCoverageExtension implements Extension
      * directory writability is checked here so misconfigurations surface at
      * bootstrap rather than as a runtime WARN after tests ran.
      *
+     * A missing parent directory is not treated as a misconfiguration (issue
+     * #448): the conventional target is a gitignored build directory that
+     * does not exist on a fresh clone or CI runner, so bootstrap creates it
+     * recursively. Only a failed creation (permissions, a file occupying the
+     * path, a read-only mount) or an existing-but-unwritable directory stays
+     * FATAL.
+     *
      * Note the bootstrap-vs-runtime severity asymmetry: the parent-dir check
      * here hard-fails the run, but a `dirname()` that disappears mid-run will
      * trip the dispatch loop's existing `file_put_contents() === false` branch,
@@ -846,14 +854,31 @@ final class OpenApiCoverageExtension implements Extension
             $raw = getcwd() . '/' . $raw;
         }
 
+        // Single emission site on purpose: the identity-neutral
+        // "[OpenAPI Coverage]" diagnostic category is frozen at its v1.9
+        // shape (see DiagnosticPrefixesBaselineTest), so both failure
+        // branches share one prefixed literal.
         $parentDir = dirname($raw);
-        if (!is_dir($parentDir) || !is_writable($parentDir)) {
+        $reason = null;
+        if (!is_dir($parentDir) && !@mkdir($parentDir, 0o777, true) && !is_dir($parentDir)) {
             $reason = sprintf(
-                '%s=%s: parent directory %s does not exist or is not writable.',
+                '%s=%s: parent directory %s does not exist and could not be created. '
+                . 'Create it manually or point the parameter at a writable location.',
                 $name,
                 $raw,
                 $parentDir,
             );
+        } elseif (!is_writable($parentDir)) {
+            $reason = sprintf(
+                '%s=%s: parent directory %s is not writable. '
+                . 'Fix its permissions or point the parameter at a writable location.',
+                $name,
+                $raw,
+                $parentDir,
+            );
+        }
+
+        if ($reason !== null) {
             self::writeStderr("[OpenAPI Coverage] FATAL: {$reason}\n");
             self::appendGithubStepSummaryFatalBlock($githubSummaryPath, $name, $reason);
 

--- a/tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php
+++ b/tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php
@@ -29,16 +29,21 @@ use Studio\Gesso\Validation\Strict\StrictRequiredPerCallMode;
 use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
 use Studio\Gesso\Validation\Support\DiscriminatorEnforcement;
 
+use function chmod;
 use function fclose;
 use function file_get_contents;
 use function fopen;
 use function getcwd;
+use function is_writable;
+use function mkdir;
 use function restore_error_handler;
 use function rewind;
+use function rmdir;
 use function set_error_handler;
 use function stream_get_contents;
 use function sys_get_temp_dir;
 use function tempnam;
+use function uniqid;
 use function unlink;
 
 class OpenApiCoverageExtensionTest extends TestCase
@@ -948,11 +953,12 @@ class OpenApiCoverageExtensionTest extends TestCase
     }
 
     #[Test]
-    public function bootstrap_fatal_when_junit_output_parent_dir_not_writable(): void
+    public function bootstrap_fatal_when_junit_output_parent_dir_cannot_be_created(): void
     {
         // Surface the misconfiguration at bootstrap rather than as a runtime
         // file_put_contents() WARN after every test ran. /proc/0 does not
-        // exist on macOS and is unwritable on Linux — fails closed either way.
+        // exist on macOS and is unwritable on Linux, so the issue #448
+        // auto-creation attempt fails closed either way.
         $extension = new OpenApiCoverageExtension();
         $parameters = ParameterCollection::fromArray([
             'spec_base_path' => __DIR__ . '/../../fixtures/specs',
@@ -965,7 +971,7 @@ class OpenApiCoverageExtensionTest extends TestCase
             $this->fail('expected InvalidCoverageOutputPathException');
         } catch (InvalidCoverageOutputPathException $e) {
             $this->assertSame('junit_output', $e->parameterName);
-            $this->assertStringContainsString('not writable', $e->getMessage());
+            $this->assertStringContainsString('could not be created', $e->getMessage());
         }
 
         $this->assertStringContainsString('FATAL', $this->readStderr());
@@ -996,7 +1002,7 @@ class OpenApiCoverageExtensionTest extends TestCase
     }
 
     #[Test]
-    public function bootstrap_fatal_when_html_output_parent_dir_not_writable(): void
+    public function bootstrap_fatal_when_html_output_parent_dir_cannot_be_created(): void
     {
         // Parity with the junit_output / json_output checks — the shared
         // resolveOutputPathParameter() helper should fail closed for
@@ -1013,14 +1019,14 @@ class OpenApiCoverageExtensionTest extends TestCase
             $this->fail('expected InvalidCoverageOutputPathException');
         } catch (InvalidCoverageOutputPathException $e) {
             $this->assertSame('html_output', $e->parameterName);
-            $this->assertStringContainsString('not writable', $e->getMessage());
+            $this->assertStringContainsString('could not be created', $e->getMessage());
         }
 
         $this->assertStringContainsString('FATAL', $this->readStderr());
     }
 
     #[Test]
-    public function bootstrap_fatal_when_json_output_parent_dir_not_writable(): void
+    public function bootstrap_fatal_when_json_output_parent_dir_cannot_be_created(): void
     {
         // Parity with the junit_output check — the shared
         // resolveOutputPathParameter() helper should fail closed for
@@ -1038,7 +1044,143 @@ class OpenApiCoverageExtensionTest extends TestCase
             $this->fail('expected InvalidCoverageOutputPathException');
         } catch (InvalidCoverageOutputPathException $e) {
             $this->assertSame('json_output', $e->parameterName);
+            $this->assertStringContainsString('could not be created', $e->getMessage());
+        }
+
+        $this->assertStringContainsString('FATAL', $this->readStderr());
+    }
+
+    #[Test]
+    public function bootstrap_creates_missing_parent_directory_for_json_output(): void
+    {
+        // Issue #448: json_output pointing into a gitignored build directory
+        // must work on a fresh clone. The parent chain does not exist yet —
+        // bootstrap should mkdir it recursively instead of hard-failing.
+        $base = sys_get_temp_dir() . '/gesso-448-' . uniqid();
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'json_output' => $base . '/build/openapi-coverage.json',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+
+            $this->assertDirectoryExists($base . '/build');
+            $this->assertSame('', $this->readStderr());
+        } finally {
+            @rmdir($base . '/build');
+            @rmdir($base);
+        }
+    }
+
+    #[Test]
+    public function bootstrap_creates_missing_parent_directory_for_junit_output(): void
+    {
+        // Issue #448 parity: the shared resolveOutputPathParameter() helper
+        // should auto-create for junit_output too.
+        $base = sys_get_temp_dir() . '/gesso-448-' . uniqid();
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'junit_output' => $base . '/build/coverage.junit.xml',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+
+            $this->assertDirectoryExists($base . '/build');
+            $this->assertSame('', $this->readStderr());
+        } finally {
+            @rmdir($base . '/build');
+            @rmdir($base);
+        }
+    }
+
+    #[Test]
+    public function bootstrap_creates_missing_parent_directory_for_html_output(): void
+    {
+        // Issue #448 parity: the shared resolveOutputPathParameter() helper
+        // should auto-create for html_output too.
+        $base = sys_get_temp_dir() . '/gesso-448-' . uniqid();
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'html_output' => $base . '/build/coverage.html',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+
+            $this->assertDirectoryExists($base . '/build');
+            $this->assertSame('', $this->readStderr());
+        } finally {
+            @rmdir($base . '/build');
+            @rmdir($base);
+        }
+    }
+
+    #[Test]
+    public function bootstrap_fatal_when_json_output_parent_path_is_occupied_by_a_file(): void
+    {
+        // A file sitting where the parent directory should be is a genuine
+        // misconfiguration: mkdir() cannot succeed, so the issue #448
+        // auto-creation must fail closed with a message that names the fix.
+        $file = tempnam(sys_get_temp_dir(), 'gesso-448-occupied-');
+        $this->assertNotFalse($file);
+
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'json_output' => $file . '/openapi-coverage.json',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+            $this->fail('expected InvalidCoverageOutputPathException');
+        } catch (InvalidCoverageOutputPathException $e) {
+            $this->assertSame('json_output', $e->parameterName);
+            $this->assertStringContainsString('could not be created', $e->getMessage());
+            $this->assertStringContainsString('point the parameter at a writable location', $e->getMessage());
+        } finally {
+            @unlink($file);
+        }
+
+        $this->assertStringContainsString('FATAL', $this->readStderr());
+    }
+
+    #[Test]
+    public function bootstrap_fatal_when_json_output_parent_dir_exists_but_not_writable(): void
+    {
+        // The pre-#448 fail-loud policy must survive auto-creation: an
+        // existing directory without write permission is still FATAL.
+        $base = sys_get_temp_dir() . '/gesso-448-readonly-' . uniqid();
+        $this->assertTrue(mkdir($base, 0o555, true));
+        if (is_writable($base)) {
+            @rmdir($base);
+            $this->markTestSkipped('running as a user that ignores directory permissions (root)');
+        }
+
+        $extension = new OpenApiCoverageExtension();
+        $parameters = ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'refs-valid',
+            'json_output' => $base . '/openapi-coverage.json',
+        ]);
+
+        try {
+            $extension->setupExtension(null, $parameters, null);
+            $this->fail('expected InvalidCoverageOutputPathException');
+        } catch (InvalidCoverageOutputPathException $e) {
+            $this->assertSame('json_output', $e->parameterName);
             $this->assertStringContainsString('not writable', $e->getMessage());
+        } finally {
+            @chmod($base, 0o755);
+            @rmdir($base);
         }
 
         $this->assertStringContainsString('FATAL', $this->readStderr());


### PR DESCRIPTION
## Summary

`json_output` / `html_output` / `junit_output` pointing into a not-yet-existing directory (typically a gitignored `build/`) no longer FATALs at bootstrap: the parent directory is now created recursively. Failed creation, an existing-but-unwritable directory, and empty values stay FATAL, and both FATAL messages now name the fix.

## Why

The bootstrap check conflated "misconfigured path" with "conventional build directory that does not exist on a fresh clone / CI runner", forcing consumers to commit a `.gitignore` placeholder just to satisfy the check. Fixes #448.

## Verification

TDD: added failing tests first (auto-creation per parameter, mkdir-failure via a file occupying the parent path, existing read-only directory), then implemented.

- [x] `composer test` passes
- [x] `composer stan` passes
- [x] `composer cs-check` passes

## Notes for reviewers

- The two failure branches share a single `[OpenAPI Coverage] FATAL:` emission site on purpose: `DiagnosticPrefixesBaselineTest` freezes identity-neutral prefix counts at their v1.9 shape, so splitting the diagnostic into two prefixed literals would break the parity fixture.
- The read-only-directory test skips when running as root (root ignores directory permission bits).