### PR TITLE
fix(fuzz): build unsupported_method probes from path parameters only

### DIFF
--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -273,15 +273,18 @@ case-sensitively, so a (spec-invalid but runtime-honored) `"PUT"` entry
 under `additionalOperations` removes `PUT` from the candidates while a
 custom `"copy"` entry removes nothing. OpenAPI 3.2 `additionalOperations`
 are never probed themselves (case-sensitive custom methods). Concrete path
-parameters are generated from a documented
-operation of the same path. When the concrete probe URI is also an instance
+parameters are generated from a documented operation of the same path; the
+probe sends no body, query, or headers, so only path-parameter
+generatability gates it — a documented operation whose required request
+body is not JSON (for example a form-encoded OAuth token endpoint) does
+not prevent the probe. When the concrete probe URI is also an instance
 of a different documented template (`/members/me` alongside
 `/members/{member_id}`), methods documented by that colliding template are
 excluded too — the application would route the probe to the documented
 operation, so a failure there would be a false positive. Paths where every
 explorable method is documented, where every remaining candidate collides
-with another template, or where no documented operation's values can be
-generated, appear in `$summary->skips` with a reason. `ContractCheckFailure::describe()` names the
+with another template, or where no documented operation's path parameters
+can be generated, appear in `$summary->skips` with a reason. `ContractCheckFailure::describe()` names the
 check, operation, expected/actual status, and a replayable curl command.
 
 Two caveats: `HEAD`/`OPTIONS`/`TRACE` are outside the explorer's method set

--- a/src/Fuzz/ContractCheckPlan.php
+++ b/src/Fuzz/ContractCheckPlan.php
@@ -212,7 +212,10 @@ final class ContractCheckPlan
 
     /**
      * Choose one undocumented explorable method for the path and build the
-     * probe case from a generatable documented operation's concrete values.
+     * probe case from a documented operation's concrete path parameters. The
+     * probe sends no body, query, or headers, so only path-parameter
+     * generatability gates it — a documented operation whose request body or
+     * other inputs cannot be synthesized must not cause a skip (issue #439).
      * `additionalOperations` names are never probed themselves (case-sensitive
      * custom methods), but every declared name counts as documented and is
      * excluded from the candidates.
@@ -272,7 +275,7 @@ final class ContractCheckPlan
         foreach ($matching as $operation) {
             if (HttpMethod::tryFrom($operation->method) === null) {
                 $lastReason ??= sprintf(
-                    'No documented operation with an explorer-supported method (%s) is available to generate concrete request values.',
+                    'No documented operation with an explorer-supported method (%s) is available to generate concrete path parameters.',
                     HttpMethod::listOfValues(),
                 );
 
@@ -280,7 +283,7 @@ final class ContractCheckPlan
             }
 
             try {
-                $cases = OpenApiEndpointExplorer::explore($this->specName, $operation->method, $operation->path, 1, $derivedSeed);
+                $cases = OpenApiEndpointExplorer::exploreUriOnly($this->specName, $operation->method, $operation->path, 1, $derivedSeed);
             } catch (InvalidArgumentException $e) {
                 $lastReason = $e->getMessage();
 
@@ -290,7 +293,7 @@ final class ContractCheckPlan
             }
 
             foreach ($cases as $sourceCase) {
-                $concretePath = $sourceCase->withQuery([])->uri();
+                $concretePath = $sourceCase->uri();
                 $collisions = $this->collidingDocumentedMethods($concretePath, $paths, $candidates);
 
                 $safeCandidates = [];
@@ -329,7 +332,7 @@ final class ContractCheckPlan
             }
         }
 
-        $skips[] = new ContractCheckSkip($check, $path, null, $lastReason ?? 'No documented operation could generate concrete request values.');
+        $skips[] = new ContractCheckSkip($check, $path, null, $lastReason ?? 'No documented operation could generate concrete path parameters.');
 
         return null;
     }

--- a/src/Fuzz/OpenApiEndpointExplorer.php
+++ b/src/Fuzz/OpenApiEndpointExplorer.php
@@ -21,6 +21,7 @@ use ValueError;
 use function array_filter;
 use function array_keys;
 use function array_map;
+use function array_values;
 use function count;
 use function implode;
 use function is_array;
@@ -176,6 +177,55 @@ final class OpenApiEndpointExplorer
         return new ExplorationCases($built);
     }
 
+    /**
+     * Generate cases that carry only concrete path-parameter values — no
+     * body, query, or headers. Contract probes that dispatch a different
+     * method against the path (issue #439) only need a concrete URI, so the
+     * generatability of a documented operation's body, query, and header
+     * inputs must not gate them. Fails loudly only when a required path
+     * parameter cannot be generated — a real inability to construct a URI.
+     *
+     * @internal probe-construction primitive for {@see ContractCheckPlan}, not public API
+     *
+     * @throws InvalidArgumentException when $cases < 1, the spec path is not
+     *                                  found, the operation is not declared,
+     *                                  or a path parameter is not generatable.
+     */
+    public static function exploreUriOnly(
+        string $specName,
+        string $method,
+        string $path,
+        int $cases = 1,
+        ?int $seed = null,
+    ): ExplorationCases {
+        [$spec, $methodEnum, $matchedPath, $pathSpec, $operation] = self::resolveOperationContext($specName, $method, $path, $cases);
+
+        $version = OpenApiVersion::fromSpec($spec);
+        $jsonSchemaDialect = OpenApiSchemaDialect::fromSpec($spec, $version);
+        $pathParameters = array_values(array_filter(
+            ParameterCollector::collect($methodEnum->value, $matchedPath, $pathSpec, $operation)->parameters,
+            static fn(array $p): bool => ($p['in'] ?? null) === 'path',
+        ));
+        self::assertParametersGeneratable($pathParameters, $methodEnum->value, $matchedPath, $specName);
+
+        $faker = SchemaDataGenerator::createFaker($seed);
+        $built = [];
+        for ($i = 0; $i < $cases; $i++) {
+            $built[] = new ExploredCase(
+                body: null,
+                query: [],
+                headers: [],
+                pathParams: self::generateParameterValues($pathParameters, 'path', $version, $jsonSchemaDialect, $faker, $i),
+                method: $methodEnum,
+                matchedPath: $matchedPath,
+                seed: $seed,
+                caseIndex: $i,
+            );
+        }
+
+        return new ExplorationCases($built);
+    }
+
     private static function buildValidCases(
         string $specName,
         string $method,
@@ -183,6 +233,55 @@ final class OpenApiEndpointExplorer
         int $cases,
         ?int $seed,
     ): ExplorationCases {
+        [$spec, $methodEnum, $matchedPath, $pathSpec, $operation] = self::resolveOperationContext($specName, $method, $path, $cases);
+        $methodUpper = $methodEnum->value;
+
+        $version = OpenApiVersion::fromSpec($spec);
+        $jsonSchemaDialect = OpenApiSchemaDialect::fromSpec($spec, $version);
+        $bodySchema = self::extractRequestBodySchema($operation, $version, $methodUpper, $matchedPath, $specName, $jsonSchemaDialect, $spec);
+        /** @var list<array<string, mixed>> $parameters */
+        $parameters = ParameterCollector::collect($methodUpper, $matchedPath, $pathSpec, $operation)->parameters;
+        self::assertParametersGeneratable($parameters, $methodUpper, $matchedPath, $specName);
+
+        $faker = SchemaDataGenerator::createFaker($seed);
+        $built = [];
+        for ($i = 0; $i < $cases; $i++) {
+            $body = $bodySchema !== null ? SchemaDataGenerator::generateOne($bodySchema, $faker, $i) : null;
+            if ($bodySchema !== null) {
+                SchemaValueValidator::assertValid($body, $bodySchema, $i);
+            }
+            $query = self::generateParameterValues($parameters, 'query', $version, $jsonSchemaDialect, $faker, $i);
+            $headers = self::generateParameterValues($parameters, 'header', $version, $jsonSchemaDialect, $faker, $i);
+            $pathParams = self::generateParameterValues($parameters, 'path', $version, $jsonSchemaDialect, $faker, $i);
+            $built[] = new ExploredCase(
+                body: $body,
+                query: $query,
+                headers: $headers,
+                pathParams: $pathParams,
+                method: $methodEnum,
+                matchedPath: $matchedPath,
+                seed: $seed,
+                caseIndex: $i,
+            );
+        }
+
+        return new ExplorationCases($built);
+    }
+
+    /**
+     * Resolve the shared generation context: loaded spec, method enum, spec
+     * path template, path item, and operation node — failing loudly on an
+     * invalid case count, unsupported method, unknown path, or undeclared
+     * operation.
+     *
+     * @return array{0: array<string, mixed>, 1: HttpMethod, 2: string, 3: array<string, mixed>, 4: array<string, mixed>}
+     */
+    private static function resolveOperationContext(
+        string $specName,
+        string $method,
+        string $path,
+        int $cases,
+    ): array {
         if ($cases < 1) {
             throw new InvalidArgumentException(sprintf(
                 'OpenApiEndpointExplorer::explore() requires cases >= 1, got %d.',
@@ -228,36 +327,7 @@ final class OpenApiEndpointExplorer
             ));
         }
 
-        $version = OpenApiVersion::fromSpec($spec);
-        $jsonSchemaDialect = OpenApiSchemaDialect::fromSpec($spec, $version);
-        $bodySchema = self::extractRequestBodySchema($operation, $version, $methodUpper, $matchedPath, $specName, $jsonSchemaDialect, $spec);
-        /** @var list<array<string, mixed>> $parameters */
-        $parameters = ParameterCollector::collect($methodUpper, $matchedPath, $pathSpec, $operation)->parameters;
-        self::assertParametersGeneratable($parameters, $methodUpper, $matchedPath, $specName);
-
-        $faker = SchemaDataGenerator::createFaker($seed);
-        $built = [];
-        for ($i = 0; $i < $cases; $i++) {
-            $body = $bodySchema !== null ? SchemaDataGenerator::generateOne($bodySchema, $faker, $i) : null;
-            if ($bodySchema !== null) {
-                SchemaValueValidator::assertValid($body, $bodySchema, $i);
-            }
-            $query = self::generateParameterValues($parameters, 'query', $version, $jsonSchemaDialect, $faker, $i);
-            $headers = self::generateParameterValues($parameters, 'header', $version, $jsonSchemaDialect, $faker, $i);
-            $pathParams = self::generateParameterValues($parameters, 'path', $version, $jsonSchemaDialect, $faker, $i);
-            $built[] = new ExploredCase(
-                body: $body,
-                query: $query,
-                headers: $headers,
-                pathParams: $pathParams,
-                method: $methodEnum,
-                matchedPath: $matchedPath,
-                seed: $seed,
-                caseIndex: $i,
-            );
-        }
-
-        return new ExplorationCases($built);
+        return [$spec, $methodEnum, $matchedPath, $pathSpec, $operation];
     }
 
     /**

--- a/tests/Unit/Fuzz/OpenApiContractChecksTest.php
+++ b/tests/Unit/Fuzz/OpenApiContractChecksTest.php
@@ -317,6 +317,97 @@ class OpenApiContractChecksTest extends TestCase
     }
 
     #[Test]
+    public function probes_a_path_whose_only_operation_requires_a_non_json_body(): void
+    {
+        $dispatched = [];
+
+        $summary = OpenApiContractChecks::run('contract-checks', seed: 7)
+            ->checks([ContractCheck::UnsupportedMethod])
+            ->includePaths(['/oauth/token'])
+            ->dispatchUsing(static function (ExploredCase $case) use (&$dispatched): int {
+                $dispatched[] = $case;
+
+                return 405;
+            })
+            ->report();
+
+        // Issue #439: the probe never sends a body, so a documented operation
+        // whose required body is form-encoded (not JSON) must not gate it.
+        $this->assertSame([], $summary->skips);
+        $this->assertCount(1, $dispatched);
+        $this->assertNull($dispatched[0]->body);
+        $this->assertSame([], $dispatched[0]->query);
+        $this->assertSame([], $dispatched[0]->headers);
+        $this->assertNotSame('POST', $dispatched[0]->method->value);
+        $this->assertSame(1, $summary->dispatchedProbes);
+    }
+
+    #[Test]
+    public function generates_path_parameters_even_when_the_documented_body_is_not_json(): void
+    {
+        $uris = [];
+
+        $summary = OpenApiContractChecks::run('contract-checks', seed: 7)
+            ->checks([ContractCheck::UnsupportedMethod])
+            ->includePaths(['/uploads/{uploadId}'])
+            ->dispatchUsing(static function (ExploredCase $case) use (&$uris): int {
+                $uris[] = $case->uri();
+
+                return 405;
+            })
+            ->report();
+
+        $this->assertSame([], $summary->skips);
+        $this->assertCount(1, $uris);
+        $this->assertStringNotContainsString('{uploadId}', $uris[0]);
+    }
+
+    #[Test]
+    public function an_ungeneratable_query_parameter_does_not_gate_the_probe(): void
+    {
+        $dispatched = [];
+
+        $summary = OpenApiContractChecks::run('contract-checks', seed: 7)
+            ->checks([ContractCheck::UnsupportedMethod])
+            ->includePaths(['/search'])
+            ->dispatchUsing(static function (ExploredCase $case) use (&$dispatched): int {
+                $dispatched[] = $case;
+
+                return 405;
+            })
+            ->report();
+
+        // The probe sends no query string, so a required `content`-form query
+        // parameter must not gate probe construction either.
+        $this->assertSame([], $summary->skips);
+        $this->assertCount(1, $dispatched);
+        $this->assertSame([], $dispatched[0]->query);
+    }
+
+    #[Test]
+    public function skips_when_a_path_parameter_cannot_be_generated(): void
+    {
+        $dispatched = 0;
+
+        $summary = OpenApiContractChecks::run('contract-checks', seed: 7)
+            ->checks([ContractCheck::UnsupportedMethod])
+            ->includePaths(['/callbacks/{payload}'])
+            ->dispatchUsing(static function (ExploredCase $case) use (&$dispatched): int {
+                $dispatched++;
+
+                return 405;
+            })
+            ->report();
+
+        // A path parameter the explorer cannot generate is a real inability
+        // to construct the probe URI — the skip must remain.
+        $this->assertSame(0, $dispatched);
+        $this->assertCount(1, $summary->skips);
+        $this->assertSame('/callbacks/{payload}', $summary->skips[0]->path);
+        $this->assertStringContainsString("path parameter 'payload'", $summary->skips[0]->reason);
+    }
+
+    #[Test]
     public function probe_method_is_deterministic_for_a_seed_and_undocumented(): void
     {
         $probeFor = static function (int $seed): string {

--- a/tests/fixtures/specs/contract-checks.json
+++ b/tests/fixtures/specs/contract-checks.json
@@ -192,6 +192,114 @@
                 }
             }
         },
+        "/oauth/token": {
+            "post": {
+                "operationId": "issueToken",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "required": [
+                                    "grant_type"
+                                ],
+                                "properties": {
+                                    "grant_type": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "ok"
+                    }
+                }
+            }
+        },
+        "/uploads/{uploadId}": {
+            "put": {
+                "operationId": "replaceUpload",
+                "parameters": [
+                    {
+                        "name": "uploadId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/octet-stream": {
+                            "schema": {
+                                "type": "string",
+                                "format": "binary"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "ok"
+                    }
+                }
+            }
+        },
+        "/search": {
+            "get": {
+                "operationId": "search",
+                "parameters": [
+                    {
+                        "name": "filter",
+                        "in": "query",
+                        "required": true,
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ok"
+                    }
+                }
+            }
+        },
+        "/callbacks/{payload}": {
+            "get": {
+                "operationId": "showCallback",
+                "parameters": [
+                    {
+                        "name": "payload",
+                        "in": "path",
+                        "required": true,
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ok"
+                    }
+                }
+            }
+        },
         "/things/mine": {
             "get": {
                 "operationId": "getMyThing",


### PR DESCRIPTION
# Summary

`unsupported_method` probes dispatch an undocumented method with no request body, but probe construction went through the full case generator, so paths whose documented operation declares a required non-JSON body (e.g. form-encoded OAuth token endpoints) were skipped even though the probe never needs that body.

## Changes

- Add an internal URI-only case builder (`OpenApiEndpointExplorer::exploreUriOnly()`, `@internal`) that generates concrete path-parameter values only — no body, query, or headers — reusing the shared operation-resolution and parameter-generation logic.
- Switch `ContractCheckPlan::buildUnsupportedMethodProbe()` to the URI-only builder, so neither a required non-JSON request body nor an ungeneratable query/header parameter gates probe construction anymore.
- A path is still skipped when its *path parameters* cannot be generated (a real inability to construct the probe URI), with the same loud skip reason.
- Fixture + regression tests: form-encoded required body (issue reproduction), non-JSON body with a path parameter, `content`-form query parameter, and the preserved path-parameter skip.
- Docs: update the probe-construction paragraph in `docs/fuzzing.md`.

Verified with `composer ci` (cs-check, PHPStan, full PHPUnit suite — 2585 tests green).

## Related

- Fixes #439