### PR TITLE
feat(schema): support YAML files in #[BoundToOpenApiEnum] bindings

### DIFF
--- a/docs/enum-drift.md
+++ b/docs/enum-drift.md
@@ -39,7 +39,7 @@ The path is resolved relative to the configured enum root (`OpenApiSpecLoader::g
 }
 ```
 
-Both JSON and YAML bound files are supported. The file extension picks the parser: `.yaml` / `.yml` (case-insensitive) decode as YAML — through the same optional `symfony/yaml` dependency the spec loader uses — and every other path, including extension-less ones, is parsed as JSON. Binding a YAML file without `symfony/yaml` installed throws `EnumBindingException` with reason `YamlLibraryMissing`.
+Both JSON and YAML bound files are supported. The binding path's extension — as written in the attribute — picks the parser: `.yaml` / `.yml` (case-insensitive) decode as YAML — through the same optional `symfony/yaml` dependency the spec loader uses — and every other path, including extension-less ones, is parsed as JSON. Binding a YAML file without `symfony/yaml` installed throws `EnumBindingException` with reason `YamlLibraryMissing`.
 
 ```php
 #[BoundToOpenApiEnum('components/schemas/GrantType.yaml')]

--- a/docs/enum-drift.md
+++ b/docs/enum-drift.md
@@ -30,13 +30,20 @@ enum NotificationCodeEnum: string
 }
 ```
 
-The path is resolved relative to the configured enum root (`OpenApiSpecLoader::getEnumBasePath()`), falling back to the spec root (`OpenApiSpecLoader::getBasePath()`) when the enum-specific root is unset. The bound JSON file must contain an `enum:` array, e.g.:
+The path is resolved relative to the configured enum root (`OpenApiSpecLoader::getEnumBasePath()`), falling back to the spec root (`OpenApiSpecLoader::getBasePath()`) when the enum-specific root is unset. The bound file must contain an `enum:` array, e.g.:
 
 ```json
 {
   "type": "string",
   "enum": ["studioPaymentOld", "studioPaymentNew"]
 }
+```
+
+Both JSON and YAML bound files are supported. The file extension picks the parser: `.yaml` / `.yml` (case-insensitive) decode as YAML — through the same optional `symfony/yaml` dependency the spec loader uses — and every other path, including extension-less ones, is parsed as JSON. Binding a YAML file without `symfony/yaml` installed throws `EnumBindingException` with reason `YamlLibraryMissing`.
+
+```php
+#[BoundToOpenApiEnum('components/schemas/GrantType.yaml')]
+enum GrantType: string { /* ... */ }
 ```
 
 ### Bundled-external enum sources (`enum_spec_base_path`)
@@ -156,7 +163,7 @@ class EnumDriftTest extends TestCase
 
 Failures throw `PHPUnit\Framework\AssertionFailedError` with the same `[OpenAPI Enum Drift] FATAL` block as the static asserter, routed through `Assert::fail()` so PHPUnit's diff-aware reporter picks it up. Stack frames inside this library are filtered out so the failure points at the consumer's test line.
 
-Misconfiguration (`EnumBindingException` — missing `#[BoundToOpenApiEnum]`, spec file not found, malformed JSON, etc.) is **not** wrapped — it bubbles unchanged so the structured `$reason`/`$enumFqcn`/`$specPath` properties stay accessible to downstream tooling.
+Misconfiguration (`EnumBindingException` — missing `#[BoundToOpenApiEnum]`, spec file not found, malformed JSON/YAML, etc.) is **not** wrapped — it bubbles unchanged so the structured `$reason`/`$enumFqcn`/`$specPath` properties stay accessible to downstream tooling.
 
 The static `EnumDriftAsserter::assertNoDrift()` is unchanged. Non-PHPUnit consumers (dedicated drift CI scripts that catch `EnumDriftException` directly) keep working as before.
 
@@ -175,7 +182,7 @@ Each `EnumDriftReport` carries `enumFqcn`, `specPath`, `phpOnly`, and `specOnly`
 
 ## Misconfiguration vs drift
 
-`EnumBindingException` is thrown when the comparison cannot be performed at all — missing `#[BoundToOpenApiEnum]`, target is not a backed enum, spec file not found, malformed JSON, `enum` key missing or not an array, or an `enum` array entry is non-scalar (`null` / `bool` / nested arrays — backed PHP enums can only carry `string` or `int`). `$reason` carries an `EnumBindingReason` enum so you can branch programmatically. These errors fire regardless of `failOnDrift` — they are setup mistakes, not drift signals.
+`EnumBindingException` is thrown when the comparison cannot be performed at all — missing `#[BoundToOpenApiEnum]`, target is not a backed enum, spec file not found, malformed JSON/YAML, YAML binding without `symfony/yaml` installed, `enum` key missing or not an array, or an `enum` array entry is non-scalar (`null` / `bool` / nested arrays — backed PHP enums can only carry `string` or `int`). `$reason` carries an `EnumBindingReason` enum so you can branch programmatically. These errors fire regardless of `failOnDrift` — they are setup mistakes, not drift signals.
 
 ## Auto-discovery via the PHPUnit extension
 
@@ -234,7 +241,6 @@ If `enum_drift_scan_namespaces` resolves but no `#[BoundToOpenApiEnum]`-attribut
 
 ## Known limitations
 
-- **JSON only.** The asserter currently reads the bound enum file with `file_get_contents` + `json_decode`. YAML enum files are not supported in v1; convert them to JSON or extract the enum into a `.json` sidecar.
-- **No `$ref` traversal on the bound file.** Unlike `OpenApiSpecLoader::load()`, the asserter does not resolve `$ref` inside the bound JSON. Bind to the leaf file containing the literal `enum:` array.
-- **`oneOf` enum unions** (e.g., `code: oneOf: [CommonCode, AdminCode]`) are not yet auto-resolved. Bind each PHP enum to its leaf JSON file directly.
+- **No `$ref` traversal on the bound file.** Unlike `OpenApiSpecLoader::load()`, the asserter does not resolve `$ref` inside the bound file. Bind to the leaf file containing the literal `enum:` array.
+- **`oneOf` enum unions** (e.g., `code: oneOf: [CommonCode, AdminCode]`) are not yet auto-resolved. Bind each PHP enum to its leaf file directly.
 - **`x-enum-varnames` / `x-enum-descriptions`** are not validated. Only the `enum` value array is compared.

--- a/src/Exception/EnumBindingReason.php
+++ b/src/Exception/EnumBindingReason.php
@@ -21,6 +21,8 @@ enum EnumBindingReason
     case EnumSpecBasePathOrphaned;
     case SpecFileNotFound;
     case MalformedJson;
+    case MalformedYaml;
+    case YamlLibraryMissing;
     case NonMappingRoot;
     case EnumKeyMissing;
     case EnumKeyNotArray;

--- a/src/Schema/EnumDriftAsserter.php
+++ b/src/Schema/EnumDriftAsserter.php
@@ -7,6 +7,7 @@ namespace Studio\Gesso\Schema;
 use const DIRECTORY_SEPARATOR;
 use const E_USER_WARNING;
 use const JSON_THROW_ON_ERROR;
+use const PATHINFO_EXTENSION;
 
 use BackedEnum;
 use JsonException;
@@ -18,7 +19,10 @@ use Studio\Gesso\Exception\EnumBindingReason;
 use Studio\Gesso\Exception\EnumDriftException;
 use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
+use Studio\Gesso\Internal\YamlAvailability;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
+use Symfony\Component\Yaml\Yaml;
+use Throwable;
 
 use function array_filter;
 use function array_map;
@@ -37,6 +41,7 @@ use function is_dir;
 use function is_int;
 use function is_string;
 use function json_decode;
+use function pathinfo;
 use function preg_match;
 use function realpath;
 use function rtrim;
@@ -84,7 +89,7 @@ final class EnumDriftAsserter
      * fire `E_USER_WARNING` (when false) if any drift is detected.
      *
      * Misconfigured bindings (missing attribute, missing file, malformed
-     * JSON, etc.) always throw `EnumBindingException` regardless of
+     * JSON/YAML, etc.) always throw `EnumBindingException` regardless of
      * `$failOnDrift` — those are setup errors, not drift signals.
      *
      * `$enumFqcns` are validated at runtime via `enum_exists()`; the type
@@ -238,7 +243,7 @@ final class EnumDriftAsserter
             throw new EnumBindingException(
                 EnumBindingReason::AttributeMissing,
                 sprintf(
-                    '%s is missing the #[BoundToOpenApiEnum] attribute. Add it with the spec-relative path of the JSON file containing the bound enum array.',
+                    '%s is missing the #[BoundToOpenApiEnum] attribute. Add it with the spec-relative path of the JSON or YAML file containing the bound enum array.',
                     $fqcn,
                 ),
                 enumFqcn: $fqcn,
@@ -396,26 +401,12 @@ final class EnumDriftAsserter
             );
         }
 
-        try {
-            $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException $e) {
-            throw new EnumBindingException(
-                EnumBindingReason::MalformedJson,
-                sprintf(
-                    'Failed to parse bound spec file %s: %s',
-                    $absolute,
-                    $e->getMessage(),
-                ),
-                enumFqcn: $fqcn,
-                specPath: $specPath,
-                previous: $e,
-            );
-        }
+        $decoded = self::decodeSpecContent($fqcn, $specPath, $absolute, $content);
 
         if (!is_array($decoded)) {
             throw new EnumBindingException(
                 EnumBindingReason::NonMappingRoot,
-                sprintf('Bound spec file %s must decode to a JSON object', $absolute),
+                sprintf('Bound spec file %s must decode to a mapping (JSON object / YAML mapping)', $absolute),
                 enumFqcn: $fqcn,
                 specPath: $specPath,
             );
@@ -471,6 +462,72 @@ final class EnumDriftAsserter
         }
 
         return $values;
+    }
+
+    /**
+     * Decode the raw bound-file body, picking the parser from the file
+     * extension the way `OpenApiSpecLoader::load()` does for spec documents:
+     * `.yaml` / `.yml` (case-insensitive) decode as YAML through the same
+     * optional `symfony/yaml` dependency, everything else — including
+     * extension-less paths — keeps the historical JSON parse.
+     */
+    private static function decodeSpecContent(
+        string $fqcn,
+        string $specPath,
+        string $absolute,
+        string $content,
+    ): mixed {
+        $extension = strtolower(pathinfo($absolute, PATHINFO_EXTENSION));
+        if (!in_array($extension, ['yaml', 'yml'], true)) {
+            try {
+                return json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+            } catch (JsonException $e) {
+                throw new EnumBindingException(
+                    EnumBindingReason::MalformedJson,
+                    sprintf(
+                        'Failed to parse bound spec file %s: %s',
+                        $absolute,
+                        $e->getMessage(),
+                    ),
+                    enumFqcn: $fqcn,
+                    specPath: $specPath,
+                    previous: $e,
+                );
+            }
+        }
+
+        if (!YamlAvailability::isAvailable()) {
+            throw new EnumBindingException(
+                EnumBindingReason::YamlLibraryMissing,
+                sprintf(
+                    'Reading YAML bound spec file %s requires symfony/yaml. '
+                    . 'Install it via: composer require --dev symfony/yaml',
+                    $absolute,
+                ),
+                enumFqcn: $fqcn,
+                specPath: $specPath,
+            );
+        }
+
+        try {
+            return Yaml::parse($content);
+        } catch (Throwable $e) {
+            // Symfony's parser raises non-ParseException classes for some
+            // inputs (e.g. \InvalidArgumentException on malformed Unicode),
+            // so catch broadly — every decode failure of the bound file is
+            // the same misconfiguration category to the caller.
+            throw new EnumBindingException(
+                EnumBindingReason::MalformedYaml,
+                sprintf(
+                    'Failed to parse bound spec file %s: %s',
+                    $absolute,
+                    $e->getMessage(),
+                ),
+                enumFqcn: $fqcn,
+                specPath: $specPath,
+                previous: $e,
+            );
+        }
     }
 
     private static function joinBasePath(string $basePath, string $relativePath): string

--- a/src/Schema/EnumDriftAsserter.php
+++ b/src/Schema/EnumDriftAsserter.php
@@ -470,6 +470,12 @@ final class EnumDriftAsserter
      * `.yaml` / `.yml` (case-insensitive) decode as YAML through the same
      * optional `symfony/yaml` dependency, everything else — including
      * extension-less paths — keeps the historical JSON parse.
+     *
+     * The extension is read from the binding path as written in the
+     * attribute, not from `$absolute`: realpath() resolves within-root
+     * symlinks, so an `alias.json -> target.yaml` link would otherwise
+     * silently switch parsers (or dodge the symfony/yaml gate) based on
+     * the link target. `$absolute` is only for reading and diagnostics.
      */
     private static function decodeSpecContent(
         string $fqcn,
@@ -477,7 +483,7 @@ final class EnumDriftAsserter
         string $absolute,
         string $content,
     ): mixed {
-        $extension = strtolower(pathinfo($absolute, PATHINFO_EXTENSION));
+        $extension = strtolower(pathinfo($specPath, PATHINFO_EXTENSION));
         if (!in_array($extension, ['yaml', 'yml'], true)) {
             try {
                 return json_decode($content, true, 512, JSON_THROW_ON_ERROR);

--- a/tests/Unit/Compatibility/PublicApiBaselineTest.php
+++ b/tests/Unit/Compatibility/PublicApiBaselineTest.php
@@ -19,6 +19,7 @@ use Studio\Gesso\Coverage\InvalidThresholdConfigurationException;
 use Studio\Gesso\Coverage\JsonCoverageRenderer;
 use Studio\Gesso\Coverage\JUnitCoverageRenderer;
 use Studio\Gesso\Coverage\MarkdownCoverageRenderer;
+use Studio\Gesso\Exception\EnumBindingReason;
 use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
 use Studio\Gesso\Fuzz\ContractCheck;
 use Studio\Gesso\Fuzz\ContractCheckFailure;
@@ -218,6 +219,16 @@ final class PublicApiBaselineTest extends TestCase
             }
         }
         $expected[InvalidOpenApiSpecReason::class]['cases'] = $reasonCases;
+        $bindingReasonCases = [];
+        foreach ($expected[EnumBindingReason::class]['cases'] as $name => $value) {
+            $bindingReasonCases[$name] = $value;
+            if ($name === 'MalformedJson') {
+                // #433: YAML bound enum files (minor additions).
+                $bindingReasonCases['MalformedYaml'] = null;
+                $bindingReasonCases['YamlLibraryMissing'] = null;
+            }
+        }
+        $expected[EnumBindingReason::class]['cases'] = $bindingReasonCases;
         $expected[OpenApiSpecLoader::class]['constants']['DEFAULT_MAX_REMOTE_REF_BYTES'] = 10_485_760;
         $expected[OpenApiSpecLoader::class]['methods']['configure']['parameters'][] = [
             'name' => 'allowedRemoteRefHosts',

--- a/tests/Unit/Schema/EnumDriftAsserterTest.php
+++ b/tests/Unit/Schema/EnumDriftAsserterTest.php
@@ -681,6 +681,46 @@ class EnumDriftAsserterTest extends TestCase
     }
 
     #[Test]
+    public function parser_follows_the_binding_path_extension_not_the_symlink_target(): void
+    {
+        // A within-root symlink is allowed, but the binding path's extension
+        // — not the realpath()-resolved target's — must pick the parser.
+        // Here matching.json links to a YAML-content .yaml file inside the
+        // root: the .json binding must keep the JSON parser and fail loudly
+        // instead of silently switching to YAML because of the link target.
+        $scratchDir = sys_get_temp_dir() . '/gesso-enum-alias-' . uniqid('', true);
+        $enumDir = $scratchDir . '/enum-drift';
+        $target = $enumDir . '/target.yaml';
+        $link = $enumDir . '/matching.json';
+        mkdir($scratchDir);
+        mkdir($enumDir);
+        file_put_contents($target, "type: string\nenum:\n  - red\n  - green\n  - blue\n");
+        if (!@symlink('target.yaml', $link)) {
+            unlink($target);
+            rmdir($enumDir);
+            rmdir($scratchDir);
+            $this->markTestSkipped('symlinks are unavailable on this platform');
+        }
+
+        try {
+            OpenApiSpecLoader::reset();
+            OpenApiSpecLoader::configure(basePath: $scratchDir, enumBasePath: $scratchDir);
+
+            try {
+                EnumDriftAsserter::assertNoDrift([MatchingEnum::class]);
+                $this->fail('expected EnumBindingException');
+            } catch (EnumBindingException $e) {
+                $this->assertSame(EnumBindingReason::MalformedJson, $e->reason);
+            }
+        } finally {
+            unlink($link);
+            unlink($target);
+            rmdir($enumDir);
+            rmdir($scratchDir);
+        }
+    }
+
+    #[Test]
     public function extensionless_bound_file_is_still_parsed_as_json(): void
     {
         EnumDriftAsserter::assertNoDrift([NoExtensionSpecEnum::class]);

--- a/tests/Unit/Schema/EnumDriftAsserterTest.php
+++ b/tests/Unit/Schema/EnumDriftAsserterTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 use Studio\Gesso\Exception\EnumBindingException;
 use Studio\Gesso\Exception\EnumBindingReason;
 use Studio\Gesso\Exception\EnumDriftException;
+use Studio\Gesso\Internal\YamlAvailability;
 use Studio\Gesso\Schema\EnumDriftAsserter;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 use Studio\Gesso\Tests\Unit\Schema\Fixture\EmptySpecEnum;
@@ -21,6 +22,7 @@ use Studio\Gesso\Tests\Unit\Schema\Fixture\IntegerBackedEnum;
 use Studio\Gesso\Tests\Unit\Schema\Fixture\MalformedSpecEnum;
 use Studio\Gesso\Tests\Unit\Schema\Fixture\MatchingEnum;
 use Studio\Gesso\Tests\Unit\Schema\Fixture\NoEnumKeySpecEnum;
+use Studio\Gesso\Tests\Unit\Schema\Fixture\NoExtensionSpecEnum;
 use Studio\Gesso\Tests\Unit\Schema\Fixture\NonScalarSpecValueEnum;
 use Studio\Gesso\Tests\Unit\Schema\Fixture\NotAnEnum;
 use Studio\Gesso\Tests\Unit\Schema\Fixture\PhpExtraEnum;
@@ -28,6 +30,12 @@ use Studio\Gesso\Tests\Unit\Schema\Fixture\PureEnum;
 use Studio\Gesso\Tests\Unit\Schema\Fixture\SpecExtraEnum;
 use Studio\Gesso\Tests\Unit\Schema\Fixture\SpecFileMissingEnum;
 use Studio\Gesso\Tests\Unit\Schema\Fixture\UnattributedEnum;
+use Studio\Gesso\Tests\Unit\Schema\Fixture\UppercaseYamlExtensionEnum;
+use Studio\Gesso\Tests\Unit\Schema\Fixture\YamlMalformedSpecEnum;
+use Studio\Gesso\Tests\Unit\Schema\Fixture\YamlMatchingEnum;
+use Studio\Gesso\Tests\Unit\Schema\Fixture\YamlScalarRootEnum;
+use Studio\Gesso\Tests\Unit\Schema\Fixture\YamlSpecExtraEnum;
+use Studio\Gesso\Tests\Unit\Schema\Fixture\YmlMatchingEnum;
 
 use function file_exists;
 use function file_put_contents;
@@ -53,6 +61,7 @@ class EnumDriftAsserterTest extends TestCase
 
     protected function tearDown(): void
     {
+        YamlAvailability::reset();
         OpenApiSpecLoader::reset();
         parent::tearDown();
     }
@@ -573,6 +582,111 @@ class EnumDriftAsserterTest extends TestCase
             rmdir($enumRoot);
             rmdir($scratchDir);
         }
+    }
+
+    #[Test]
+    public function yaml_bound_file_passes_for_matching_pair(): void
+    {
+        EnumDriftAsserter::assertNoDrift([YamlMatchingEnum::class]);
+
+        $reports = EnumDriftAsserter::detectAll([YamlMatchingEnum::class]);
+        $this->assertCount(1, $reports);
+        $this->assertFalse($reports[0]->hasDrift());
+    }
+
+    #[Test]
+    public function yml_extension_is_parsed_as_yaml(): void
+    {
+        EnumDriftAsserter::assertNoDrift([YmlMatchingEnum::class]);
+
+        $reports = EnumDriftAsserter::detectAll([YmlMatchingEnum::class]);
+        $this->assertFalse($reports[0]->hasDrift());
+    }
+
+    #[Test]
+    public function uppercase_yaml_extension_is_parsed_as_yaml(): void
+    {
+        EnumDriftAsserter::assertNoDrift([UppercaseYamlExtensionEnum::class]);
+
+        $reports = EnumDriftAsserter::detectAll([UppercaseYamlExtensionEnum::class]);
+        $this->assertFalse($reports[0]->hasDrift());
+    }
+
+    #[Test]
+    public function yaml_bound_file_surfaces_spec_only_drift(): void
+    {
+        try {
+            EnumDriftAsserter::assertNoDrift([YamlSpecExtraEnum::class]);
+            $this->fail('expected EnumDriftException');
+        } catch (EnumDriftException $e) {
+            $this->assertSame([], $e->reports[0]->phpOnly);
+            $this->assertSame(['yellow'], $e->reports[0]->specOnly);
+        }
+    }
+
+    #[Test]
+    public function malformed_yaml_throws_binding_exception_with_malformed_yaml_reason(): void
+    {
+        try {
+            EnumDriftAsserter::assertNoDrift([YamlMalformedSpecEnum::class]);
+            $this->fail('expected EnumBindingException');
+        } catch (EnumBindingException $e) {
+            $this->assertSame(EnumBindingReason::MalformedYaml, $e->reason);
+            $this->assertSame('enum-drift/yaml-malformed.yaml', $e->specPath);
+        }
+    }
+
+    #[Test]
+    public function yaml_scalar_root_throws_non_mapping_root(): void
+    {
+        try {
+            EnumDriftAsserter::assertNoDrift([YamlScalarRootEnum::class]);
+            $this->fail('expected EnumBindingException');
+        } catch (EnumBindingException $e) {
+            $this->assertSame(EnumBindingReason::NonMappingRoot, $e->reason);
+        }
+    }
+
+    #[Test]
+    public function yaml_binding_without_symfony_yaml_throws_yaml_library_missing(): void
+    {
+        YamlAvailability::overrideForTesting(false);
+
+        try {
+            EnumDriftAsserter::assertNoDrift([YamlMatchingEnum::class]);
+            $this->fail('expected EnumBindingException');
+        } catch (EnumBindingException $e) {
+            $this->assertSame(EnumBindingReason::YamlLibraryMissing, $e->reason);
+            $this->assertStringContainsString('symfony/yaml', $e->getMessage());
+        } finally {
+            YamlAvailability::reset();
+        }
+    }
+
+    #[Test]
+    public function json_binding_still_resolves_when_symfony_yaml_is_absent(): void
+    {
+        // The optional dependency must stay optional for JSON-only projects:
+        // only bindings that actually point at a YAML file may demand it.
+        YamlAvailability::overrideForTesting(false);
+
+        try {
+            EnumDriftAsserter::assertNoDrift([MatchingEnum::class]);
+        } finally {
+            YamlAvailability::reset();
+        }
+
+        $reports = EnumDriftAsserter::detectAll([MatchingEnum::class]);
+        $this->assertFalse($reports[0]->hasDrift());
+    }
+
+    #[Test]
+    public function extensionless_bound_file_is_still_parsed_as_json(): void
+    {
+        EnumDriftAsserter::assertNoDrift([NoExtensionSpecEnum::class]);
+
+        $reports = EnumDriftAsserter::detectAll([NoExtensionSpecEnum::class]);
+        $this->assertFalse($reports[0]->hasDrift());
     }
 
     #[Test]

--- a/tests/Unit/Schema/Fixture/NoExtensionSpecEnum.php
+++ b/tests/Unit/Schema/Fixture/NoExtensionSpecEnum.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Schema\Fixture;
+
+use Studio\Gesso\Attribute\BoundToOpenApiEnum;
+
+#[BoundToOpenApiEnum('enum-drift/matching-noext')]
+enum NoExtensionSpecEnum: string
+{
+    case Red = 'red';
+    case Green = 'green';
+    case Blue = 'blue';
+}

--- a/tests/Unit/Schema/Fixture/UppercaseYamlExtensionEnum.php
+++ b/tests/Unit/Schema/Fixture/UppercaseYamlExtensionEnum.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Schema\Fixture;
+
+use Studio\Gesso\Attribute\BoundToOpenApiEnum;
+
+#[BoundToOpenApiEnum('enum-drift/yaml-upper.YAML')]
+enum UppercaseYamlExtensionEnum: string
+{
+    case Red = 'red';
+    case Green = 'green';
+    case Blue = 'blue';
+}

--- a/tests/Unit/Schema/Fixture/YamlMalformedSpecEnum.php
+++ b/tests/Unit/Schema/Fixture/YamlMalformedSpecEnum.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Schema\Fixture;
+
+use Studio\Gesso\Attribute\BoundToOpenApiEnum;
+
+#[BoundToOpenApiEnum('enum-drift/yaml-malformed.yaml')]
+enum YamlMalformedSpecEnum: string
+{
+    case A = 'a';
+}

--- a/tests/Unit/Schema/Fixture/YamlMatchingEnum.php
+++ b/tests/Unit/Schema/Fixture/YamlMatchingEnum.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Schema\Fixture;
+
+use Studio\Gesso\Attribute\BoundToOpenApiEnum;
+
+#[BoundToOpenApiEnum('enum-drift/yaml-matching.yaml')]
+enum YamlMatchingEnum: string
+{
+    case Red = 'red';
+    case Green = 'green';
+    case Blue = 'blue';
+}

--- a/tests/Unit/Schema/Fixture/YamlScalarRootEnum.php
+++ b/tests/Unit/Schema/Fixture/YamlScalarRootEnum.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Schema\Fixture;
+
+use Studio\Gesso\Attribute\BoundToOpenApiEnum;
+
+#[BoundToOpenApiEnum('enum-drift/yaml-scalar-root.yaml')]
+enum YamlScalarRootEnum: string
+{
+    case A = 'a';
+}

--- a/tests/Unit/Schema/Fixture/YamlSpecExtraEnum.php
+++ b/tests/Unit/Schema/Fixture/YamlSpecExtraEnum.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Schema\Fixture;
+
+use Studio\Gesso\Attribute\BoundToOpenApiEnum;
+
+#[BoundToOpenApiEnum('enum-drift/yaml-spec-extra.yaml')]
+enum YamlSpecExtraEnum: string
+{
+    case Red = 'red';
+    case Green = 'green';
+    case Blue = 'blue';
+}

--- a/tests/Unit/Schema/Fixture/YmlMatchingEnum.php
+++ b/tests/Unit/Schema/Fixture/YmlMatchingEnum.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Schema\Fixture;
+
+use Studio\Gesso\Attribute\BoundToOpenApiEnum;
+
+#[BoundToOpenApiEnum('enum-drift/yml-matching.yml')]
+enum YmlMatchingEnum: string
+{
+    case Red = 'red';
+    case Green = 'green';
+    case Blue = 'blue';
+}

--- a/tests/fixtures/compatibility/v2-public-api.json
+++ b/tests/fixtures/compatibility/v2-public-api.json
@@ -1167,6 +1167,8 @@
             "EnumSpecBasePathOrphaned": null,
             "SpecFileNotFound": null,
             "MalformedJson": null,
+            "MalformedYaml": null,
+            "YamlLibraryMissing": null,
             "NonMappingRoot": null,
             "EnumKeyMissing": null,
             "EnumKeyNotArray": null,

--- a/tests/fixtures/specs/enum-drift/matching-noext
+++ b/tests/fixtures/specs/enum-drift/matching-noext
@@ -1,0 +1,4 @@
+{
+  "type": "string",
+  "enum": ["red", "green", "blue"]
+}

--- a/tests/fixtures/specs/enum-drift/yaml-malformed.yaml
+++ b/tests/fixtures/specs/enum-drift/yaml-malformed.yaml
@@ -1,0 +1,1 @@
+enum: [red, green

--- a/tests/fixtures/specs/enum-drift/yaml-matching.yaml
+++ b/tests/fixtures/specs/enum-drift/yaml-matching.yaml
@@ -1,0 +1,5 @@
+type: string
+enum:
+  - red
+  - green
+  - blue

--- a/tests/fixtures/specs/enum-drift/yaml-scalar-root.yaml
+++ b/tests/fixtures/specs/enum-drift/yaml-scalar-root.yaml
@@ -1,0 +1,1 @@
+just a scalar

--- a/tests/fixtures/specs/enum-drift/yaml-spec-extra.yaml
+++ b/tests/fixtures/specs/enum-drift/yaml-spec-extra.yaml
@@ -1,0 +1,6 @@
+type: string
+enum:
+  - red
+  - green
+  - blue
+  - yellow

--- a/tests/fixtures/specs/enum-drift/yaml-upper.YAML
+++ b/tests/fixtures/specs/enum-drift/yaml-upper.YAML
@@ -1,0 +1,5 @@
+type: string
+enum:
+  - red
+  - green
+  - blue

--- a/tests/fixtures/specs/enum-drift/yml-matching.yml
+++ b/tests/fixtures/specs/enum-drift/yml-matching.yml
@@ -1,0 +1,2 @@
+type: string
+enum: [red, green, blue]


### PR DESCRIPTION
## Summary

`EnumDriftAsserter` now decodes bound enum files as YAML when the binding path ends in `.yaml` / `.yml` (case-insensitive), using the same optional `symfony/yaml` dependency the spec loader already uses. Every other path — including extension-less ones — keeps the historical JSON parse, and the filesystem trust boundary (`enum_spec_base_path` canonicalization, `..` / absolute / symlink rejection) is unchanged.

## Why

Fixes #433. YAML is a first-class input everywhere else in the library, but enum drift bindings required JSON, forcing multi-file YAML spec trees to maintain JSON sidecars — a second source of truth that can itself drift.

`EnumBindingReason` gains `MalformedYaml` and `YamlLibraryMissing` (minor additions per `docs/versioning.md`); the public API baseline is regenerated and the documented-contract-changes test updated accordingly.

## Verification

TDD: the new YAML tests were written first and failed with the current JSON-only parse before the implementation. Covered: `.yaml` / `.yml` / uppercase-extension matching pairs, drift through a YAML file, malformed YAML → `MalformedYaml`, scalar root → `NonMappingRoot`, missing `symfony/yaml` → `YamlLibraryMissing` (and JSON bindings staying independent of it), extension-less paths still parsed as JSON.

- [x] `composer test` passes
- [x] `composer stan` passes
- [x] `composer cs-check` passes

## Notes for reviewers

- YAML parse failures get their own `MalformedYaml` reason (mirroring `InvalidOpenApiSpecReason`) rather than reusing `MalformedJson`, as the issue suggested was preferable for downstream branching.
- The `NonMappingRoot` message was neutralized ("must decode to a mapping (JSON object / YAML mapping)") since it now covers both formats; error prose is not a compatibility surface.
- `docs/enum-drift.md` drops the "JSON only" known limitation and documents the extension-based parser selection.