### PR TITLE
feat(validation): extract shared response schema resolution for reuse outside the response validator

### DIFF
--- a/docs/adr/0003-sdk-roundtrip-harness.md
+++ b/docs/adr/0003-sdk-roundtrip-harness.md
@@ -1,0 +1,145 @@
+# ADR 0003: branch-complete response payloads and an SDK round-trip harness
+
+- Status: Proposed
+- Date: 2026-07-31
+- Issue: [#441](https://github.com/studio-design/gesso/issues/441)
+- Related: [#403](https://github.com/studio-design/gesso/issues/403)
+
+## Context
+
+Gesso validates the server ⇄ spec side of a contract. Nothing validates the
+SDK ⇄ spec side: whether a generated client SDK can deserialize every payload
+the spec allows. That gap shipped studio-design/studio-auth#1520 —
+openapi-generator rendered a primitive-only inline `oneOf`
+(`string | string[]`) as a property-less wrapper model, and every existing
+gate stayed green because none of them fed spec-derived payloads to the
+generated decoder.
+
+Most of the machinery already exists:
+
+- `Fuzz\SchemaDataGenerator` generates deterministic values through
+  `oneOf`/`anyOf`/`allOf`, but it is `@internal`, resolves branches by
+  rotating the case index, and nested compositions share that index in
+  lockstep. Branch coverage is therefore best-effort: a case count smaller
+  than a branch fan-out, or a branch nested under an optional property (the
+  studio-auth incident shape), can go unexercised.
+- Response-schema selection by `(method, path, status, content-type)` exists
+  only inlined in the response validator, entangled with assertion flow.
+- Round-trip re-validation is the existing JSON Schema engine plus
+  `SchemaValueValidator`, unchanged.
+
+## Decision
+
+Build a public response-payload explorer in the fuzz family that generates
+deterministic, branch-complete valid payloads for a resolved response schema
+(or a named component schema) and hands them to user-supplied decode/encode
+callbacks, asserting acceptance and round-trip fidelity.
+
+Follow the established facade-over-internal pattern: the documented strategy
+matrix in `docs/fuzzing.md` is the contract, `SchemaDataGenerator` stays
+`@internal`, and the public surface mirrors the existing explorer family
+(`explore*` entry points, readonly case DTOs, `each()` collections that
+reject empty runs, `*Using(callable)` hooks, fluent plans with derived
+per-operation seeds).
+
+Schema-to-model mapping stays user-side through explicit callbacks per
+(operation, status). Guessing codegen naming conventions (openapi-generator,
+Kiota, …) is a non-goal.
+
+## Branch-coverage guarantee
+
+Rotation becomes a documented guarantee: for a fixed (schema, seed), every
+branch of every reachable composition choice point — `oneOf`/`anyOf`
+branches, conditional branches, nullable and optional-property presence —
+appears in at least one generated case.
+
+This requires a pre-pass enumerator that collects choice points with their
+JSON Pointers, and a pinned per-case selection plan that replaces the shared
+iteration cursor. Ancestors of a targeted choice point are forced present so
+nested branches are reachable; the incident's `oneOf` sat inside an optional
+property and top-level-only coverage would have missed it. The case count is
+derived from the enumeration (at least one case per (choice point, branch)
+pair) plus caller-requested extras. Existing exclusions (recursive schemas,
+`contains`, …) stay explicit and loud, with documented enumeration bounds.
+
+Every generated case keeps the existing self-check against the converted
+schema before it reaches user code.
+
+## Round-trip fidelity
+
+`assertRoundTrip($reEncoded)` asserts two things:
+
+1. The re-encoded value validates against the same converted schema, through
+   the same validator used for generation self-checks, so generation and
+   verification cannot drift.
+2. Every key and value of the generated payload survives recursively (arrays
+   compared exactly). This catches silent value swallowing — the same
+   generator bug minus the TypeError.
+
+Failure messages carry the seed, case index, and pinned branch pointer, in
+the style of the existing replayable exploration failures.
+
+## Reuse boundaries
+
+- Response-schema resolution is extracted into an `@internal` resolver shared
+  with the response validator, preserving discriminator enforcement, dialect
+  selection, and doctor/runtime diagnostic consistency. No re-implementation
+  in the new entry point.
+- No-content, non-JSON-only, and OAS 3.2 `itemSchema` responses are loud
+  structured outcomes, never silent skips.
+- Coverage-style reporting of exercised response schemas follows the
+  parallel-tracker precedent (own state version, sidecar envelope
+  participation, JSON report schema bump, reject-unknown-versions).
+- #403 (spec-driven HTTP client fakes) targets consumer application code
+  through faked transports; this harness targets the generated decode layer
+  in-process. Whichever lands first, both share the generation facade.
+- No new production dependency. Faker remains optional; generation stays
+  deterministic without it.
+
+## Delivery phases
+
+1. Shared response-schema resolution —
+   [#442](https://github.com/studio-design/gesso/issues/442).
+2. Branch-complete generation across composition choice points —
+   [#443](https://github.com/studio-design/gesso/issues/443).
+3. Public response payload explorer with round-trip assertions (MVP that
+   catches the incident) —
+   [#444](https://github.com/studio-design/gesso/issues/444).
+4. Named component schema entry point —
+   [#446](https://github.com/studio-design/gesso/issues/446).
+5. Spec-wide plan with loud mapping gaps —
+   [#447](https://github.com/studio-design/gesso/issues/447).
+6. SDK-exercise coverage reporting —
+   [#449](https://github.com/studio-design/gesso/issues/449).
+
+Phases 1 and 2 are independent; 3 needs both; 4–6 build on 3. Each phase
+adds malformed-input tests and fails loudly on inputs it cannot handle.
+
+## Consequences
+
+- The strategy matrix gains a guarantee, not just a description; future
+  generator changes must preserve branch-completeness or bump it visibly.
+- The fuzz public surface grows a response-side family covered by the
+  compatibility policy; naming and hook shapes are constrained by the
+  existing explorer precedent.
+- Coverage wire formats gain a new observation kind with its own version
+  obligations.
+- Request fuzzing keeps its documented rotation strategy until it opts into
+  the pinned-plan generator, so existing seeds keep reproducing.
+
+## Revisit criteria
+
+Reconsider the derived-case-count model if real specs make enumeration
+explode (many choice points × deep nesting); a bounded covering strategy
+with a documented cap would replace it. Reconsider shipping phase 6 if
+phases 3–5 show the summary output already serves the "degrades loudly"
+requirement without new wire formats.
+
+## Sources
+
+- [OpenAPI 3.2](https://spec.openapis.org/oas/v3.2.0.html)
+- [JSON Schema 2020-12](https://json-schema.org/specification)
+- [RFC 7662: OAuth 2.0 Token Introspection](https://www.rfc-editor.org/rfc/rfc7662)
+- Incident and interim mitigation: studio-design/studio-auth#1520,
+  studio-design/studio-auth#1523
+- `docs/fuzzing.md` strategy matrix and determinism contract

--- a/src/OpenApiResponseValidator.php
+++ b/src/OpenApiResponseValidator.php
@@ -5,33 +5,27 @@ declare(strict_types=1);
 namespace Studio\Gesso;
 
 use InvalidArgumentException;
+use LogicException;
 use RuntimeException;
 use Studio\Gesso\PHPUnit\OpenApiCoverageExtension;
 use Studio\Gesso\Spec\OpenApiOperationResolver;
-use Studio\Gesso\Spec\OpenApiPathMatcher;
-use Studio\Gesso\Spec\OpenApiSchemaDialect;
-use Studio\Gesso\Spec\OpenApiSpecLoader;
 use Studio\Gesso\Validation\Response\ResponseBodyValidationResult;
 use Studio\Gesso\Validation\Response\ResponseBodyValidator;
 use Studio\Gesso\Validation\Response\ResponseHeaderValidator;
+use Studio\Gesso\Validation\Response\ResponseSchemaResolution;
+use Studio\Gesso\Validation\Response\ResponseSchemaResolutionOutcome;
+use Studio\Gesso\Validation\Response\ResponseSchemaResolver;
 use Studio\Gesso\Validation\Strict\StrictAdditionalPropertiesInspector;
 use Studio\Gesso\Validation\Strict\StrictAdditionalPropertiesPerCallChecker;
 use Studio\Gesso\Validation\Strict\StrictAdditionalPropertiesTracker;
 use Studio\Gesso\Validation\Strict\StrictRequiredBodyWalker;
 use Studio\Gesso\Validation\Strict\StrictRequiredPerCallChecker;
 use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
-use Studio\Gesso\Validation\Support\DiscriminatorContext;
-use Studio\Gesso\Validation\Support\DiscriminatorEnforcement;
-use Studio\Gesso\Validation\Support\MalformedSpecNode;
 use Studio\Gesso\Validation\Support\NamedError;
-use Studio\Gesso\Validation\Support\PathDiagnosticsFormatter;
 use Studio\Gesso\Validation\Support\SchemaValidatorRunner;
-use Studio\Gesso\Validation\Support\SpecResponseKeyResolver;
 use Studio\Gesso\Validation\Support\StatusCodePatternSet;
 use Studio\Gesso\Validation\Support\ValidatorErrorBoundary;
 
-use function array_key_exists;
-use function array_keys;
 use function array_map;
 use function array_merge;
 use function array_values;
@@ -49,9 +43,7 @@ final class OpenApiResponseValidator
      * the common convention of not documenting production 5xx in specs.
      */
     public const DEFAULT_SKIP_RESPONSE_CODES = ['5\d\d'];
-
-    /** @var array<string, OpenApiPathMatcher> */
-    private array $pathMatchers = [];
+    private readonly ResponseSchemaResolver $schemaResolver;
     private readonly ResponseBodyValidator $bodyValidator;
     private readonly ResponseHeaderValidator $headerValidator;
     private readonly StatusCodePatternSet $skipPatterns;
@@ -75,6 +67,7 @@ final class OpenApiResponseValidator
         array $skipResponseCodes = self::DEFAULT_SKIP_RESPONSE_CODES,
     ) {
         $this->skipPatterns = new StatusCodePatternSet($skipResponseCodes, 'skipResponseCodes');
+        $this->schemaResolver = new ResponseSchemaResolver();
         $runner = new SchemaValidatorRunner($maxErrors);
         $this->bodyValidator = new ResponseBodyValidator($runner);
         $this->headerValidator = new ResponseHeaderValidator($runner);
@@ -111,164 +104,56 @@ final class OpenApiResponseValidator
         // (a plain `null` becomes an absent body — see {@see DecodedBody}).
         $body = DecodedBody::fromLegacy($responseBody);
 
-        $spec = OpenApiSpecLoader::load($specName);
+        // Spec traversal — the `paths` guard, path matching, operation
+        // lookup, and the `responses`-map guard — is shared with every other
+        // response-schema consumer through {@see ResponseSchemaResolver}
+        // (issue #442). The resolver formats the failure diagnostics; this
+        // validator only maps each outcome onto its historical result shape.
+        $operationResolution = $this->schemaResolver->resolveOperation($specName, $method, $requestPath);
 
-        $version = OpenApiVersion::fromSpec($spec);
-        $jsonSchemaDialect = OpenApiSchemaDialect::fromSpec($spec, $version);
-
-        // The root `paths` must decode to a JSON object; a scalar, `null`, or
-        // a JSON list is a malformed spec ({@see MalformedSpecNode}).
-        // Unguarded, a non-array reaches the `array_keys()` call below
-        // (uncaught TypeError) and a list mis-resolves silently. The presence
-        // test uses `array_key_exists` (not `isset`) so a present-but-`null`
-        // `paths` is caught here rather than coalesced to an empty map by
-        // `?? []`. Surface it as a loud spec error instead — the
-        // traversal-level sibling of the per-response content/schema guards
-        // (issue #259).
-        if (array_key_exists('paths', $spec) && MalformedSpecNode::isMalformed($spec['paths'])) {
-            $message = sprintf(
-                "Malformed 'paths' for %s %s in '%s' spec: expected object, got %s.",
-                $method,
-                $requestPath,
-                $specName,
-                MalformedSpecNode::describe($spec['paths']),
-            );
+        if ($operationResolution->outcome !== ResponseSchemaResolutionOutcome::Resolved) {
+            $message = (string) $operationResolution->message;
+            // Structural spec defects and request-context mismatches keep
+            // their historical issue categories: malformed nodes are spec
+            // errors, an unmatched path/method is a request-context error.
+            $category = $operationResolution->outcome === ResponseSchemaResolutionOutcome::MalformedSpec
+                ? 'response.spec'
+                : 'response.request_context';
 
             return OpenApiValidationResult::failure(
                 [$message],
-                issues: [new ValidationIssue('response.spec', $message, method: $method)],
+                $operationResolution->matchedPath,
+                issues: [new ValidationIssue($category, $message, method: $method, path: $operationResolution->matchedPath)],
             );
         }
 
-        /** @var string[] $specPaths */
-        $specPaths = array_keys($spec['paths'] ?? []);
-        $matcher = $this->getPathMatcher($specName, $specPaths);
-        $matchedPath = $matcher->match($requestPath);
-
-        if ($matchedPath === null) {
-            $message = PathDiagnosticsFormatter::pathNotFound($specName, $method, $requestPath, $matcher, $spec);
-
-            return OpenApiValidationResult::failure(
-                [$message],
-                issues: [new ValidationIssue('response.request_context', $message, method: $method)],
-            );
+        $matchedPath = $operationResolution->matchedPath;
+        $version = $operationResolution->version;
+        $jsonSchemaDialect = $operationResolution->jsonSchemaDialect;
+        if ($matchedPath === null || $version === null || $jsonSchemaDialect === null) {
+            throw new LogicException('Resolved operation resolution must carry matchedPath, version, and dialect.');
         }
 
-        // `$matchedPath` is always a key of `$spec['paths']` (the matcher was
-        // built from its `array_keys()`), so `?? null` here only fires for an
-        // explicit `null` *value* — which the guard below then treats as
-        // malformed, exactly like a scalar path item.
-        $pathSpec = $spec['paths'][$matchedPath] ?? null;
-
-        // A path item must decode to a JSON object; a scalar, `null`, or a
-        // JSON list is malformed ({@see MalformedSpecNode}). Unguarded, a
-        // non-array reaches the `array_key_exists()` method lookup below
-        // (uncaught TypeError) and a list mis-resolves silently. Surface it
-        // loudly instead (issue #259).
-        if (MalformedSpecNode::isMalformed($pathSpec)) {
-            $message = sprintf(
-                "Malformed 'paths[\"%s\"]' for %s %s in '%s' spec: expected object, got %s.",
-                $matchedPath,
-                $method,
-                $matchedPath,
-                $specName,
-                MalformedSpecNode::describe($pathSpec),
-            );
-
-            return OpenApiValidationResult::failure(
-                [$message],
-                $matchedPath,
-                issues: [new ValidationIssue('response.spec', $message, method: $method, path: $matchedPath)],
-            );
-        }
-
-        $resolvedOperation = OpenApiOperationResolver::resolve($pathSpec, $method);
-        if (!$resolvedOperation['found']) {
-            $message = PathDiagnosticsFormatter::methodNotDefined($specName, $method, $matchedPath, $spec);
-
-            return OpenApiValidationResult::failure(
-                [$message],
-                $matchedPath,
-                issues: [new ValidationIssue('response.request_context', $message, method: $method, path: $matchedPath)],
-            );
-        }
-
-        $operation = $resolvedOperation['operation'];
-        $operationLocation = $resolvedOperation['location'];
-
-        // An operation must decode to a JSON object; a scalar, `null`, or a
-        // JSON list is malformed ({@see MalformedSpecNode}). Unguarded, a
-        // non-array reaches the `array_key_exists()` `responses` lookup below
-        // (uncaught TypeError) and a list mis-resolves silently (issue #259).
-        if (MalformedSpecNode::isMalformed($operation)) {
-            $message = sprintf(
-                "Malformed 'paths[\"%s\"].%s' for %s %s in '%s' spec: expected object, got %s.",
-                $matchedPath,
-                $operationLocation,
-                $method,
-                $matchedPath,
-                $specName,
-                MalformedSpecNode::describe($operation),
-            );
-
-            return OpenApiValidationResult::failure(
-                [$message],
-                $matchedPath,
-                issues: [new ValidationIssue('response.spec', $message, method: $method, path: $matchedPath)],
-            );
-        }
-
-        /** @var array<string, mixed> $operation */
         $statusCodeStr = (string) $statusCode;
-        // `array_key_exists` (not `?? []`) so a present-but-`null` `responses`
-        // is caught by the guard below as malformed, while a genuinely absent
-        // `responses` key still falls back to an empty map (resolved later as
-        // "status code not defined").
-        $responses = array_key_exists('responses', $operation) ? $operation['responses'] : [];
 
-        // The `responses` map must decode to a JSON object; a scalar, `null`,
-        // or a JSON list is malformed ({@see MalformedSpecNode}). Unguarded,
-        // a non-array reaches `SpecResponseKeyResolver::resolve()`'s `array
-        // $responses` parameter (uncaught TypeError) and a list mis-resolves
-        // silently. The guard runs BEFORE the skip-by-status-code check
-        // below: a malformed `responses` map is a structural spec error, not
-        // a status-code-level failure mode, so a configured skip pattern must
-        // not hide it. This is the traversal-level sibling of the #258
-        // `responses[$status]` per-entry guard (issue #259).
-        if (MalformedSpecNode::isMalformed($responses)) {
-            $message = sprintf(
-                "Malformed 'paths[\"%s\"].%s.responses' for %s %s in '%s' spec: expected object, got %s.",
-                $matchedPath,
-                $operationLocation,
-                $method,
-                $matchedPath,
-                $specName,
-                MalformedSpecNode::describe($responses),
-            );
-
-            return OpenApiValidationResult::failure(
-                [$message],
-                $matchedPath,
-                issues: [new ValidationIssue('response.spec', $message, method: $method, path: $matchedPath)],
-            );
-        }
-
-        // Skip-by-status-code: applied before the "Status code not defined"
-        // branch so a configured skip suppresses both status-code-level failure
-        // modes — "this code isn't in the spec's responses map" AND "this code
-        // IS documented but the body doesn't match its schema". Earlier checks
-        // (path / method not in spec) still fail loudly so typos stay visible.
+        // Skip-by-status-code: applied after the resolver's structural
+        // guards (a malformed `responses` map is a spec error a skip pattern
+        // must not hide — issue #259) but before status-key resolution, so a
+        // configured skip suppresses both status-code-level failure modes —
+        // "this code isn't in the spec's responses map" AND "this code IS
+        // documented but the body doesn't match its schema". Earlier checks
+        // (path / method not in spec) still fail loudly so typos stay
+        // visible. This interleaved policy is why the validator consumes the
+        // resolver's staged API rather than its composed resolve().
         $matchingPattern = $this->skipPatterns->match($statusCodeStr);
         if ($matchingPattern !== null) {
             // matchedStatusCode here is the literal HTTP status string, not a
-            // spec key. Skip happens BEFORE key resolution
-            // ({@see SpecResponseKeyResolver::resolve()} runs further
-            // down), so we don't yet know which spec key would have
-            // matched — and even when the spec only declares `default`
-            // or a `5XX` range, callers that gate on isSkipped() expect
-            // the wire status, not the resolved spec key. The coverage
-            // tracker's statusKeyMatches() reconciles literal-vs-range
-            // at compute time.
+            // spec key. Skip happens BEFORE key resolution, so we don't yet
+            // know which spec key would have matched — and even when the
+            // spec only declares `default` or a `5XX` range, callers that
+            // gate on isSkipped() expect the wire status, not the resolved
+            // spec key. The coverage tracker's statusKeyMatches() reconciles
+            // literal-vs-range at compute time.
             return OpenApiValidationResult::skipped(
                 $matchedPath,
                 sprintf('status %s matched skip pattern %s', $statusCodeStr, $matchingPattern),
@@ -276,18 +161,10 @@ final class OpenApiResponseValidator
             );
         }
 
-        // Spec lookup priority per OpenAPI 3.0/3.1:
-        //   1. Exact code match (e.g. spec declares "503", response is 503)
-        //   2. Range key match (e.g. spec declares "5XX", response is 503)
-        //   3. `default` catch-all
-        // Explicit codes take precedence over range keys; range keys take
-        // precedence over `default`. Without this fallback, a spec that
-        // documents only `default` (or only `5XX`) would fail every real
-        // status — both patterns are common (Problem Details responses
-        // typically use `default` for the error envelope).
-        $matchedResponseKey = SpecResponseKeyResolver::resolve($statusCodeStr, $responses);
-        if ($matchedResponseKey === null) {
-            $message = "Status code {$statusCode} not defined for {$method} {$matchedPath} in '{$specName}' spec.";
+        $resolution = $this->schemaResolver->resolveResponseSchema($operationResolution, $statusCode, $responseContentType);
+
+        if ($resolution->outcome === ResponseSchemaResolutionOutcome::StatusNotDeclared) {
+            $message = (string) $resolution->message;
 
             return OpenApiValidationResult::failure(
                 [$message],
@@ -295,44 +172,19 @@ final class OpenApiResponseValidator
                 issues: [new ValidationIssue('response.status', $message, method: $method, path: $matchedPath, statusCode: $statusCodeStr)],
             );
         }
-        // Before silently surfacing a `default` fallback, surface any keys
-        // that LOOK like attempted spec keys but don't satisfy the exact /
-        // range / default form. `$statusCodeStr` is always a wire status
-        // here (numeric string from `(string) $statusCode`), never the
-        // literal `default`, so falling-through to `default` always means
-        // a real fallback. Both the request-side downgrade
-        // ({@see OpenApiRequestValidator::validate()}) and this
-        // response-side path call the same helper so a test class with
-        // only one hook enabled still sees the diagnostic — duplicate
-        // warnings under both hooks are accepted noise.
-        if ($matchedResponseKey === 'default') {
-            SpecResponseKeyResolver::warnSuspiciousKeys($specName, $method, $matchedPath, $responses);
+
+        $statusKey = $resolution->statusKey;
+        if ($statusKey === null) {
+            throw new LogicException('Response schema resolution past status lookup must carry the matched status key.');
         }
 
         // Coverage tracking records under the spec key actually matched
         // (e.g. "5XX" or "default"), not the literal status — that lets
         // the renderer surface the spec's intent rather than the wire value.
-        $statusCodeStr = $matchedResponseKey;
-        $responseSpec = $responses[$matchedResponseKey];
+        $statusCodeStr = $statusKey;
 
-        // A response entry must decode to a JSON object; a scalar, `null`, or
-        // a JSON list is a malformed spec ({@see MalformedSpecNode}) — e.g.
-        // an unresolved $ref. Surface it as a loud spec error (issue #258).
-        // Without this guard the bad value reaches the `array $responseSpec`
-        // parameters of validateBody() / validateHeaders() and raises an
-        // uncaught TypeError (TypeError extends Error, not RuntimeException,
-        // so validateBody()'s catch would not see it). This mirrors the
-        // content-level guards in validateBody() and RequestBodyValidator's
-        // `requestBody` guard.
-        if (MalformedSpecNode::isMalformed($responseSpec)) {
-            $message = sprintf(
-                "Malformed 'responses[%s]' for %s %s in '%s' spec: expected object, got %s.",
-                $matchedResponseKey,
-                $method,
-                $matchedPath,
-                $specName,
-                MalformedSpecNode::describe($responseSpec),
-            );
+        if ($resolution->outcome === ResponseSchemaResolutionOutcome::MalformedResponse) {
+            $message = (string) $resolution->message;
 
             return OpenApiValidationResult::failure(
                 [$message],
@@ -342,24 +194,18 @@ final class OpenApiResponseValidator
             );
         }
 
-        // Carry the resolved root + enforce gate so the body validator can
-        // lower `discriminator.mapping` into enforceable conditionals (#262).
-        // The mapping pointers reference subtype schemas elsewhere in the
-        // document, which only the root can resolve.
-        $discriminatorContext = new DiscriminatorContext($spec, DiscriminatorEnforcement::isEnabled());
+        $responseSpec = $resolution->responseSpec;
+        if ($responseSpec === null) {
+            throw new LogicException('Response schema resolution past the entry guard must carry the response spec node.');
+        }
 
-        /** @var array<string, mixed> $responseSpec */
         $bodyResult = $this->validateBody(
             $specName,
             $method,
             $matchedPath,
             $statusCode,
-            $responseSpec,
+            $resolution,
             $body,
-            $responseContentType,
-            $version,
-            $discriminatorContext,
-            $jsonSchemaDialect,
         );
 
         $headerErrors = $this->validateHeaders(
@@ -657,67 +503,90 @@ final class OpenApiResponseValidator
     }
 
     /**
-     * @param array<string, mixed> $responseSpec
+     * Map a post-entry response-schema resolution onto the historical body
+     * result shape. Content negotiation, media-type guards, and schema
+     * selection already ran in {@see ResponseSchemaResolver}; only the
+     * `Resolved` outcome still validates the actual body. Pre-body outcomes
+     * (operation failures, `StatusNotDeclared`, `MalformedResponse`) are
+     * handled by {@see validate()} before this method and throw here.
      */
     private function validateBody(
         string $specName,
         string $method,
         string $matchedPath,
         int $statusCode,
-        array $responseSpec,
+        ResponseSchemaResolution $resolution,
         DecodedBody $responseBody,
-        ?string $responseContentType,
-        OpenApiVersion $version,
-        DiscriminatorContext $discriminatorContext,
-        string $jsonSchemaDialect,
     ): ResponseBodyValidationResult {
-        // 204 No Content (and similar) declare no `content` block. Nothing
-        // to validate — return empty so the result aggregates cleanly.
-        if (!isset($responseSpec['content'])) {
-            return new ResponseBodyValidationResult([], null);
-        }
+        return match ($resolution->outcome) {
+            // 204-style responses without a `content` block, and content
+            // blocks with no JSON-compatible media type: nothing this engine
+            // can validate — return empty so the result aggregates cleanly
+            // (the orchestrator decides between Success and the non-JSON
+            // skip using the spec's content block).
+            ResponseSchemaResolutionOutcome::NoContent,
+            ResponseSchemaResolutionOutcome::NoJsonContent => new ResponseBodyValidationResult([], null),
+            // Malformed content-level spec nodes and an actual Content-Type
+            // the spec never declared surface as loud body errors.
+            ResponseSchemaResolutionOutcome::MalformedContent,
+            ResponseSchemaResolutionOutcome::ContentTypeNotDeclared => new ResponseBodyValidationResult(
+                [(string) $resolution->message],
+                null,
+            ),
+            // A matched media type without a `schema` has nothing to
+            // validate; record the matched key for coverage.
+            ResponseSchemaResolutionOutcome::MissingSchema => new ResponseBodyValidationResult(
+                [],
+                $resolution->contentType,
+            ),
+            // Deliberately unvalidated bodies (non-JSON schema, OAS 3.2
+            // itemSchema streaming) carry the skip reason so the
+            // orchestrator surfaces a Skipped result, not a clean pass.
+            ResponseSchemaResolutionOutcome::NonJsonSchema,
+            ResponseSchemaResolutionOutcome::ItemSchemaStreaming => new ResponseBodyValidationResult(
+                [],
+                $resolution->contentType,
+                $resolution->skipReason,
+            ),
+            ResponseSchemaResolutionOutcome::Resolved => $this->validateResolvedBody(
+                $specName,
+                $method,
+                $matchedPath,
+                $statusCode,
+                $resolution,
+                $responseBody,
+            ),
+            default => throw new LogicException(sprintf(
+                'validateBody() received a pre-body resolution outcome %s; validate() must handle it first.',
+                $resolution->outcome->name,
+            )),
+        };
+    }
 
-        // A `content` block must decode to a JSON object; a scalar or a JSON
-        // list is a malformed spec ({@see MalformedSpecNode}) — e.g. an
-        // unresolved $ref. Surface it before it reaches
-        // ResponseBodyValidator::validate()'s `array $content` parameter,
-        // where a non-array would raise an uncaught TypeError (TypeError
-        // extends Error, not RuntimeException, so the catch below would not
-        // see it). Mirrors RequestBodyValidator's `requestBody.content` guard
-        // (issue #256).
-        if (MalformedSpecNode::isMalformed($responseSpec['content'])) {
-            return new ResponseBodyValidationResult([
-                sprintf(
-                    "Malformed 'responses[%s].content' for %s %s in '%s' spec: expected object, got %s.",
-                    $statusCode,
-                    $method,
-                    $matchedPath,
-                    $specName,
-                    MalformedSpecNode::describe($responseSpec['content']),
-                ),
-            ], null);
-        }
-
-        /** @var array<string, mixed> $content */
-        $content = $responseSpec['content'];
-
+    private function validateResolvedBody(
+        string $specName,
+        string $method,
+        string $matchedPath,
+        int $statusCode,
+        ResponseSchemaResolution $resolution,
+        DecodedBody $responseBody,
+    ): ResponseBodyValidationResult {
         // Inlined try/catch mirrors ValidatorErrorBoundary::safely() for the
         // body validator: same narrow `RuntimeException` catch, same error
-        // formatting. The boundary returns string[]; the body validator now
+        // formatting. The boundary returns string[]; the body validator
         // returns a richer DTO carrying matchedContentType, so we can't reuse
-        // the helper as-is. \LogicException and \Error still bubble.
+        // the helper as-is. Schema conversion happens lazily inside this
+        // boundary ({@see ResponseSchemaResolution::convertedSchema()}), so
+        // converter rejections keep their historical error shape.
+        // \LogicException and \Error still bubble.
         try {
             return $this->bodyValidator->validate(
                 $specName,
                 $method,
                 $matchedPath,
                 $statusCode,
-                $content,
+                $resolution,
                 $responseBody,
-                $responseContentType,
-                $version,
-                $discriminatorContext,
-                $jsonSchemaDialect,
             );
         } catch (RuntimeException $e) {
             $previous = $e->getPrevious();
@@ -796,13 +665,5 @@ final class OpenApiResponseValidator
             $matchedPath,
             fn(): array => $this->headerValidator->validate($headersSpec, $responseHeaders, $version, $jsonSchemaDialect),
         );
-    }
-
-    /**
-     * @param string[] $specPaths
-     */
-    private function getPathMatcher(string $specName, array $specPaths): OpenApiPathMatcher
-    {
-        return $this->pathMatchers[$specName] ??= new OpenApiPathMatcher($specPaths, OpenApiSpecLoader::getStripPrefixes());
     }
 }

--- a/src/Validation/Response/ResponseBodyValidationResult.php
+++ b/src/Validation/Response/ResponseBodyValidationResult.php
@@ -5,11 +5,15 @@ declare(strict_types=1);
 namespace Studio\Gesso\Validation\Response;
 
 use InvalidArgumentException;
+use Studio\Gesso\OpenApiResponseValidator;
 use Studio\Gesso\OpenApiValidationResult;
 use Studio\Gesso\Validation\Support\SchemaViolation;
 
 /**
- * Outcome of {@see ResponseBodyValidator::validate()}.
+ * Outcome of response-body validation: produced by
+ * {@see ResponseBodyValidator::validate()} for `Resolved` schema resolutions
+ * and by {@see OpenApiResponseValidator}'s mapping of every
+ * other {@see ResponseSchemaResolution} outcome.
  *
  * `errors` carries the same string payload the validator previously returned
  * (empty list = body acceptable). `matchedContentType` is the spec key (with

--- a/src/Validation/Response/ResponseBodyValidator.php
+++ b/src/Validation/Response/ResponseBodyValidator.php
@@ -4,22 +4,13 @@ declare(strict_types=1);
 
 namespace Studio\Gesso\Validation\Response;
 
+use LogicException;
 use stdClass;
 use Studio\Gesso\DecodedBody;
 use Studio\Gesso\OpenApiResponseValidator;
-use Studio\Gesso\OpenApiValidationResult;
-use Studio\Gesso\OpenApiVersion;
-use Studio\Gesso\SchemaContext;
-use Studio\Gesso\Spec\OpenApiSchemaConverter;
-use Studio\Gesso\Validation\Support\ContentTypeMatcher;
-use Studio\Gesso\Validation\Support\DiscriminatorContext;
-use Studio\Gesso\Validation\Support\MalformedSpecNode;
 use Studio\Gesso\Validation\Support\ObjectConverter;
 use Studio\Gesso\Validation\Support\SchemaValidatorRunner;
 
-use function array_key_exists;
-use function array_keys;
-use function implode;
 use function in_array;
 use function is_array;
 use function is_string;
@@ -35,193 +26,45 @@ final class ResponseBodyValidator
     ) {}
 
     /**
-     * Validate the response body against the matched operation's response
-     * entry. Returns a {@see ResponseBodyValidationResult} with an empty
-     * `errors` list when the body is acceptable (non-JSON content types that
-     * are present in the spec, JSON media types with no `schema` key, and
-     * JSON bodies that pass schema validation). Hard failures (content-type
-     * not defined, empty body against a JSON schema, schema mismatch) are
-     * returned as error strings so the orchestrator can assemble the final
-     * {@see OpenApiValidationResult}.
+     * Validate the decoded response body against a `Resolved` response-schema
+     * resolution. Content negotiation, media-type guards, and schema
+     * selection happen upstream in {@see ResponseSchemaResolver}; every
+     * non-`Resolved` outcome is mapped to a result by
+     * {@see OpenApiResponseValidator} before this validator is invoked —
+     * receiving one here is a wiring bug and throws.
      *
-     * `matchedContentType` is the spec key (with its original casing) the
-     * body was checked against, or `null` when no spec lookup occurred —
-     * used by coverage tracking to record per-(status, media-type) granularity.
-     *
-     * The 204-style "no content" case is handled upstream in
-     * {@see OpenApiResponseValidator::validate()} — when the response spec
-     * has no `content` key, this validator is never invoked.
-     *
-     * @param array<string, mixed> $content the `responses[$status].content` map.
-     *                                      Values are media-type objects, but a malformed spec can
-     *                                      carry a scalar — the guard loop below rejects those loudly
-     *                                      before any value is dereferenced as an array.
-     * @param null|DiscriminatorContext $discriminatorContext carries the resolved root + enforce gate
-     *                                                        for `discriminator.mapping` lowering (Issue
-     *                                                        #262). `null` (the default for direct
-     *                                                        callers) means no enforcement.
+     * Returns a {@see ResponseBodyValidationResult} with an empty `errors`
+     * list when the body passes schema validation. Hard failures (empty body
+     * against a JSON schema, schema mismatch) are returned as error strings
+     * so the orchestrator can assemble the final result.
      */
     public function validate(
         string $specName,
         string $method,
         string $matchedPath,
         int $statusCode,
-        array $content,
+        ResponseSchemaResolution $resolution,
         DecodedBody $responseBody,
-        ?string $responseContentType,
-        OpenApiVersion $version,
-        ?DiscriminatorContext $discriminatorContext = null,
-        ?string $jsonSchemaDialect = null,
     ): ResponseBodyValidationResult {
-        // Pre-scan the content map for malformed media-type entries before any
-        // content negotiation runs. This mirrors RequestBodyValidator's
-        // per-media-type guards: a media-type entry and its `schema` must each
-        // decode to a JSON object — a scalar entry would slip past the
-        // downstream `isset(...['schema'])` checks as a silent pass, a non-array
-        // `schema` on a JSON media type would reach OpenApiSchemaConverter and
-        // raise a confusing TypeError, and a JSON list mis-resolves silently.
-        // Surface all of them as loud spec-level errors via
-        // {@see MalformedSpecNode} (issue #256). `matchedContentType` is null:
-        // no content-type lookup succeeded.
-        foreach ($content as $mediaType => $mediaTypeSpec) {
-            if (MalformedSpecNode::isMalformed($mediaTypeSpec)) {
-                return new ResponseBodyValidationResult([
-                    sprintf(
-                        "Malformed 'responses[%s].content[\"%s\"]' for %s %s in '%s' spec: expected object, got %s.",
-                        $statusCode,
-                        $mediaType,
-                        $method,
-                        $matchedPath,
-                        $specName,
-                        MalformedSpecNode::describe($mediaTypeSpec),
-                    ),
-                ], null);
-            }
-
-            // array_key_exists rather than isset so an explicit `schema: null`
-            // is also flagged — otherwise it falls through the downstream
-            // presence check as a silent "no schema" pass.
-            if (array_key_exists('schema', $mediaTypeSpec) && MalformedSpecNode::isMalformed($mediaTypeSpec['schema'])) {
-                return new ResponseBodyValidationResult([
-                    sprintf(
-                        "Malformed 'responses[%s].content[\"%s\"].schema' for %s %s in '%s' spec: expected object, got %s.",
-                        $statusCode,
-                        $mediaType,
-                        $method,
-                        $matchedPath,
-                        $specName,
-                        MalformedSpecNode::describe($mediaTypeSpec['schema']),
-                    ),
-                ], null);
-            }
-
-            if (array_key_exists('itemSchema', $mediaTypeSpec) && MalformedSpecNode::isMalformed($mediaTypeSpec['itemSchema'])) {
-                return new ResponseBodyValidationResult([
-                    sprintf(
-                        "Malformed 'responses[%s].content[\"%s\"].itemSchema' for %s %s in '%s' spec: expected object, got %s.",
-                        $statusCode,
-                        $mediaType,
-                        $method,
-                        $matchedPath,
-                        $specName,
-                        MalformedSpecNode::describe($mediaTypeSpec['itemSchema']),
-                    ),
-                ], null);
-            }
-        }
-
-        // When the actual response Content-Type is provided, handle content negotiation:
-        // non-JSON types are checked for spec presence only, while JSON-compatible types
-        // fall through to schema validation. For JSON-flavoured response Content-Types
-        // we prefer the spec key that exactly matches the response Content-Type before
-        // falling back to the first JSON key — this lets multi-JSON specs (e.g.
-        // `application/json` + `application/problem+json` for the same status) validate
-        // each Content-Type against its own schema.
-        $jsonContentType = null;
-        if ($responseContentType !== null) {
-            $normalizedType = ContentTypeMatcher::normalizeMediaType($responseContentType);
-
-            if (!ContentTypeMatcher::isJsonContentType($normalizedType)) {
-                // Non-JSON response: check if the content type is defined in the spec.
-                $matchedKey = ContentTypeMatcher::findContentTypeKey($normalizedType, $content);
-                if ($matchedKey !== null) {
-                    if (isset($content[$matchedKey]['itemSchema'])) {
-                        return self::unsupportedItemSchemaResult($matchedKey, $normalizedType);
-                    }
-
-                    // A matched non-JSON media type that declares a `schema`
-                    // is an unvalidatable contract: OpenAPI permits a schema
-                    // on any media type, but this engine only evaluates JSON
-                    // Schema. Surface a skip (issue #254) so the unchecked
-                    // body is not recorded as a clean pass. A non-JSON entry
-                    // with no `schema` has nothing to validate — stay
-                    // silently successful, as before.
-                    //
-                    // `isset` (not `array_key_exists`) is deliberate: an
-                    // explicit `schema: null` is a degenerate entry, and the
-                    // per-media-type malformed-schema guard above already
-                    // rejected it loudly before this point — so it never
-                    // reaches here as a silent "no schema" case.
-                    if (isset($content[$matchedKey]['schema'])) {
-                        return new ResponseBodyValidationResult(
-                            [],
-                            $matchedKey,
-                            sprintf(
-                                "response Content-Type '%s' matched non-JSON spec media type '%s', "
-                                . 'which declares a schema this validator cannot evaluate (JSON Schema engine only)',
-                                $normalizedType,
-                                $matchedKey,
-                            ),
-                        );
-                    }
-
-                    return new ResponseBodyValidationResult([], $matchedKey);
-                }
-
-                $defined = implode(', ', array_keys($content));
-
-                return new ResponseBodyValidationResult(
-                    [
-                        "Response Content-Type '{$normalizedType}' is not defined for {$method} {$matchedPath} (status {$statusCode}) in '{$specName}' spec. Defined content types: {$defined}",
-                    ],
-                    null,
-                );
-            }
-
-            // JSON-compatible response: prefer exact match, then fall back to the first JSON key.
-            $jsonContentType = ContentTypeMatcher::findJsonContentTypeForResponse($normalizedType, $content);
-        }
-
-        if ($jsonContentType === null) {
-            $jsonContentType = ContentTypeMatcher::findJsonContentType($content);
-        }
-
-        // If no JSON-compatible content type is defined, skip body validation.
-        // This validator only handles JSON schemas; non-JSON types (e.g. text/html,
-        // application/xml) are outside its scope.
-        if ($jsonContentType === null) {
-            foreach ($content as $mediaType => $mediaTypeSpec) {
-                if (isset($mediaTypeSpec['itemSchema'])) {
-                    return self::unsupportedItemSchemaResult((string) $mediaType, (string) $mediaType);
-                }
-            }
-
-            return new ResponseBodyValidationResult([], null);
-        }
-
-        if (!isset($content[$jsonContentType]['schema'])) {
-            if (isset($content[$jsonContentType]['itemSchema'])) {
-                return self::unsupportedItemSchemaResult($jsonContentType, $jsonContentType);
-            }
-
-            return new ResponseBodyValidationResult([], $jsonContentType);
+        $jsonContentType = $resolution->contentType;
+        $schema = $resolution->schema;
+        if ($resolution->outcome !== ResponseSchemaResolutionOutcome::Resolved ||
+            $jsonContentType === null ||
+            $schema === null
+        ) {
+            throw new LogicException(sprintf(
+                'ResponseBodyValidator requires a Resolved response schema resolution; got %s.',
+                $resolution->outcome->name,
+            ));
         }
 
         // An absent body fails the contract: this validator only runs once the
         // spec is known to declare a JSON-compatible schema for the response.
         // A literal JSON `null` body is distinct — `$responseBody->present` is
         // true with a `null` value (issues #246 / #248), so it falls through
-        // to schema type-checking below instead of taking this branch.
+        // to schema type-checking below instead of taking this branch. The
+        // check deliberately runs BEFORE schema conversion so a spec whose
+        // schema the converter rejects still reports the missing body first.
         if (!$responseBody->present) {
             return new ResponseBodyValidationResult(
                 [
@@ -233,9 +76,7 @@ final class ResponseBodyValidator
 
         $bodyValue = $responseBody->value;
 
-        /** @var array<string, mixed> $schema */
-        $schema = $content[$jsonContentType]['schema'];
-        $jsonSchema = OpenApiSchemaConverter::convert($schema, $version, SchemaContext::Response, $discriminatorContext, $jsonSchemaDialect);
+        $jsonSchema = $resolution->convertedSchema();
 
         // PHP's `json_decode($json, true)` returns `[]` for both `[]` and `{}`.
         // The Laravel trait's response decoder uses associative-array decoding
@@ -261,19 +102,6 @@ final class ResponseBodyValidator
         }
 
         return new ResponseBodyValidationResult($errors, $jsonContentType, violations: $violations);
-    }
-
-    private static function unsupportedItemSchemaResult(string $matchedKey, string $actualMediaType): ResponseBodyValidationResult
-    {
-        return new ResponseBodyValidationResult(
-            [],
-            $matchedKey,
-            sprintf(
-                "response Content-Type '%s' uses OpenAPI 3.2 itemSchema streaming semantics; "
-                . 'stream items cannot be validated from the buffered response body and were explicitly skipped',
-                $actualMediaType,
-            ),
-        );
     }
 
     /**

--- a/src/Validation/Response/ResponseOperationResolution.php
+++ b/src/Validation/Response/ResponseOperationResolution.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Validation\Response;
+
+use Studio\Gesso\OpenApiVersion;
+
+/**
+ * First-stage result of {@see ResponseSchemaResolver::resolveOperation()}:
+ * the spec is loaded, the path matched, the operation resolved, and its
+ * `responses` map structurally verified. The stage boundary exists because
+ * the response validator applies its skip-by-status-code policy between
+ * operation resolution and status-key resolution; callers without that
+ * policy use {@see ResponseSchemaResolver::resolve()} instead.
+ *
+ * `outcome` is restricted to `Resolved`, `MalformedSpec`, `PathNotFound`,
+ * and `MethodNotDefined`. On failures `message` carries the exact diagnostic
+ * the response validator historically produced; the spec-document fields are
+ * null. On `Resolved` the document fields are set and `message` is null.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+final readonly class ResponseOperationResolution
+{
+    /**
+     * @param null|array<string, mixed> $spec the loaded, reference-resolved spec document
+     * @param null|array<array-key, mixed> $responses the operation's `responses` map. Keys are
+     *                                                `array-key` because PHP coerces numeric-string
+     *                                                keys (`"200"`) to int.
+     */
+    private function __construct(
+        public ResponseSchemaResolutionOutcome $outcome,
+        public string $specName,
+        public string $method,
+        public ?string $message,
+        public ?string $matchedPath,
+        public ?array $spec,
+        public ?OpenApiVersion $version,
+        public ?string $jsonSchemaDialect,
+        public ?array $responses,
+    ) {}
+
+    public static function malformedSpec(
+        string $specName,
+        string $method,
+        string $message,
+        ?string $matchedPath = null,
+    ): self {
+        return new self(
+            ResponseSchemaResolutionOutcome::MalformedSpec,
+            $specName,
+            $method,
+            $message,
+            $matchedPath,
+            spec: null,
+            version: null,
+            jsonSchemaDialect: null,
+            responses: null,
+        );
+    }
+
+    public static function pathNotFound(string $specName, string $method, string $message): self
+    {
+        return new self(
+            ResponseSchemaResolutionOutcome::PathNotFound,
+            $specName,
+            $method,
+            $message,
+            matchedPath: null,
+            spec: null,
+            version: null,
+            jsonSchemaDialect: null,
+            responses: null,
+        );
+    }
+
+    public static function methodNotDefined(
+        string $specName,
+        string $method,
+        string $message,
+        string $matchedPath,
+    ): self {
+        return new self(
+            ResponseSchemaResolutionOutcome::MethodNotDefined,
+            $specName,
+            $method,
+            $message,
+            $matchedPath,
+            spec: null,
+            version: null,
+            jsonSchemaDialect: null,
+            responses: null,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $spec
+     * @param array<array-key, mixed> $responses
+     */
+    public static function resolved(
+        string $specName,
+        string $method,
+        string $matchedPath,
+        array $spec,
+        OpenApiVersion $version,
+        string $jsonSchemaDialect,
+        array $responses,
+    ): self {
+        return new self(
+            ResponseSchemaResolutionOutcome::Resolved,
+            $specName,
+            $method,
+            message: null,
+            matchedPath: $matchedPath,
+            spec: $spec,
+            version: $version,
+            jsonSchemaDialect: $jsonSchemaDialect,
+            responses: $responses,
+        );
+    }
+}

--- a/src/Validation/Response/ResponseSchemaResolution.php
+++ b/src/Validation/Response/ResponseSchemaResolution.php
@@ -1,0 +1,328 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Validation\Response;
+
+use LogicException;
+use Studio\Gesso\OpenApiVersion;
+use Studio\Gesso\SchemaContext;
+use Studio\Gesso\Spec\OpenApiSchemaConverter;
+use Studio\Gesso\Validation\Support\DiscriminatorContext;
+
+use function sprintf;
+
+/**
+ * Result of resolving a response schema by `(method, path, status, content
+ * type)` through {@see ResponseSchemaResolver} (issue #442).
+ *
+ * Field availability follows the outcome:
+ *
+ *  - `message` carries the failure diagnostic — verbatim what the response
+ *    validator historically rendered — for every non-`Resolved` outcome
+ *    except the deliberate skips and empty successes (`NoContent`,
+ *    `NoJsonContent`, `MissingSchema`, `NonJsonSchema`,
+ *    `ItemSchemaStreaming`).
+ *  - `skipReason` is set on `NonJsonSchema` / `ItemSchemaStreaming` only:
+ *    the media type matched but its schema is deliberately not evaluated.
+ *  - `responseSpec` is the raw `responses[<statusKey>]` node, available once
+ *    the entry resolved as an object (content-level outcomes and later).
+ *  - `schema` is the raw media-type `schema` node on `Resolved` only;
+ *    {@see convertedSchema()} lowers it on demand.
+ *
+ * Conversion is deliberately lazy: the response validator reports an absent
+ * body *before* converting the schema, so an eagerly-converted (and
+ * possibly throwing) schema would change which diagnostic wins. Callers that
+ * only need the metadata never pay for — or trip over — the conversion.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+final readonly class ResponseSchemaResolution
+{
+    /**
+     * @param null|array<string, mixed> $responseSpec
+     * @param null|array<string, mixed> $schema
+     */
+    private function __construct(
+        public ResponseSchemaResolutionOutcome $outcome,
+        public ?string $matchedPath,
+        public ?string $statusKey,
+        public ?string $contentType,
+        public ?string $message,
+        public ?string $skipReason,
+        public ?array $responseSpec,
+        public ?array $schema,
+        private ?OpenApiVersion $version,
+        private ?string $jsonSchemaDialect,
+        private ?DiscriminatorContext $discriminatorContext,
+    ) {}
+
+    /**
+     * Map a failed first-stage resolution into the composed result shape so
+     * {@see ResponseSchemaResolver::resolve()} reports one type.
+     */
+    public static function fromOperationFailure(ResponseOperationResolution $operation): self
+    {
+        if ($operation->outcome === ResponseSchemaResolutionOutcome::Resolved) {
+            throw new LogicException('fromOperationFailure() requires a failed operation resolution.');
+        }
+
+        return new self(
+            $operation->outcome,
+            $operation->matchedPath,
+            statusKey: null,
+            contentType: null,
+            message: $operation->message,
+            skipReason: null,
+            responseSpec: null,
+            schema: null,
+            version: null,
+            jsonSchemaDialect: null,
+            discriminatorContext: null,
+        );
+    }
+
+    public static function statusNotDeclared(string $matchedPath, string $message): self
+    {
+        return self::failure(ResponseSchemaResolutionOutcome::StatusNotDeclared, $matchedPath, null, $message);
+    }
+
+    public static function malformedResponse(string $matchedPath, string $statusKey, string $message): self
+    {
+        return self::failure(ResponseSchemaResolutionOutcome::MalformedResponse, $matchedPath, $statusKey, $message);
+    }
+
+    /**
+     * @param array<string, mixed> $responseSpec
+     */
+    public static function malformedContent(
+        string $matchedPath,
+        string $statusKey,
+        array $responseSpec,
+        string $message,
+    ): self {
+        return new self(
+            ResponseSchemaResolutionOutcome::MalformedContent,
+            $matchedPath,
+            $statusKey,
+            contentType: null,
+            message: $message,
+            skipReason: null,
+            responseSpec: $responseSpec,
+            schema: null,
+            version: null,
+            jsonSchemaDialect: null,
+            discriminatorContext: null,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $responseSpec
+     */
+    public static function contentTypeNotDeclared(
+        string $matchedPath,
+        string $statusKey,
+        array $responseSpec,
+        string $message,
+    ): self {
+        return new self(
+            ResponseSchemaResolutionOutcome::ContentTypeNotDeclared,
+            $matchedPath,
+            $statusKey,
+            contentType: null,
+            message: $message,
+            skipReason: null,
+            responseSpec: $responseSpec,
+            schema: null,
+            version: null,
+            jsonSchemaDialect: null,
+            discriminatorContext: null,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $responseSpec
+     */
+    public static function noContent(string $matchedPath, string $statusKey, array $responseSpec): self
+    {
+        return self::withoutSchema(ResponseSchemaResolutionOutcome::NoContent, $matchedPath, $statusKey, null, $responseSpec);
+    }
+
+    /**
+     * @param array<string, mixed> $responseSpec
+     */
+    public static function noJsonContent(string $matchedPath, string $statusKey, array $responseSpec): self
+    {
+        return self::withoutSchema(ResponseSchemaResolutionOutcome::NoJsonContent, $matchedPath, $statusKey, null, $responseSpec);
+    }
+
+    /**
+     * @param array<string, mixed> $responseSpec
+     */
+    public static function missingSchema(
+        string $matchedPath,
+        string $statusKey,
+        string $contentType,
+        array $responseSpec,
+    ): self {
+        return self::withoutSchema(ResponseSchemaResolutionOutcome::MissingSchema, $matchedPath, $statusKey, $contentType, $responseSpec);
+    }
+
+    /**
+     * @param array<string, mixed> $responseSpec
+     */
+    public static function nonJsonSchema(
+        string $matchedPath,
+        string $statusKey,
+        string $contentType,
+        array $responseSpec,
+        string $skipReason,
+    ): self {
+        return self::skipped(ResponseSchemaResolutionOutcome::NonJsonSchema, $matchedPath, $statusKey, $contentType, $responseSpec, $skipReason);
+    }
+
+    /**
+     * @param array<string, mixed> $responseSpec
+     */
+    public static function itemSchemaStreaming(
+        string $matchedPath,
+        string $statusKey,
+        string $contentType,
+        array $responseSpec,
+        string $skipReason,
+    ): self {
+        return self::skipped(ResponseSchemaResolutionOutcome::ItemSchemaStreaming, $matchedPath, $statusKey, $contentType, $responseSpec, $skipReason);
+    }
+
+    /**
+     * @param array<string, mixed> $responseSpec
+     * @param array<string, mixed> $schema
+     */
+    public static function resolved(
+        string $matchedPath,
+        string $statusKey,
+        string $contentType,
+        array $responseSpec,
+        array $schema,
+        OpenApiVersion $version,
+        string $jsonSchemaDialect,
+        DiscriminatorContext $discriminatorContext,
+    ): self {
+        return new self(
+            ResponseSchemaResolutionOutcome::Resolved,
+            $matchedPath,
+            $statusKey,
+            $contentType,
+            message: null,
+            skipReason: null,
+            responseSpec: $responseSpec,
+            schema: $schema,
+            version: $version,
+            jsonSchemaDialect: $jsonSchemaDialect,
+            discriminatorContext: $discriminatorContext,
+        );
+    }
+
+    /**
+     * Convert the resolved raw schema for validation, preserving the schema
+     * dialect and discriminator enforcement selected at resolution time.
+     *
+     * Throws the converter's usual `RuntimeException` subclasses for schemas
+     * it rejects (unsupported dialect, malformed discriminator, ...) — the
+     * caller decides whether that is a test failure or a fatal error.
+     *
+     * @return array<string, mixed>
+     */
+    public function convertedSchema(): array
+    {
+        if ($this->outcome !== ResponseSchemaResolutionOutcome::Resolved ||
+            $this->schema === null ||
+            $this->version === null
+        ) {
+            throw new LogicException(sprintf(
+                'convertedSchema() is only available on a Resolved response schema resolution; got %s.',
+                $this->outcome->name,
+            ));
+        }
+
+        return OpenApiSchemaConverter::convert(
+            $this->schema,
+            $this->version,
+            SchemaContext::Response,
+            $this->discriminatorContext,
+            $this->jsonSchemaDialect,
+        );
+    }
+
+    private static function failure(
+        ResponseSchemaResolutionOutcome $outcome,
+        string $matchedPath,
+        ?string $statusKey,
+        string $message,
+    ): self {
+        return new self(
+            $outcome,
+            $matchedPath,
+            $statusKey,
+            contentType: null,
+            message: $message,
+            skipReason: null,
+            responseSpec: null,
+            schema: null,
+            version: null,
+            jsonSchemaDialect: null,
+            discriminatorContext: null,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $responseSpec
+     */
+    private static function withoutSchema(
+        ResponseSchemaResolutionOutcome $outcome,
+        string $matchedPath,
+        string $statusKey,
+        ?string $contentType,
+        array $responseSpec,
+    ): self {
+        return new self(
+            $outcome,
+            $matchedPath,
+            $statusKey,
+            $contentType,
+            message: null,
+            skipReason: null,
+            responseSpec: $responseSpec,
+            schema: null,
+            version: null,
+            jsonSchemaDialect: null,
+            discriminatorContext: null,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $responseSpec
+     */
+    private static function skipped(
+        ResponseSchemaResolutionOutcome $outcome,
+        string $matchedPath,
+        string $statusKey,
+        string $contentType,
+        array $responseSpec,
+        string $skipReason,
+    ): self {
+        return new self(
+            $outcome,
+            $matchedPath,
+            $statusKey,
+            $contentType,
+            message: null,
+            skipReason: $skipReason,
+            responseSpec: $responseSpec,
+            schema: null,
+            version: null,
+            jsonSchemaDialect: null,
+            discriminatorContext: null,
+        );
+    }
+}

--- a/src/Validation/Response/ResponseSchemaResolutionOutcome.php
+++ b/src/Validation/Response/ResponseSchemaResolutionOutcome.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Validation\Response;
+
+/**
+ * Outcome of resolving a response schema by `(method, path, status,
+ * content type)` through {@see ResponseSchemaResolver} (issue #442).
+ *
+ * Every way the resolution pipeline can stop short of a converted schema is
+ * its own loud case — never a silent `null` — so consumers outside the
+ * response validator (the response-payload explorer, #441) cannot mistake
+ * "nothing to validate" for "resolved". The response validator maps each
+ * case back onto its historical failure / skip / success behavior.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+enum ResponseSchemaResolutionOutcome
+{
+    /** A JSON-compatible media type with a schema was resolved and converted. */
+    case Resolved;
+
+    /**
+     * A structural spec node above the response entry (`paths`, the path
+     * item, the operation, or the `responses` map) is not a JSON object.
+     */
+    case MalformedSpec;
+
+    /** The request path matched no spec path. */
+    case PathNotFound;
+
+    /** The matched path item declares no operation for the method. */
+    case MethodNotDefined;
+
+    /** No exact, range (`5XX`), or `default` response key covers the status. */
+    case StatusNotDeclared;
+
+    /** The matched `responses[<key>]` entry is not a JSON object. */
+    case MalformedResponse;
+
+    /**
+     * The response's `content` block, a media-type entry, or its
+     * `schema` / `itemSchema` node is not a JSON object.
+     */
+    case MalformedContent;
+
+    /** The response declares no `content` block (204-style). */
+    case NoContent;
+
+    /**
+     * The `content` block declares no JSON-compatible media type (and no
+     * actual response Content-Type narrowed the lookup to a non-JSON entry).
+     */
+    case NoJsonContent;
+
+    /** The actual response Content-Type matches no declared media type. */
+    case ContentTypeNotDeclared;
+
+    /** The matched media type declares no `schema` to validate against. */
+    case MissingSchema;
+
+    /**
+     * The matched media type is non-JSON but declares a `schema` this
+     * JSON-Schema engine cannot evaluate (issue #254).
+     */
+    case NonJsonSchema;
+
+    /**
+     * The matched media type uses OpenAPI 3.2 `itemSchema` streaming
+     * semantics; stream items cannot be resolved to one buffered schema.
+     */
+    case ItemSchemaStreaming;
+}

--- a/src/Validation/Response/ResponseSchemaResolver.php
+++ b/src/Validation/Response/ResponseSchemaResolver.php
@@ -1,0 +1,467 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Validation\Response;
+
+use LogicException;
+use Studio\Gesso\OpenApiResponseValidator;
+use Studio\Gesso\OpenApiVersion;
+use Studio\Gesso\Spec\OpenApiOperationResolver;
+use Studio\Gesso\Spec\OpenApiPathMatcher;
+use Studio\Gesso\Spec\OpenApiSchemaDialect;
+use Studio\Gesso\Spec\OpenApiSpecLoader;
+use Studio\Gesso\Validation\Support\ContentTypeMatcher;
+use Studio\Gesso\Validation\Support\DiscriminatorContext;
+use Studio\Gesso\Validation\Support\DiscriminatorEnforcement;
+use Studio\Gesso\Validation\Support\MalformedSpecNode;
+use Studio\Gesso\Validation\Support\PathDiagnosticsFormatter;
+use Studio\Gesso\Validation\Support\SpecResponseKeyResolver;
+
+use function array_key_exists;
+use function array_keys;
+use function implode;
+use function sprintf;
+
+/**
+ * Resolves the response schema selected by `(method, path, status, content
+ * type)` in a named spec: path matching, operation lookup, status-key
+ * resolution (exact → range → `default`), content-type negotiation, and
+ * schema conversion with the selected dialect and discriminator enforcement.
+ *
+ * This is the single implementation behind both the response validator and
+ * schema-driven consumers that need a response schema outside an assertion
+ * flow (the response-payload explorer, #441). Alternate entry points MUST
+ * route through it rather than re-inline the pipeline — that is the
+ * invariant that keeps discriminator enforcement, dialect selection, and
+ * doctor/runtime malformed-node diagnostics from drifting apart (issue #442).
+ *
+ * The two-stage API ({@see resolveOperation()} then
+ * {@see resolveResponseSchema()}) exists for
+ * {@see OpenApiResponseValidator}, whose skip-by-status-code policy applies
+ * after the operation's `responses` map is structurally verified but before
+ * status-key resolution. Callers without an interleaved policy use
+ * {@see resolve()}.
+ *
+ * Failure diagnostics are formatted here, verbatim to what the validator
+ * historically produced, so both consumers surface identical messages.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+final class ResponseSchemaResolver
+{
+    /** @var array<string, OpenApiPathMatcher> */
+    private array $pathMatchers = [];
+
+    /**
+     * Stage 1: load the spec and resolve the operation's `responses` map.
+     *
+     * Spec-loading failures (unknown name, undecodable document) throw the
+     * loader's usual exceptions; everything below that surfaces as a
+     * structured outcome.
+     */
+    public function resolveOperation(string $specName, string $method, string $requestPath): ResponseOperationResolution
+    {
+        $spec = OpenApiSpecLoader::load($specName);
+
+        $version = OpenApiVersion::fromSpec($spec);
+        $jsonSchemaDialect = OpenApiSchemaDialect::fromSpec($spec, $version);
+
+        // The root `paths` must decode to a JSON object; a scalar, `null`, or
+        // a JSON list is a malformed spec ({@see MalformedSpecNode}).
+        // Unguarded, a non-array reaches the `array_keys()` call below
+        // (uncaught TypeError) and a list mis-resolves silently. The presence
+        // test uses `array_key_exists` (not `isset`) so a present-but-`null`
+        // `paths` is caught here rather than coalesced to an empty map by
+        // `?? []` (issue #259).
+        if (array_key_exists('paths', $spec) && MalformedSpecNode::isMalformed($spec['paths'])) {
+            return ResponseOperationResolution::malformedSpec($specName, $method, sprintf(
+                "Malformed 'paths' for %s %s in '%s' spec: expected object, got %s.",
+                $method,
+                $requestPath,
+                $specName,
+                MalformedSpecNode::describe($spec['paths']),
+            ));
+        }
+
+        /** @var string[] $specPaths */
+        $specPaths = array_keys($spec['paths'] ?? []);
+        $matcher = $this->pathMatchers[$specName] ??= new OpenApiPathMatcher($specPaths, OpenApiSpecLoader::getStripPrefixes());
+        $matchedPath = $matcher->match($requestPath);
+
+        if ($matchedPath === null) {
+            return ResponseOperationResolution::pathNotFound(
+                $specName,
+                $method,
+                PathDiagnosticsFormatter::pathNotFound($specName, $method, $requestPath, $matcher, $spec),
+            );
+        }
+
+        // `$matchedPath` is always a key of `$spec['paths']` (the matcher was
+        // built from its `array_keys()`), so `?? null` here only fires for an
+        // explicit `null` *value* — which the guard below then treats as
+        // malformed, exactly like a scalar path item (issue #259).
+        $pathSpec = $spec['paths'][$matchedPath] ?? null;
+
+        if (MalformedSpecNode::isMalformed($pathSpec)) {
+            return ResponseOperationResolution::malformedSpec($specName, $method, sprintf(
+                "Malformed 'paths[\"%s\"]' for %s %s in '%s' spec: expected object, got %s.",
+                $matchedPath,
+                $method,
+                $matchedPath,
+                $specName,
+                MalformedSpecNode::describe($pathSpec),
+            ), $matchedPath);
+        }
+
+        $resolvedOperation = OpenApiOperationResolver::resolve($pathSpec, $method);
+        if (!$resolvedOperation['found']) {
+            return ResponseOperationResolution::methodNotDefined(
+                $specName,
+                $method,
+                PathDiagnosticsFormatter::methodNotDefined($specName, $method, $matchedPath, $spec),
+                $matchedPath,
+            );
+        }
+
+        $operation = $resolvedOperation['operation'];
+        $operationLocation = $resolvedOperation['location'];
+
+        if (MalformedSpecNode::isMalformed($operation)) {
+            return ResponseOperationResolution::malformedSpec($specName, $method, sprintf(
+                "Malformed 'paths[\"%s\"].%s' for %s %s in '%s' spec: expected object, got %s.",
+                $matchedPath,
+                $operationLocation,
+                $method,
+                $matchedPath,
+                $specName,
+                MalformedSpecNode::describe($operation),
+            ), $matchedPath);
+        }
+
+        /** @var array<string, mixed> $operation */
+        // `array_key_exists` (not `?? []`) so a present-but-`null` `responses`
+        // is caught by the guard below as malformed, while a genuinely absent
+        // `responses` key still falls back to an empty map (resolved later as
+        // "status code not defined").
+        $responses = array_key_exists('responses', $operation) ? $operation['responses'] : [];
+
+        if (MalformedSpecNode::isMalformed($responses)) {
+            return ResponseOperationResolution::malformedSpec($specName, $method, sprintf(
+                "Malformed 'paths[\"%s\"].%s.responses' for %s %s in '%s' spec: expected object, got %s.",
+                $matchedPath,
+                $operationLocation,
+                $method,
+                $matchedPath,
+                $specName,
+                MalformedSpecNode::describe($responses),
+            ), $matchedPath);
+        }
+
+        /** @var array<array-key, mixed> $responses */
+        return ResponseOperationResolution::resolved(
+            $specName,
+            $method,
+            $matchedPath,
+            $spec,
+            $version,
+            $jsonSchemaDialect,
+            $responses,
+        );
+    }
+
+    /**
+     * Stage 2: resolve the response entry for the wire status, negotiate the
+     * media type against the optional actual response Content-Type, and hand
+     * back the selected raw schema with lazy conversion.
+     *
+     * `$responseContentType` may carry parameters (`; charset=utf-8`) and any
+     * casing — it is normalized before matching, exactly like the validator's
+     * body path always did.
+     */
+    public function resolveResponseSchema(
+        ResponseOperationResolution $operation,
+        int $statusCode,
+        ?string $responseContentType = null,
+    ): ResponseSchemaResolution {
+        if ($operation->outcome !== ResponseSchemaResolutionOutcome::Resolved ||
+            $operation->matchedPath === null ||
+            $operation->spec === null ||
+            $operation->version === null ||
+            $operation->jsonSchemaDialect === null ||
+            $operation->responses === null
+        ) {
+            throw new LogicException(sprintf(
+                'resolveResponseSchema() requires a Resolved operation resolution; got %s.',
+                $operation->outcome->name,
+            ));
+        }
+
+        $specName = $operation->specName;
+        $method = $operation->method;
+        $matchedPath = $operation->matchedPath;
+        $responses = $operation->responses;
+        $statusCodeStr = (string) $statusCode;
+
+        // Spec lookup priority per OpenAPI 3.0/3.1: exact code, then range
+        // key (`5XX`), then `default`. Without this fallback, a spec that
+        // documents only `default` (or only `5XX`) would fail every real
+        // status — both patterns are common (Problem Details responses
+        // typically use `default` for the error envelope).
+        $matchedResponseKey = SpecResponseKeyResolver::resolve($statusCodeStr, $responses);
+        if ($matchedResponseKey === null) {
+            return ResponseSchemaResolution::statusNotDeclared(
+                $matchedPath,
+                "Status code {$statusCode} not defined for {$method} {$matchedPath} in '{$specName}' spec.",
+            );
+        }
+
+        // Before silently surfacing a `default` fallback, surface any keys
+        // that LOOK like attempted spec keys but don't satisfy the exact /
+        // range / default form. The wire status is never the literal
+        // `default`, so landing on `default` always means a real fallback.
+        // Fired here — not in the validator — so every consumer of the
+        // shared resolution sees the same typo diagnostic.
+        if ($matchedResponseKey === 'default') {
+            SpecResponseKeyResolver::warnSuspiciousKeys($specName, $method, $matchedPath, $responses);
+        }
+
+        $responseSpec = $responses[$matchedResponseKey];
+
+        // A response entry must decode to a JSON object; a scalar, `null`, or
+        // a JSON list is a malformed spec — e.g. an unresolved $ref. The
+        // message keys off the matched spec key, not the wire status, so it
+        // points at a map entry the spec author actually wrote (issue #258).
+        if (MalformedSpecNode::isMalformed($responseSpec)) {
+            return ResponseSchemaResolution::malformedResponse($matchedPath, $matchedResponseKey, sprintf(
+                "Malformed 'responses[%s]' for %s %s in '%s' spec: expected object, got %s.",
+                $matchedResponseKey,
+                $method,
+                $matchedPath,
+                $specName,
+                MalformedSpecNode::describe($responseSpec),
+            ));
+        }
+
+        /** @var array<string, mixed> $responseSpec */
+        // 204 No Content (and similar) declare no `content` block. `isset`
+        // (not `array_key_exists`) is the historical validator behavior: an
+        // explicit `content: null` also lands here.
+        if (!isset($responseSpec['content'])) {
+            return ResponseSchemaResolution::noContent($matchedPath, $matchedResponseKey, $responseSpec);
+        }
+
+        // A `content` block must decode to a JSON object; a scalar or a JSON
+        // list is a malformed spec — e.g. an unresolved $ref (issue #256).
+        // Content-level malformed diagnostics key off the wire status (the
+        // caller's request context), matching the historical validator
+        // messages.
+        if (MalformedSpecNode::isMalformed($responseSpec['content'])) {
+            return ResponseSchemaResolution::malformedContent($matchedPath, $matchedResponseKey, $responseSpec, sprintf(
+                "Malformed 'responses[%s].content' for %s %s in '%s' spec: expected object, got %s.",
+                $statusCode,
+                $method,
+                $matchedPath,
+                $specName,
+                MalformedSpecNode::describe($responseSpec['content']),
+            ));
+        }
+
+        /** @var array<string, mixed> $content */
+        $content = $responseSpec['content'];
+
+        // Pre-scan the content map for malformed media-type entries before
+        // any content negotiation runs: a media-type entry and its `schema` /
+        // `itemSchema` must each decode to a JSON object — a scalar entry
+        // would slip past the downstream `isset(...['schema'])` checks as a
+        // silent pass, a non-array `schema` would reach the converter and
+        // raise a confusing TypeError (issue #256). `array_key_exists` rather
+        // than `isset` so an explicit `schema: null` is also flagged.
+        foreach ($content as $mediaType => $mediaTypeSpec) {
+            if (MalformedSpecNode::isMalformed($mediaTypeSpec)) {
+                return ResponseSchemaResolution::malformedContent($matchedPath, $matchedResponseKey, $responseSpec, sprintf(
+                    "Malformed 'responses[%s].content[\"%s\"]' for %s %s in '%s' spec: expected object, got %s.",
+                    $statusCode,
+                    $mediaType,
+                    $method,
+                    $matchedPath,
+                    $specName,
+                    MalformedSpecNode::describe($mediaTypeSpec),
+                ));
+            }
+
+            if (array_key_exists('schema', $mediaTypeSpec) && MalformedSpecNode::isMalformed($mediaTypeSpec['schema'])) {
+                return ResponseSchemaResolution::malformedContent($matchedPath, $matchedResponseKey, $responseSpec, sprintf(
+                    "Malformed 'responses[%s].content[\"%s\"].schema' for %s %s in '%s' spec: expected object, got %s.",
+                    $statusCode,
+                    $mediaType,
+                    $method,
+                    $matchedPath,
+                    $specName,
+                    MalformedSpecNode::describe($mediaTypeSpec['schema']),
+                ));
+            }
+
+            if (array_key_exists('itemSchema', $mediaTypeSpec) && MalformedSpecNode::isMalformed($mediaTypeSpec['itemSchema'])) {
+                return ResponseSchemaResolution::malformedContent($matchedPath, $matchedResponseKey, $responseSpec, sprintf(
+                    "Malformed 'responses[%s].content[\"%s\"].itemSchema' for %s %s in '%s' spec: expected object, got %s.",
+                    $statusCode,
+                    $mediaType,
+                    $method,
+                    $matchedPath,
+                    $specName,
+                    MalformedSpecNode::describe($mediaTypeSpec['itemSchema']),
+                ));
+            }
+        }
+
+        // When the actual response Content-Type is provided, handle content
+        // negotiation: non-JSON types are checked for spec presence only,
+        // while JSON-compatible types fall through to schema selection. For
+        // JSON-flavoured Content-Types we prefer the spec key that exactly
+        // matches before falling back to the first JSON key — this lets
+        // multi-JSON specs (e.g. `application/json` +
+        // `application/problem+json` for the same status) resolve each
+        // Content-Type to its own schema.
+        $jsonContentType = null;
+        if ($responseContentType !== null) {
+            $normalizedType = ContentTypeMatcher::normalizeMediaType($responseContentType);
+
+            if (!ContentTypeMatcher::isJsonContentType($normalizedType)) {
+                $matchedKey = ContentTypeMatcher::findContentTypeKey($normalizedType, $content);
+                if ($matchedKey !== null) {
+                    if (isset($content[$matchedKey]['itemSchema'])) {
+                        return ResponseSchemaResolution::itemSchemaStreaming(
+                            $matchedPath,
+                            $matchedResponseKey,
+                            $matchedKey,
+                            $responseSpec,
+                            self::itemSchemaSkipReason($normalizedType),
+                        );
+                    }
+
+                    // A matched non-JSON media type that declares a `schema`
+                    // is an unvalidatable contract: OpenAPI permits a schema
+                    // on any media type, but this engine only evaluates JSON
+                    // Schema (issue #254). A non-JSON entry with no `schema`
+                    // has nothing to resolve — `isset` is deliberate: an
+                    // explicit `schema: null` was already rejected loudly by
+                    // the per-media-type guard above.
+                    if (isset($content[$matchedKey]['schema'])) {
+                        return ResponseSchemaResolution::nonJsonSchema(
+                            $matchedPath,
+                            $matchedResponseKey,
+                            $matchedKey,
+                            $responseSpec,
+                            sprintf(
+                                "response Content-Type '%s' matched non-JSON spec media type '%s', "
+                                . 'which declares a schema this validator cannot evaluate (JSON Schema engine only)',
+                                $normalizedType,
+                                $matchedKey,
+                            ),
+                        );
+                    }
+
+                    return ResponseSchemaResolution::missingSchema($matchedPath, $matchedResponseKey, $matchedKey, $responseSpec);
+                }
+
+                $defined = implode(', ', array_keys($content));
+
+                return ResponseSchemaResolution::contentTypeNotDeclared(
+                    $matchedPath,
+                    $matchedResponseKey,
+                    $responseSpec,
+                    "Response Content-Type '{$normalizedType}' is not defined for {$method} {$matchedPath} "
+                    . "(status {$statusCode}) in '{$specName}' spec. Defined content types: {$defined}",
+                );
+            }
+
+            $jsonContentType = ContentTypeMatcher::findJsonContentTypeForResponse($normalizedType, $content);
+        }
+
+        if ($jsonContentType === null) {
+            $jsonContentType = ContentTypeMatcher::findJsonContentType($content);
+        }
+
+        // No JSON-compatible content type is defined. A declared `itemSchema`
+        // stream stays a loud dedicated outcome; everything else is the
+        // "nothing this JSON-Schema engine can select" case.
+        if ($jsonContentType === null) {
+            foreach ($content as $mediaType => $mediaTypeSpec) {
+                if (isset($mediaTypeSpec['itemSchema'])) {
+                    return ResponseSchemaResolution::itemSchemaStreaming(
+                        $matchedPath,
+                        $matchedResponseKey,
+                        (string) $mediaType,
+                        $responseSpec,
+                        self::itemSchemaSkipReason((string) $mediaType),
+                    );
+                }
+            }
+
+            return ResponseSchemaResolution::noJsonContent($matchedPath, $matchedResponseKey, $responseSpec);
+        }
+
+        if (!isset($content[$jsonContentType]['schema'])) {
+            if (isset($content[$jsonContentType]['itemSchema'])) {
+                return ResponseSchemaResolution::itemSchemaStreaming(
+                    $matchedPath,
+                    $matchedResponseKey,
+                    $jsonContentType,
+                    $responseSpec,
+                    self::itemSchemaSkipReason($jsonContentType),
+                );
+            }
+
+            return ResponseSchemaResolution::missingSchema($matchedPath, $matchedResponseKey, $jsonContentType, $responseSpec);
+        }
+
+        /** @var array<string, mixed> $schema */
+        $schema = $content[$jsonContentType]['schema'];
+
+        // Carry the resolved root + enforce gate so conversion can lower
+        // `discriminator.mapping` into enforceable conditionals (#262). The
+        // mapping pointers reference subtype schemas elsewhere in the
+        // document, which only the root can resolve.
+        $discriminatorContext = new DiscriminatorContext($operation->spec, DiscriminatorEnforcement::isEnabled());
+
+        return ResponseSchemaResolution::resolved(
+            $matchedPath,
+            $matchedResponseKey,
+            $jsonContentType,
+            $responseSpec,
+            $schema,
+            $operation->version,
+            $operation->jsonSchemaDialect,
+            $discriminatorContext,
+        );
+    }
+
+    /**
+     * Composed resolution for callers without an interleaved policy between
+     * operation lookup and status resolution.
+     */
+    public function resolve(
+        string $specName,
+        string $method,
+        string $requestPath,
+        int $statusCode,
+        ?string $responseContentType = null,
+    ): ResponseSchemaResolution {
+        $operation = $this->resolveOperation($specName, $method, $requestPath);
+        if ($operation->outcome !== ResponseSchemaResolutionOutcome::Resolved) {
+            return ResponseSchemaResolution::fromOperationFailure($operation);
+        }
+
+        return $this->resolveResponseSchema($operation, $statusCode, $responseContentType);
+    }
+
+    private static function itemSchemaSkipReason(string $actualMediaType): string
+    {
+        return sprintf(
+            "response Content-Type '%s' uses OpenAPI 3.2 itemSchema streaming semantics; "
+            . 'stream items cannot be validated from the buffered response body and were explicitly skipped',
+            $actualMediaType,
+        );
+    }
+}

--- a/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
+++ b/tests/Unit/Validation/Response/ResponseBodyValidatorTest.php
@@ -5,14 +5,23 @@ declare(strict_types=1);
 namespace Studio\Gesso\Tests\Unit\Validation\Response;
 
 use InvalidArgumentException;
+use LogicException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\Gesso\DecodedBody;
 use Studio\Gesso\OpenApiVersion;
+use Studio\Gesso\Spec\OpenApiSchemaDialect;
 use Studio\Gesso\Validation\Response\ResponseBodyValidationResult;
 use Studio\Gesso\Validation\Response\ResponseBodyValidator;
+use Studio\Gesso\Validation\Response\ResponseSchemaResolution;
+use Studio\Gesso\Validation\Support\DiscriminatorContext;
 use Studio\Gesso\Validation\Support\SchemaValidatorRunner;
 
+/**
+ * Body-vs-schema validation only: content negotiation, media-type guards,
+ * and schema selection moved to {@see ResponseSchemaResolver} (issue #442)
+ * and are pinned in ResponseSchemaResolverTest.
+ */
 class ResponseBodyValidatorTest extends TestCase
 {
     private ResponseBodyValidator $validator;
@@ -26,25 +35,19 @@ class ResponseBodyValidatorTest extends TestCase
     #[Test]
     public function validate_passes_valid_json_body_against_schema(): void
     {
-        $content = [
-            'application/json' => [
-                'schema' => [
-                    'type' => 'object',
-                    'properties' => ['id' => ['type' => 'integer']],
-                    'required' => ['id'],
-                ],
-            ],
-        ];
+        $resolution = self::resolution([
+            'type' => 'object',
+            'properties' => ['id' => ['type' => 'integer']],
+            'required' => ['id'],
+        ]);
 
         $result = $this->validator->validate(
             'spec',
             'GET',
             '/pets/{id}',
             200,
-            $content,
+            $resolution,
             DecodedBody::present(['id' => 1]),
-            'application/json',
-            OpenApiVersion::V3_0,
         );
 
         $this->assertSame([], $result->errors);
@@ -54,19 +57,13 @@ class ResponseBodyValidatorTest extends TestCase
     #[Test]
     public function validate_flags_empty_body_against_json_schema(): void
     {
-        $content = [
-            'application/json' => ['schema' => ['type' => 'object']],
-        ];
-
         $result = $this->validator->validate(
             'spec',
             'GET',
             '/pets',
             200,
-            $content,
+            self::resolution(['type' => 'object']),
             DecodedBody::absent(),
-            'application/json',
-            OpenApiVersion::V3_0,
         );
 
         $this->assertCount(1, $result->errors);
@@ -79,25 +76,19 @@ class ResponseBodyValidatorTest extends TestCase
     {
         // Issue #282 stage 2: schema errors keep their structured twin so the
         // orchestrator can attach instancePath/keyword to response.body issues.
-        $content = [
-            'application/json' => [
-                'schema' => [
-                    'type' => 'object',
-                    'properties' => ['id' => ['type' => 'integer']],
-                    'required' => ['id', 'name'],
-                ],
-            ],
-        ];
+        $resolution = self::resolution([
+            'type' => 'object',
+            'properties' => ['id' => ['type' => 'integer']],
+            'required' => ['id', 'name'],
+        ]);
 
         $result = $this->validator->validate(
             'spec',
             'GET',
             '/pets',
             200,
-            $content,
+            $resolution,
             DecodedBody::present(['id' => 'not-an-int']),
-            'application/json',
-            OpenApiVersion::V3_0,
         );
 
         $this->assertCount(2, $result->errors);
@@ -114,19 +105,13 @@ class ResponseBodyValidatorTest extends TestCase
     #[Test]
     public function validate_reports_no_violations_for_non_schema_errors(): void
     {
-        $content = [
-            'application/json' => ['schema' => ['type' => 'object']],
-        ];
-
         $result = $this->validator->validate(
             'spec',
             'GET',
             '/pets',
             200,
-            $content,
+            self::resolution(['type' => 'object']),
             DecodedBody::absent(),
-            'application/json',
-            OpenApiVersion::V3_0,
         );
 
         $this->assertNotSame([], $result->errors);
@@ -143,19 +128,13 @@ class ResponseBodyValidatorTest extends TestCase
         // "Response body is empty" message reserved for a genuinely absent
         // body. A present DecodedBody carrying `null` is how an adapter
         // signals "the wire carried a body and its decoded value is null".
-        $content = [
-            'application/json' => ['schema' => ['type' => 'object']],
-        ];
-
         $result = $this->validator->validate(
             'spec',
             'GET',
             '/pets',
             200,
-            $content,
+            self::resolution(['type' => 'object']),
             DecodedBody::present(null),
-            'application/json',
-            OpenApiVersion::V3_0,
         );
 
         $this->assertNotEmpty($result->errors);
@@ -170,19 +149,13 @@ class ResponseBodyValidatorTest extends TestCase
         // OAS 3.1 `type: ["object", "null"]` explicitly permits a null body.
         // A present literal `null` validates cleanly against it — the pre-#246
         // "body is empty" short-circuit would have wrongly rejected it.
-        $content = [
-            'application/json' => ['schema' => ['type' => ['object', 'null']]],
-        ];
-
         $result = $this->validator->validate(
             'spec',
             'GET',
             '/pets',
             200,
-            $content,
+            self::resolution(['type' => ['object', 'null']], version: OpenApiVersion::V3_1),
             DecodedBody::present(null),
-            'application/json',
-            OpenApiVersion::V3_1,
         );
 
         $this->assertSame([], $result->errors);
@@ -197,19 +170,13 @@ class ResponseBodyValidatorTest extends TestCase
         // array for Draft 07. A present literal `null` must validate cleanly
         // against it — distinct conversion branch from the OAS 3.1 type-array
         // form covered above.
-        $content = [
-            'application/json' => ['schema' => ['type' => 'object', 'nullable' => true]],
-        ];
-
         $result = $this->validator->validate(
             'spec',
             'GET',
             '/pets',
             200,
-            $content,
+            self::resolution(['type' => 'object', 'nullable' => true]),
             DecodedBody::present(null),
-            'application/json',
-            OpenApiVersion::V3_0,
         );
 
         $this->assertSame([], $result->errors);
@@ -217,88 +184,143 @@ class ResponseBodyValidatorTest extends TestCase
     }
 
     #[Test]
-    public function validate_skips_non_json_content_type_when_spec_entry_has_a_schema(): void
+    public function validate_rejects_non_resolved_resolution(): void
     {
-        // Issue #254: the response Content-Type matched the spec's `text/plain`
-        // media-type key, and that key declares a `schema`. OpenAPI permits a
-        // schema on any media type, but this engine only evaluates JSON Schema
-        // — the body cannot be checked. The validator must surface a skip
-        // (empty errors + non-null skipReason) so the unvalidated body is not
-        // recorded as a clean pass. matchedContentType is still the matched
-        // key so coverage records the skip against that exact media-type row.
-        $content = [
-            'text/plain' => ['schema' => ['type' => 'string']],
-        ];
+        // Non-Resolved outcomes are mapped by the orchestrator before the
+        // body validator runs; reaching here with one is a wiring bug.
+        $resolution = ResponseSchemaResolution::noContent('/pets', '204', []);
 
-        $result = $this->validator->validate(
-            'spec',
-            'GET',
-            '/robots.txt',
-            200,
-            $content,
-            DecodedBody::present('User-agent: *'),
-            'text/plain; charset=utf-8',
-            OpenApiVersion::V3_0,
-        );
-
-        $this->assertSame([], $result->errors);
-        $this->assertSame('text/plain', $result->matchedContentType);
-        $this->assertNotNull($result->skipReason);
-        $this->assertStringContainsString('text/plain', $result->skipReason);
-        $this->assertStringContainsString('JSON Schema engine only', $result->skipReason);
+        $this->expectException(LogicException::class);
+        $this->validator->validate('spec', 'GET', '/pets', 204, $resolution, DecodedBody::absent());
     }
 
     #[Test]
-    public function validate_does_not_skip_non_json_content_type_without_a_schema(): void
+    public function validate_accepts_empty_object_body_against_type_object(): void
     {
-        // A non-JSON media type with NO `schema` has nothing to validate — it
-        // stays silently successful (no errors, no skipReason) so it is not
-        // noisily surfaced in coverage as an unvalidated endpoint.
-        $content = [
-            'text/plain' => [],
-        ];
-
+        // PHP's `json_decode('{}', true) === []` — the Laravel trait's
+        // associative-array decoding loses the {} vs [] distinction. Without
+        // schema-aware coercion the validator would reject `[]` against
+        // `type: object`. Pin the fix so empty-{} responses validate.
         $result = $this->validator->validate(
             'spec',
             'GET',
-            '/robots.txt',
+            '/p',
             200,
-            $content,
-            DecodedBody::present('User-agent: *'),
-            'text/plain; charset=utf-8',
-            OpenApiVersion::V3_0,
+            self::resolution(['type' => 'object']),
+            DecodedBody::present([]),
         );
 
         $this->assertSame([], $result->errors);
-        $this->assertSame('text/plain', $result->matchedContentType);
-        $this->assertNull($result->skipReason);
     }
 
     #[Test]
-    public function validate_skips_non_json_content_type_matched_via_wildcard_range_with_a_schema(): void
+    public function validate_accepts_empty_object_body_against_oas_31_nullable_object(): void
     {
-        // Issue #254 skip detection keys off `findContentTypeKey()`, which
-        // also matches `<type>/*` ranges. A non-JSON Content-Type that
-        // matches a wildcard spec key declaring a `schema` must skip too —
-        // not just exact-key matches.
-        $content = [
-            'application/*' => ['schema' => ['type' => 'string']],
-        ];
+        // OAS 3.1 type-array form: `type: ["object", "null"]`. Same coercion.
+        $result = $this->validator->validate(
+            'spec',
+            'GET',
+            '/p',
+            200,
+            self::resolution(['type' => ['object', 'null']], version: OpenApiVersion::V3_1),
+            DecodedBody::present([]),
+        );
+
+        $this->assertSame([], $result->errors);
+    }
+
+    #[Test]
+    public function validate_does_not_coerce_empty_array_when_schema_has_no_explicit_type(): void
+    {
+        // A schema that only declares `properties` (no `type`) is common in
+        // third-party specs. `schemaAcceptsObject` returns false for this
+        // shape — pin so a future "infer object from properties" change
+        // doesn't silently start coercing array bodies.
+        $result = $this->validator->validate(
+            'spec',
+            'GET',
+            '/p',
+            200,
+            self::resolution(['properties' => ['id' => ['type' => 'integer']]]),
+            DecodedBody::present([]),
+        );
+
+        // No error AND no coercion fired — the property bag is permissive
+        // so empty input passes for either array or object interpretation.
+        // What we're pinning here: the implementation returned and we did
+        // not promote `[]` to `(object) []`. Verify by also recording the
+        // matched content type — the success path always sets it.
+        $this->assertSame([], $result->errors);
+        $this->assertSame('application/json', $result->matchedContentType);
+    }
+
+    #[Test]
+    public function validate_does_not_coerce_empty_array_for_oneof_with_object_branch(): void
+    {
+        // `oneOf: [{type: object, required: [foo]}]` with body `[]`. Composition
+        // keywords are NOT walked by `schemaAcceptsObject` — by design — so the
+        // body is validated as a JSON array against the oneOf and fails. Pin
+        // the design choice so a future "let's walk oneOf" change is forced
+        // through review.
+        $resolution = self::resolution([
+            'oneOf' => [
+                ['type' => 'object', 'required' => ['foo'], 'properties' => ['foo' => ['type' => 'string']]],
+            ],
+        ]);
 
         $result = $this->validator->validate(
             'spec',
             'GET',
-            '/blob',
+            '/p',
             200,
-            $content,
-            DecodedBody::present('binary-ish blob'),
-            'application/octet-stream',
-            OpenApiVersion::V3_0,
+            $resolution,
+            DecodedBody::present([]),
+        );
+
+        // Coercion did NOT fire — body remained a JSON array, oneOf failed.
+        // (Tracker / orchestrator surface a non-empty errors list.)
+        $this->assertNotEmpty($result->errors);
+    }
+
+    #[Test]
+    public function validate_does_not_coerce_empty_array_when_schema_is_array_type(): void
+    {
+        // Coercion must NOT fire when the schema actually wants an array —
+        // an empty array is a legitimate value for `type: array` (with no
+        // minItems constraint).
+        $result = $this->validator->validate(
+            'spec',
+            'GET',
+            '/p',
+            200,
+            self::resolution(['type' => 'array', 'items' => ['type' => 'string']]),
+            DecodedBody::present([]),
         );
 
         $this->assertSame([], $result->errors);
-        $this->assertSame('application/*', $result->matchedContentType);
-        $this->assertNotNull($result->skipReason);
+    }
+
+    #[Test]
+    public function validate_flags_schema_mismatch(): void
+    {
+        $resolution = self::resolution([
+            'type' => 'object',
+            'properties' => ['id' => ['type' => 'integer']],
+            'required' => ['id'],
+        ]);
+
+        $result = $this->validator->validate(
+            'spec',
+            'GET',
+            '/pets/{id}',
+            200,
+            $resolution,
+            DecodedBody::present(['id' => 'not-an-int']),
+        );
+
+        $this->assertNotEmpty($result->errors);
+        $this->assertStringContainsString('/id', $result->errors[0]);
+        $this->assertSame('application/json', $result->matchedContentType);
     }
 
     #[Test]
@@ -325,477 +347,23 @@ class ResponseBodyValidatorTest extends TestCase
         new ResponseBodyValidationResult([], null, 'a skip reason');
     }
 
-    #[Test]
-    public function validate_preserves_spec_content_type_casing(): void
-    {
-        // The spec author wrote a mixed-case media type — the matched key
-        // should keep that casing so coverage reports show it verbatim.
-        $content = [
-            'Application/Problem+JSON' => [
-                'schema' => ['type' => 'object'],
-            ],
-        ];
-
-        $result = $this->validator->validate(
-            'spec',
-            'GET',
+    /**
+     * @param array<string, mixed> $schema
+     */
+    private static function resolution(
+        array $schema,
+        string $contentType = 'application/json',
+        OpenApiVersion $version = OpenApiVersion::V3_0,
+    ): ResponseSchemaResolution {
+        return ResponseSchemaResolution::resolved(
             '/pets',
-            422,
-            $content,
-            DecodedBody::present(['detail' => 'oops']),
-            'application/problem+json',
-            OpenApiVersion::V3_0,
-        );
-
-        $this->assertSame([], $result->errors);
-        $this->assertSame('Application/Problem+JSON', $result->matchedContentType);
-    }
-
-    #[Test]
-    public function validate_flags_non_json_content_type_not_in_spec(): void
-    {
-        $content = [
-            'application/json' => ['schema' => ['type' => 'object']],
-        ];
-
-        $result = $this->validator->validate(
-            'spec',
-            'GET',
-            '/pets',
-            200,
-            $content,
-            DecodedBody::present('blob'),
-            'application/xml',
-            OpenApiVersion::V3_0,
-        );
-
-        $this->assertCount(1, $result->errors);
-        $this->assertStringContainsString("Content-Type 'application/xml' is not defined", $result->errors[0]);
-        $this->assertNull($result->matchedContentType);
-    }
-
-    #[Test]
-    public function validate_returns_empty_when_no_json_content_defined(): void
-    {
-        // Non-JSON spec entries with no Content-Type header → out-of-scope, pass.
-        $content = ['application/xml' => ['schema' => ['type' => 'string']]];
-
-        $result = $this->validator->validate(
-            'spec',
-            'GET',
-            '/pets',
-            200,
-            $content,
-            DecodedBody::present('<pets/>'),
-            null,
-            OpenApiVersion::V3_0,
-        );
-
-        $this->assertSame([], $result->errors);
-        $this->assertNull($result->matchedContentType);
-    }
-
-    #[Test]
-    public function validate_accepts_empty_object_body_against_type_object(): void
-    {
-        // PHP's `json_decode('{}', true) === []` — the Laravel trait's
-        // associative-array decoding loses the {} vs [] distinction. Without
-        // schema-aware coercion the validator would reject `[]` against
-        // `type: object`. Pin the fix so empty-{} responses validate.
-        $content = [
-            'application/json' => [
-                'schema' => ['type' => 'object'],
-            ],
-        ];
-
-        $result = $this->validator->validate(
-            'spec',
-            'GET',
-            '/p',
-            200,
-            $content,
-            DecodedBody::present([]),
-            'application/json',
-            OpenApiVersion::V3_0,
-        );
-
-        $this->assertSame([], $result->errors);
-    }
-
-    #[Test]
-    public function validate_accepts_empty_object_body_against_oas_31_nullable_object(): void
-    {
-        // OAS 3.1 type-array form: `type: ["object", "null"]`. Same coercion.
-        $content = [
-            'application/json' => [
-                'schema' => ['type' => ['object', 'null']],
-            ],
-        ];
-
-        $result = $this->validator->validate(
-            'spec',
-            'GET',
-            '/p',
-            200,
-            $content,
-            DecodedBody::present([]),
-            'application/json',
-            OpenApiVersion::V3_1,
-        );
-
-        $this->assertSame([], $result->errors);
-    }
-
-    #[Test]
-    public function validate_does_not_coerce_empty_array_when_schema_has_no_explicit_type(): void
-    {
-        // A schema that only declares `properties` (no `type`) is common in
-        // third-party specs. `schemaAcceptsObject` returns false for this
-        // shape — pin so a future "infer object from properties" change
-        // doesn't silently start coercing array bodies.
-        $content = [
-            'application/json' => [
-                'schema' => [
-                    'properties' => ['id' => ['type' => 'integer']],
-                ],
-            ],
-        ];
-
-        $result = $this->validator->validate(
-            'spec',
-            'GET',
-            '/p',
-            200,
-            $content,
-            DecodedBody::present([]),
-            'application/json',
-            OpenApiVersion::V3_0,
-        );
-
-        // No error AND no coercion fired — the property bag is permissive
-        // so empty input passes for either array or object interpretation.
-        // What we're pinning here: the implementation returned and we did
-        // not promote `[]` to `(object) []`. Verify by also recording the
-        // matched content type — the success path always sets it.
-        $this->assertSame([], $result->errors);
-        $this->assertSame('application/json', $result->matchedContentType);
-    }
-
-    #[Test]
-    public function validate_does_not_coerce_empty_array_for_oneof_with_object_branch(): void
-    {
-        // `oneOf: [{type: object, required: [foo]}]` with body `[]`. Composition
-        // keywords are NOT walked by `schemaAcceptsObject` — by design — so the
-        // body is validated as a JSON array against the oneOf and fails. Pin
-        // the design choice so a future "let's walk oneOf" change is forced
-        // through review.
-        $content = [
-            'application/json' => [
-                'schema' => [
-                    'oneOf' => [
-                        ['type' => 'object', 'required' => ['foo'], 'properties' => ['foo' => ['type' => 'string']]],
-                    ],
-                ],
-            ],
-        ];
-
-        $result = $this->validator->validate(
-            'spec',
-            'GET',
-            '/p',
-            200,
-            $content,
-            DecodedBody::present([]),
-            'application/json',
-            OpenApiVersion::V3_0,
-        );
-
-        // Coercion did NOT fire — body remained a JSON array, oneOf failed.
-        // (Tracker / orchestrator surface a non-empty errors list.)
-        $this->assertNotEmpty($result->errors);
-    }
-
-    #[Test]
-    public function validate_does_not_coerce_empty_array_when_schema_is_array_type(): void
-    {
-        // Coercion must NOT fire when the schema actually wants an array —
-        // an empty array is a legitimate value for `type: array` (with no
-        // minItems constraint).
-        $content = [
-            'application/json' => [
-                'schema' => ['type' => 'array', 'items' => ['type' => 'string']],
-            ],
-        ];
-
-        $result = $this->validator->validate(
-            'spec',
-            'GET',
-            '/p',
-            200,
-            $content,
-            DecodedBody::present([]),
-            'application/json',
-            OpenApiVersion::V3_0,
-        );
-
-        $this->assertSame([], $result->errors);
-    }
-
-    #[Test]
-    public function validate_flags_schema_mismatch(): void
-    {
-        $content = [
-            'application/json' => [
-                'schema' => [
-                    'type' => 'object',
-                    'properties' => ['id' => ['type' => 'integer']],
-                    'required' => ['id'],
-                ],
-            ],
-        ];
-
-        $result = $this->validator->validate(
-            'spec',
-            'GET',
-            '/pets/{id}',
-            200,
-            $content,
-            DecodedBody::present(['id' => 'not-an-int']),
-            'application/json',
-            OpenApiVersion::V3_0,
-        );
-
-        $this->assertNotEmpty($result->errors);
-        $this->assertStringContainsString('/id', $result->errors[0]);
-        $this->assertSame('application/json', $result->matchedContentType);
-    }
-
-    // ========================================
-    // Malformed-spec guards (issue #256) — symmetric with RequestBodyValidator
-    // ========================================
-
-    #[Test]
-    public function validate_flags_malformed_media_type_entry(): void
-    {
-        // `content: {"application/json": "oops"}` — a scalar where a media
-        // type object was expected. Without the guard the scalar slips past
-        // the downstream `isset(...['schema'])` presence check and the body
-        // is silently recorded as a clean pass. Surface a loud spec error,
-        // mirroring RequestBodyValidator's sibling guard.
-        $content = ['application/json' => 'oops'];
-
-        $result = $this->validator->validate(
-            'spec',
-            'GET',
-            '/pets',
-            200,
-            $content,
-            DecodedBody::present(['id' => 1]),
-            'application/json',
-            OpenApiVersion::V3_0,
-        );
-
-        $this->assertCount(1, $result->errors);
-        $this->assertStringContainsString(
-            'Malformed \'responses[200].content["application/json"]\'',
-            $result->errors[0],
-        );
-        $this->assertStringContainsString('expected object, got string', $result->errors[0]);
-        $this->assertNull($result->matchedContentType);
-    }
-
-    #[Test]
-    public function validate_flags_malformed_media_type_schema_for_json_content_type(): void
-    {
-        // A non-array `schema` on a JSON media type would reach
-        // OpenApiSchemaConverter::convert() as a scalar and raise a confusing
-        // TypeError. The guard turns it into a spec-level error instead.
-        $content = ['application/json' => ['schema' => 'oops']];
-
-        $result = $this->validator->validate(
-            'spec',
-            'GET',
-            '/pets',
-            200,
-            $content,
-            DecodedBody::present(['id' => 1]),
-            'application/json',
-            OpenApiVersion::V3_0,
-        );
-
-        $this->assertCount(1, $result->errors);
-        $this->assertStringContainsString(
-            'Malformed \'responses[200].content["application/json"].schema\'',
-            $result->errors[0],
-        );
-        $this->assertStringContainsString('expected object, got string', $result->errors[0]);
-        $this->assertNull($result->matchedContentType);
-    }
-
-    #[Test]
-    public function validate_flags_list_media_type_entry(): void
-    {
-        // A media-type entry written as a JSON list passes `is_array()` but is
-        // not an object. The shared MalformedSpecNode guard surfaces it with
-        // the same loud diagnostic as a scalar entry (issue #256).
-        $content = ['application/json' => ['this should have been an object']];
-
-        $result = $this->validator->validate(
-            'spec',
-            'GET',
-            '/pets',
-            200,
-            $content,
-            DecodedBody::present(['id' => 1]),
-            'application/json',
-            OpenApiVersion::V3_0,
-        );
-
-        $this->assertCount(1, $result->errors);
-        $this->assertStringContainsString(
-            'Malformed \'responses[200].content["application/json"]\'',
-            $result->errors[0],
-        );
-        $this->assertStringContainsString('expected object, got list', $result->errors[0]);
-    }
-
-    #[Test]
-    public function validate_flags_list_media_type_schema(): void
-    {
-        // A `schema` written as a JSON list is malformed the same way
-        // (issue #256).
-        $content = ['application/json' => ['schema' => ['this should have been an object']]];
-
-        $result = $this->validator->validate(
-            'spec',
-            'GET',
-            '/pets',
-            200,
-            $content,
-            DecodedBody::present(['id' => 1]),
-            'application/json',
-            OpenApiVersion::V3_0,
-        );
-
-        $this->assertCount(1, $result->errors);
-        $this->assertStringContainsString(
-            'Malformed \'responses[200].content["application/json"].schema\'',
-            $result->errors[0],
-        );
-        $this->assertStringContainsString('expected object, got list', $result->errors[0]);
-    }
-
-    #[Test]
-    public function validate_flags_null_media_type_schema_for_json_content_type(): void
-    {
-        // Locks in `array_key_exists` over `isset`: an explicit `schema: null`
-        // must be flagged. With `isset` it would fall through the downstream
-        // presence check and accept any body — a silent pass.
-        $content = ['application/json' => ['schema' => null]];
-
-        $result = $this->validator->validate(
-            'spec',
-            'GET',
-            '/pets',
-            200,
-            $content,
-            DecodedBody::present(['id' => 1]),
-            'application/json',
-            OpenApiVersion::V3_0,
-        );
-
-        $this->assertCount(1, $result->errors);
-        $this->assertStringContainsString(
-            'Malformed \'responses[200].content["application/json"].schema\'',
-            $result->errors[0],
-        );
-    }
-
-    #[Test]
-    public function validate_flags_null_media_type_schema_for_non_json_content_type(): void
-    {
-        // Before the guard, a non-JSON entry with `schema: null` slipped
-        // through the `isset(...['schema'])` skip check (issue #254) as a
-        // silent success — asymmetric with the request validator, which
-        // rejects the same `schema: null` loudly. The guard runs before
-        // content negotiation, so request and response now agree.
-        $content = ['text/plain' => ['schema' => null]];
-
-        $result = $this->validator->validate(
-            'spec',
-            'GET',
-            '/pets',
-            200,
-            $content,
-            DecodedBody::present('blob'),
-            'text/plain',
-            OpenApiVersion::V3_0,
-        );
-
-        $this->assertCount(1, $result->errors);
-        $this->assertStringContainsString(
-            'Malformed \'responses[200].content["text/plain"].schema\'',
-            $result->errors[0],
-        );
-        $this->assertNull($result->skipReason);
-    }
-
-    #[Test]
-    public function validate_flags_malformed_media_type_schema_for_non_json_content_type(): void
-    {
-        // A non-null scalar `schema` (the natural shape of an unresolved $ref
-        // that decoded to a string) on a non-JSON media type. Like the
-        // `schema: null` case, the guard runs before content negotiation, so
-        // it is flagged regardless of the actual response Content-Type.
-        $content = ['text/plain' => ['schema' => 'oops']];
-
-        $result = $this->validator->validate(
-            'spec',
-            'GET',
-            '/pets',
-            200,
-            $content,
-            DecodedBody::present('blob'),
-            'text/plain',
-            OpenApiVersion::V3_0,
-        );
-
-        $this->assertCount(1, $result->errors);
-        $this->assertStringContainsString(
-            'Malformed \'responses[200].content["text/plain"].schema\'',
-            $result->errors[0],
-        );
-        $this->assertNull($result->skipReason);
-    }
-
-    #[Test]
-    public function validate_flags_malformed_entry_even_when_not_the_negotiated_content_type(): void
-    {
-        // The guard loop pre-scans every media-type entry before content
-        // negotiation runs. A malformed `text/plain` entry must be flagged
-        // even though the JSON response Content-Type would negotiate the
-        // well-formed `application/json` entry — a malformed spec is surfaced
-        // regardless of which entry the request would have matched.
-        $content = [
-            'application/json' => ['schema' => ['type' => 'object']],
-            'text/plain' => 'oops',
-        ];
-
-        $result = $this->validator->validate(
-            'spec',
-            'GET',
-            '/pets',
-            200,
-            $content,
-            DecodedBody::present(['id' => 1]),
-            'application/json',
-            OpenApiVersion::V3_0,
-        );
-
-        $this->assertCount(1, $result->errors);
-        $this->assertStringContainsString(
-            'Malformed \'responses[200].content["text/plain"]\'',
-            $result->errors[0],
+            '200',
+            $contentType,
+            ['content' => [$contentType => ['schema' => $schema]]],
+            $schema,
+            $version,
+            $version === OpenApiVersion::V3_0 ? OpenApiSchemaDialect::DRAFT_07 : OpenApiSchemaDialect::OAS_3_1,
+            DiscriminatorContext::disabled(),
         );
     }
 }

--- a/tests/Unit/Validation/Response/ResponseSchemaResolverTest.php
+++ b/tests/Unit/Validation/Response/ResponseSchemaResolverTest.php
@@ -1,0 +1,445 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Validation\Response;
+
+use LogicException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\Gesso\OpenApiVersion;
+use Studio\Gesso\Spec\OpenApiSchemaDialect;
+use Studio\Gesso\Spec\OpenApiSpecLoader;
+use Studio\Gesso\Validation\Response\ResponseSchemaResolutionOutcome;
+use Studio\Gesso\Validation\Response\ResponseSchemaResolver;
+use Studio\Gesso\Validation\Support\DiscriminatorEnforcement;
+
+/**
+ * Shared response-schema resolution (issue #442): one implementation feeds
+ * both the response validator and the response-payload explorer (#441), so
+ * every outcome — including the resolution failures the validator renders as
+ * assertion messages — must be a loud structured result here.
+ */
+class ResponseSchemaResolverTest extends TestCase
+{
+    private ResponseSchemaResolver $resolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../../../fixtures/specs');
+        $this->resolver = new ResponseSchemaResolver();
+    }
+
+    protected function tearDown(): void
+    {
+        OpenApiSpecLoader::reset();
+        DiscriminatorEnforcement::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function resolve_returns_converted_schema_and_metadata_for_exact_status_key(): void
+    {
+        $resolution = $this->resolver->resolve('petstore-3.0', 'GET', '/v1/pets/1', 200, 'application/json');
+
+        $this->assertSame(ResponseSchemaResolutionOutcome::Resolved, $resolution->outcome);
+        $this->assertSame('/v1/pets/{petId}', $resolution->matchedPath);
+        $this->assertSame('200', $resolution->statusKey);
+        $this->assertSame('application/json', $resolution->contentType);
+        $this->assertNull($resolution->message);
+        $this->assertNull($resolution->skipReason);
+
+        // The raw schema node is the spec author's OAS 3.0 shape …
+        $this->assertIsArray($resolution->schema);
+        $this->assertTrue($resolution->schema['properties']['data']['properties']['tag']['nullable']);
+        $this->assertArrayNotHasKey('$schema', $resolution->schema);
+
+        // … while the converted schema went through the Draft 07 pipeline:
+        // `nullable` lowered to a type array, dialect stamped.
+        $converted = $resolution->convertedSchema();
+        $this->assertSame(OpenApiSchemaDialect::DRAFT_07, $converted['$schema']);
+        $tag = $converted['properties']['data']['properties']['tag'];
+        $this->assertSame(['string', 'null'], $tag['type']);
+        $this->assertArrayNotHasKey('nullable', $tag);
+    }
+
+    #[Test]
+    public function resolve_matches_range_status_key(): void
+    {
+        $resolution = $this->resolver->resolve('range-keys', 'GET', '/widgets', 503, 'application/json');
+
+        $this->assertSame(ResponseSchemaResolutionOutcome::Resolved, $resolution->outcome);
+        $this->assertSame('5XX', $resolution->statusKey);
+        $this->assertSame('application/json', $resolution->contentType);
+    }
+
+    #[Test]
+    public function resolve_falls_back_to_default_status_key(): void
+    {
+        $resolution = $this->resolver->resolve('range-keys', 'GET', '/widgets-default', 404, 'application/json');
+
+        $this->assertSame(ResponseSchemaResolutionOutcome::Resolved, $resolution->outcome);
+        $this->assertSame('default', $resolution->statusKey);
+    }
+
+    #[Test]
+    public function resolve_reports_undeclared_status(): void
+    {
+        $resolution = $this->resolver->resolve('range-keys', 'GET', '/widgets', 404, 'application/json');
+
+        $this->assertSame(ResponseSchemaResolutionOutcome::StatusNotDeclared, $resolution->outcome);
+        $this->assertSame('/widgets', $resolution->matchedPath);
+        $this->assertNull($resolution->statusKey);
+        $this->assertSame(
+            "Status code 404 not defined for GET /widgets in 'range-keys' spec.",
+            $resolution->message,
+        );
+    }
+
+    #[Test]
+    public function resolve_reports_path_not_found(): void
+    {
+        $resolution = $this->resolver->resolve('petstore-3.0', 'GET', '/nope', 200, 'application/json');
+
+        $this->assertSame(ResponseSchemaResolutionOutcome::PathNotFound, $resolution->outcome);
+        $this->assertNull($resolution->matchedPath);
+        $this->assertNull($resolution->statusKey);
+        $this->assertStringContainsString(
+            "No matching path found in 'petstore-3.0' spec for GET /nope",
+            (string) $resolution->message,
+        );
+    }
+
+    #[Test]
+    public function resolve_reports_method_not_defined(): void
+    {
+        $resolution = $this->resolver->resolve('petstore-3.0', 'DELETE', '/v1/health', 200, 'application/json');
+
+        $this->assertSame(ResponseSchemaResolutionOutcome::MethodNotDefined, $resolution->outcome);
+        $this->assertSame('/v1/health', $resolution->matchedPath);
+        $this->assertStringContainsString(
+            "Method DELETE not defined for path /v1/health in 'petstore-3.0' spec.",
+            (string) $resolution->message,
+        );
+    }
+
+    #[Test]
+    public function resolve_reports_malformed_paths_node(): void
+    {
+        $resolution = $this->resolver->resolve('malformed-paths', 'GET', '/things', 200, 'application/json');
+
+        $this->assertSame(ResponseSchemaResolutionOutcome::MalformedSpec, $resolution->outcome);
+        $this->assertNull($resolution->matchedPath);
+        $this->assertStringContainsString("Malformed 'paths'", (string) $resolution->message);
+        $this->assertStringContainsString('expected object, got string', (string) $resolution->message);
+    }
+
+    #[Test]
+    public function resolve_reports_malformed_responses_map(): void
+    {
+        $resolution = $this->resolver->resolve('malformed', 'GET', '/scalar-responses-map', 200, 'application/json');
+
+        $this->assertSame(ResponseSchemaResolutionOutcome::MalformedSpec, $resolution->outcome);
+        $this->assertSame('/scalar-responses-map', $resolution->matchedPath);
+        $this->assertStringContainsString(
+            "Malformed 'paths[\"/scalar-responses-map\"].get.responses'",
+            (string) $resolution->message,
+        );
+    }
+
+    #[Test]
+    public function resolve_reports_malformed_response_entry_keyed_off_matched_spec_key(): void
+    {
+        $resolution = $this->resolver->resolve('malformed-response', 'GET', '/things', 200, 'application/json');
+
+        $this->assertSame(ResponseSchemaResolutionOutcome::MalformedResponse, $resolution->outcome);
+        $this->assertSame('200', $resolution->statusKey);
+        $this->assertStringContainsString("Malformed 'responses[200]'", (string) $resolution->message);
+        $this->assertStringContainsString('expected object, got string', (string) $resolution->message);
+
+        // A wire status resolved through `default` must key the message off
+        // the matched spec key, not the literal status (issue #258).
+        $viaDefault = $this->resolver->resolve('malformed', 'GET', '/response-default-status-scalar', 200, 'application/json');
+        $this->assertSame(ResponseSchemaResolutionOutcome::MalformedResponse, $viaDefault->outcome);
+        $this->assertSame('default', $viaDefault->statusKey);
+        $this->assertStringContainsString("Malformed 'responses[default]'", (string) $viaDefault->message);
+    }
+
+    #[Test]
+    public function resolve_reports_malformed_content_nodes(): void
+    {
+        $contentBlock = $this->resolver->resolve('malformed', 'GET', '/response-scalar-content', 200, 'application/json');
+        $this->assertSame(ResponseSchemaResolutionOutcome::MalformedContent, $contentBlock->outcome);
+        $this->assertStringContainsString("Malformed 'responses[200].content'", (string) $contentBlock->message);
+
+        $mediaType = $this->resolver->resolve('malformed', 'GET', '/response-scalar-content-media-type', 200, 'application/json');
+        $this->assertSame(ResponseSchemaResolutionOutcome::MalformedContent, $mediaType->outcome);
+        $this->assertStringContainsString(
+            'Malformed \'responses[200].content["application/json"]\'',
+            (string) $mediaType->message,
+        );
+
+        $schema = $this->resolver->resolve('malformed', 'GET', '/response-scalar-content-schema', 200, 'application/json');
+        $this->assertSame(ResponseSchemaResolutionOutcome::MalformedContent, $schema->outcome);
+        $this->assertStringContainsString(
+            'Malformed \'responses[200].content["application/json"].schema\'',
+            (string) $schema->message,
+        );
+
+        $nullSchema = $this->resolver->resolve('malformed', 'GET', '/response-null-content-schema', 200, 'application/json');
+        $this->assertSame(ResponseSchemaResolutionOutcome::MalformedContent, $nullSchema->outcome);
+        $this->assertStringContainsString(
+            'Malformed \'responses[200].content["application/json"].schema\'',
+            (string) $nullSchema->message,
+        );
+    }
+
+    #[Test]
+    public function resolve_reports_no_content_for_content_less_response(): void
+    {
+        $resolution = $this->resolver->resolve('petstore-3.0', 'DELETE', '/v1/pets/1', 204);
+
+        $this->assertSame(ResponseSchemaResolutionOutcome::NoContent, $resolution->outcome);
+        $this->assertSame('/v1/pets/{petId}', $resolution->matchedPath);
+        $this->assertSame('204', $resolution->statusKey);
+        $this->assertNull($resolution->contentType);
+        $this->assertIsArray($resolution->responseSpec);
+    }
+
+    #[Test]
+    public function resolve_reports_no_json_content(): void
+    {
+        $resolution = $this->resolver->resolve('non-json-content-schema', 'GET', '/text-without-schema', 200);
+
+        $this->assertSame(ResponseSchemaResolutionOutcome::NoJsonContent, $resolution->outcome);
+        $this->assertSame('200', $resolution->statusKey);
+        $this->assertNull($resolution->contentType);
+    }
+
+    #[Test]
+    public function resolve_reports_missing_schema_for_matched_non_json_type(): void
+    {
+        $resolution = $this->resolver->resolve('non-json-content-schema', 'GET', '/text-without-schema', 200, 'text/plain');
+
+        $this->assertSame(ResponseSchemaResolutionOutcome::MissingSchema, $resolution->outcome);
+        $this->assertSame('text/plain', $resolution->contentType);
+    }
+
+    #[Test]
+    public function resolve_reports_missing_schema_for_json_key_without_schema(): void
+    {
+        $resolution = $this->resolver->resolve('content-without-schema', 'GET', '/widgets', 201, 'application/json');
+
+        $this->assertSame(ResponseSchemaResolutionOutcome::MissingSchema, $resolution->outcome);
+        $this->assertSame('application/json', $resolution->contentType);
+    }
+
+    #[Test]
+    public function resolve_reports_unvalidatable_non_json_schema(): void
+    {
+        // The charset parameter exercises the same normalization the
+        // validator's body path always applied before matching.
+        $resolution = $this->resolver->resolve('non-json-content-schema', 'GET', '/text-with-schema', 200, 'text/plain; charset=utf-8');
+
+        $this->assertSame(ResponseSchemaResolutionOutcome::NonJsonSchema, $resolution->outcome);
+        $this->assertSame('text/plain', $resolution->contentType);
+        $this->assertStringContainsString('cannot evaluate', (string) $resolution->skipReason);
+        $this->assertStringContainsString('JSON Schema engine only', (string) $resolution->skipReason);
+    }
+
+    #[Test]
+    public function resolve_reports_unvalidatable_schema_matched_via_wildcard_range(): void
+    {
+        // Issue #254 skip detection keys off `findContentTypeKey()`, which
+        // also matches `<type>/*` ranges — not just exact keys.
+        $resolution = $this->resolver->resolve('response-negotiation-edge', 'GET', '/wildcard-schema', 200, 'application/octet-stream');
+
+        $this->assertSame(ResponseSchemaResolutionOutcome::NonJsonSchema, $resolution->outcome);
+        $this->assertSame('application/*', $resolution->contentType);
+        $this->assertNotNull($resolution->skipReason);
+    }
+
+    #[Test]
+    public function resolve_preserves_spec_content_type_casing(): void
+    {
+        // The spec author wrote a mixed-case media type — the matched key
+        // keeps that casing so coverage reports show it verbatim.
+        $resolution = $this->resolver->resolve('response-negotiation-edge', 'GET', '/casing', 200, 'application/problem+json');
+
+        $this->assertSame(ResponseSchemaResolutionOutcome::Resolved, $resolution->outcome);
+        $this->assertSame('Application/Problem+JSON', $resolution->contentType);
+    }
+
+    #[Test]
+    public function resolve_reports_list_shaped_media_type_nodes(): void
+    {
+        // JSON lists pass `is_array()` but are not objects; the shared
+        // MalformedSpecNode guard flags them like scalars (issue #256).
+        $entry = $this->resolver->resolve('response-negotiation-edge', 'GET', '/list-media-entry', 200, 'application/json');
+        $this->assertSame(ResponseSchemaResolutionOutcome::MalformedContent, $entry->outcome);
+        $this->assertStringContainsString('expected object, got list', (string) $entry->message);
+
+        $schema = $this->resolver->resolve('response-negotiation-edge', 'GET', '/list-media-schema', 200, 'application/json');
+        $this->assertSame(ResponseSchemaResolutionOutcome::MalformedContent, $schema->outcome);
+        $this->assertStringContainsString(
+            'Malformed \'responses[200].content["application/json"].schema\'',
+            (string) $schema->message,
+        );
+    }
+
+    #[Test]
+    public function resolve_flags_null_schema_on_non_json_media_type(): void
+    {
+        // Before the guard, a non-JSON entry with `schema: null` slipped
+        // through the `isset(...['schema'])` skip check (issue #254) as a
+        // silent success. The guard runs before content negotiation, so the
+        // node is rejected loudly regardless of the actual Content-Type.
+        $resolution = $this->resolver->resolve('response-negotiation-edge', 'GET', '/null-schema-non-json', 200, 'text/plain');
+
+        $this->assertSame(ResponseSchemaResolutionOutcome::MalformedContent, $resolution->outcome);
+        $this->assertStringContainsString(
+            'Malformed \'responses[200].content["text/plain"].schema\'',
+            (string) $resolution->message,
+        );
+        $this->assertNull($resolution->skipReason);
+    }
+
+    #[Test]
+    public function resolve_flags_malformed_entry_even_when_not_the_negotiated_content_type(): void
+    {
+        // The guard loop pre-scans every media-type entry before content
+        // negotiation runs: a malformed `text/plain` entry is flagged even
+        // though the JSON Content-Type would negotiate the well-formed
+        // `application/json` entry.
+        $resolution = $this->resolver->resolve('response-negotiation-edge', 'GET', '/guard-order', 200, 'application/json');
+
+        $this->assertSame(ResponseSchemaResolutionOutcome::MalformedContent, $resolution->outcome);
+        $this->assertStringContainsString(
+            'Malformed \'responses[200].content["text/plain"]\'',
+            (string) $resolution->message,
+        );
+    }
+
+    #[Test]
+    public function resolve_reports_undeclared_content_type(): void
+    {
+        $resolution = $this->resolver->resolve('petstore-3.0', 'GET', '/v1/pets/1', 200, 'text/html');
+
+        $this->assertSame(ResponseSchemaResolutionOutcome::ContentTypeNotDeclared, $resolution->outcome);
+        $this->assertNull($resolution->contentType);
+        $this->assertSame(
+            "Response Content-Type 'text/html' is not defined for GET /v1/pets/{petId} (status 200) "
+            . "in 'petstore-3.0' spec. Defined content types: application/json",
+            $resolution->message,
+        );
+    }
+
+    #[Test]
+    public function resolve_reports_item_schema_streaming(): void
+    {
+        $withContentType = $this->resolver->resolve('openapi-3.2', 'GET', '/v1/events', 200, 'text/event-stream');
+        $this->assertSame(ResponseSchemaResolutionOutcome::ItemSchemaStreaming, $withContentType->outcome);
+        $this->assertSame('text/event-stream', $withContentType->contentType);
+        $this->assertStringContainsString('itemSchema streaming', (string) $withContentType->skipReason);
+
+        // Without an actual Content-Type, the streaming media type is still
+        // detected by the no-JSON-key scan and stays a loud outcome.
+        $withoutContentType = $this->resolver->resolve('openapi-3.2', 'GET', '/v1/events', 200);
+        $this->assertSame(ResponseSchemaResolutionOutcome::ItemSchemaStreaming, $withoutContentType->outcome);
+        $this->assertSame('text/event-stream', $withoutContentType->contentType);
+    }
+
+    #[Test]
+    public function resolve_prefers_exact_json_content_type_match(): void
+    {
+        $resolution = $this->resolver->resolve('petstore-3.1', 'GET', '/v1/v31/multi-content', 200, 'application/problem+json');
+
+        $this->assertSame(ResponseSchemaResolutionOutcome::Resolved, $resolution->outcome);
+        $this->assertSame('application/problem+json', $resolution->contentType);
+        $this->assertSame(['title'], $resolution->schema['required'] ?? null);
+    }
+
+    #[Test]
+    public function resolve_falls_back_to_first_json_content_type(): void
+    {
+        $resolution = $this->resolver->resolve('petstore-3.1', 'GET', '/v1/v31/multi-content', 200);
+
+        $this->assertSame(ResponseSchemaResolutionOutcome::Resolved, $resolution->outcome);
+        $this->assertSame('application/json', $resolution->contentType);
+
+        // 3.1 documents convert through their declared dialect, not Draft 07.
+        $this->assertSame(OpenApiSchemaDialect::DRAFT_2020_12, $resolution->convertedSchema()['$schema']);
+    }
+
+    #[Test]
+    public function resolve_preserves_discriminator_enforcement(): void
+    {
+        $enforced = $this->resolver->resolve('openapi-3.2', 'GET', '/v1/pets/1', 200, 'application/json')->convertedSchema();
+
+        DiscriminatorEnforcement::configure(false);
+        $stripped = $this->resolver->resolve('openapi-3.2', 'GET', '/v1/pets/1', 200, 'application/json')->convertedSchema();
+
+        // Both pipelines consume the raw `discriminator` keyword, but only the
+        // enforcing conversion lowers the mapping into extra constraints — if
+        // the resolver dropped the discriminator context, the two would agree.
+        $this->assertArrayNotHasKey('discriminator', $enforced);
+        $this->assertArrayNotHasKey('discriminator', $stripped);
+        $this->assertNotSame($enforced, $stripped);
+    }
+
+    #[Test]
+    public function staged_resolution_matches_composed_resolve(): void
+    {
+        $operation = $this->resolver->resolveOperation('petstore-3.0', 'GET', '/v1/pets/1');
+
+        $this->assertSame(ResponseSchemaResolutionOutcome::Resolved, $operation->outcome);
+        $this->assertSame('/v1/pets/{petId}', $operation->matchedPath);
+        $this->assertSame(OpenApiVersion::V3_0, $operation->version);
+        $this->assertSame(OpenApiSchemaDialect::DRAFT_07, $operation->jsonSchemaDialect);
+        $this->assertIsArray($operation->responses);
+        $this->assertArrayHasKey('200', $operation->responses);
+
+        $staged = $this->resolver->resolveResponseSchema($operation, 200, 'application/json');
+        $composed = $this->resolver->resolve('petstore-3.0', 'GET', '/v1/pets/1', 200, 'application/json');
+
+        $this->assertSame($composed->outcome, $staged->outcome);
+        $this->assertSame($composed->matchedPath, $staged->matchedPath);
+        $this->assertSame($composed->statusKey, $staged->statusKey);
+        $this->assertSame($composed->contentType, $staged->contentType);
+        $this->assertSame($composed->schema, $staged->schema);
+    }
+
+    #[Test]
+    public function resolve_response_schema_rejects_unresolved_operation(): void
+    {
+        $operation = $this->resolver->resolveOperation('petstore-3.0', 'GET', '/nope');
+        $this->assertSame(ResponseSchemaResolutionOutcome::PathNotFound, $operation->outcome);
+
+        $this->expectException(LogicException::class);
+        $this->resolver->resolveResponseSchema($operation, 200, 'application/json');
+    }
+
+    #[Test]
+    public function composed_resolve_maps_operation_failures_into_schema_resolution(): void
+    {
+        $resolution = $this->resolver->resolve('petstore-3.0', 'DELETE', '/v1/health', 200);
+
+        $this->assertSame(ResponseSchemaResolutionOutcome::MethodNotDefined, $resolution->outcome);
+        $this->assertSame('/v1/health', $resolution->matchedPath);
+        $this->assertNull($resolution->statusKey);
+        $this->assertNull($resolution->contentType);
+        $this->assertNotNull($resolution->message);
+    }
+
+    #[Test]
+    public function converted_schema_is_only_available_on_resolved_outcomes(): void
+    {
+        $resolution = $this->resolver->resolve('range-keys', 'GET', '/widgets', 404, 'application/json');
+        $this->assertSame(ResponseSchemaResolutionOutcome::StatusNotDeclared, $resolution->outcome);
+
+        $this->expectException(LogicException::class);
+        $resolution->convertedSchema();
+    }
+}

--- a/tests/Unit/Validation/Support/ContentTypeMatcherTest.php
+++ b/tests/Unit/Validation/Support/ContentTypeMatcherTest.php
@@ -142,9 +142,9 @@ class ContentTypeMatcherTest extends TestCase
     {
         // `*&#47;*` covers everything (binary, image, html). Returning it from a
         // method whose contract is "find a JSON-validatable spec key" would let
-        // ResponseBodyValidator validate non-JSON bodies as JSON when the response
-        // omits Content-Type. Conservative: skip JSON validation rather than
-        // pretend `*&#47;*` means JSON.
+        // ResponseSchemaResolver select non-JSON bodies for JSON validation when
+        // the response omits Content-Type. Conservative: skip JSON validation
+        // rather than pretend `*&#47;*` means JSON.
         $content = ['*/*' => ['schema' => ['type' => 'object']]];
 
         $this->assertNull(ContentTypeMatcher::findJsonContentType($content));

--- a/tests/fixtures/specs/response-negotiation-edge.json
+++ b/tests/fixtures/specs/response-negotiation-edge.json
@@ -1,0 +1,114 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Response content negotiation edge cases (issue #442)",
+        "version": "1.0.0"
+    },
+    "paths": {
+        "/wildcard-schema": {
+            "get": {
+                "summary": "non-JSON Content-Type matched via a wildcard range key that declares a schema",
+                "operationId": "wildcardSchema",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/*": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/casing": {
+            "get": {
+                "summary": "media-type key with the spec author's mixed casing",
+                "operationId": "mixedCasing",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "Application/Problem+JSON": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/list-media-entry": {
+            "get": {
+                "summary": "content[mediaType] is a JSON list (not an object)",
+                "operationId": "listMediaEntry",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": [
+                                "this should have been an object"
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/list-media-schema": {
+            "get": {
+                "summary": "content[mediaType].schema is a JSON list (not an object)",
+                "operationId": "listMediaSchema",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": [
+                                    "this should have been an object"
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/null-schema-non-json": {
+            "get": {
+                "summary": "non-JSON media type with an explicit schema: null",
+                "operationId": "nullSchemaNonJson",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "text/plain": {
+                                "schema": null
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/guard-order": {
+            "get": {
+                "summary": "malformed non-negotiated entry next to a well-formed JSON entry",
+                "operationId": "guardOrder",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            },
+                            "text/plain": "this should have been an object"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Extracts the response-schema selection pipeline — path matching, operation lookup, status-key resolution (exact → range → `default`), content-type negotiation, and `OpenApiSchemaConverter` conversion with the selected dialect and discriminator context — out of `OpenApiResponseValidator` into an `@internal` `ResponseSchemaResolver`, and rewires the validator through it with no observable behavior change. Also commits ADR 0003, which records the design this is phase 1 of.

## Why

Fixes #442 (phase 1 of #441, per `docs/adr/0003-sdk-roundtrip-harness.md`). #441 needs the converted JSON schema for a response selected by `(method, path, status, content-type)` outside the response validator; re-implementing the inlined pipeline in a new entry point would break the invariant that alternate validation entry points preserve discriminator enforcement and the schema dialect.

## Design notes

- `ResponseSchemaResolver` exposes a composed `resolve()` plus a staged API (`resolveOperation()` / `resolveResponseSchema()`). The stage boundary exists because the validator's skip-by-status-code policy applies after the `responses`-map guard but before status-key resolution.
- Every stop-short is a loud `ResponseSchemaResolutionOutcome` case — unmatched path/method, undeclared status, malformed nodes (message text verbatim from the validator, so doctor/runtime diagnostics stay consistent), no-content, non-JSON-only content, and OAS 3.2 `itemSchema` streaming — never a silent null.
- Schema conversion is lazy (`ResponseSchemaResolution::convertedSchema()`): the validator reports an absent body *before* converting, so an eagerly-converted (and possibly throwing) schema would change which diagnostic wins.
- `ResponseBodyValidator` slims to body-vs-resolved-schema validation; its negotiation/guard pins moved to `ResponseSchemaResolverTest` (with a new `response-negotiation-edge.json` fixture for the wildcard-range, mixed-casing, list-node, and guard-ordering cases that were only pinned there).
- The `default`-fallback suspicious-key warning now fires inside the resolver so every consumer of the shared resolution sees it; for the validator the timing and output are unchanged.

No new public API; all new symbols are `@internal`.

## Verification

- New `ResponseSchemaResolverTest` (29 tests) covers exact/range/`default` status keys, content-type negotiation, malformed nodes, and the loud structured outcomes, TDD-first.
- Full `OpenApiResponseValidatorTest` (137 tests) passes unmodified — the regression net for "no observable behavior change".
- [x] `composer test` passes (2626 tests)
- [x] `composer stan` passes (run with `--memory-limit=1G`; the default 128M parallel-worker limit crashes locally on this machine independent of this change)
- [x] `composer cs-check` passes

## Notes for reviewers

`ResponseBodyValidatorTest` shrank because negotiation moved upstream: body-shape tests were rewritten against the new `ResponseSchemaResolution`-consuming signature, and each deleted negotiation test has a ported twin in `ResponseSchemaResolverTest` (same assertions, resolver outcomes instead of `ResponseBodyValidationResult` shapes).