### PR TITLE
fix(coverage): skip the threshold gate on partial runs

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -114,10 +114,23 @@ stage selections that bypass the `TestSuite\Filtered` event):
 
 Skipped artifacts: `output_file`, `junit_output`, `json_output`,
 `html_output`, and `GITHUB_STEP_SUMMARY`. Console rendering still prints
-(it's transient, scoped to your terminal), and the optional coverage
-threshold gate (`min_endpoint_coverage` / `min_response_coverage`) still
-evaluates against the in-memory subset — re-run the full suite to refresh
-the persistent doc.
+(it's transient, scoped to your terminal). The optional coverage threshold
+gate (`min_endpoint_coverage` / `min_response_coverage`) is also skipped —
+a subset cannot prove a suite-wide coverage rate, so evaluating it would
+fail every suite-selecting run (issue #438). A one-line NOTE names the
+selection signal, mirroring the `strict_required` skip:
+
+```text
+[Gesso] NOTE: the coverage threshold gate is skipped on partial runs
+(--testsuite) because a subset cannot prove a suite-wide coverage rate.
+Run the full suite to evaluate the gate.
+```
+
+This means a CI matrix that shards by `--testsuite` can keep the gate
+configured in the shared `phpunit.xml`: shard jobs skip it, and only a
+full-suite run (or the `coverage:merge` step for parallel runs) evaluates
+it. If a `--testsuite` selection *is* your canonical full run, see the
+`default_testsuite_as_full` opt-in below.
 
 ```text
 $ vendor/bin/phpunit --filter UserTest

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -138,6 +138,8 @@ Failure looks like:
 
 Out-of-range or non-numeric values produce a `WARNING` to stderr and skip that gate (rather than silently treating the misconfiguration as `0%`).
 
+On a partial run (`--filter`, `--testsuite`, path args, …) the gate is skipped with a one-line NOTE instead of evaluating — a subset cannot prove a suite-wide coverage rate. See [Partial test runs](ci.md#partial-test-runs-filter-testsuite-path-args-) for details.
+
 For paratest / `pest --parallel`, the merge CLI accepts the same options as flags:
 
 ```bash

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -94,11 +94,12 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
      * @param null|PartialRunDecision $partialRun Issue #221: when non-null (the run is partial), the subscriber
      *                                            skips every persistent file write (output_file, junit_output,
      *                                            json_output, html_output, GITHUB_STEP_SUMMARY) and emits one
-     *                                            stderr WARNING listing the skipped targets. Console rendering
-     *                                            and the threshold gate are unaffected — they read in-memory
-     *                                            state and don't risk overwriting a committed doc with subset
-     *                                            data. `null` (the backwards-compat default) means full-run
-     *                                            behavior.
+     *                                            stderr WARNING listing the skipped targets. Issue #438: the
+     *                                            threshold gate is skipped too (with a one-line NOTE) — a subset
+     *                                            cannot prove a suite-wide coverage rate, so evaluating it would
+     *                                            fail every suite-selecting CI shard. Console rendering is
+     *                                            unaffected — it reads in-memory state and is transient. `null`
+     *                                            (the backwards-compat default) means full-run behavior.
      */
     public function __construct(
         private array $specs,
@@ -345,6 +346,16 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
             return;
         }
 
+        // Issue #438 alignment with the other partial-aware gates: a subset
+        // run cannot prove a suite-wide coverage rate — `--testsuite=Feature`
+        // reports the Feature-only rate against a threshold set for the whole
+        // suite. Skip and say why, matching strict_required's shape.
+        if ($this->partialRun !== null) {
+            $this->emitThresholdGatePartialRunNote();
+
+            return;
+        }
+
         $evaluation = CoverageThresholdEvaluator::evaluate(
             $results,
             $this->minEndpointCoverage,
@@ -393,6 +404,16 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
             return;
         }
 
+        // Issue #438: `--testsuite=Unit` records zero contract coverage —
+        // correctly. There is nothing wrong with the run; the gate simply
+        // cannot be evaluated from it, so failing (or even warning) here
+        // would punish every suite-selecting CI shard.
+        if ($this->partialRun !== null) {
+            $this->emitThresholdGatePartialRunNote();
+
+            return;
+        }
+
         $severity = $this->minCoverageStrict ? 'FATAL' : 'WARNING';
         $this->writeStderr(sprintf(
             "[OpenAPI Coverage] %s: no contract test coverage was recorded; configured threshold cannot be evaluated.\n",
@@ -415,6 +436,28 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         }
 
         exit(1);
+    }
+
+    /**
+     * One-line NOTE mirroring the strict_required partial-run skip, so a
+     * user who configured the gate can see why no FAIL/WARN/FATAL line
+     * appeared. Callers guarantee a threshold is configured and
+     * `$partialRun` is non-null. Uses the branded `[Gesso]` prefix per the
+     * v2 identity policy: identity-neutral categories (here
+     * `[OpenAPI Coverage]`) are frozen at their v1.9 shape.
+     */
+    private function emitThresholdGatePartialRunNote(): void
+    {
+        $partialRun = $this->partialRun;
+        if ($partialRun === null) {
+            return;
+        }
+
+        $this->writeStderr(sprintf(
+            '[Gesso] NOTE: the coverage threshold gate is skipped on partial runs (%s) '
+            . "because a subset cannot prove a suite-wide coverage rate. Run the full suite to evaluate the gate.\n",
+            $partialRun->reason,
+        ));
     }
 
     private function writeWorkerSidecar(string $token): void

--- a/tests/Unit/PHPUnit/CoverageReportSubscriberPartialRunTest.php
+++ b/tests/Unit/PHPUnit/CoverageReportSubscriberPartialRunTest.php
@@ -35,7 +35,8 @@ use function unlink;
  * skip every persistent file write (output_file, junit_output,
  * json_output, html_output, GITHUB_STEP_SUMMARY) and emit a single
  * stderr WARNING enumerating the skipped targets. Console rendering
- * and the threshold gate must remain unaffected.
+ * must remain unaffected; the threshold gate skips with a NOTE
+ * (issue #438).
  */
 class CoverageReportSubscriberPartialRunTest extends TestCase
 {
@@ -202,12 +203,12 @@ class CoverageReportSubscriberPartialRunTest extends TestCase
     }
 
     #[Test]
-    public function partial_run_still_evaluates_threshold_gate(): void
+    public function partial_run_skips_threshold_gate(): void
     {
-        // The threshold gate runs against in-memory results; it does not
-        // touch persistent files. Issue #221 is about persistent docs, so
-        // the gate keeps firing under partial runs (consumers who wanted
-        // gate exemption already opt out via non-strict mode).
+        // Issue #438 (reverses the original issue #221 stance): a subset
+        // cannot prove a suite-wide coverage rate, so the gate skips on
+        // partial runs like strict_required and baseline staleness do,
+        // leaving a NOTE in place of the FAIL/exit.
         $this->recordOneEndpoint();
 
         $exitCode = null;
@@ -233,8 +234,10 @@ class CoverageReportSubscriberPartialRunTest extends TestCase
         $subscriber->notify($this->fakeExecutionFinished());
         ob_get_clean();
 
-        $this->assertSame(1, $exitCode, 'threshold gate must still fire on partial runs');
-        $this->assertStringContainsString('[OpenAPI Coverage] FAIL:', $stderr);
+        $this->assertNull($exitCode, 'threshold gate must not fire on partial runs');
+        $this->assertStringNotContainsString('FAIL:', $stderr);
+        $this->assertStringContainsString('[Gesso] NOTE:', $stderr);
+        $this->assertStringContainsString('skipped on partial runs', $stderr);
     }
 
     #[Test]

--- a/tests/Unit/PHPUnit/CoverageReportSubscriberThresholdTest.php
+++ b/tests/Unit/PHPUnit/CoverageReportSubscriberThresholdTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Studio\Gesso\Coverage\OpenApiCoverageTracker;
+use Studio\Gesso\Internal\PartialRunDecision;
 use Studio\Gesso\PHPUnit\ConsoleOutput;
 use Studio\Gesso\PHPUnit\CoverageReportSubscriber;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
@@ -363,6 +364,161 @@ class CoverageReportSubscriberThresholdTest extends TestCase
         $this->assertNull($exitCode);
         $this->assertStringNotContainsString('FAIL:', $stderr);
         $this->assertStringNotContainsString('WARN:', $stderr);
+    }
+
+    #[Test]
+    public function partial_run_skips_strict_threshold_gate_with_note(): void
+    {
+        // Issue #438: a subset run cannot prove a suite-wide coverage rate
+        // any more than it can prove a strict_required intersection. The
+        // gate must skip (with a NOTE naming the selection signal) instead
+        // of failing a correct-but-partial run.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        $exitCode = null;
+        $stderr = '';
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            sidecarDir: $this->tmpDir,
+            minEndpointCoverage: 80.0,
+            minCoverageStrict: true,
+            exitHandler: static function (int $code) use (&$exitCode): void {
+                $exitCode = $code;
+            },
+            partialRun: PartialRunDecision::partial('--testsuite'),
+        );
+
+        ob_start();
+        $subscriber->notify($this->fakeExecutionFinished());
+        ob_get_clean();
+
+        $this->assertNull($exitCode, 'partial run must not trip the strict threshold gate');
+        $this->assertStringNotContainsString('FAIL:', $stderr);
+        $this->assertStringContainsString('[Gesso] NOTE:', $stderr);
+        $this->assertStringContainsString('skipped on partial runs', $stderr);
+        $this->assertStringContainsString('--testsuite', $stderr);
+    }
+
+    #[Test]
+    public function partial_run_with_no_coverage_skips_strict_gate_with_note(): void
+    {
+        // Issue #438 reproduction: `--testsuite=Unit` records zero contract
+        // coverage — correctly — and the empty-results strict gate exited 1.
+        // No recordResponse() call here so computeAllResults() returns [].
+        $exitCode = null;
+        $stderr = '';
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            sidecarDir: $this->tmpDir,
+            minEndpointCoverage: 80.0,
+            minCoverageStrict: true,
+            exitHandler: static function (int $code) use (&$exitCode): void {
+                $exitCode = $code;
+            },
+            partialRun: PartialRunDecision::partial('--testsuite'),
+        );
+
+        ob_start();
+        $subscriber->notify($this->fakeExecutionFinished());
+        ob_get_clean();
+
+        $this->assertNull($exitCode, 'a partial run with no coverage must not exit non-zero');
+        $this->assertStringNotContainsString('FATAL', $stderr);
+        $this->assertStringContainsString('[Gesso] NOTE:', $stderr);
+        $this->assertStringContainsString('skipped on partial runs', $stderr);
+    }
+
+    #[Test]
+    public function partial_run_skips_warn_only_threshold_gate_with_note(): void
+    {
+        // The warn-only gate skips too: a subset rate compared against a
+        // whole-suite threshold is noise, not signal. The NOTE replaces it.
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        $exitCode = null;
+        $stderr = '';
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            sidecarDir: $this->tmpDir,
+            minEndpointCoverage: 80.0,
+            minCoverageStrict: false,
+            exitHandler: static function (int $code) use (&$exitCode): void {
+                $exitCode = $code;
+            },
+            partialRun: PartialRunDecision::partial('--filter'),
+        );
+
+        ob_start();
+        $subscriber->notify($this->fakeExecutionFinished());
+        ob_get_clean();
+
+        $this->assertNull($exitCode);
+        $this->assertStringNotContainsString('WARN:', $stderr);
+        $this->assertStringContainsString('[Gesso] NOTE:', $stderr);
+        $this->assertStringContainsString('skipped on partial runs', $stderr);
+        $this->assertStringContainsString('--filter', $stderr);
+    }
+
+    #[Test]
+    public function partial_run_without_threshold_emits_no_gate_note(): void
+    {
+        // No threshold configured → the skip NOTE would be noise about a
+        // gate the user never opted into.
+        $exitCode = null;
+        $stderr = '';
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            sidecarDir: $this->tmpDir,
+            exitHandler: static function (int $code) use (&$exitCode): void {
+                $exitCode = $code;
+            },
+            partialRun: PartialRunDecision::partial('--testsuite'),
+        );
+
+        ob_start();
+        $subscriber->notify($this->fakeExecutionFinished());
+        ob_get_clean();
+
+        $this->assertNull($exitCode);
+        $this->assertSame('', $stderr);
     }
 
     private function fakeExecutionFinished(): ExecutionFinished

--- a/tests/fixtures/compatibility/v2-diagnostic-prefixes.json
+++ b/tests/fixtures/compatibility/v2-diagnostic-prefixes.json
@@ -3,7 +3,7 @@
         "src/Coverage/CoverageMergeCommand.php": 5,
         "src/Fuzz/SchemaDataGenerator.php": 1,
         "src/Laravel/ValidatesOpenApiSchema.php": 1,
-        "src/PHPUnit/CoverageReportSubscriber.php": 10,
+        "src/PHPUnit/CoverageReportSubscriber.php": 11,
         "src/PHPUnit/OpenApiCoverageExtension.php": 6,
         "src/Validation/Request/SecurityValidator.php": 2,
         "src/ValidationOutput.php": 1


### PR DESCRIPTION
## Summary

The coverage threshold gate (`min_endpoint_coverage` / `min_response_coverage`) now skips on partial runs (`--filter`, `--testsuite`, path args, …) instead of evaluating — and, under `min_coverage_strict=true`, failing — a subset that cannot prove a suite-wide coverage rate. A one-line `[Gesso] NOTE:` names the selection signal, mirroring the `strict_required` skip.

## Why

Fixes #438. Every other feature that would draw a wrong conclusion from a subset already skips on partial runs (persistent artifact writes, `strict_required`, baseline staleness). The threshold gate was the exception and the one that exits non-zero: a CI matrix sharding by `--testsuite` could not enable the gate at all, because the `Unit` shard records no contract coverage — correctly — and still exited 1.

Both gate paths are covered: the subset evaluation (`evaluateThresholdGate()`) and the empty-results fail-fast (`failOnEmptyResultsIfGated()`). Full runs, worker mode (`TEST_TOKEN`), and the `coverage:merge` gate are unchanged.

## Verification

Failing tests first (pre-fix: strict exits 1 on a partial run / warn-only emits a subset WARN), then the fix.

- [x] `composer test` passes (2579 tests)
- [x] `composer stan` passes
- [x] `composer cs-check` passes
- `npm run docs:build` and link check on the changed docs pass

## Notes for reviewers

- The warn-only gate also skips (the issue offered keeping it as an option): a subset rate compared against a whole-suite threshold is noise, and `docs/ci.md` now documents the skip instead of the old "still evaluates against the in-memory subset" stance. `partial_run_still_evaluates_threshold_gate` (issue #221 pin) is rewritten to pin the new behavior.
- The NOTE uses the branded `[Gesso]` prefix, not `[OpenAPI Coverage]`: `docs/migration/v2-compatibility-inventory.md` freezes identity-neutral diagnostic categories at their v1.9 shape, so post-2.0 diagnostics must be `[Gesso]`. The v2 prefix inventory fixture is updated accordingly.
- No env override (`OPENAPI_MIN_COVERAGE_STRICT`) was added — the skip removes the need the issue raised it for. `default_testsuite_as_full` remains the opt-in for projects whose `--testsuite` selection is their canonical full run.