### PR TITLE
fix(fuzz): exclude methods documented by colliding path templates from unsupported_method probes

### DIFF
--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -274,9 +274,14 @@ under `additionalOperations` removes `PUT` from the candidates while a
 custom `"copy"` entry removes nothing. OpenAPI 3.2 `additionalOperations`
 are never probed themselves (case-sensitive custom methods). Concrete path
 parameters are generated from a documented
-operation of the same path. Paths where every explorable method is documented,
-or where no documented operation's values can be generated, appear in
-`$summary->skips` with a reason. `ContractCheckFailure::describe()` names the
+operation of the same path. When the concrete probe URI is also an instance
+of a different documented template (`/members/me` alongside
+`/members/{member_id}`), methods documented by that colliding template are
+excluded too — the application would route the probe to the documented
+operation, so a failure there would be a false positive. Paths where every
+explorable method is documented, where every remaining candidate collides
+with another template, or where no documented operation's values can be
+generated, appear in `$summary->skips` with a reason. `ContractCheckFailure::describe()` names the
 check, operation, expected/actual status, and a replayable curl command.
 
 Two caveats: `HEAD`/`OPTIONS`/`TRACE` are outside the explorer's method set

--- a/src/Fuzz/ContractCheckPlan.php
+++ b/src/Fuzz/ContractCheckPlan.php
@@ -13,6 +13,7 @@ use Studio\Gesso\Spec\OpenApiSpecLoader;
 use Throwable;
 
 use function array_key_exists;
+use function array_keys;
 use function array_values;
 use function count;
 use function crc32;
@@ -47,8 +48,11 @@ final class ContractCheckPlan
     /** @var null|callable(ExploredCase): mixed */
     private $dispatch;
 
-    /** @var array<string, ?OpenApiPathMatcher> single-template matchers for collision scans, null when uncompilable */
-    private array $templateMatchers = [];
+    /** @var null|array<string, list<string>> templates grouped by each method name they document, built once per plan */
+    private ?array $templatesByDocumentedMethod = null;
+
+    /** @var array<string, ?OpenApiPathMatcher> one collision matcher over every template documenting a method, null when none compile */
+    private array $methodMatchers = [];
 
     public function __construct(
         private readonly string $specName,
@@ -287,7 +291,7 @@ final class ContractCheckPlan
 
             foreach ($cases as $sourceCase) {
                 $concretePath = $sourceCase->withQuery([])->uri();
-                $collisions = $this->collidingDocumentedMethods($path, $concretePath, $paths);
+                $collisions = $this->collidingDocumentedMethods($concretePath, $paths, $candidates);
 
                 $safeCandidates = [];
                 foreach ($candidates as $candidate) {
@@ -331,49 +335,86 @@ final class ContractCheckPlan
     }
 
     /**
-     * Methods that a probe against `$concretePath` cannot disprove: every
-     * method documented by a path template other than `$probedPath` that the
-     * concrete URI also matches.
+     * Candidate methods that a probe against `$concretePath` cannot disprove:
+     * a candidate collides when a documented template also matches the
+     * concrete URI and declares it. Candidates are undocumented on the probed
+     * template by construction, so that template never appears in its
+     * candidates' matchers and any match is a genuine collision. One matcher
+     * per method keeps the scan at a handful of match calls per probe instead
+     * of one per documented template.
      *
      * @param array<string, array<string, mixed>> $paths
+     * @param non-empty-list<HttpMethod> $candidates
      *
-     * @return array<string, string> documented method name => first colliding template declaring it
+     * @return array<string, string> candidate method name => colliding template declaring it
      */
-    private function collidingDocumentedMethods(string $probedPath, string $concretePath, array $paths): array
+    private function collidingDocumentedMethods(string $concretePath, array $paths, array $candidates): array
     {
         $collisions = [];
-        foreach ($paths as $template => $pathItem) {
-            if ($template === $probedPath) {
-                continue;
-            }
-
-            $matcher = $this->templateMatcher($template);
-            if ($matcher === null || $matcher->match($concretePath) === null) {
-                continue;
-            }
-
-            foreach (OpenApiOperationResolver::declaredOperations($pathItem) as $declared) {
-                $collisions[$declared['method']] ??= $template;
+        foreach ($candidates as $candidate) {
+            $template = $this->methodMatcher($candidate->value, $paths)?->match($concretePath);
+            if ($template !== null) {
+                $collisions[$candidate->value] = $template;
             }
         }
 
         return $collisions;
     }
 
-    private function templateMatcher(string $template): ?OpenApiPathMatcher
+    /** @param array<string, array<string, mixed>> $paths */
+    private function methodMatcher(string $method, array $paths): ?OpenApiPathMatcher
     {
-        if (!array_key_exists($template, $this->templateMatchers)) {
-            try {
-                $this->templateMatchers[$template] = new OpenApiPathMatcher([$template]);
-            } catch (InvalidArgumentException) {
-                // A template the runtime matcher refuses to compile (e.g.
-                // duplicate placeholder names) cannot route a request, so it
-                // cannot collide with a probe URI either.
-                $this->templateMatchers[$template] = null;
+        if ($this->templatesByDocumentedMethod === null) {
+            // Keyed by template to deduplicate a (spec-invalid but
+            // runtime-honored) fixed field repeated under additionalOperations.
+            $grouped = [];
+            foreach ($paths as $template => $pathItem) {
+                foreach (OpenApiOperationResolver::declaredOperations($pathItem) as $declared) {
+                    $grouped[$declared['method']][$template] = true;
+                }
+            }
+
+            $this->templatesByDocumentedMethod = [];
+            foreach ($grouped as $documentedMethod => $templates) {
+                $this->templatesByDocumentedMethod[$documentedMethod] = array_keys($templates);
             }
         }
 
-        return $this->templateMatchers[$template];
+        if (!array_key_exists($method, $this->methodMatchers)) {
+            $this->methodMatchers[$method] = $this->compileCollisionMatcher(
+                $this->templatesByDocumentedMethod[$method] ?? [],
+            );
+        }
+
+        return $this->methodMatchers[$method];
+    }
+
+    /** @param list<string> $templates */
+    private function compileCollisionMatcher(array $templates): ?OpenApiPathMatcher
+    {
+        if ($templates === []) {
+            return null;
+        }
+
+        try {
+            return new OpenApiPathMatcher($templates);
+        } catch (InvalidArgumentException) {
+            // At least one template cannot compile (e.g. duplicate placeholder
+            // names). Such a template cannot route a request, so it cannot
+            // collide either; retry with the ones the matcher accepts.
+        }
+
+        $compilable = [];
+        foreach ($templates as $template) {
+            try {
+                new OpenApiPathMatcher([$template]);
+                $compilable[] = $template;
+            } catch (InvalidArgumentException) {
+                continue;
+            }
+        }
+
+        return $compilable === [] ? null : new OpenApiPathMatcher($compilable);
     }
 
     private function generationFailureMessage(

--- a/src/Fuzz/ContractCheckPlan.php
+++ b/src/Fuzz/ContractCheckPlan.php
@@ -8,9 +8,11 @@ use InvalidArgumentException;
 use RuntimeException;
 use Studio\Gesso\HttpMethod;
 use Studio\Gesso\Spec\OpenApiOperationResolver;
+use Studio\Gesso\Spec\OpenApiPathMatcher;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 use Throwable;
 
+use function array_key_exists;
 use function array_values;
 use function count;
 use function crc32;
@@ -44,6 +46,9 @@ final class ContractCheckPlan
 
     /** @var null|callable(ExploredCase): mixed */
     private $dispatch;
+
+    /** @var array<string, ?OpenApiPathMatcher> single-template matchers for collision scans, null when uncompilable */
+    private array $templateMatchers = [];
 
     public function __construct(
         private readonly string $specName,
@@ -160,7 +165,7 @@ final class ContractCheckPlan
                 $selected += count($matching);
 
                 $probe = match ($check) {
-                    ContractCheck::UnsupportedMethod => $this->buildUnsupportedMethodProbe($check, $path, $pathItem, $matching, $derivedSeed, $skips),
+                    ContractCheck::UnsupportedMethod => $this->buildUnsupportedMethodProbe($check, $path, $pathItem, $matching, $derivedSeed, $skips, $paths),
                 };
                 if ($probe === null) {
                     continue;
@@ -208,9 +213,17 @@ final class ContractCheckPlan
      * custom methods), but every declared name counts as documented and is
      * excluded from the candidates.
      *
+     * The concrete probe URI can also be an instance of a different documented
+     * template (`/members/me` alongside `/members/{member_id}`), and the
+     * application would route the probe to that template's operation. Methods
+     * documented by any colliding template are therefore excluded too; when
+     * none survive, the path is skipped instead of reporting a failure the
+     * spec does not contain.
+     *
      * @param array<string, mixed> $pathItem
      * @param non-empty-list<ExploredOperation> $matching
      * @param list<ContractCheckSkip> $skips
+     * @param array<string, array<string, mixed>> $paths every documented path item, unfiltered
      *
      * @return null|array{ExploredCase, ExploredOperation}
      */
@@ -221,6 +234,7 @@ final class ContractCheckPlan
         array $matching,
         int $derivedSeed,
         array &$skips,
+        array $paths,
     ): ?array {
         // Every declared method name counts as documented: fixed fields under
         // their canonical uppercase key, additionalOperations entries verbatim.
@@ -250,8 +264,6 @@ final class ContractCheckPlan
             return null;
         }
 
-        $probeMethod = $candidates[$derivedSeed % count($candidates)];
-
         $lastReason = null;
         foreach ($matching as $operation) {
             if (HttpMethod::tryFrom($operation->method) === null) {
@@ -274,13 +286,36 @@ final class ContractCheckPlan
             }
 
             foreach ($cases as $sourceCase) {
+                $concretePath = $sourceCase->withQuery([])->uri();
+                $collisions = $this->collidingDocumentedMethods($path, $concretePath, $paths);
+
+                $safeCandidates = [];
+                foreach ($candidates as $candidate) {
+                    if (!isset($collisions[$candidate->value])) {
+                        $safeCandidates[] = $candidate;
+                    }
+                }
+                if ($safeCandidates === []) {
+                    $collisionDetails = [];
+                    foreach ($candidates as $candidate) {
+                        $collisionDetails[] = sprintf("%s is documented by '%s'", $candidate->value, $collisions[$candidate->value]);
+                    }
+                    $skips[] = new ContractCheckSkip($check, $path, null, sprintf(
+                        "The concrete probe URI '%s' is also an instance of other documented path templates that declare every undocumented method for this path (%s); a probe would be routed to a documented operation and proves nothing.",
+                        $concretePath,
+                        implode(', ', $collisionDetails),
+                    ));
+
+                    return null;
+                }
+
                 return [
                     new ExploredCase(
                         null,
                         [],
                         [],
                         $sourceCase->pathParams,
-                        $probeMethod,
+                        $safeCandidates[$derivedSeed % count($safeCandidates)],
                         $path,
                         seed: $derivedSeed,
                         caseIndex: 0,
@@ -293,6 +328,52 @@ final class ContractCheckPlan
         $skips[] = new ContractCheckSkip($check, $path, null, $lastReason ?? 'No documented operation could generate concrete request values.');
 
         return null;
+    }
+
+    /**
+     * Methods that a probe against `$concretePath` cannot disprove: every
+     * method documented by a path template other than `$probedPath` that the
+     * concrete URI also matches.
+     *
+     * @param array<string, array<string, mixed>> $paths
+     *
+     * @return array<string, string> documented method name => first colliding template declaring it
+     */
+    private function collidingDocumentedMethods(string $probedPath, string $concretePath, array $paths): array
+    {
+        $collisions = [];
+        foreach ($paths as $template => $pathItem) {
+            if ($template === $probedPath) {
+                continue;
+            }
+
+            $matcher = $this->templateMatcher($template);
+            if ($matcher === null || $matcher->match($concretePath) === null) {
+                continue;
+            }
+
+            foreach (OpenApiOperationResolver::declaredOperations($pathItem) as $declared) {
+                $collisions[$declared['method']] ??= $template;
+            }
+        }
+
+        return $collisions;
+    }
+
+    private function templateMatcher(string $template): ?OpenApiPathMatcher
+    {
+        if (!array_key_exists($template, $this->templateMatchers)) {
+            try {
+                $this->templateMatchers[$template] = new OpenApiPathMatcher([$template]);
+            } catch (InvalidArgumentException) {
+                // A template the runtime matcher refuses to compile (e.g.
+                // duplicate placeholder names) cannot route a request, so it
+                // cannot collide with a probe URI either.
+                $this->templateMatchers[$template] = null;
+            }
+        }
+
+        return $this->templateMatchers[$template];
     }
 
     private function generationFailureMessage(

--- a/tests/Unit/Fuzz/OpenApiContractChecksTest.php
+++ b/tests/Unit/Fuzz/OpenApiContractChecksTest.php
@@ -263,6 +263,60 @@ class OpenApiContractChecksTest extends TestCase
     }
 
     #[Test]
+    public function probe_avoids_methods_documented_by_a_colliding_path_template(): void
+    {
+        $methods = [];
+        foreach (range(1, 10) as $seed) {
+            OpenApiContractChecks::run('contract-checks', seed: $seed)
+                ->checks([ContractCheck::UnsupportedMethod])
+                ->includePaths(['/members/me'])
+                ->dispatchUsing(static function (ExploredCase $case) use (&$methods): int {
+                    $methods[] = $case->method->value;
+
+                    return 405;
+                })
+                ->report();
+        }
+
+        // '/members/me' documents only GET, but the concrete probe URI is an
+        // instance of '/members/{member_id}' (member_id = "me"), which
+        // documents PATCH and DELETE. Probing those methods would be routed
+        // to the documented operations and prove nothing (issue #440).
+        $this->assertNotSame([], $methods);
+        $this->assertNotContains('GET', $methods);
+        $this->assertNotContains('PATCH', $methods);
+        $this->assertNotContains('DELETE', $methods);
+    }
+
+    #[Test]
+    public function skips_when_every_undocumented_method_is_documented_by_a_colliding_template(): void
+    {
+        $dispatched = 0;
+
+        $summary = OpenApiContractChecks::run('contract-checks', seed: 7)
+            ->checks([ContractCheck::UnsupportedMethod])
+            ->includePaths(['/things/mine'])
+            ->dispatchUsing(static function (ExploredCase $case) use (&$dispatched): int {
+                $dispatched++;
+
+                return 405;
+            })
+            ->report();
+
+        // '/things/{thing_id}' documents every method '/things/mine' leaves
+        // undocumented, and '/things/mine' is an instance of that template,
+        // so no probe method can prove anything.
+        $this->assertSame(0, $dispatched);
+        $this->assertSame(0, $summary->dispatchedProbes);
+        $this->assertCount(1, $summary->skips);
+        $skip = $summary->skips[0];
+        $this->assertSame('/things/mine', $skip->path);
+        $this->assertNull($skip->method);
+        $this->assertStringContainsString('/things/mine', $skip->reason);
+        $this->assertStringContainsString('/things/{thing_id}', $skip->reason);
+    }
+
+    #[Test]
     public function probe_method_is_deterministic_for_a_seed_and_undocumented(): void
     {
         $probeFor = static function (int $seed): string {

--- a/tests/fixtures/specs/contract-checks.json
+++ b/tests/fixtures/specs/contract-checks.json
@@ -152,6 +152,108 @@
                     }
                 }
             }
+        },
+        "/members/me": {
+            "get": {
+                "operationId": "getMyMember",
+                "responses": {
+                    "200": {
+                        "description": "ok"
+                    }
+                }
+            }
+        },
+        "/members/{member_id}": {
+            "parameters": [
+                {
+                    "name": "member_id",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string",
+                        "minLength": 1
+                    }
+                }
+            ],
+            "patch": {
+                "operationId": "updateMember",
+                "responses": {
+                    "200": {
+                        "description": "ok"
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "removeMember",
+                "responses": {
+                    "204": {
+                        "description": "gone"
+                    }
+                }
+            }
+        },
+        "/things/mine": {
+            "get": {
+                "operationId": "getMyThing",
+                "responses": {
+                    "200": {
+                        "description": "ok"
+                    }
+                }
+            }
+        },
+        "/things/{thing_id}": {
+            "parameters": [
+                {
+                    "name": "thing_id",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string",
+                        "minLength": 1
+                    }
+                }
+            ],
+            "post": {
+                "operationId": "createThing",
+                "responses": {
+                    "201": {
+                        "description": "created"
+                    }
+                }
+            },
+            "put": {
+                "operationId": "replaceThing",
+                "responses": {
+                    "200": {
+                        "description": "ok"
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "updateThing",
+                "responses": {
+                    "200": {
+                        "description": "ok"
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "removeThing",
+                "responses": {
+                    "204": {
+                        "description": "gone"
+                    }
+                }
+            },
+            "query": {
+                "operationId": "queryThing",
+                "responses": {
+                    "200": {
+                        "description": "ok"
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

`unsupported_method` probes now check the concrete probe URI against every other documented path template before choosing the probe method. Methods documented by a colliding template (`/members/me` vs `/members/{member_id}`) are excluded from the candidates; when no candidate survives, the path is skipped with a reason naming the colliding template instead of dispatching a probe.

## Why

The check decided "undocumented" per path template, but dispatched a concrete URI. That URI can also be an instance of a broader documented template that does declare the probed method — the application routes the request there and answers normally, and the check reported a failure the spec does not contain. Fixes #440.

This implements the issue's narrower alternative (prefer methods undocumented across every template the URI can match) so the probe keeps running whenever a meaningful method exists, and only falls back to the skip-with-reason behaviour when none does.

## Verification

Failing tests first: the issue's literal-vs-parameter overlap reproduced both the false-positive probe method and the missing skip before the fix.

- [x] `composer test` passes (2581 tests, including the two new regression tests)
- [x] `composer stan` passes
- [x] `composer cs-check` passes
- Collision-scan cost is linear in spec size: plan runtime on a synthetic spec went from 0.48s/3.62s (1,000/3,000 paths, per-template scanning) to 0.09s/0.26s, and 0.88s at 10,000 paths.

## Notes for reviewers

- The collision scan compiles one combined `OpenApiPathMatcher` per candidate method over every template documenting that method (built lazily, cached per plan), so each probe costs at most one match call per explorer-supported method instead of one per documented template. A candidate is undocumented on the probed template by construction, so that template is never in its candidates' matchers and any match is a genuine collision.
- A template the matcher refuses to compile (e.g. duplicate placeholder names) is dropped from the collision matcher: it cannot route a request at runtime either.
- The scan runs over all documented paths regardless of `includePaths()`/tag filters — routing does not care about test filters.
- Probe-method selection is unchanged for specs without overlapping templates (the pinned determinism test for `/pets` still selects PUT at seed 7).
