### PR TITLE
feat(fuzz): branch-complete case generation across composition choice points

### DIFF
--- a/src/Fuzz/BranchCompleteCaseGenerator.php
+++ b/src/Fuzz/BranchCompleteCaseGenerator.php
@@ -21,11 +21,12 @@ use InvalidArgumentException;
  * generator defect fails loudly here instead of reaching user code. The one
  * exception is probe cases — branches whose reachability the schema alone
  * cannot decide, i.e. the none-match state of conditional `allOf` and choice
- * points discovered inside it: when generation, including its bounded
- * deterministic retry search, cannot produce a valid value — a closed
- * discriminator set genuinely forbids the state — the probe case is dropped
- * instead of failing the run. The drop is best-effort by construction, not a
- * reachability proof. Schemas outside the enumeration subset or beyond its
+ * points discovered inside it: when generation cannot produce a valid value,
+ * the probe case is dropped instead of failing the run. For enum-driven
+ * discriminators that decision is exact — the admissible domain is filtered
+ * exhaustively, so the drop means a closed set genuinely forbids the state;
+ * for other shapes it rests on the bounded deterministic retry search and
+ * remains best-effort. Schemas outside the enumeration subset or beyond its
  * documented bounds throw from the pre-pass before anything is generated.
  *
  * @internal Not part of the package's public API. Do not use from user code.

--- a/src/Fuzz/BranchCompleteCaseGenerator.php
+++ b/src/Fuzz/BranchCompleteCaseGenerator.php
@@ -21,10 +21,12 @@ use InvalidArgumentException;
  * generator defect fails loudly here instead of reaching user code. The one
  * exception is probe cases — branches whose reachability the schema alone
  * cannot decide, i.e. the none-match state of conditional `allOf` and choice
- * points discovered inside it: when the schema forbids that state (a closed
- * discriminator set), the probe case is dropped instead of failing the run.
- * Schemas outside the enumeration subset or beyond its documented bounds
- * throw from the pre-pass before anything is generated.
+ * points discovered inside it: when generation, including its bounded
+ * deterministic retry search, cannot produce a valid value — a closed
+ * discriminator set genuinely forbids the state — the probe case is dropped
+ * instead of failing the run. The drop is best-effort by construction, not a
+ * reachability proof. Schemas outside the enumeration subset or beyond its
+ * documented bounds throw from the pre-pass before anything is generated.
  *
  * @internal Not part of the package's public API. Do not use from user code.
  */
@@ -67,8 +69,9 @@ final class BranchCompleteCaseGenerator
             $value = SchemaDataGenerator::generateOne($schema, $faker, $index, $plan);
             // A probe pins a state whose reachability the schema alone cannot
             // decide (the none-match side of conditional allOf — unreachable
-            // for closed discriminator sets). Its case is dropped when the
-            // schema forbids the state; every other case stays loud.
+            // for closed discriminator sets). Its case is dropped only after
+            // generation's bounded retry search failed to produce a valid
+            // value; every other case stays loud.
             if ($plan->probe && !SchemaValueValidator::isValid($value, $schema)) {
                 continue;
             }

--- a/src/Fuzz/BranchCompleteCaseGenerator.php
+++ b/src/Fuzz/BranchCompleteCaseGenerator.php
@@ -6,6 +6,8 @@ namespace Studio\Gesso\Fuzz;
 
 use InvalidArgumentException;
 
+use function count;
+
 /**
  * Deterministic branch-complete case generation over a converted JSON Schema.
  *
@@ -17,17 +19,18 @@ use InvalidArgumentException;
  * For a fixed (schema, seed) every branch of every reachable choice point
  * therefore appears in at least one generated case.
  *
- * Every case keeps the existing self-check against the converted schema, so a
- * generator defect fails loudly here instead of reaching user code. The one
- * exception is probe cases — branches whose reachability the schema alone
- * cannot decide, i.e. the none-match state of conditional `allOf` and choice
- * points discovered inside it: when generation cannot produce a valid value,
- * the probe case is dropped instead of failing the run. For enum-driven
- * discriminators that decision is exact — the admissible domain is filtered
- * exhaustively, so the drop means a closed set genuinely forbids the state;
- * for other shapes it rests on the bounded deterministic retry search and
- * remains best-effort. Schemas outside the enumeration subset or beyond its
- * documented bounds throw from the pre-pass before anything is generated.
+ * Every untargeted case keeps the existing loud self-check against the
+ * converted schema. Targeted cases are different: a pinned branch's
+ * reachability is undecidable in general — parent constraints such as
+ * `oneOf` exclusivity, `const`, `minProperties`, or folded conditional
+ * suppressions can forbid the pinned state on a perfectly valid schema — so
+ * a targeted case whose value cannot be generated valid (after the
+ * deterministic search machinery: enum-domain filtering, `not` retries,
+ * conditional closure) is treated as an unreachable branch and dropped
+ * rather than failing the run. If every case is dropped, one rotation-only
+ * case still runs loudly, so an unsatisfiable schema remains an error.
+ * Schemas outside the enumeration subset or beyond its documented bounds
+ * throw from the pre-pass before anything is generated.
  *
  * @internal Not part of the package's public API. Do not use from user code.
  */
@@ -53,7 +56,6 @@ final class BranchCompleteCaseGenerator
                     [...$point->ancestors, $point->pointer => $branch],
                     $point->pointer,
                     $branch,
-                    $point->probeContext || $branch === $point->probeBranch,
                 );
             }
         }
@@ -68,16 +70,28 @@ final class BranchCompleteCaseGenerator
         $cases = [];
         foreach ($plans as $index => $plan) {
             $value = SchemaDataGenerator::generateOne($schema, $faker, $index, $plan);
-            // A probe pins a state whose reachability the schema alone cannot
-            // decide (the none-match side of conditional allOf — unreachable
-            // for closed discriminator sets). Its case is dropped only after
-            // generation's bounded retry search failed to produce a valid
-            // value; every other case stays loud.
-            if ($plan->probe && !SchemaValueValidator::isValid($value, $schema)) {
+            // A pinned branch's reachability is undecidable in general:
+            // parent constraints — oneOf exclusivity, const, minProperties,
+            // folded suppressions — can forbid the pinned state on a
+            // perfectly valid schema. When generation (including its
+            // deterministic search machinery) cannot realize a targeted
+            // case, the branch is treated as unreachable and the case is
+            // dropped; untargeted cases stay loud.
+            if ($plan->targetPointer !== null && !SchemaValueValidator::isValid($value, $schema)) {
                 continue;
             }
             SchemaValueValidator::assertValid($value, $schema, $index);
             $cases[] = new PlannedSchemaCase($index, $value, $plan);
+        }
+
+        // Dropping must never swallow a schema no value satisfies: if every
+        // targeted case was dropped, one rotation-only case still runs and
+        // fails loudly on an unsatisfiable schema.
+        if ($cases === []) {
+            $index = count($plans);
+            $value = SchemaDataGenerator::generateOne($schema, $faker, $index, new CaseSelectionPlan([]));
+            SchemaValueValidator::assertValid($value, $schema, $index);
+            $cases[] = new PlannedSchemaCase($index, $value, new CaseSelectionPlan([]));
         }
 
         return $cases;

--- a/src/Fuzz/BranchCompleteCaseGenerator.php
+++ b/src/Fuzz/BranchCompleteCaseGenerator.php
@@ -18,9 +18,13 @@ use InvalidArgumentException;
  * therefore appears in at least one generated case.
  *
  * Every case keeps the existing self-check against the converted schema, so a
- * generator defect fails loudly here instead of reaching user code. Schemas
- * outside the enumeration subset or beyond its documented bounds throw from
- * the pre-pass before anything is generated.
+ * generator defect fails loudly here instead of reaching user code. The one
+ * exception is probe cases — branches whose reachability the schema alone
+ * cannot decide, i.e. the none-match state of conditional `allOf` and choice
+ * points discovered inside it: when the schema forbids that state (a closed
+ * discriminator set), the probe case is dropped instead of failing the run.
+ * Schemas outside the enumeration subset or beyond its documented bounds
+ * throw from the pre-pass before anything is generated.
  *
  * @internal Not part of the package's public API. Do not use from user code.
  */
@@ -41,11 +45,12 @@ final class BranchCompleteCaseGenerator
 
         $plans = [];
         foreach (SchemaChoicePointEnumerator::enumerate($schema) as $point) {
-            for ($branch = $point->firstBranch; $branch < $point->branchCount; $branch++) {
+            for ($branch = 0; $branch < $point->branchCount; $branch++) {
                 $plans[] = new CaseSelectionPlan(
                     [...$point->ancestors, $point->pointer => $branch],
                     $point->pointer,
                     $branch,
+                    $point->probeContext || $branch === $point->probeBranch,
                 );
             }
         }
@@ -60,6 +65,13 @@ final class BranchCompleteCaseGenerator
         $cases = [];
         foreach ($plans as $index => $plan) {
             $value = SchemaDataGenerator::generateOne($schema, $faker, $index, $plan);
+            // A probe pins a state whose reachability the schema alone cannot
+            // decide (the none-match side of conditional allOf — unreachable
+            // for closed discriminator sets). Its case is dropped when the
+            // schema forbids the state; every other case stays loud.
+            if ($plan->probe && !SchemaValueValidator::isValid($value, $schema)) {
+                continue;
+            }
             SchemaValueValidator::assertValid($value, $schema, $index);
             $cases[] = new PlannedSchemaCase($index, $value, $plan);
         }

--- a/src/Fuzz/BranchCompleteCaseGenerator.php
+++ b/src/Fuzz/BranchCompleteCaseGenerator.php
@@ -41,7 +41,7 @@ final class BranchCompleteCaseGenerator
 
         $plans = [];
         foreach (SchemaChoicePointEnumerator::enumerate($schema) as $point) {
-            for ($branch = 0; $branch < $point->branchCount; $branch++) {
+            for ($branch = $point->firstBranch; $branch < $point->branchCount; $branch++) {
                 $plans[] = new CaseSelectionPlan(
                     [...$point->ancestors, $point->pointer => $branch],
                     $point->pointer,

--- a/src/Fuzz/BranchCompleteCaseGenerator.php
+++ b/src/Fuzz/BranchCompleteCaseGenerator.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Fuzz;
+
+use InvalidArgumentException;
+
+/**
+ * Deterministic branch-complete case generation over a converted JSON Schema.
+ *
+ * A pre-pass ({@see SchemaChoicePointEnumerator}) collects every composition
+ * choice point; the derived case list contains one case per (choice point,
+ * branch) pair — each pinned through a {@see CaseSelectionPlan} whose ancestor
+ * selections force the targeted branch to be reachable — plus any
+ * caller-requested extra rotation-only cases, and always at least one case.
+ * For a fixed (schema, seed) every branch of every reachable choice point
+ * therefore appears in at least one generated case.
+ *
+ * Every case keeps the existing self-check against the converted schema, so a
+ * generator defect fails loudly here instead of reaching user code. Schemas
+ * outside the enumeration subset or beyond its documented bounds throw from
+ * the pre-pass before anything is generated.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+final class BranchCompleteCaseGenerator
+{
+    /**
+     * @param array<string, mixed> $schema
+     *
+     * @return list<PlannedSchemaCase>
+     */
+    public static function generate(array $schema, ?int $seed = null, int $extraCases = 0): array
+    {
+        if ($extraCases < 0) {
+            throw new InvalidArgumentException(
+                'BranchCompleteCaseGenerator::generate() requires extraCases >= 0, got ' . $extraCases . '.',
+            );
+        }
+
+        $plans = [];
+        foreach (SchemaChoicePointEnumerator::enumerate($schema) as $point) {
+            for ($branch = 0; $branch < $point->branchCount; $branch++) {
+                $plans[] = new CaseSelectionPlan(
+                    [...$point->ancestors, $point->pointer => $branch],
+                    $point->pointer,
+                    $branch,
+                );
+            }
+        }
+        for ($extra = 0; $extra < $extraCases; $extra++) {
+            $plans[] = new CaseSelectionPlan([]);
+        }
+        if ($plans === []) {
+            $plans[] = new CaseSelectionPlan([]);
+        }
+
+        $faker = SchemaDataGenerator::createFaker($seed);
+        $cases = [];
+        foreach ($plans as $index => $plan) {
+            $value = SchemaDataGenerator::generateOne($schema, $faker, $index, $plan);
+            SchemaValueValidator::assertValid($value, $schema, $index);
+            $cases[] = new PlannedSchemaCase($index, $value, $plan);
+        }
+
+        return $cases;
+    }
+}

--- a/src/Fuzz/BranchCompleteCaseGenerator.php
+++ b/src/Fuzz/BranchCompleteCaseGenerator.php
@@ -7,9 +7,7 @@ namespace Studio\Gesso\Fuzz;
 use Faker\Generator;
 use InvalidArgumentException;
 
-use function array_unique;
 use function count;
-use function json_encode;
 use function max;
 use function sprintf;
 
@@ -42,17 +40,18 @@ use function sprintf;
  * domains — at least {@see self::TARGET_SEARCH_ITERATIONS} offsets, widened
  * to cycle the widest choice point completely, since an unpinned sibling
  * rotation can gate the target's validity (e.g. via `dependentSchemas`).
- * The branch is treated as a proven dead end and dropped only when
- * retrying demonstrably cannot help: either every attempt produced the
- * identical whole value (generation is fully deterministic for this case),
- * or the target state itself was never realized and its node-level outcome
- * never moved. When the target was realized but whole-schema validity
- * never held, or the outcomes vary without success, unreachability is
- * unproven and the run fails loudly instead of silently under-covering. If
- * every case is dropped, one rotation-only case still runs loudly, so an
- * unsatisfiable schema remains an error. Schemas outside the enumeration
- * subset or beyond its documented bounds throw from the pre-pass before
- * anything is generated.
+ * A branch is dropped only on a static unreachability proof — generation
+ * recorded a schema-derived contradiction at a node whose constraints are
+ * unavoidable under the plan ({@see PinnedBranchObservation::$provenDeadEnd}):
+ * an emptied enum/type intersection or const conflict, an absorbing `not`,
+ * an exhausted finite const/enum domain, or impossible presence arithmetic.
+ * Search failure is kept strictly apart: generator determinism is not
+ * evidence that no other value exists on the schema, so without a proof the
+ * run fails loudly instead of silently under-covering. If every case is
+ * dropped, one rotation-only case still runs loudly, so an unsatisfiable
+ * schema remains an error. Schemas outside the enumeration subset or beyond
+ * its documented bounds throw from the pre-pass before anything is
+ * generated.
  *
  * @internal Not part of the package's public API. Do not use from user code.
  */
@@ -145,9 +144,7 @@ final class BranchCompleteCaseGenerator
         CaseSelectionPlan $plan,
         int $rounds,
     ): ?PlannedSchemaCase {
-        $wholes = [];
-        $locals = [];
-        $everSatisfied = false;
+        $attempts = 0;
         for ($round = 0; $round < $rounds; $round++) {
             foreach ([false, true] as $refine) {
                 $attempt = new CaseSelectionPlan(
@@ -160,36 +157,26 @@ final class BranchCompleteCaseGenerator
                 if ($attempt->observation->targetSatisfied && SchemaValueValidator::isValid($value, $schema)) {
                     return new PlannedSchemaCase($index, $value, $attempt);
                 }
-                $everSatisfied = $everSatisfied || $attempt->observation->targetSatisfied;
-                $wholes[] = (string) json_encode($value);
-                $locals[] = $attempt->observation->observed
-                    ? (string) json_encode($attempt->observation->targetLocal)
-                    : "\0unobserved";
+                if ($attempt->observation->provenDeadEnd) {
+                    // A schema-derived proof (statically empty domain at a
+                    // forced node, presence arithmetic) that the pinned view
+                    // admits no value: no search can succeed, drop now.
+                    return null;
+                }
+                $attempts++;
             }
         }
 
-        // Two shapes of proof that retrying cannot help:
-        //  - every attempt produced the identical whole value: generation is
-        //    fully deterministic for this case, so no further search can
-        //    change the outcome;
-        //  - the target state itself was never realized and its node-level
-        //    outcome never moved: the miss is deterministic at the target,
-        //    whatever unrelated parts of the value did around it.
-        // An attempt that realized the target but failed whole-schema
-        // validity is neither: the branch is demonstrably reachable and only
-        // the surrounding context is missing, so concluding "unreachable"
-        // would silently under-cover — fail loudly instead.
-        if (count(array_unique($wholes)) === 1 ||
-            (!$everSatisfied && count(array_unique($locals)) === 1)) {
-            return null;
-        }
-
+        // No proof and no success: generator determinism or a too-narrow
+        // synthesis repertoire is not evidence that no other value exists
+        // on the schema, so silent dropping here would under-cover. Fail
+        // loudly instead.
         throw new FuzzGenerationException(sprintf(
             "Branch %d of choice point '%s' was not realized after %d attempts and could not be "
             . 'proven unreachable; this schema is outside the branch-complete generation subset.',
             $plan->targetBranch ?? -1,
             $plan->targetPointer ?? '',
-            count($wholes),
+            $attempts,
         ), $index);
     }
 }

--- a/src/Fuzz/BranchCompleteCaseGenerator.php
+++ b/src/Fuzz/BranchCompleteCaseGenerator.php
@@ -10,6 +10,7 @@ use InvalidArgumentException;
 use function array_unique;
 use function count;
 use function json_encode;
+use function max;
 use function sprintf;
 
 /**
@@ -37,26 +38,34 @@ use function sprintf;
  * searched: attempts alternate the plain pinned view with a branch-refined
  * view (the branch content re-merged last, restoring non-conjunctive
  * keywords such as `pattern` that a later `allOf` merge displaced) across
- * several iteration offsets that re-rotate every unpinned choice and redraw
- * random domains. Only when every attempt produces the identical node-level
- * outcome at the target — generation is deterministic for this case, the
- * deterministic machinery (enum-domain filtering, `not` retries,
- * conditional closure) has already had its say, and retrying cannot change
- * anything — is the branch treated as a proven dead end and dropped. If the
- * outcomes vary and none succeeds, unreachability is unproven and the run
- * fails loudly instead of silently under-covering. If every case is
- * dropped, one rotation-only case still runs loudly, so an unsatisfiable
- * schema remains an error. Schemas outside the enumeration subset or beyond
- * its documented bounds throw from the pre-pass before anything is
- * generated.
+ * iteration offsets that re-rotate every unpinned choice and redraw random
+ * domains — at least {@see self::TARGET_SEARCH_ITERATIONS} offsets, widened
+ * to cycle the widest choice point completely, since an unpinned sibling
+ * rotation can gate the target's validity (e.g. via `dependentSchemas`).
+ * The branch is treated as a proven dead end and dropped only when
+ * retrying demonstrably cannot help: either every attempt produced the
+ * identical whole value (generation is fully deterministic for this case),
+ * or the target state itself was never realized and its node-level outcome
+ * never moved. When the target was realized but whole-schema validity
+ * never held, or the outcomes vary without success, unreachability is
+ * unproven and the run fails loudly instead of silently under-covering. If
+ * every case is dropped, one rotation-only case still runs loudly, so an
+ * unsatisfiable schema remains an error. Schemas outside the enumeration
+ * subset or beyond its documented bounds throw from the pre-pass before
+ * anything is generated.
  *
  * @internal Not part of the package's public API. Do not use from user code.
  */
 final class BranchCompleteCaseGenerator
 {
     /**
-     * Iteration offsets tried per targeted case before concluding; each
-     * offset runs a plain and a branch-refined attempt.
+     * Minimum iteration offsets tried per targeted case before concluding;
+     * each offset runs a plain and a branch-refined attempt. The actual
+     * width grows to the widest choice point's branch count plus one so a
+     * single untargeted rotation is always cycled through completely — an
+     * unpinned sibling choice can gate the target's validity (e.g. via
+     * `dependentSchemas`) and must not run out of rounds before its
+     * admissible pick comes up.
      */
     private const TARGET_SEARCH_ITERATIONS = 4;
 
@@ -74,7 +83,9 @@ final class BranchCompleteCaseGenerator
         }
 
         $plans = [];
+        $widestChoice = 0;
         foreach (SchemaChoicePointEnumerator::enumerate($schema) as $point) {
+            $widestChoice = max($widestChoice, $point->branchCount);
             for ($branch = 0; $branch < $point->branchCount; $branch++) {
                 $plans[] = new CaseSelectionPlan(
                     [...$point->ancestors, $point->pointer => $branch],
@@ -101,7 +112,7 @@ final class BranchCompleteCaseGenerator
                 continue;
             }
 
-            $case = self::searchTarget($schema, $faker, $index, $plan);
+            $case = self::searchTarget($schema, $faker, $index, $plan, max(self::TARGET_SEARCH_ITERATIONS, $widestChoice + 1));
             if ($case !== null) {
                 $cases[] = $case;
             }
@@ -132,9 +143,12 @@ final class BranchCompleteCaseGenerator
         ?Generator $faker,
         int $index,
         CaseSelectionPlan $plan,
+        int $rounds,
     ): ?PlannedSchemaCase {
-        $outcomes = [];
-        for ($round = 0; $round < self::TARGET_SEARCH_ITERATIONS; $round++) {
+        $wholes = [];
+        $locals = [];
+        $everSatisfied = false;
+        for ($round = 0; $round < $rounds; $round++) {
             foreach ([false, true] as $refine) {
                 $attempt = new CaseSelectionPlan(
                     $plan->selections,
@@ -146,22 +160,36 @@ final class BranchCompleteCaseGenerator
                 if ($attempt->observation->targetSatisfied && SchemaValueValidator::isValid($value, $schema)) {
                     return new PlannedSchemaCase($index, $value, $attempt);
                 }
-                $outcomes[] = $attempt->observation->observed
+                $everSatisfied = $everSatisfied || $attempt->observation->targetSatisfied;
+                $wholes[] = (string) json_encode($value);
+                $locals[] = $attempt->observation->observed
                     ? (string) json_encode($attempt->observation->targetLocal)
                     : "\0unobserved";
             }
         }
 
-        if (count(array_unique($outcomes)) > 1) {
-            throw new FuzzGenerationException(sprintf(
-                "Branch %d of choice point '%s' was not realized after %d attempts and could not be "
-                . 'proven unreachable; this schema is outside the branch-complete generation subset.',
-                $plan->targetBranch ?? -1,
-                $plan->targetPointer ?? '',
-                count($outcomes),
-            ), $index);
+        // Two shapes of proof that retrying cannot help:
+        //  - every attempt produced the identical whole value: generation is
+        //    fully deterministic for this case, so no further search can
+        //    change the outcome;
+        //  - the target state itself was never realized and its node-level
+        //    outcome never moved: the miss is deterministic at the target,
+        //    whatever unrelated parts of the value did around it.
+        // An attempt that realized the target but failed whole-schema
+        // validity is neither: the branch is demonstrably reachable and only
+        // the surrounding context is missing, so concluding "unreachable"
+        // would silently under-cover — fail loudly instead.
+        if (count(array_unique($wholes)) === 1 ||
+            (!$everSatisfied && count(array_unique($locals)) === 1)) {
+            return null;
         }
 
-        return null;
+        throw new FuzzGenerationException(sprintf(
+            "Branch %d of choice point '%s' was not realized after %d attempts and could not be "
+            . 'proven unreachable; this schema is outside the branch-complete generation subset.',
+            $plan->targetBranch ?? -1,
+            $plan->targetPointer ?? '',
+            count($wholes),
+        ), $index);
     }
 }

--- a/src/Fuzz/BranchCompleteCaseGenerator.php
+++ b/src/Fuzz/BranchCompleteCaseGenerator.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Studio\Gesso\Fuzz;
 
+use Faker\Generator;
 use InvalidArgumentException;
 
+use function array_unique;
 use function count;
+use function json_encode;
+use function sprintf;
 
 /**
  * Deterministic branch-complete case generation over a converted JSON Schema.
@@ -23,23 +27,39 @@ use function count;
  * converted schema. Targeted cases are different: a pinned branch's
  * reachability is undecidable in general — parent constraints such as
  * `oneOf` exclusivity, `const`, `minProperties`, or folded conditional
- * suppressions can forbid the pinned state on a perfectly valid schema — so
- * a targeted case that cannot realize its branch (after the deterministic
- * search machinery: enum-domain filtering, `not` retries, conditional
- * closure) is treated as an unreachable branch and dropped rather than
- * failing the run. Realizing the branch means both whole-schema validity
- * and the generation-site observation that the target branch itself was
- * taken ({@see PinnedBranchObservation}) — whole-schema validity alone
- * cannot tell the target from a sibling branch that also matches the
- * value. If every case is dropped, one rotation-only
- * case still runs loudly, so an unsatisfiable schema remains an error.
- * Schemas outside the enumeration subset or beyond its documented bounds
- * throw from the pre-pass before anything is generated.
+ * suppressions can forbid the pinned state on a perfectly valid schema. A
+ * targeted case counts as covering its branch only when the value is valid
+ * for the whole schema AND generation observed the target branch itself
+ * being taken ({@see PinnedBranchObservation}) — whole-schema validity alone
+ * cannot tell the target from a sibling branch that also matches the value.
+ *
+ * A single failed candidate proves nothing, so an unrealized target is
+ * searched: attempts alternate the plain pinned view with a branch-refined
+ * view (the branch content re-merged last, restoring non-conjunctive
+ * keywords such as `pattern` that a later `allOf` merge displaced) across
+ * several iteration offsets that re-rotate every unpinned choice and redraw
+ * random domains. Only when every attempt produces the identical node-level
+ * outcome at the target — generation is deterministic for this case, the
+ * deterministic machinery (enum-domain filtering, `not` retries,
+ * conditional closure) has already had its say, and retrying cannot change
+ * anything — is the branch treated as a proven dead end and dropped. If the
+ * outcomes vary and none succeeds, unreachability is unproven and the run
+ * fails loudly instead of silently under-covering. If every case is
+ * dropped, one rotation-only case still runs loudly, so an unsatisfiable
+ * schema remains an error. Schemas outside the enumeration subset or beyond
+ * its documented bounds throw from the pre-pass before anything is
+ * generated.
  *
  * @internal Not part of the package's public API. Do not use from user code.
  */
 final class BranchCompleteCaseGenerator
 {
+    /**
+     * Iteration offsets tried per targeted case before concluding; each
+     * offset runs a plain and a branch-refined attempt.
+     */
+    private const TARGET_SEARCH_ITERATIONS = 4;
+
     /**
      * @param array<string, mixed> $schema
      *
@@ -73,25 +93,18 @@ final class BranchCompleteCaseGenerator
         $faker = SchemaDataGenerator::createFaker($seed);
         $cases = [];
         foreach ($plans as $index => $plan) {
-            $value = SchemaDataGenerator::generateOne($schema, $faker, $index, $plan);
-            // A pinned branch's reachability is undecidable in general:
-            // parent constraints — oneOf exclusivity, const, minProperties,
-            // folded suppressions — can forbid the pinned state on a
-            // perfectly valid schema. A targeted case counts as covering
-            // its branch only when the value is valid for the whole schema
-            // AND generation observed the target branch itself being taken
-            // — whole-schema validity alone cannot tell the target from a
-            // sibling that also matches (`anyOf`, an `if` firing on an
-            // else-targeted value). When generation (including its
-            // deterministic search machinery) cannot realize such a value,
-            // the branch is treated as unreachable and the case is dropped;
-            // untargeted cases stay loud.
-            if ($plan->targetPointer !== null &&
-                (!$plan->observation->targetSatisfied || !SchemaValueValidator::isValid($value, $schema))) {
+            if ($plan->targetPointer === null) {
+                $value = SchemaDataGenerator::generateOne($schema, $faker, $index, $plan);
+                SchemaValueValidator::assertValid($value, $schema, $index);
+                $cases[] = new PlannedSchemaCase($index, $value, $plan);
+
                 continue;
             }
-            SchemaValueValidator::assertValid($value, $schema, $index);
-            $cases[] = new PlannedSchemaCase($index, $value, $plan);
+
+            $case = self::searchTarget($schema, $faker, $index, $plan);
+            if ($case !== null) {
+                $cases[] = $case;
+            }
         }
 
         // Dropping must never swallow a schema no value satisfies: if every
@@ -105,5 +118,50 @@ final class BranchCompleteCaseGenerator
         }
 
         return $cases;
+    }
+
+    /**
+     * Search for a value that realizes the plan's target branch; null means
+     * the branch is a proven (deterministic) dead end and its case is
+     * dropped. See the class docblock for the drop/throw semantics.
+     *
+     * @param array<string, mixed> $schema
+     */
+    private static function searchTarget(
+        array $schema,
+        ?Generator $faker,
+        int $index,
+        CaseSelectionPlan $plan,
+    ): ?PlannedSchemaCase {
+        $outcomes = [];
+        for ($round = 0; $round < self::TARGET_SEARCH_ITERATIONS; $round++) {
+            foreach ([false, true] as $refine) {
+                $attempt = new CaseSelectionPlan(
+                    $plan->selections,
+                    $plan->targetPointer,
+                    $plan->targetBranch,
+                    $refine,
+                );
+                $value = SchemaDataGenerator::generateOne($schema, $faker, $index + $round, $attempt);
+                if ($attempt->observation->targetSatisfied && SchemaValueValidator::isValid($value, $schema)) {
+                    return new PlannedSchemaCase($index, $value, $attempt);
+                }
+                $outcomes[] = $attempt->observation->observed
+                    ? (string) json_encode($attempt->observation->targetLocal)
+                    : "\0unobserved";
+            }
+        }
+
+        if (count(array_unique($outcomes)) > 1) {
+            throw new FuzzGenerationException(sprintf(
+                "Branch %d of choice point '%s' was not realized after %d attempts and could not be "
+                . 'proven unreachable; this schema is outside the branch-complete generation subset.',
+                $plan->targetBranch ?? -1,
+                $plan->targetPointer ?? '',
+                count($outcomes),
+            ), $index);
+        }
+
+        return null;
     }
 }

--- a/src/Fuzz/BranchCompleteCaseGenerator.php
+++ b/src/Fuzz/BranchCompleteCaseGenerator.php
@@ -24,10 +24,14 @@ use function count;
  * reachability is undecidable in general — parent constraints such as
  * `oneOf` exclusivity, `const`, `minProperties`, or folded conditional
  * suppressions can forbid the pinned state on a perfectly valid schema — so
- * a targeted case whose value cannot be generated valid (after the
- * deterministic search machinery: enum-domain filtering, `not` retries,
- * conditional closure) is treated as an unreachable branch and dropped
- * rather than failing the run. If every case is dropped, one rotation-only
+ * a targeted case that cannot realize its branch (after the deterministic
+ * search machinery: enum-domain filtering, `not` retries, conditional
+ * closure) is treated as an unreachable branch and dropped rather than
+ * failing the run. Realizing the branch means both whole-schema validity
+ * and the generation-site observation that the target branch itself was
+ * taken ({@see PinnedBranchObservation}) — whole-schema validity alone
+ * cannot tell the target from a sibling branch that also matches the
+ * value. If every case is dropped, one rotation-only
  * case still runs loudly, so an unsatisfiable schema remains an error.
  * Schemas outside the enumeration subset or beyond its documented bounds
  * throw from the pre-pass before anything is generated.
@@ -73,11 +77,17 @@ final class BranchCompleteCaseGenerator
             // A pinned branch's reachability is undecidable in general:
             // parent constraints — oneOf exclusivity, const, minProperties,
             // folded suppressions — can forbid the pinned state on a
-            // perfectly valid schema. When generation (including its
-            // deterministic search machinery) cannot realize a targeted
-            // case, the branch is treated as unreachable and the case is
-            // dropped; untargeted cases stay loud.
-            if ($plan->targetPointer !== null && !SchemaValueValidator::isValid($value, $schema)) {
+            // perfectly valid schema. A targeted case counts as covering
+            // its branch only when the value is valid for the whole schema
+            // AND generation observed the target branch itself being taken
+            // — whole-schema validity alone cannot tell the target from a
+            // sibling that also matches (`anyOf`, an `if` firing on an
+            // else-targeted value). When generation (including its
+            // deterministic search machinery) cannot realize such a value,
+            // the branch is treated as unreachable and the case is dropped;
+            // untargeted cases stay loud.
+            if ($plan->targetPointer !== null &&
+                (!$plan->observation->targetSatisfied || !SchemaValueValidator::isValid($value, $schema))) {
                 continue;
             }
             SchemaValueValidator::assertValid($value, $schema, $index);

--- a/src/Fuzz/CaseSelectionPlan.php
+++ b/src/Fuzz/CaseSelectionPlan.php
@@ -18,19 +18,11 @@ namespace Studio\Gesso\Fuzz;
  */
 final readonly class CaseSelectionPlan
 {
-    /**
-     * `probe` marks a case that pins a branch whose reachability cannot be
-     * determined from the schema alone (see {@see SchemaChoicePoint}); its
-     * generated value is dropped instead of failing loudly when the schema
-     * forbids that state.
-     *
-     * @param array<string, int> $selections
-     */
+    /** @param array<string, int> $selections */
     public function __construct(
         public array $selections,
         public ?string $targetPointer = null,
         public ?int $targetBranch = null,
-        public bool $probe = false,
     ) {}
 
     public function branchFor(string $pointer): ?int

--- a/src/Fuzz/CaseSelectionPlan.php
+++ b/src/Fuzz/CaseSelectionPlan.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Fuzz;
+
+/**
+ * A pinned per-case branch selection for {@see SchemaDataGenerator}.
+ *
+ * `selections` maps choice-point JSON Pointers (as reported by
+ * {@see SchemaChoicePointEnumerator}) to the branch generation must take
+ * there; every choice point without an entry keeps the documented rotation
+ * strategy for the case's iteration index. `targetPointer`/`targetBranch`
+ * identify the (choice point, branch) pair the case exists to cover — null
+ * for extra rotation-only cases — so failures can name the pinned branch.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+final readonly class CaseSelectionPlan
+{
+    /** @param array<string, int> $selections */
+    public function __construct(
+        public array $selections,
+        public ?string $targetPointer = null,
+        public ?int $targetBranch = null,
+    ) {}
+
+    public function branchFor(string $pointer): ?int
+    {
+        return $this->selections[$pointer] ?? null;
+    }
+}

--- a/src/Fuzz/CaseSelectionPlan.php
+++ b/src/Fuzz/CaseSelectionPlan.php
@@ -13,17 +13,23 @@ namespace Studio\Gesso\Fuzz;
  * strategy for the case's iteration index. `targetPointer`/`targetBranch`
  * identify the (choice point, branch) pair the case exists to cover — null
  * for extra rotation-only cases — so failures can name the pinned branch.
+ * `observation` is filled in by generation: it records whether the target
+ * branch was actually taken by the produced value.
  *
  * @internal Not part of the package's public API. Do not use from user code.
  */
 final readonly class CaseSelectionPlan
 {
+    public PinnedBranchObservation $observation;
+
     /** @param array<string, int> $selections */
     public function __construct(
         public array $selections,
         public ?string $targetPointer = null,
         public ?int $targetBranch = null,
-    ) {}
+    ) {
+        $this->observation = new PinnedBranchObservation();
+    }
 
     public function branchFor(string $pointer): ?int
     {

--- a/src/Fuzz/CaseSelectionPlan.php
+++ b/src/Fuzz/CaseSelectionPlan.php
@@ -14,7 +14,11 @@ namespace Studio\Gesso\Fuzz;
  * identify the (choice point, branch) pair the case exists to cover — null
  * for extra rotation-only cases — so failures can name the pinned branch.
  * `observation` is filled in by generation: it records whether the target
- * branch was actually taken by the produced value.
+ * branch was actually taken by the produced value. `refineTarget` marks a
+ * target-search retry attempt: the composition site re-merges the target
+ * branch's own content after all other merges, so non-conjunctive keywords
+ * (`pattern`, `format`) displaced by a later `allOf` merge aim back at the
+ * branch itself.
  *
  * @internal Not part of the package's public API. Do not use from user code.
  */
@@ -27,6 +31,7 @@ final readonly class CaseSelectionPlan
         public array $selections,
         public ?string $targetPointer = null,
         public ?int $targetBranch = null,
+        public bool $refineTarget = false,
     ) {
         $this->observation = new PinnedBranchObservation();
     }

--- a/src/Fuzz/CaseSelectionPlan.php
+++ b/src/Fuzz/CaseSelectionPlan.php
@@ -18,11 +18,19 @@ namespace Studio\Gesso\Fuzz;
  */
 final readonly class CaseSelectionPlan
 {
-    /** @param array<string, int> $selections */
+    /**
+     * `probe` marks a case that pins a branch whose reachability cannot be
+     * determined from the schema alone (see {@see SchemaChoicePoint}); its
+     * generated value is dropped instead of failing loudly when the schema
+     * forbids that state.
+     *
+     * @param array<string, int> $selections
+     */
     public function __construct(
         public array $selections,
         public ?string $targetPointer = null,
         public ?int $targetBranch = null,
+        public bool $probe = false,
     ) {}
 
     public function branchFor(string $pointer): ?int

--- a/src/Fuzz/PinnedBranchObservation.php
+++ b/src/Fuzz/PinnedBranchObservation.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Fuzz;
+
+use Closure;
+
+/**
+ * Records whether a case's target branch was actually taken by generation.
+ *
+ * A whole-schema validity check cannot distinguish a value that took the
+ * targeted branch from one that merely passes through a sibling — `anyOf`
+ * admits any matching branch, an `if` may fire on an else-targeted value.
+ * So the generation site that applies the pinned target registers a
+ * branch-level check ({@see self::expect()}) against the branch content it
+ * has in hand, and the node's generated value is evaluated against it once
+ * the value exists ({@see self::evaluate()}). Sites that can decide on the
+ * spot (property presence after the maxProperties trim) report directly.
+ *
+ * Regenerated nodes — `not` retries, conditional closure expansion —
+ * re-register and re-evaluate; the invocation that produced the returned
+ * value always evaluates last, so the final state describes the final tree.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+final class PinnedBranchObservation
+{
+    public bool $targetSatisfied = false;
+    private ?string $owner = null;
+
+    /** @var ?Closure(mixed): bool */
+    private ?Closure $check = null;
+
+    /**
+     * Register the branch-level check for the target applied at the node
+     * generating under `$ownerPointer`.
+     *
+     * @param Closure(mixed): bool $check
+     */
+    public function expect(string $ownerPointer, Closure $check): void
+    {
+        $this->owner = $ownerPointer;
+        $this->check = $check;
+    }
+
+    /** Run the registered check when `$pointer` is the registering node. */
+    public function evaluate(string $pointer, mixed $value): void
+    {
+        if ($this->check !== null && $this->owner === $pointer) {
+            $this->targetSatisfied = ($this->check)($value);
+        }
+    }
+
+    /** Record an on-the-spot decision from a site that needs no deferral. */
+    public function report(bool $satisfied): void
+    {
+        $this->targetSatisfied = $satisfied;
+    }
+}

--- a/src/Fuzz/PinnedBranchObservation.php
+++ b/src/Fuzz/PinnedBranchObservation.php
@@ -18,6 +18,18 @@ use Closure;
  * the value exists ({@see self::evaluate()}). Sites that can decide on the
  * spot (property presence after the maxProperties trim) report directly.
  *
+ * `targetLocal` keeps the node-level outcome at the target site — the value
+ * the check ran on, or the reported state. The target search compares it
+ * across attempts: identical failing outcomes mean generation is
+ * deterministic for this case and the branch is a proven dead end; varying
+ * outcomes mean the search cannot conclude and must fail loudly.
+ *
+ * A composition site also stages its branch content here when the plan asks
+ * for a refinement attempt ({@see CaseSelectionPlan::$refineTarget}); the
+ * composition resolver re-merges it after all other merges so
+ * non-conjunctive keywords (`pattern`, `format`) displaced by a later
+ * `allOf` merge are restored to the branch's own constraint.
+ *
  * Regenerated nodes — `not` retries, conditional closure expansion —
  * re-register and re-evaluate; the invocation that produced the returned
  * value always evaluates last, so the final state describes the final tree.
@@ -27,10 +39,15 @@ use Closure;
 final class PinnedBranchObservation
 {
     public bool $targetSatisfied = false;
+    public bool $observed = false;
+    public mixed $targetLocal = null;
     private ?string $owner = null;
 
     /** @var ?Closure(mixed): bool */
     private ?Closure $check = null;
+
+    /** @var ?array<string, mixed> */
+    private ?array $refinement = null;
 
     /**
      * Register the branch-level check for the target applied at the node
@@ -48,6 +65,8 @@ final class PinnedBranchObservation
     public function evaluate(string $pointer, mixed $value): void
     {
         if ($this->check !== null && $this->owner === $pointer) {
+            $this->observed = true;
+            $this->targetLocal = $value;
             $this->targetSatisfied = ($this->check)($value);
         }
     }
@@ -55,6 +74,23 @@ final class PinnedBranchObservation
     /** Record an on-the-spot decision from a site that needs no deferral. */
     public function report(bool $satisfied): void
     {
+        $this->observed = true;
+        $this->targetLocal = $satisfied;
         $this->targetSatisfied = $satisfied;
+    }
+
+    /** @param array<string, mixed> $branch */
+    public function stageRefinement(array $branch): void
+    {
+        $this->refinement = $branch;
+    }
+
+    /** @return ?array<string, mixed> */
+    public function takeRefinement(): ?array
+    {
+        $refinement = $this->refinement;
+        $this->refinement = null;
+
+        return $refinement;
     }
 }

--- a/src/Fuzz/PinnedBranchObservation.php
+++ b/src/Fuzz/PinnedBranchObservation.php
@@ -41,6 +41,15 @@ final class PinnedBranchObservation
     public bool $targetSatisfied = false;
     public bool $observed = false;
     public mixed $targetLocal = null;
+
+    /**
+     * Set when generation hit a statically empty value domain at a forced
+     * node — a schema-derived proof that no value can satisfy the pinned
+     * view, so the targeted branch is unreachable and its case may be
+     * dropped. Search failure without this proof must stay loud: generator
+     * determinism is not evidence that no other value exists.
+     */
+    public bool $provenDeadEnd = false;
     private ?string $owner = null;
 
     /** @var ?Closure(mixed): bool */
@@ -69,6 +78,12 @@ final class PinnedBranchObservation
             $this->targetLocal = $value;
             $this->targetSatisfied = ($this->check)($value);
         }
+    }
+
+    /** Record a schema-derived proof that the pinned view admits no value. */
+    public function proveDeadEnd(): void
+    {
+        $this->provenDeadEnd = true;
     }
 
     /** Record an on-the-spot decision from a site that needs no deferral. */

--- a/src/Fuzz/PlannedSchemaCase.php
+++ b/src/Fuzz/PlannedSchemaCase.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Fuzz;
+
+/**
+ * One generated branch-complete case: the schema-valid value together with
+ * the selection plan that produced it, so callers can name the pinned
+ * (choice point, branch) pair in replayable failure output.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+final readonly class PlannedSchemaCase
+{
+    public function __construct(
+        public int $index,
+        public mixed $value,
+        public CaseSelectionPlan $plan,
+    ) {}
+}

--- a/src/Fuzz/SchemaChoicePoint.php
+++ b/src/Fuzz/SchemaChoicePoint.php
@@ -30,11 +30,19 @@ final readonly class SchemaChoicePoint
     /** Branch index that emits null for a nullable node. */
     public const NULL_VALUE = 1;
 
-    /** @param array<string, int> $ancestors */
+    /**
+     * `firstBranch` is the first branch index this entry still needs to
+     * cover: 0 for a first discovery; the previously covered count when the
+     * same pointer reappears under another branch context with more branches,
+     * so only the uncovered tail gains cases.
+     *
+     * @param array<string, int> $ancestors
+     */
     public function __construct(
         public SchemaChoicePointKind $kind,
         public string $pointer,
         public int $branchCount,
         public array $ancestors,
+        public int $firstBranch = 0,
     ) {}
 }

--- a/src/Fuzz/SchemaChoicePoint.php
+++ b/src/Fuzz/SchemaChoicePoint.php
@@ -31,10 +31,11 @@ final readonly class SchemaChoicePoint
     public const NULL_VALUE = 1;
 
     /**
-     * `firstBranch` is the first branch index this entry still needs to
-     * cover: 0 for a first discovery; the previously covered count when the
-     * same pointer reappears under another branch context with more branches,
-     * so only the uncovered tail gains cases.
+     * `probeBranch` names a branch whose reachability cannot be determined
+     * from the schema alone (the none-match state of conditional `allOf`);
+     * `probeContext` marks a choice point discovered inside such a state.
+     * Cases pinning either are reachability probes: they are dropped instead
+     * of failing loudly when the schema forbids that state.
      *
      * @param array<string, int> $ancestors
      */
@@ -43,6 +44,7 @@ final readonly class SchemaChoicePoint
         public string $pointer,
         public int $branchCount,
         public array $ancestors,
-        public int $firstBranch = 0,
+        public ?int $probeBranch = null,
+        public bool $probeContext = false,
     ) {}
 }

--- a/src/Fuzz/SchemaChoicePoint.php
+++ b/src/Fuzz/SchemaChoicePoint.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Fuzz;
+
+/**
+ * One composition choice point discovered by {@see SchemaChoicePointEnumerator}.
+ *
+ * `pointer` addresses the choice keyword on the effective schema — the view the
+ * generator sees after `allOf`/branch merging — so a pinned selection plan and
+ * generation resolve the same location. `ancestors` are the pinned selections
+ * (pointer => branch) required for this choice point to be reachable at all:
+ * enclosing optional properties forced present, nullable ancestors forced to
+ * the value branch, enclosing composition branches, and minimum array sizes.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+final readonly class SchemaChoicePoint
+{
+    /** Branch index that includes an optional property / keeps a value. */
+    public const PRESENT = 0;
+
+    /** Branch index that omits an optional property. */
+    public const OMITTED = 1;
+
+    /** Branch index that keeps the non-null value of a nullable node. */
+    public const VALUE = 0;
+
+    /** Branch index that emits null for a nullable node. */
+    public const NULL_VALUE = 1;
+
+    /** @param array<string, int> $ancestors */
+    public function __construct(
+        public SchemaChoicePointKind $kind,
+        public string $pointer,
+        public int $branchCount,
+        public array $ancestors,
+    ) {}
+}

--- a/src/Fuzz/SchemaChoicePoint.php
+++ b/src/Fuzz/SchemaChoicePoint.php
@@ -30,21 +30,11 @@ final readonly class SchemaChoicePoint
     /** Branch index that emits null for a nullable node. */
     public const NULL_VALUE = 1;
 
-    /**
-     * `probeBranch` names a branch whose reachability cannot be determined
-     * from the schema alone (the none-match state of conditional `allOf`);
-     * `probeContext` marks a choice point discovered inside such a state.
-     * Cases pinning either are reachability probes: they are dropped instead
-     * of failing loudly when the schema forbids that state.
-     *
-     * @param array<string, int> $ancestors
-     */
+    /** @param array<string, int> $ancestors */
     public function __construct(
         public SchemaChoicePointKind $kind,
         public string $pointer,
         public int $branchCount,
         public array $ancestors,
-        public ?int $probeBranch = null,
-        public bool $probeContext = false,
     ) {}
 }

--- a/src/Fuzz/SchemaChoicePointEnumerator.php
+++ b/src/Fuzz/SchemaChoicePointEnumerator.php
@@ -226,6 +226,16 @@ final class SchemaChoicePointEnumerator
             }
         }
 
+        if ($conditionals !== []) {
+            // Boolean consequents leave no choice; fold them exactly like
+            // generation does. An unsatisfiable node keeps only the base —
+            // its cases fail the self-check loudly.
+            [$base, $conditionals, $unsatisfiable] = SchemaDataGenerator::partitionConditionals($base, $conditionals);
+            if ($unsatisfiable) {
+                $conditionals = [];
+            }
+        }
+
         if ($conditionals === []) {
             $this->rejectReintroduced($base, ['oneOf', 'anyOf', 'allOf'], $pointer);
             $this->visitIfPhase($base, $pointer, $ancestors, $depth, $probe);
@@ -400,6 +410,12 @@ final class SchemaChoicePointEnumerator
         if (is_array($prefixItems)) {
             $prefixCount = count($prefixItems);
             foreach (array_values($prefixItems) as $index => $item) {
+                if ($item === false) {
+                    // Nothing matches a false prefix item, so any array long
+                    // enough to contain it — or anything behind it — is
+                    // invalid: it is an effective maxItems.
+                    return;
+                }
                 if (!is_array($item) || ($maxItems !== null && $maxItems <= $index)) {
                     continue;
                 }

--- a/src/Fuzz/SchemaChoicePointEnumerator.php
+++ b/src/Fuzz/SchemaChoicePointEnumerator.php
@@ -13,6 +13,7 @@ use function count;
 use function implode;
 use function in_array;
 use function is_array;
+use function is_bool;
 use function is_int;
 use function is_string;
 use function json_encode;
@@ -104,7 +105,7 @@ final class SchemaChoicePointEnumerator
                 continue;
             }
             if ($keyword === 'if' || $keyword === 'allOf' ||
-                array_filter($value, is_array(...)) !== []) {
+                array_filter($value, static fn(mixed $branch): bool => is_array($branch) || is_bool($branch)) !== []) {
                 $found[] = $keyword;
             }
         }
@@ -162,13 +163,24 @@ final class SchemaChoicePointEnumerator
 
         if ($keywords !== []) {
             $keyword = $keywords[0];
-            /** @var list<array<string, mixed>> $branches */
-            $branches = array_values(array_filter($schema[$keyword], is_array(...)));
+            [$branches, $enumerable] = SchemaDataGenerator::compositionBranchSpace(
+                array_values($schema[$keyword]),
+                $keyword,
+            );
+            if ($enumerable === []) {
+                // No branch is generatable (e.g. every branch is `false`);
+                // the keyword stays unresolved and generation fails its
+                // self-check loudly, mirrored here by not descending.
+                $this->visitAllOfPhase($schema, $pointer, $ancestors, $depth, $probe);
+
+                return;
+            }
+
             $choicePointer = $pointer . '/' . $keyword;
             $this->record(
                 $keyword === 'oneOf' ? SchemaChoicePointKind::OneOf : SchemaChoicePointKind::AnyOf,
                 $choicePointer,
-                count($branches),
+                count($enumerable),
                 $ancestors,
                 $branches,
                 $probe,
@@ -176,10 +188,10 @@ final class SchemaChoicePointEnumerator
 
             $base = $schema;
             unset($base[$keyword]);
-            foreach ($branches as $index => $branch) {
-                $merged = SchemaDataGenerator::mergeSchemas($base, $branch);
+            foreach ($enumerable as $branch => $selected) {
+                $merged = SchemaDataGenerator::applyCompositionBranch($base, $branches, $selected, $keyword);
                 $this->rejectReintroduced($merged, ['oneOf', 'anyOf'], $pointer);
-                $this->visitAllOfPhase($merged, $pointer, [...$ancestors, $choicePointer => $index], $depth, $probe);
+                $this->visitAllOfPhase($merged, $pointer, [...$ancestors, $choicePointer => $branch], $depth, $probe);
             }
 
             return;
@@ -254,6 +266,20 @@ final class SchemaChoicePointEnumerator
      */
     private function visitIfPhase(array $schema, string $pointer, array $ancestors, int $depth, bool $probe): void
     {
+        if (is_bool($schema['if'] ?? null)) {
+            // A boolean if has no branch to choose: `if: true` makes the
+            // then unconditional, `if: false` the else. No choice point.
+            $branchSchema = $schema['if'] === true ? ($schema['then'] ?? null) : ($schema['else'] ?? null);
+            unset($schema['if'], $schema['then'], $schema['else']);
+            if (is_array($branchSchema)) {
+                $schema = SchemaDataGenerator::mergeSchemas($schema, $branchSchema);
+            }
+            $this->rejectReintroduced($schema, ['oneOf', 'anyOf', 'allOf', 'if'], $pointer);
+            $this->visitLeaf($schema, $pointer, $ancestors, $depth, $probe);
+
+            return;
+        }
+
         if (!isset($schema['if']) || !is_array($schema['if'])) {
             $this->visitLeaf($schema, $pointer, $ancestors, $depth, $probe);
 

--- a/src/Fuzz/SchemaChoicePointEnumerator.php
+++ b/src/Fuzz/SchemaChoicePointEnumerator.php
@@ -34,10 +34,13 @@ use function str_replace;
  * unresolved composition on the same node, keywords reintroduced by a branch
  * merge) are rejected loudly instead of silently dropping branches.
  *
- * A choice point rediscovered at the same pointer under another branch
- * context is deduplicated only when its branch content is identical; a
- * context that gives the same pointer different branches keeps its own entry
- * under its own ancestors, so context-specific branches stay covered.
+ * A choice point rediscovered at the same pointer keeps one entry per
+ * discovery context (ancestors + branch content); only exact revisits
+ * collapse. Contexts are not interchangeable: generation can leave a branch
+ * context mid-case when suppressed conditionals fire, but every reachable
+ * state retains at least one generation-stable context whose case realizes
+ * it — `then` content under its own branch, `else` content under the
+ * none-match state.
  *
  * Enumeration bounds, all loud on excess:
  *  - {@see self::MAX_DEPTH} nested property/item levels;
@@ -409,26 +412,16 @@ final class SchemaChoicePointEnumerator
         ?int $probeBranch = null,
     ): void {
         // The same effective pointer can be rediscovered under a different
-        // branch context. Identical branch content means identical coverage,
-        // so the first discovery suffices — unless the first sat inside a
-        // probe context and this one does not: the non-probe rediscovery is
-        // strictly more reliable, so it takes over the entry. Different
-        // content keeps its own entry under the ancestors that make its
-        // branches reachable.
-        $key = $pointer . '#' . md5((string) json_encode($content));
-        $existing = $this->seen[$key] ?? null;
-        if ($existing !== null) {
-            if ($this->points[$existing]->probeContext && !$probeContext) {
-                $this->points[$existing] = new SchemaChoicePoint(
-                    $kind,
-                    $pointer,
-                    $branchCount,
-                    $ancestors,
-                    $probeBranch,
-                    false,
-                );
-            }
-
+        // branch context. Each context keeps its own entry: generation may
+        // leave a context mid-case (closure expansion when suppressed
+        // conditionals fire), so no single context's claim is authoritative
+        // — but every reachable state has at least one context that is
+        // stable under generation (its own branch for `then` content, the
+        // none-match state for `else` content), and that context's case
+        // realizes the branch. Only exact revisits — same pointer, same
+        // content, same ancestors — collapse.
+        $key = $pointer . '#' . md5((string) json_encode([$ancestors, $content]));
+        if (isset($this->seen[$key])) {
             return;
         }
         $this->seen[$key] = count($this->points);

--- a/src/Fuzz/SchemaChoicePointEnumerator.php
+++ b/src/Fuzz/SchemaChoicePointEnumerator.php
@@ -286,29 +286,28 @@ final class SchemaChoicePointEnumerator
             return;
         }
 
+        $sides = SchemaDataGenerator::ifBranchSides($schema);
+        if ($sides === []) {
+            // Both consequents are `false`: neither side is satisfiable.
+            // Generation leaves the keyword unresolved and fails its
+            // self-check loudly; mirror by not descending the consequents.
+            $this->visitLeaf($schema, $pointer, $ancestors, $depth, $probe);
+
+            return;
+        }
+
         $choicePointer = $pointer . '/if';
         $this->record(
             SchemaChoicePointKind::IfThenElse,
             $choicePointer,
-            2,
+            count($sides),
             $ancestors,
             [$schema['if'], $schema['then'] ?? null, $schema['else'] ?? null],
             $probe,
         );
 
-        $base = $schema;
-        unset($base['if'], $base['then'], $base['else']);
-        $views = [
-            SchemaDataGenerator::mergeSchemas($base, SchemaDataGenerator::mergeSchemas(
-                $schema['if'],
-                is_array($schema['then'] ?? null) ? $schema['then'] : [],
-            )),
-            SchemaDataGenerator::mergeSchemas($base, SchemaDataGenerator::mergeSchemas(
-                ['not' => $schema['if']],
-                is_array($schema['else'] ?? null) ? $schema['else'] : [],
-            )),
-        ];
-        foreach ($views as $branch => $view) {
+        foreach ($sides as $branch => $side) {
+            $view = SchemaDataGenerator::applyIfSide($schema, $side);
             $this->rejectReintroduced($view, ['oneOf', 'anyOf', 'allOf', 'if'], $pointer);
             $this->visitLeaf($view, $pointer, [...$ancestors, $choicePointer => $branch], $depth, $probe);
         }
@@ -365,7 +364,13 @@ final class SchemaChoicePointEnumerator
         }
 
         foreach ($properties as $name => $propertySchema) {
-            if (!is_string($name) || !is_array($propertySchema)) {
+            if (!is_string($name)) {
+                continue;
+            }
+            // Boolean property schemas: `true` admits any value, so only its
+            // presence is a choice; `false` admits none, so presence is
+            // unreachable and there is no choice at all.
+            if (!is_array($propertySchema) && $propertySchema !== true) {
                 continue;
             }
 
@@ -376,7 +381,9 @@ final class SchemaChoicePointEnumerator
                 $childAncestors = [...$childAncestors, $childPointer => SchemaChoicePoint::PRESENT];
             }
 
-            $this->visitNode($propertySchema, $childPointer, $childAncestors, $depth + 1, $probe);
+            if (is_array($propertySchema)) {
+                $this->visitNode($propertySchema, $childPointer, $childAncestors, $depth + 1, $probe);
+            }
         }
     }
 

--- a/src/Fuzz/SchemaChoicePointEnumerator.php
+++ b/src/Fuzz/SchemaChoicePointEnumerator.php
@@ -1,0 +1,405 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Fuzz;
+
+use InvalidArgumentException;
+
+use function array_filter;
+use function array_key_exists;
+use function array_values;
+use function count;
+use function implode;
+use function in_array;
+use function is_array;
+use function is_int;
+use function is_string;
+use function sprintf;
+use function str_replace;
+
+/**
+ * Pre-pass enumerator that collects every composition choice point of a
+ * converted JSON Schema: `oneOf`/`anyOf` branches, conditional branches,
+ * nullable presence, and optional-property presence.
+ *
+ * The traversal mirrors {@see SchemaDataGenerator} resolution exactly — one
+ * composition keyword per node, `allOf` branches merged into the node, `if`
+ * resolved once after `allOf` — so the JSON Pointers it reports are the ones
+ * planned generation resolves. Shapes the generator cannot resolve (a second
+ * unresolved composition on the same node, keywords reintroduced by a branch
+ * merge) are rejected loudly instead of silently dropping branches.
+ *
+ * Enumeration bounds, all loud on excess:
+ *  - {@see self::MAX_DEPTH} nested property/item levels;
+ *  - {@see self::MAX_CHOICE_POINTS} collected choice points;
+ *  - {@see self::MAX_NODE_VISITS} visited nodes across all branch contexts.
+ *
+ * `additionalProperties` filler values and keywords that are not generation
+ * strategies (`contains`, `patternProperties`, `dependentSchemas`,
+ * `unevaluated*`) contribute no choice points; they remain validator features.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+final class SchemaChoicePointEnumerator
+{
+    public const MAX_DEPTH = 32;
+    public const MAX_CHOICE_POINTS = 256;
+    public const MAX_NODE_VISITS = 10_000;
+
+    /** @var array<string, SchemaChoicePoint> */
+    private array $points = [];
+    private int $visits = 0;
+
+    private function __construct() {}
+
+    /**
+     * @param array<string, mixed> $schema
+     *
+     * @return list<SchemaChoicePoint>
+     */
+    public static function enumerate(array $schema): array
+    {
+        $enumerator = new self();
+        $enumerator->visitNode($schema, '', [], 0);
+
+        return array_values($enumerator->points);
+    }
+
+    /**
+     * Escape a property name for use as a JSON Pointer reference token.
+     */
+    public static function escapePointerSegment(string $segment): string
+    {
+        return str_replace(['~', '/'], ['~0', '~1'], $segment);
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     * @param list<string> $keywords
+     *
+     * @return list<string>
+     */
+    private static function unresolvedCompositionKeywords(array $schema, array $keywords): array
+    {
+        $found = [];
+        foreach ($keywords as $keyword) {
+            $value = $schema[$keyword] ?? null;
+            if (!is_array($value) || $value === []) {
+                continue;
+            }
+            if ($keyword === 'if' || $keyword === 'allOf' ||
+                array_filter($value, is_array(...)) !== []) {
+                $found[] = $keyword;
+            }
+        }
+
+        return $found;
+    }
+
+    /** @param array<string, mixed> $schema */
+    private static function isNullableTypeArray(array $schema): bool
+    {
+        $type = $schema['type'] ?? null;
+        if (!is_array($type) || !in_array('null', $type, true)) {
+            return false;
+        }
+
+        foreach ($type as $candidate) {
+            if (is_string($candidate) && $candidate !== 'null') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     * @param array<string, int> $ancestors
+     */
+    private function visitNode(array $schema, string $pointer, array $ancestors, int $depth): void
+    {
+        if (++$this->visits > self::MAX_NODE_VISITS) {
+            throw new InvalidArgumentException(sprintf(
+                'Choice-point enumeration exceeded the node-visit budget of %d; '
+                . 'the schema is outside the branch-complete enumeration subset.',
+                self::MAX_NODE_VISITS,
+            ));
+        }
+        if ($depth > self::MAX_DEPTH) {
+            throw new InvalidArgumentException(sprintf(
+                "Choice-point enumeration exceeded the maximum schema depth of %d at '%s'.",
+                self::MAX_DEPTH,
+                $pointer,
+            ));
+        }
+
+        $keywords = self::unresolvedCompositionKeywords($schema, ['oneOf', 'anyOf']);
+        if (count($keywords) > 1) {
+            throw new InvalidArgumentException(sprintf(
+                "Schema node '%s' carries multiple composition keywords (%s); generation resolves "
+                . 'only the first, so this shape is outside the branch-complete enumeration subset.',
+                $pointer,
+                implode(', ', $keywords),
+            ));
+        }
+
+        if ($keywords !== []) {
+            $keyword = $keywords[0];
+            /** @var list<array<string, mixed>> $branches */
+            $branches = array_values(array_filter($schema[$keyword], is_array(...)));
+            $choicePointer = $pointer . '/' . $keyword;
+            $this->record(new SchemaChoicePoint(
+                $keyword === 'oneOf' ? SchemaChoicePointKind::OneOf : SchemaChoicePointKind::AnyOf,
+                $choicePointer,
+                count($branches),
+                $ancestors,
+            ));
+
+            $base = $schema;
+            unset($base[$keyword]);
+            foreach ($branches as $index => $branch) {
+                $merged = SchemaDataGenerator::mergeSchemas($base, $branch);
+                $this->rejectReintroduced($merged, ['oneOf', 'anyOf'], $pointer);
+                $this->visitAllOfPhase($merged, $pointer, [...$ancestors, $choicePointer => $index], $depth);
+            }
+
+            return;
+        }
+
+        $this->visitAllOfPhase($schema, $pointer, $ancestors, $depth);
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     * @param array<string, int> $ancestors
+     */
+    private function visitAllOfPhase(array $schema, string $pointer, array $ancestors, int $depth): void
+    {
+        if (!isset($schema['allOf']) || !is_array($schema['allOf'])) {
+            $this->visitIfPhase($schema, $pointer, $ancestors, $depth);
+
+            return;
+        }
+
+        $base = $schema;
+        unset($base['allOf']);
+        $conditionals = [];
+        foreach ($schema['allOf'] as $branch) {
+            if (!is_array($branch)) {
+                continue;
+            }
+            if (isset($branch['if']) && is_array($branch['if'])) {
+                $conditionals[] = $branch;
+            } else {
+                $base = SchemaDataGenerator::mergeSchemas($base, $branch);
+            }
+        }
+
+        if ($conditionals === []) {
+            $this->rejectReintroduced($base, ['oneOf', 'anyOf', 'allOf'], $pointer);
+            $this->visitIfPhase($base, $pointer, $ancestors, $depth);
+
+            return;
+        }
+
+        $choicePointer = $pointer . '/allOf';
+        $this->record(new SchemaChoicePoint(
+            SchemaChoicePointKind::AllOfConditional,
+            $choicePointer,
+            count($conditionals),
+            $ancestors,
+        ));
+        foreach ($conditionals as $index => $conditional) {
+            $merged = SchemaDataGenerator::mergeSchemas($base, $conditional['if']);
+            if (isset($conditional['then']) && is_array($conditional['then'])) {
+                $merged = SchemaDataGenerator::mergeSchemas($merged, $conditional['then']);
+            }
+            $this->rejectReintroduced($merged, ['oneOf', 'anyOf', 'allOf'], $pointer);
+            $this->visitIfPhase($merged, $pointer, [...$ancestors, $choicePointer => $index], $depth);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     * @param array<string, int> $ancestors
+     */
+    private function visitIfPhase(array $schema, string $pointer, array $ancestors, int $depth): void
+    {
+        if (!isset($schema['if']) || !is_array($schema['if'])) {
+            $this->visitLeaf($schema, $pointer, $ancestors, $depth);
+
+            return;
+        }
+
+        $choicePointer = $pointer . '/if';
+        $this->record(new SchemaChoicePoint(SchemaChoicePointKind::IfThenElse, $choicePointer, 2, $ancestors));
+
+        $base = $schema;
+        unset($base['if'], $base['then'], $base['else']);
+        $views = [
+            SchemaDataGenerator::mergeSchemas($base, SchemaDataGenerator::mergeSchemas(
+                $schema['if'],
+                is_array($schema['then'] ?? null) ? $schema['then'] : [],
+            )),
+            SchemaDataGenerator::mergeSchemas($base, SchemaDataGenerator::mergeSchemas(
+                ['not' => $schema['if']],
+                is_array($schema['else'] ?? null) ? $schema['else'] : [],
+            )),
+        ];
+        foreach ($views as $branch => $view) {
+            $this->rejectReintroduced($view, ['oneOf', 'anyOf', 'allOf', 'if'], $pointer);
+            $this->visitLeaf($view, $pointer, [...$ancestors, $choicePointer => $branch], $depth);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     * @param array<string, int> $ancestors
+     */
+    private function visitLeaf(array $schema, string $pointer, array $ancestors, int $depth): void
+    {
+        if (array_key_exists('const', $schema)) {
+            return;
+        }
+        if (isset($schema['enum']) && is_array($schema['enum']) && $schema['enum'] !== []) {
+            return;
+        }
+
+        if (self::isNullableTypeArray($schema)) {
+            $choicePointer = $pointer . '/type';
+            $this->record(new SchemaChoicePoint(SchemaChoicePointKind::Nullable, $choicePointer, 2, $ancestors));
+            $ancestors = [...$ancestors, $choicePointer => SchemaChoicePoint::VALUE];
+        }
+
+        if (isset($schema['not']) && is_array($schema['not'])) {
+            unset($schema['not']);
+        }
+
+        match (SchemaDataGenerator::resolveType($schema)) {
+            'object' => $this->visitObject($schema, $pointer, $ancestors, $depth),
+            'array' => $this->visitArray($schema, $pointer, $ancestors, $depth),
+            default => null,
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     * @param array<string, int> $ancestors
+     */
+    private function visitObject(array $schema, string $pointer, array $ancestors, int $depth): void
+    {
+        $properties = $schema['properties'] ?? [];
+        if (!is_array($properties)) {
+            return;
+        }
+
+        $required = [];
+        if (isset($schema['required']) && is_array($schema['required'])) {
+            foreach ($schema['required'] as $name) {
+                if (is_string($name)) {
+                    $required[] = $name;
+                }
+            }
+        }
+
+        foreach ($properties as $name => $propertySchema) {
+            if (!is_string($name) || !is_array($propertySchema)) {
+                continue;
+            }
+
+            $childPointer = $pointer . '/properties/' . self::escapePointerSegment($name);
+            $childAncestors = $ancestors;
+            if (!in_array($name, $required, true)) {
+                $this->record(new SchemaChoicePoint(
+                    SchemaChoicePointKind::OptionalProperty,
+                    $childPointer,
+                    2,
+                    $ancestors,
+                ));
+                $childAncestors = [...$childAncestors, $childPointer => SchemaChoicePoint::PRESENT];
+            }
+
+            $this->visitNode($propertySchema, $childPointer, $childAncestors, $depth + 1);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     * @param array<string, int> $ancestors
+     */
+    private function visitArray(array $schema, string $pointer, array $ancestors, int $depth): void
+    {
+        $maxItems = isset($schema['maxItems']) && is_int($schema['maxItems']) ? $schema['maxItems'] : null;
+        $sizePointer = $pointer . '/items';
+
+        $prefixItems = $schema['prefixItems'] ?? null;
+        if (is_array($prefixItems)) {
+            $prefixCount = count($prefixItems);
+            foreach (array_values($prefixItems) as $index => $item) {
+                if (!is_array($item) || ($maxItems !== null && $maxItems <= $index)) {
+                    continue;
+                }
+                $this->visitNode(
+                    $item,
+                    $pointer . '/prefixItems/' . $index,
+                    [...$ancestors, $sizePointer => $index + 1],
+                    $depth + 1,
+                );
+            }
+
+            $items = $schema['items'] ?? null;
+            if (is_array($items) && ($maxItems === null || $maxItems > $prefixCount)) {
+                $this->visitNode(
+                    $items,
+                    $sizePointer,
+                    [...$ancestors, $sizePointer => $prefixCount + 1],
+                    $depth + 1,
+                );
+            }
+
+            return;
+        }
+
+        $items = $schema['items'] ?? null;
+        if (is_array($items) && ($maxItems === null || $maxItems >= 1)) {
+            $this->visitNode($items, $sizePointer, [...$ancestors, $sizePointer => 1], $depth + 1);
+        }
+    }
+
+    private function record(SchemaChoicePoint $point): void
+    {
+        // The same effective pointer can be rediscovered under a different
+        // branch context; the first discovery's ancestor chain already makes
+        // it reachable, so later contexts only need to keep descending.
+        if (isset($this->points[$point->pointer])) {
+            return;
+        }
+
+        $this->points[$point->pointer] = $point;
+        if (count($this->points) > self::MAX_CHOICE_POINTS) {
+            throw new InvalidArgumentException(sprintf(
+                'Choice-point enumeration exceeded the maximum of %d choice points.',
+                self::MAX_CHOICE_POINTS,
+            ));
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     * @param list<string> $keywords
+     */
+    private function rejectReintroduced(array $schema, array $keywords, string $pointer): void
+    {
+        $found = self::unresolvedCompositionKeywords($schema, $keywords);
+        if ($found !== []) {
+            throw new InvalidArgumentException(sprintf(
+                "Resolving a branch at '%s' reintroduces composition keywords (%s) that generation "
+                . 'would not resolve again; this shape is outside the branch-complete enumeration subset.',
+                $pointer,
+                implode(', ', $found),
+            ));
+        }
+    }
+}

--- a/src/Fuzz/SchemaChoicePointEnumerator.php
+++ b/src/Fuzz/SchemaChoicePointEnumerator.php
@@ -15,6 +15,8 @@ use function in_array;
 use function is_array;
 use function is_int;
 use function is_string;
+use function json_encode;
+use function md5;
 use function sprintf;
 use function str_replace;
 
@@ -24,11 +26,18 @@ use function str_replace;
  * nullable presence, and optional-property presence.
  *
  * The traversal mirrors {@see SchemaDataGenerator} resolution exactly — one
- * composition keyword per node, `allOf` branches merged into the node, `if`
- * resolved once after `allOf` — so the JSON Pointers it reports are the ones
- * planned generation resolves. Shapes the generator cannot resolve (a second
+ * composition keyword per node, `allOf` branches merged into the node,
+ * conditional-`allOf` branches materialised through
+ * {@see SchemaDataGenerator::conditionalBranchView()}, `if` resolved once
+ * after `allOf` — so the JSON Pointers it reports are the ones planned
+ * generation resolves. Shapes the generator cannot resolve (a second
  * unresolved composition on the same node, keywords reintroduced by a branch
  * merge) are rejected loudly instead of silently dropping branches.
+ *
+ * A choice point rediscovered at the same pointer under another branch
+ * context is deduplicated only when its branch content is identical; a
+ * context that gives the same pointer different branches keeps its own entry
+ * under its own ancestors, so context-specific branches stay covered.
  *
  * Enumeration bounds, all loud on excess:
  *  - {@see self::MAX_DEPTH} nested property/item levels;
@@ -50,8 +59,8 @@ final class SchemaChoicePointEnumerator
     /** @var list<SchemaChoicePoint> */
     private array $points = [];
 
-    /** @var array<string, int> */
-    private array $coveredBranches = [];
+    /** @var array<string, int> Dedupe key to index into {@see self::$points}. */
+    private array $seen = [];
     private int $visits = 0;
 
     private function __construct() {}
@@ -64,7 +73,7 @@ final class SchemaChoicePointEnumerator
     public static function enumerate(array $schema): array
     {
         $enumerator = new self();
-        $enumerator->visitNode($schema, '', [], 0);
+        $enumerator->visitNode($schema, '', [], 0, false);
 
         return $enumerator->points;
     }
@@ -121,7 +130,7 @@ final class SchemaChoicePointEnumerator
      * @param array<string, mixed> $schema
      * @param array<string, int> $ancestors
      */
-    private function visitNode(array $schema, string $pointer, array $ancestors, int $depth): void
+    private function visitNode(array $schema, string $pointer, array $ancestors, int $depth, bool $probe): void
     {
         if (++$this->visits > self::MAX_NODE_VISITS) {
             throw new InvalidArgumentException(sprintf(
@@ -153,35 +162,37 @@ final class SchemaChoicePointEnumerator
             /** @var list<array<string, mixed>> $branches */
             $branches = array_values(array_filter($schema[$keyword], is_array(...)));
             $choicePointer = $pointer . '/' . $keyword;
-            $this->record(new SchemaChoicePoint(
+            $this->record(
                 $keyword === 'oneOf' ? SchemaChoicePointKind::OneOf : SchemaChoicePointKind::AnyOf,
                 $choicePointer,
                 count($branches),
                 $ancestors,
-            ));
+                $branches,
+                $probe,
+            );
 
             $base = $schema;
             unset($base[$keyword]);
             foreach ($branches as $index => $branch) {
                 $merged = SchemaDataGenerator::mergeSchemas($base, $branch);
                 $this->rejectReintroduced($merged, ['oneOf', 'anyOf'], $pointer);
-                $this->visitAllOfPhase($merged, $pointer, [...$ancestors, $choicePointer => $index], $depth);
+                $this->visitAllOfPhase($merged, $pointer, [...$ancestors, $choicePointer => $index], $depth, $probe);
             }
 
             return;
         }
 
-        $this->visitAllOfPhase($schema, $pointer, $ancestors, $depth);
+        $this->visitAllOfPhase($schema, $pointer, $ancestors, $depth, $probe);
     }
 
     /**
      * @param array<string, mixed> $schema
      * @param array<string, int> $ancestors
      */
-    private function visitAllOfPhase(array $schema, string $pointer, array $ancestors, int $depth): void
+    private function visitAllOfPhase(array $schema, string $pointer, array $ancestors, int $depth, bool $probe): void
     {
         if (!isset($schema['allOf']) || !is_array($schema['allOf'])) {
-            $this->visitIfPhase($schema, $pointer, $ancestors, $depth);
+            $this->visitIfPhase($schema, $pointer, $ancestors, $depth, $probe);
 
             return;
         }
@@ -202,33 +213,35 @@ final class SchemaChoicePointEnumerator
 
         if ($conditionals === []) {
             $this->rejectReintroduced($base, ['oneOf', 'anyOf', 'allOf'], $pointer);
-            $this->visitIfPhase($base, $pointer, $ancestors, $depth);
+            $this->visitIfPhase($base, $pointer, $ancestors, $depth, $probe);
 
             return;
         }
 
-        // Two branches per conditional, mirroring pinned generation: even
-        // branches satisfy if+then, odd branches take not-if+else.
+        // One branch per conditional (if+then with the others suppressed)
+        // plus the trailing none-match branch, whose reachability cannot be
+        // pre-determined: it and everything discovered under it are probes.
+        $count = count($conditionals);
         $choicePointer = $pointer . '/allOf';
-        $this->record(new SchemaChoicePoint(
+        $this->record(
             SchemaChoicePointKind::AllOfConditional,
             $choicePointer,
-            2 * count($conditionals),
+            $count + 1,
             $ancestors,
-        ));
-        foreach ($conditionals as $index => $conditional) {
-            $thenView = SchemaDataGenerator::mergeSchemas($base, $conditional['if']);
-            if (isset($conditional['then']) && is_array($conditional['then'])) {
-                $thenView = SchemaDataGenerator::mergeSchemas($thenView, $conditional['then']);
-            }
-            $elseView = SchemaDataGenerator::mergeSchemas($base, SchemaDataGenerator::mergeSchemas(
-                ['not' => $conditional['if']],
-                is_array($conditional['else'] ?? null) ? $conditional['else'] : [],
-            ));
-            foreach ([2 * $index => $thenView, 2 * $index + 1 => $elseView] as $branch => $view) {
-                $this->rejectReintroduced($view, ['oneOf', 'anyOf', 'allOf'], $pointer);
-                $this->visitIfPhase($view, $pointer, [...$ancestors, $choicePointer => $branch], $depth);
-            }
+            $conditionals,
+            $probe,
+            probeBranch: $count,
+        );
+        for ($branch = 0; $branch <= $count; $branch++) {
+            $view = SchemaDataGenerator::conditionalBranchView($base, $conditionals, $branch);
+            $this->rejectReintroduced($view, ['oneOf', 'anyOf', 'allOf'], $pointer);
+            $this->visitIfPhase(
+                $view,
+                $pointer,
+                [...$ancestors, $choicePointer => $branch],
+                $depth,
+                $probe || $branch === $count,
+            );
         }
     }
 
@@ -236,16 +249,23 @@ final class SchemaChoicePointEnumerator
      * @param array<string, mixed> $schema
      * @param array<string, int> $ancestors
      */
-    private function visitIfPhase(array $schema, string $pointer, array $ancestors, int $depth): void
+    private function visitIfPhase(array $schema, string $pointer, array $ancestors, int $depth, bool $probe): void
     {
         if (!isset($schema['if']) || !is_array($schema['if'])) {
-            $this->visitLeaf($schema, $pointer, $ancestors, $depth);
+            $this->visitLeaf($schema, $pointer, $ancestors, $depth, $probe);
 
             return;
         }
 
         $choicePointer = $pointer . '/if';
-        $this->record(new SchemaChoicePoint(SchemaChoicePointKind::IfThenElse, $choicePointer, 2, $ancestors));
+        $this->record(
+            SchemaChoicePointKind::IfThenElse,
+            $choicePointer,
+            2,
+            $ancestors,
+            [$schema['if'], $schema['then'] ?? null, $schema['else'] ?? null],
+            $probe,
+        );
 
         $base = $schema;
         unset($base['if'], $base['then'], $base['else']);
@@ -261,7 +281,7 @@ final class SchemaChoicePointEnumerator
         ];
         foreach ($views as $branch => $view) {
             $this->rejectReintroduced($view, ['oneOf', 'anyOf', 'allOf', 'if'], $pointer);
-            $this->visitLeaf($view, $pointer, [...$ancestors, $choicePointer => $branch], $depth);
+            $this->visitLeaf($view, $pointer, [...$ancestors, $choicePointer => $branch], $depth, $probe);
         }
     }
 
@@ -269,7 +289,7 @@ final class SchemaChoicePointEnumerator
      * @param array<string, mixed> $schema
      * @param array<string, int> $ancestors
      */
-    private function visitLeaf(array $schema, string $pointer, array $ancestors, int $depth): void
+    private function visitLeaf(array $schema, string $pointer, array $ancestors, int $depth, bool $probe): void
     {
         if (array_key_exists('const', $schema)) {
             return;
@@ -280,7 +300,7 @@ final class SchemaChoicePointEnumerator
 
         if (self::isNullableTypeArray($schema)) {
             $choicePointer = $pointer . '/type';
-            $this->record(new SchemaChoicePoint(SchemaChoicePointKind::Nullable, $choicePointer, 2, $ancestors));
+            $this->record(SchemaChoicePointKind::Nullable, $choicePointer, 2, $ancestors, null, $probe);
             $ancestors = [...$ancestors, $choicePointer => SchemaChoicePoint::VALUE];
         }
 
@@ -289,8 +309,8 @@ final class SchemaChoicePointEnumerator
         }
 
         match (SchemaDataGenerator::resolveType($schema)) {
-            'object' => $this->visitObject($schema, $pointer, $ancestors, $depth),
-            'array' => $this->visitArray($schema, $pointer, $ancestors, $depth),
+            'object' => $this->visitObject($schema, $pointer, $ancestors, $depth, $probe),
+            'array' => $this->visitArray($schema, $pointer, $ancestors, $depth, $probe),
             default => null,
         };
     }
@@ -299,7 +319,7 @@ final class SchemaChoicePointEnumerator
      * @param array<string, mixed> $schema
      * @param array<string, int> $ancestors
      */
-    private function visitObject(array $schema, string $pointer, array $ancestors, int $depth): void
+    private function visitObject(array $schema, string $pointer, array $ancestors, int $depth, bool $probe): void
     {
         $properties = $schema['properties'] ?? [];
         if (!is_array($properties)) {
@@ -323,16 +343,11 @@ final class SchemaChoicePointEnumerator
             $childPointer = $pointer . '/properties/' . self::escapePointerSegment($name);
             $childAncestors = $ancestors;
             if (!in_array($name, $required, true)) {
-                $this->record(new SchemaChoicePoint(
-                    SchemaChoicePointKind::OptionalProperty,
-                    $childPointer,
-                    2,
-                    $ancestors,
-                ));
+                $this->record(SchemaChoicePointKind::OptionalProperty, $childPointer, 2, $ancestors, null, $probe);
                 $childAncestors = [...$childAncestors, $childPointer => SchemaChoicePoint::PRESENT];
             }
 
-            $this->visitNode($propertySchema, $childPointer, $childAncestors, $depth + 1);
+            $this->visitNode($propertySchema, $childPointer, $childAncestors, $depth + 1, $probe);
         }
     }
 
@@ -340,7 +355,7 @@ final class SchemaChoicePointEnumerator
      * @param array<string, mixed> $schema
      * @param array<string, int> $ancestors
      */
-    private function visitArray(array $schema, string $pointer, array $ancestors, int $depth): void
+    private function visitArray(array $schema, string $pointer, array $ancestors, int $depth, bool $probe): void
     {
         $maxItems = isset($schema['maxItems']) && is_int($schema['maxItems']) ? $schema['maxItems'] : null;
         $sizePointer = $pointer . '/items';
@@ -357,6 +372,7 @@ final class SchemaChoicePointEnumerator
                     $pointer . '/prefixItems/' . $index,
                     [...$ancestors, $sizePointer => $index + 1],
                     $depth + 1,
+                    $probe,
                 );
             }
 
@@ -367,6 +383,7 @@ final class SchemaChoicePointEnumerator
                     $sizePointer,
                     [...$ancestors, $sizePointer => $prefixCount + 1],
                     $depth + 1,
+                    $probe,
                 );
             }
 
@@ -375,29 +392,48 @@ final class SchemaChoicePointEnumerator
 
         $items = $schema['items'] ?? null;
         if (is_array($items) && ($maxItems === null || $maxItems >= 1)) {
-            $this->visitNode($items, $sizePointer, [...$ancestors, $sizePointer => 1], $depth + 1);
+            $this->visitNode($items, $sizePointer, [...$ancestors, $sizePointer => 1], $depth + 1, $probe);
         }
     }
 
-    private function record(SchemaChoicePoint $point): void
-    {
+    /**
+     * @param array<string, int> $ancestors
+     */
+    private function record(
+        SchemaChoicePointKind $kind,
+        string $pointer,
+        int $branchCount,
+        array $ancestors,
+        mixed $content,
+        bool $probeContext,
+        ?int $probeBranch = null,
+    ): void {
         // The same effective pointer can be rediscovered under a different
-        // branch context. Branches an earlier discovery already covers stay
-        // covered; a wider rediscovery contributes only its uncovered tail,
-        // under the ancestor chain that makes those extra branches reachable.
-        $covered = $this->coveredBranches[$point->pointer] ?? 0;
-        if ($point->branchCount <= $covered) {
+        // branch context. Identical branch content means identical coverage,
+        // so the first discovery suffices — unless the first sat inside a
+        // probe context and this one does not: the non-probe rediscovery is
+        // strictly more reliable, so it takes over the entry. Different
+        // content keeps its own entry under the ancestors that make its
+        // branches reachable.
+        $key = $pointer . '#' . md5((string) json_encode($content));
+        $existing = $this->seen[$key] ?? null;
+        if ($existing !== null) {
+            if ($this->points[$existing]->probeContext && !$probeContext) {
+                $this->points[$existing] = new SchemaChoicePoint(
+                    $kind,
+                    $pointer,
+                    $branchCount,
+                    $ancestors,
+                    $probeBranch,
+                    false,
+                );
+            }
+
             return;
         }
+        $this->seen[$key] = count($this->points);
 
-        $this->points[] = new SchemaChoicePoint(
-            $point->kind,
-            $point->pointer,
-            $point->branchCount,
-            $point->ancestors,
-            $covered,
-        );
-        $this->coveredBranches[$point->pointer] = $point->branchCount;
+        $this->points[] = new SchemaChoicePoint($kind, $pointer, $branchCount, $ancestors, $probeBranch, $probeContext);
         if (count($this->points) > self::MAX_CHOICE_POINTS) {
             throw new InvalidArgumentException(sprintf(
                 'Choice-point enumeration exceeded the maximum of %d choice points.',

--- a/src/Fuzz/SchemaChoicePointEnumerator.php
+++ b/src/Fuzz/SchemaChoicePointEnumerator.php
@@ -35,6 +35,13 @@ use function str_replace;
  * unresolved composition on the same node, keywords reintroduced by a branch
  * merge) are rejected loudly instead of silently dropping branches.
  *
+ * Statically decidable unreachability is pruned during the walk — `false`
+ * schemas in branches, consequents, properties, and prefix items, and
+ * `oneOf` siblings shadowed by a `true` branch. Everything else is emitted
+ * even though reachability in general is undecidable: a pinned case whose
+ * branch turns out to be forbidden by parent constraints is dropped by
+ * {@see BranchCompleteCaseGenerator}, not failed.
+ *
  * A choice point rediscovered at the same pointer keeps one entry per
  * discovery context (ancestors + branch content); only exact revisits
  * collapse. Contexts are not interchangeable: generation can leave a branch
@@ -63,7 +70,7 @@ final class SchemaChoicePointEnumerator
     /** @var list<SchemaChoicePoint> */
     private array $points = [];
 
-    /** @var array<string, int> Dedupe key to index into {@see self::$points}. */
+    /** @var array<string, true> Dedupe keys of recorded choice points. */
     private array $seen = [];
     private int $visits = 0;
 
@@ -77,7 +84,7 @@ final class SchemaChoicePointEnumerator
     public static function enumerate(array $schema): array
     {
         $enumerator = new self();
-        $enumerator->visitNode($schema, '', [], 0, false);
+        $enumerator->visitNode($schema, '', [], 0);
 
         return $enumerator->points;
     }
@@ -134,7 +141,7 @@ final class SchemaChoicePointEnumerator
      * @param array<string, mixed> $schema
      * @param array<string, int> $ancestors
      */
-    private function visitNode(array $schema, string $pointer, array $ancestors, int $depth, bool $probe): void
+    private function visitNode(array $schema, string $pointer, array $ancestors, int $depth): void
     {
         if (++$this->visits > self::MAX_NODE_VISITS) {
             throw new InvalidArgumentException(sprintf(
@@ -171,7 +178,7 @@ final class SchemaChoicePointEnumerator
                 // No branch is generatable (e.g. every branch is `false`);
                 // the keyword stays unresolved and generation fails its
                 // self-check loudly, mirrored here by not descending.
-                $this->visitAllOfPhase($schema, $pointer, $ancestors, $depth, $probe);
+                $this->visitAllOfPhase($schema, $pointer, $ancestors, $depth);
 
                 return;
             }
@@ -183,7 +190,6 @@ final class SchemaChoicePointEnumerator
                 count($enumerable),
                 $ancestors,
                 $branches,
-                $probe,
             );
 
             $base = $schema;
@@ -191,23 +197,23 @@ final class SchemaChoicePointEnumerator
             foreach ($enumerable as $branch => $selected) {
                 $merged = SchemaDataGenerator::applyCompositionBranch($base, $branches, $selected, $keyword);
                 $this->rejectReintroduced($merged, ['oneOf', 'anyOf'], $pointer);
-                $this->visitAllOfPhase($merged, $pointer, [...$ancestors, $choicePointer => $branch], $depth, $probe);
+                $this->visitAllOfPhase($merged, $pointer, [...$ancestors, $choicePointer => $branch], $depth);
             }
 
             return;
         }
 
-        $this->visitAllOfPhase($schema, $pointer, $ancestors, $depth, $probe);
+        $this->visitAllOfPhase($schema, $pointer, $ancestors, $depth);
     }
 
     /**
      * @param array<string, mixed> $schema
      * @param array<string, int> $ancestors
      */
-    private function visitAllOfPhase(array $schema, string $pointer, array $ancestors, int $depth, bool $probe): void
+    private function visitAllOfPhase(array $schema, string $pointer, array $ancestors, int $depth): void
     {
         if (!isset($schema['allOf']) || !is_array($schema['allOf'])) {
-            $this->visitIfPhase($schema, $pointer, $ancestors, $depth, $probe);
+            $this->visitIfPhase($schema, $pointer, $ancestors, $depth);
 
             return;
         }
@@ -238,14 +244,13 @@ final class SchemaChoicePointEnumerator
 
         if ($conditionals === []) {
             $this->rejectReintroduced($base, ['oneOf', 'anyOf', 'allOf'], $pointer);
-            $this->visitIfPhase($base, $pointer, $ancestors, $depth, $probe);
+            $this->visitIfPhase($base, $pointer, $ancestors, $depth);
 
             return;
         }
 
         // One branch per conditional (if+then with the others suppressed)
-        // plus the trailing none-match branch, whose reachability cannot be
-        // pre-determined: it and everything discovered under it are probes.
+        // plus the trailing none-match branch where every else applies.
         $count = count($conditionals);
         $choicePointer = $pointer . '/allOf';
         $this->record(
@@ -254,19 +259,11 @@ final class SchemaChoicePointEnumerator
             $count + 1,
             $ancestors,
             $conditionals,
-            $probe,
-            probeBranch: $count,
         );
         for ($branch = 0; $branch <= $count; $branch++) {
             $view = SchemaDataGenerator::conditionalBranchView($base, $conditionals, $branch);
             $this->rejectReintroduced($view, ['oneOf', 'anyOf', 'allOf'], $pointer);
-            $this->visitIfPhase(
-                $view,
-                $pointer,
-                [...$ancestors, $choicePointer => $branch],
-                $depth,
-                $probe || $branch === $count,
-            );
+            $this->visitIfPhase($view, $pointer, [...$ancestors, $choicePointer => $branch], $depth);
         }
     }
 
@@ -274,7 +271,7 @@ final class SchemaChoicePointEnumerator
      * @param array<string, mixed> $schema
      * @param array<string, int> $ancestors
      */
-    private function visitIfPhase(array $schema, string $pointer, array $ancestors, int $depth, bool $probe): void
+    private function visitIfPhase(array $schema, string $pointer, array $ancestors, int $depth): void
     {
         if (is_bool($schema['if'] ?? null)) {
             // A boolean if has no branch to choose: `if: true` makes the
@@ -285,13 +282,13 @@ final class SchemaChoicePointEnumerator
                 $schema = SchemaDataGenerator::mergeSchemas($schema, $branchSchema);
             }
             $this->rejectReintroduced($schema, ['oneOf', 'anyOf', 'allOf', 'if'], $pointer);
-            $this->visitLeaf($schema, $pointer, $ancestors, $depth, $probe);
+            $this->visitLeaf($schema, $pointer, $ancestors, $depth);
 
             return;
         }
 
         if (!isset($schema['if']) || !is_array($schema['if'])) {
-            $this->visitLeaf($schema, $pointer, $ancestors, $depth, $probe);
+            $this->visitLeaf($schema, $pointer, $ancestors, $depth);
 
             return;
         }
@@ -301,7 +298,7 @@ final class SchemaChoicePointEnumerator
             // Both consequents are `false`: neither side is satisfiable.
             // Generation leaves the keyword unresolved and fails its
             // self-check loudly; mirror by not descending the consequents.
-            $this->visitLeaf($schema, $pointer, $ancestors, $depth, $probe);
+            $this->visitLeaf($schema, $pointer, $ancestors, $depth);
 
             return;
         }
@@ -313,13 +310,12 @@ final class SchemaChoicePointEnumerator
             count($sides),
             $ancestors,
             [$schema['if'], $schema['then'] ?? null, $schema['else'] ?? null],
-            $probe,
         );
 
         foreach ($sides as $branch => $side) {
             $view = SchemaDataGenerator::applyIfSide($schema, $side);
             $this->rejectReintroduced($view, ['oneOf', 'anyOf', 'allOf', 'if'], $pointer);
-            $this->visitLeaf($view, $pointer, [...$ancestors, $choicePointer => $branch], $depth, $probe);
+            $this->visitLeaf($view, $pointer, [...$ancestors, $choicePointer => $branch], $depth);
         }
     }
 
@@ -327,7 +323,7 @@ final class SchemaChoicePointEnumerator
      * @param array<string, mixed> $schema
      * @param array<string, int> $ancestors
      */
-    private function visitLeaf(array $schema, string $pointer, array $ancestors, int $depth, bool $probe): void
+    private function visitLeaf(array $schema, string $pointer, array $ancestors, int $depth): void
     {
         if (array_key_exists('const', $schema)) {
             return;
@@ -338,7 +334,7 @@ final class SchemaChoicePointEnumerator
 
         if (self::isNullableTypeArray($schema)) {
             $choicePointer = $pointer . '/type';
-            $this->record(SchemaChoicePointKind::Nullable, $choicePointer, 2, $ancestors, null, $probe);
+            $this->record(SchemaChoicePointKind::Nullable, $choicePointer, 2, $ancestors, null);
             $ancestors = [...$ancestors, $choicePointer => SchemaChoicePoint::VALUE];
         }
 
@@ -347,8 +343,8 @@ final class SchemaChoicePointEnumerator
         }
 
         match (SchemaDataGenerator::resolveType($schema)) {
-            'object' => $this->visitObject($schema, $pointer, $ancestors, $depth, $probe),
-            'array' => $this->visitArray($schema, $pointer, $ancestors, $depth, $probe),
+            'object' => $this->visitObject($schema, $pointer, $ancestors, $depth),
+            'array' => $this->visitArray($schema, $pointer, $ancestors, $depth),
             default => null,
         };
     }
@@ -357,7 +353,7 @@ final class SchemaChoicePointEnumerator
      * @param array<string, mixed> $schema
      * @param array<string, int> $ancestors
      */
-    private function visitObject(array $schema, string $pointer, array $ancestors, int $depth, bool $probe): void
+    private function visitObject(array $schema, string $pointer, array $ancestors, int $depth): void
     {
         $properties = $schema['properties'] ?? [];
         if (!is_array($properties)) {
@@ -387,12 +383,12 @@ final class SchemaChoicePointEnumerator
             $childPointer = $pointer . '/properties/' . self::escapePointerSegment($name);
             $childAncestors = $ancestors;
             if (!in_array($name, $required, true)) {
-                $this->record(SchemaChoicePointKind::OptionalProperty, $childPointer, 2, $ancestors, null, $probe);
+                $this->record(SchemaChoicePointKind::OptionalProperty, $childPointer, 2, $ancestors, null);
                 $childAncestors = [...$childAncestors, $childPointer => SchemaChoicePoint::PRESENT];
             }
 
             if (is_array($propertySchema)) {
-                $this->visitNode($propertySchema, $childPointer, $childAncestors, $depth + 1, $probe);
+                $this->visitNode($propertySchema, $childPointer, $childAncestors, $depth + 1);
             }
         }
     }
@@ -401,7 +397,7 @@ final class SchemaChoicePointEnumerator
      * @param array<string, mixed> $schema
      * @param array<string, int> $ancestors
      */
-    private function visitArray(array $schema, string $pointer, array $ancestors, int $depth, bool $probe): void
+    private function visitArray(array $schema, string $pointer, array $ancestors, int $depth): void
     {
         $maxItems = isset($schema['maxItems']) && is_int($schema['maxItems']) ? $schema['maxItems'] : null;
         $sizePointer = $pointer . '/items';
@@ -424,7 +420,6 @@ final class SchemaChoicePointEnumerator
                     $pointer . '/prefixItems/' . $index,
                     [...$ancestors, $sizePointer => $index + 1],
                     $depth + 1,
-                    $probe,
                 );
             }
 
@@ -435,7 +430,6 @@ final class SchemaChoicePointEnumerator
                     $sizePointer,
                     [...$ancestors, $sizePointer => $prefixCount + 1],
                     $depth + 1,
-                    $probe,
                 );
             }
 
@@ -444,7 +438,7 @@ final class SchemaChoicePointEnumerator
 
         $items = $schema['items'] ?? null;
         if (is_array($items) && ($maxItems === null || $maxItems >= 1)) {
-            $this->visitNode($items, $sizePointer, [...$ancestors, $sizePointer => 1], $depth + 1, $probe);
+            $this->visitNode($items, $sizePointer, [...$ancestors, $sizePointer => 1], $depth + 1);
         }
     }
 
@@ -457,8 +451,6 @@ final class SchemaChoicePointEnumerator
         int $branchCount,
         array $ancestors,
         mixed $content,
-        bool $probeContext,
-        ?int $probeBranch = null,
     ): void {
         // The same effective pointer can be rediscovered under a different
         // branch context. Each context keeps its own entry: generation may
@@ -473,9 +465,9 @@ final class SchemaChoicePointEnumerator
         if (isset($this->seen[$key])) {
             return;
         }
-        $this->seen[$key] = count($this->points);
+        $this->seen[$key] = true;
 
-        $this->points[] = new SchemaChoicePoint($kind, $pointer, $branchCount, $ancestors, $probeBranch, $probeContext);
+        $this->points[] = new SchemaChoicePoint($kind, $pointer, $branchCount, $ancestors);
         if (count($this->points) > self::MAX_CHOICE_POINTS) {
             throw new InvalidArgumentException(sprintf(
                 'Choice-point enumeration exceeded the maximum of %d choice points.',

--- a/src/Fuzz/SchemaChoicePointEnumerator.php
+++ b/src/Fuzz/SchemaChoicePointEnumerator.php
@@ -47,8 +47,11 @@ final class SchemaChoicePointEnumerator
     public const MAX_CHOICE_POINTS = 256;
     public const MAX_NODE_VISITS = 10_000;
 
-    /** @var array<string, SchemaChoicePoint> */
+    /** @var list<SchemaChoicePoint> */
     private array $points = [];
+
+    /** @var array<string, int> */
+    private array $coveredBranches = [];
     private int $visits = 0;
 
     private function __construct() {}
@@ -63,7 +66,7 @@ final class SchemaChoicePointEnumerator
         $enumerator = new self();
         $enumerator->visitNode($schema, '', [], 0);
 
-        return array_values($enumerator->points);
+        return $enumerator->points;
     }
 
     /**
@@ -204,20 +207,28 @@ final class SchemaChoicePointEnumerator
             return;
         }
 
+        // Two branches per conditional, mirroring pinned generation: even
+        // branches satisfy if+then, odd branches take not-if+else.
         $choicePointer = $pointer . '/allOf';
         $this->record(new SchemaChoicePoint(
             SchemaChoicePointKind::AllOfConditional,
             $choicePointer,
-            count($conditionals),
+            2 * count($conditionals),
             $ancestors,
         ));
         foreach ($conditionals as $index => $conditional) {
-            $merged = SchemaDataGenerator::mergeSchemas($base, $conditional['if']);
+            $thenView = SchemaDataGenerator::mergeSchemas($base, $conditional['if']);
             if (isset($conditional['then']) && is_array($conditional['then'])) {
-                $merged = SchemaDataGenerator::mergeSchemas($merged, $conditional['then']);
+                $thenView = SchemaDataGenerator::mergeSchemas($thenView, $conditional['then']);
             }
-            $this->rejectReintroduced($merged, ['oneOf', 'anyOf', 'allOf'], $pointer);
-            $this->visitIfPhase($merged, $pointer, [...$ancestors, $choicePointer => $index], $depth);
+            $elseView = SchemaDataGenerator::mergeSchemas($base, SchemaDataGenerator::mergeSchemas(
+                ['not' => $conditional['if']],
+                is_array($conditional['else'] ?? null) ? $conditional['else'] : [],
+            ));
+            foreach ([2 * $index => $thenView, 2 * $index + 1 => $elseView] as $branch => $view) {
+                $this->rejectReintroduced($view, ['oneOf', 'anyOf', 'allOf'], $pointer);
+                $this->visitIfPhase($view, $pointer, [...$ancestors, $choicePointer => $branch], $depth);
+            }
         }
     }
 
@@ -371,13 +382,22 @@ final class SchemaChoicePointEnumerator
     private function record(SchemaChoicePoint $point): void
     {
         // The same effective pointer can be rediscovered under a different
-        // branch context; the first discovery's ancestor chain already makes
-        // it reachable, so later contexts only need to keep descending.
-        if (isset($this->points[$point->pointer])) {
+        // branch context. Branches an earlier discovery already covers stay
+        // covered; a wider rediscovery contributes only its uncovered tail,
+        // under the ancestor chain that makes those extra branches reachable.
+        $covered = $this->coveredBranches[$point->pointer] ?? 0;
+        if ($point->branchCount <= $covered) {
             return;
         }
 
-        $this->points[$point->pointer] = $point;
+        $this->points[] = new SchemaChoicePoint(
+            $point->kind,
+            $point->pointer,
+            $point->branchCount,
+            $point->ancestors,
+            $covered,
+        );
+        $this->coveredBranches[$point->pointer] = $point->branchCount;
         if (count($this->points) > self::MAX_CHOICE_POINTS) {
             throw new InvalidArgumentException(sprintf(
                 'Choice-point enumeration exceeded the maximum of %d choice points.',

--- a/src/Fuzz/SchemaChoicePointKind.php
+++ b/src/Fuzz/SchemaChoicePointKind.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Fuzz;
+
+/**
+ * The kind of composition choice point a schema node exposes to generation.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+enum SchemaChoicePointKind: string
+{
+    /** A `oneOf` keyword; branches are the filtered branch indexes. */
+    case OneOf = 'oneOf';
+
+    /** An `anyOf` keyword; branches are the filtered branch indexes. */
+    case AnyOf = 'anyOf';
+
+    /** Conditional `allOf` entries; branches index the conditional list. */
+    case AllOfConditional = 'allOfConditional';
+
+    /** An `if`/`then`/`else` keyword; branch 0 takes `then`, 1 takes `else`. */
+    case IfThenElse = 'ifThenElse';
+
+    /** A nullable type array; branch 0 keeps the value, 1 emits null. */
+    case Nullable = 'nullable';
+
+    /** An optional object property; branch 0 includes it, 1 omits it. */
+    case OptionalProperty = 'optionalProperty';
+}

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -251,6 +251,49 @@ final class SchemaDataGenerator
     }
 
     /**
+     * Materialise one branch of the conditional-`allOf` choice space.
+     *
+     * Branches `0..n-1` satisfy that conditional's `if`+`then` while
+     * suppressing every other conditional — their `if`s are excluded through
+     * a single synthesized `not`/`anyOf` and their `else`s applied — so the
+     * generated value satisfies the complete schema rather than just the
+     * selected slice. Branch `n` is the none-match state: no `if` holds and
+     * every `else` applies. Public within the internal fuzz family so
+     * {@see SchemaChoicePointEnumerator} descends exactly these views.
+     *
+     * @param array<string, mixed> $schema node with `allOf` removed and its non-conditional branches merged
+     * @param list<array<string, mixed>> $conditionals
+     *
+     * @return array<string, mixed>
+     */
+    public static function conditionalBranchView(array $schema, array $conditionals, int $branch): array
+    {
+        if ($branch < count($conditionals)) {
+            $selected = $conditionals[$branch];
+            $schema = self::mergeSchemas($schema, $selected['if']);
+            if (isset($selected['then']) && is_array($selected['then'])) {
+                $schema = self::mergeSchemas($schema, $selected['then']);
+            }
+        }
+
+        $suppressedIfs = [];
+        foreach ($conditionals as $index => $conditional) {
+            if ($index === $branch) {
+                continue;
+            }
+            $suppressedIfs[] = $conditional['if'];
+            if (isset($conditional['else']) && is_array($conditional['else'])) {
+                $schema = self::mergeSchemas($schema, $conditional['else']);
+            }
+        }
+        if ($suppressedIfs !== []) {
+            $schema = self::mergeSchemas($schema, ['not' => ['anyOf' => $suppressedIfs]]);
+        }
+
+        return $schema;
+    }
+
+    /**
      * Merge the assertion keywords needed for deterministic allOf generation.
      *
      * Public within the internal fuzz family so
@@ -878,18 +921,15 @@ final class SchemaDataGenerator
             }
             if ($conditionals !== []) {
                 // Rotation only ever satisfies a conditional's `if`+`then`.
-                // Pinned plans encode two branches per conditional — even
-                // takes if+then, odd takes not-if+else, mirroring the
-                // standalone if/then/else resolution below — so the `else`
-                // side of every conditional is reachable.
+                // Pinned plans use the conditionalBranchView() branch space
+                // instead, which suppresses the unselected conditionals so
+                // the value satisfies the complete schema, and adds a
+                // trailing none-match branch.
                 $pinned = $plan?->branchFor($pointer . '/allOf');
-                $selected = $conditionals[($pinned !== null ? intdiv($pinned, 2) : $iteration) % count($conditionals)];
-                if ($pinned !== null && ($pinned % 2) === 1) {
-                    $schema = self::mergeSchemas($schema, self::mergeSchemas(
-                        ['not' => $selected['if']],
-                        is_array($selected['else'] ?? null) ? $selected['else'] : [],
-                    ));
+                if ($pinned !== null) {
+                    $schema = self::conditionalBranchView($schema, $conditionals, $pinned % (count($conditionals) + 1));
                 } else {
+                    $selected = $conditionals[$iteration % count($conditionals)];
                     $schema = self::mergeSchemas($schema, $selected['if']);
                     if (isset($selected['then']) && is_array($selected['then'])) {
                         $schema = self::mergeSchemas($schema, $selected['then']);

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -29,6 +29,7 @@ use function implode;
 use function in_array;
 use function intdiv;
 use function is_array;
+use function is_bool;
 use function is_float;
 use function is_int;
 use function is_string;
@@ -420,9 +421,19 @@ final class SchemaDataGenerator
         // `not` is an assertion like the bound keywords below: both sides
         // must keep holding after a merge — ¬A ∧ ¬B ⟺ ¬(anyOf [A, B]).
         // Plain array_merge would let the right side displace the left and
-        // silently widen the admissible domain.
-        if (is_array($left['not'] ?? null) && is_array($right['not'] ?? null) && $left['not'] !== $right['not']) {
-            $merged['not'] = ['anyOf' => [$left['not'], $right['not']]];
+        // silently widen the admissible domain. Operands may be JSON Schema
+        // 2020-12 booleans, which conjoin by identity: `not: false` matches
+        // everything (neutral), `not: true` matches nothing (absorbing).
+        $leftNot = $left['not'] ?? null;
+        $rightNot = $right['not'] ?? null;
+        if ((is_array($leftNot) || is_bool($leftNot)) && (is_array($rightNot) || is_bool($rightNot))) {
+            $merged['not'] = match (true) {
+                $leftNot === false => $rightNot,
+                $rightNot === false => $leftNot,
+                $leftNot === true || $rightNot === true => true,
+                $leftNot === $rightNot => $leftNot,
+                default => ['anyOf' => [$leftNot, $rightNot]],
+            };
         }
         if (isset($left['minimum'], $right['minimum'])) {
             $merged['minimum'] = max($left['minimum'], $right['minimum']);

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -888,10 +888,11 @@ final class SchemaDataGenerator
         }
 
         $items = $schema['items'] ?? null;
-        if ($plan !== null && $items === true) {
-            // A boolean-true items schema admits any value; generate from
-            // the empty schema instead of degrading to an empty array that
-            // would violate minItems.
+        if ($plan !== null && ($items === true || $items === null)) {
+            // A boolean-true items schema admits any value, and an omitted
+            // items keyword is the empty schema (2020-12 §10.3.1.2) — same
+            // assertion behaviour. Generate from the empty schema instead of
+            // degrading to an empty array that would violate minItems.
             $items = [];
         }
         if (!is_array($items)) {

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -402,11 +402,22 @@ final class SchemaDataGenerator
             }
         }
         if ($maxProperties !== null && count($result) > $maxProperties) {
-            foreach (array_keys($result) as $name) {
-                if (count($result) <= $maxProperties) {
-                    break;
-                }
-                if (!in_array($name, $required, true)) {
+            // Trim unpinned optional properties first so a plan that forces
+            // a property present keeps it through the maxProperties budget;
+            // pinned ones go only when nothing else is left to drop.
+            foreach ([true, false] as $sparePinned) {
+                foreach (array_keys($result) as $name) {
+                    if (count($result) <= $maxProperties) {
+                        break 2;
+                    }
+                    if (in_array($name, $required, true)) {
+                        continue;
+                    }
+                    if ($sparePinned && $plan?->branchFor(
+                        $pointer . '/properties/' . SchemaChoicePointEnumerator::escapePointerSegment($name),
+                    ) === SchemaChoicePoint::PRESENT) {
+                        continue;
+                    }
                     unset($result[$name]);
                 }
             }
@@ -866,11 +877,23 @@ final class SchemaDataGenerator
                 }
             }
             if ($conditionals !== []) {
+                // Rotation only ever satisfies a conditional's `if`+`then`.
+                // Pinned plans encode two branches per conditional — even
+                // takes if+then, odd takes not-if+else, mirroring the
+                // standalone if/then/else resolution below — so the `else`
+                // side of every conditional is reachable.
                 $pinned = $plan?->branchFor($pointer . '/allOf');
-                $selected = $conditionals[($pinned ?? $iteration) % count($conditionals)];
-                $schema = self::mergeSchemas($schema, $selected['if']);
-                if (isset($selected['then']) && is_array($selected['then'])) {
-                    $schema = self::mergeSchemas($schema, $selected['then']);
+                $selected = $conditionals[($pinned !== null ? intdiv($pinned, 2) : $iteration) % count($conditionals)];
+                if ($pinned !== null && ($pinned % 2) === 1) {
+                    $schema = self::mergeSchemas($schema, self::mergeSchemas(
+                        ['not' => $selected['if']],
+                        is_array($selected['else'] ?? null) ? $selected['else'] : [],
+                    ));
+                } else {
+                    $schema = self::mergeSchemas($schema, $selected['if']);
+                    if (isset($selected['then']) && is_array($selected['then'])) {
+                        $schema = self::mergeSchemas($schema, $selected['then']);
+                    }
                 }
             }
         }

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -374,12 +374,15 @@ final class SchemaDataGenerator
             }
         }
         foreach ($negatedByProperty as $property => $negated) {
+            $existing = is_array($schema['properties'] ?? null) && is_array($schema['properties'][$property] ?? null)
+                ? ($schema['properties'][$property]['not'] ?? null)
+                : null;
             $schema = self::mergeSchemas($schema, ['properties' => [
-                $property => ['not' => count($negated) === 1 ? $negated[0] : ['anyOf' => $negated]],
+                $property => ['not' => self::negation($existing, $negated)],
             ]]);
         }
         if ($suppressedIfs !== []) {
-            $schema = self::mergeSchemas($schema, ['not' => ['anyOf' => $suppressedIfs]]);
+            $schema = self::mergeSchemas($schema, ['not' => self::negation($schema['not'] ?? null, $suppressedIfs)]);
         }
 
         return $schema;
@@ -446,6 +449,27 @@ final class SchemaDataGenerator
         }
 
         return $merged;
+    }
+
+    /**
+     * Build a `not` value that adds the synthesized exclusions to whatever
+     * exclusion already sits on the target: `¬A ∧ ¬B ⟺ ¬(anyOf [A, B])`.
+     * Merging would overwrite the pre-existing `not` and silently widen the
+     * admissible domain.
+     *
+     * @param list<mixed> $disjuncts
+     *
+     * @return array<string, mixed>
+     */
+    private static function negation(mixed $existingNot, array $disjuncts): array
+    {
+        if ($existingNot !== null) {
+            $disjuncts = [$existingNot, ...$disjuncts];
+        }
+
+        return count($disjuncts) === 1 && is_array($disjuncts[0])
+            ? $disjuncts[0]
+            : ['anyOf' => $disjuncts];
     }
 
     /**

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -109,11 +109,22 @@ final class SchemaDataGenerator
      * {@see OpenApiEndpointExplorer} can share a faker instance across
      * multiple schemas (body + parameters) within a single case.
      *
+     * When a {@see CaseSelectionPlan} is supplied, choice points whose
+     * pointer (relative to `$pointer`) carries a pinned selection take that
+     * branch instead of rotating with the iteration index; everything else
+     * keeps the documented rotation strategy, so a null plan reproduces the
+     * historical output bit-for-bit.
+     *
      * @param array<string, mixed> $schema
      */
-    public static function generateOne(array $schema, ?Generator $faker, int $iteration): mixed
-    {
-        $schema = self::resolveComposition($schema, $faker, $iteration);
+    public static function generateOne(
+        array $schema,
+        ?Generator $faker,
+        int $iteration,
+        ?CaseSelectionPlan $plan = null,
+        string $pointer = '',
+    ): mixed {
+        $schema = self::resolveComposition($schema, $faker, $iteration, $plan, $pointer);
 
         if (array_key_exists('const', $schema)) {
             return $schema['const'];
@@ -125,14 +136,20 @@ final class SchemaDataGenerator
             return $values[$iteration % count($values)];
         }
 
-        if (is_array($schema['type'] ?? null) && in_array('null', $schema['type'], true) && ($iteration % 3) === 2) {
-            return null;
+        if (is_array($schema['type'] ?? null) && in_array('null', $schema['type'], true)) {
+            $pinnedNull = $plan?->branchFor($pointer . '/type');
+            $emitNull = $pinnedNull !== null
+                ? $pinnedNull === SchemaChoicePoint::NULL_VALUE
+                : ($iteration % 3) === 2;
+            if ($emitNull) {
+                return null;
+            }
         }
 
         if (isset($schema['not']) && is_array($schema['not'])) {
             $withoutNot = $schema;
             unset($withoutNot['not']);
-            $candidate = self::generateOne($withoutNot, $faker, $iteration);
+            $candidate = self::generateOne($withoutNot, $faker, $iteration, $plan, $pointer);
             if (!SchemaValueValidator::isValid($candidate, $schema)) {
                 foreach ([null, false, 0, 1, '', 'value', [], ['value' => true]] as $alternative) {
                     if (SchemaValueValidator::isValid($alternative, $schema)) {
@@ -147,8 +164,8 @@ final class SchemaDataGenerator
         $type = self::resolveType($schema);
 
         return match ($type) {
-            'object' => self::generateObject($schema, $faker, $iteration),
-            'array' => self::generateArray($schema, $faker, $iteration),
+            'object' => self::generateObject($schema, $faker, $iteration, $plan, $pointer),
+            'array' => self::generateArray($schema, $faker, $iteration, $plan, $pointer),
             'string' => self::generateString($schema, $faker, $iteration),
             'integer' => self::generateInteger($schema, $faker, $iteration),
             'number' => self::generateNumber($schema, $faker, $iteration),
@@ -195,9 +212,13 @@ final class SchemaDataGenerator
      * which case we infer from `properties`/`items` and finally default to
      * `string` so a permissive untyped schema still produces a value.
      *
+     * Public within the internal fuzz family so
+     * {@see SchemaChoicePointEnumerator} descends exactly the nodes this
+     * generator would materialise.
+     *
      * @param array<string, mixed> $schema
      */
-    private static function resolveType(array $schema): string
+    public static function resolveType(array $schema): string
     {
         $type = $schema['type'] ?? null;
         if (is_string($type)) {
@@ -230,12 +251,80 @@ final class SchemaDataGenerator
     }
 
     /**
+     * Merge the assertion keywords needed for deterministic allOf generation.
+     *
+     * Public within the internal fuzz family so
+     * {@see SchemaChoicePointEnumerator} merges branch views with exactly the
+     * semantics generation applies.
+     *
+     * @param array<string, mixed> $left
+     * @param array<string, mixed> $right
+     *
+     * @return array<string, mixed>
+     */
+    public static function mergeSchemas(array $left, array $right): array
+    {
+        $merged = array_merge($left, $right);
+        if (is_array($left['properties'] ?? null) || is_array($right['properties'] ?? null)) {
+            $merged['properties'] = self::mergePropertySchemas(
+                is_array($left['properties'] ?? null) ? $left['properties'] : [],
+                is_array($right['properties'] ?? null) ? $right['properties'] : [],
+            );
+        }
+        if (is_array($left['required'] ?? null) || is_array($right['required'] ?? null)) {
+            $merged['required'] = array_values(array_unique(array_merge(
+                is_array($left['required'] ?? null) ? $left['required'] : [],
+                is_array($right['required'] ?? null) ? $right['required'] : [],
+            )));
+        }
+        if (isset($left['minimum'], $right['minimum'])) {
+            $merged['minimum'] = max($left['minimum'], $right['minimum']);
+        }
+        if (isset($left['maximum'], $right['maximum'])) {
+            $merged['maximum'] = min($left['maximum'], $right['maximum']);
+        }
+        if (isset($left['minLength'], $right['minLength'])) {
+            $merged['minLength'] = max($left['minLength'], $right['minLength']);
+        }
+        if (isset($left['maxLength'], $right['maxLength'])) {
+            $merged['maxLength'] = min($left['maxLength'], $right['maxLength']);
+        }
+        foreach (['minItems', 'minProperties'] as $minimumKeyword) {
+            if (isset($left[$minimumKeyword], $right[$minimumKeyword])) {
+                $merged[$minimumKeyword] = max($left[$minimumKeyword], $right[$minimumKeyword]);
+            }
+        }
+        foreach (['maxItems', 'maxProperties'] as $maximumKeyword) {
+            if (isset($left[$maximumKeyword], $right[$maximumKeyword])) {
+                $merged[$maximumKeyword] = min($left[$maximumKeyword], $right[$maximumKeyword]);
+            }
+        }
+        if ((is_int($left['multipleOf'] ?? null) || is_float($left['multipleOf'] ?? null)) &&
+            (is_int($right['multipleOf'] ?? null) || is_float($right['multipleOf'] ?? null))) {
+            $multipleOf = DecimalMultiple::leastCommonMultiple($left['multipleOf'], $right['multipleOf']);
+            if ($multipleOf === null) {
+                throw new InvalidArgumentException(
+                    'Cannot compose allOf multipleOf constraints within the platform numeric range.',
+                );
+            }
+            $merged['multipleOf'] = $multipleOf;
+        }
+
+        return $merged;
+    }
+
+    /**
      * @param array<string, mixed> $schema
      *
      * @return array<string, mixed>|stdClass
      */
-    private static function generateObject(array $schema, ?Generator $faker, int $iteration): array|stdClass
-    {
+    private static function generateObject(
+        array $schema,
+        ?Generator $faker,
+        int $iteration,
+        ?CaseSelectionPlan $plan = null,
+        string $pointer = '',
+    ): array|stdClass {
         $properties = $schema['properties'] ?? [];
         if (!is_array($properties)) {
             return [];
@@ -256,16 +345,24 @@ final class SchemaDataGenerator
                 continue;
             }
 
+            $childPointer = $pointer . '/properties/' . SchemaChoicePointEnumerator::escapePointerSegment($name);
             $isRequired = in_array($name, $required, true);
             // Optional properties alternate inclusion across cases so the
             // suite exercises both "required-only" and "required+optional"
             // shapes — mirrors Schemathesis' explore-omit toggle on a small
-            // budget. Required keys are always emitted.
-            if (!$isRequired && ($iteration % 2) === 0) {
-                continue;
+            // budget. Required keys are always emitted; a pinned plan entry
+            // overrides the parity in either direction.
+            if (!$isRequired) {
+                $pinnedPresence = $plan?->branchFor($childPointer);
+                $omit = $pinnedPresence !== null
+                    ? $pinnedPresence === SchemaChoicePoint::OMITTED
+                    : ($iteration % 2) === 0;
+                if ($omit) {
+                    continue;
+                }
             }
 
-            $result[$name] = self::generateOne($propSchema, $faker, $iteration);
+            $result[$name] = self::generateOne($propSchema, $faker, $iteration, $plan, $childPointer);
         }
 
         $minProperties = isset($schema['minProperties']) && is_int($schema['minProperties'])
@@ -277,7 +374,13 @@ final class SchemaDataGenerator
                 $additionalSchema = is_array($schema['additionalProperties'] ?? null)
                     ? $schema['additionalProperties']
                     : ['type' => 'string'];
-                $result[$name] = self::generateOne($additionalSchema, $faker, $iteration + count($result));
+                $result[$name] = self::generateOne(
+                    $additionalSchema,
+                    $faker,
+                    $iteration + count($result),
+                    $plan,
+                    $pointer . '/additionalProperties',
+                );
             }
         }
         $maxProperties = isset($schema['maxProperties']) && is_int($schema['maxProperties'])
@@ -289,7 +392,13 @@ final class SchemaDataGenerator
                 $additionalSchema = is_array($schema['additionalProperties'] ?? null)
                     ? $schema['additionalProperties']
                     : ['type' => 'string'];
-                $result[$name] = self::generateOne($additionalSchema, $faker, $iteration + count($result));
+                $result[$name] = self::generateOne(
+                    $additionalSchema,
+                    $faker,
+                    $iteration + count($result),
+                    $plan,
+                    $pointer . '/additionalProperties',
+                );
             }
         }
         if ($maxProperties !== null && count($result) > $maxProperties) {
@@ -317,8 +426,18 @@ final class SchemaDataGenerator
      *
      * @return list<mixed>
      */
-    private static function generateArray(array $schema, ?Generator $faker, int $iteration): array
-    {
+    private static function generateArray(
+        array $schema,
+        ?Generator $faker,
+        int $iteration,
+        ?CaseSelectionPlan $plan = null,
+        string $pointer = '',
+    ): array {
+        // A pinned plan entry at `<pointer>/items` is a forced minimum size:
+        // it makes items reachable in the pinned case (mirroring how optional
+        // ancestors are forced present) without becoming a rotation strategy.
+        $forcedMinimum = $plan?->branchFor($pointer . '/items');
+
         $prefixItems = $schema['prefixItems'] ?? null;
         if (is_array($prefixItems)) {
             $prefixCount = count($prefixItems);
@@ -329,6 +448,9 @@ final class SchemaDataGenerator
                 1 => $maximum ?? $prefixCount,
                 default => $prefixCount,
             };
+            if ($forcedMinimum !== null) {
+                $size = max($size, $forcedMinimum);
+            }
             if ($maximum !== null) {
                 $size = min($size, $maximum);
             }
@@ -338,8 +460,11 @@ final class SchemaDataGenerator
             $result = [];
             for ($index = 0; $index < $size; $index++) {
                 $item = $prefixItems[$index] ?? ($schema['items'] ?? []);
+                $itemPointer = isset($prefixItems[$index])
+                    ? $pointer . '/prefixItems/' . $index
+                    : $pointer . '/items';
                 if (is_array($item)) {
-                    $result[] = self::generateOne($item, $faker, $iteration + $index);
+                    $result[] = self::generateOne($item, $faker, $iteration + $index, $plan, $itemPointer);
                 } else {
                     $result[] = 'item-' . $index;
                 }
@@ -360,17 +485,21 @@ final class SchemaDataGenerator
             1 => $maximum ?? max(1, $minimum),
             default => max(1, $minimum),
         };
+        if ($forcedMinimum !== null) {
+            $size = max($size, $forcedMinimum);
+        }
         if ($maximum !== null) {
             $size = min($size, $maximum);
         }
+        $itemPointer = $pointer . '/items';
         $result = [];
         for ($i = 0; $i < $size; $i++) {
-            $item = self::generateOne($items, $faker, $iteration + $i);
+            $item = self::generateOne($items, $faker, $iteration + $i, $plan, $itemPointer);
             if (($schema['uniqueItems'] ?? false) === true) {
                 $attempt = 0;
                 while (in_array($item, $result, true) && $attempt < 100) {
                     $attempt++;
-                    $item = self::generateOne($items, $faker, $iteration + $i + $attempt);
+                    $item = self::generateOne($items, $faker, $iteration + $i + $attempt, $plan, $itemPointer);
                 }
             }
             $result[] = $item;
@@ -700,8 +829,13 @@ final class SchemaDataGenerator
      *
      * @return array<string, mixed>
      */
-    private static function resolveComposition(array $schema, ?Generator $faker, int $iteration): array
-    {
+    private static function resolveComposition(
+        array $schema,
+        ?Generator $faker,
+        int $iteration,
+        ?CaseSelectionPlan $plan = null,
+        string $pointer = '',
+    ): array {
         foreach (['oneOf', 'anyOf'] as $keyword) {
             if (!isset($schema[$keyword]) || !is_array($schema[$keyword]) || $schema[$keyword] === []) {
                 continue;
@@ -711,7 +845,9 @@ final class SchemaDataGenerator
                 continue;
             }
             unset($schema[$keyword]);
-            $schema = self::mergeSchemas($schema, $branches[$iteration % count($branches)]);
+            $pinned = $plan?->branchFor($pointer . '/' . $keyword);
+            $index = ($pinned ?? $iteration) % count($branches);
+            $schema = self::mergeSchemas($schema, $branches[$index]);
             break;
         }
 
@@ -730,7 +866,8 @@ final class SchemaDataGenerator
                 }
             }
             if ($conditionals !== []) {
-                $selected = $conditionals[$iteration % count($conditionals)];
+                $pinned = $plan?->branchFor($pointer . '/allOf');
+                $selected = $conditionals[($pinned ?? $iteration) % count($conditionals)];
                 $schema = self::mergeSchemas($schema, $selected['if']);
                 if (isset($selected['then']) && is_array($selected['then'])) {
                     $schema = self::mergeSchemas($schema, $selected['then']);
@@ -739,7 +876,8 @@ final class SchemaDataGenerator
         }
 
         if (isset($schema['if']) && is_array($schema['if'])) {
-            $useThen = ($iteration % 2) === 0;
+            $pinned = $plan?->branchFor($pointer . '/if');
+            $useThen = (($pinned ?? $iteration) % 2) === 0;
             $conditional = $useThen
                 ? self::mergeSchemas($schema['if'], is_array($schema['then'] ?? null) ? $schema['then'] : [])
                 : self::mergeSchemas(
@@ -751,65 +889,6 @@ final class SchemaDataGenerator
         }
 
         return $schema;
-    }
-
-    /**
-     * Merge the assertion keywords needed for deterministic allOf generation.
-     *
-     * @param array<string, mixed> $left
-     * @param array<string, mixed> $right
-     *
-     * @return array<string, mixed>
-     */
-    private static function mergeSchemas(array $left, array $right): array
-    {
-        $merged = array_merge($left, $right);
-        if (is_array($left['properties'] ?? null) || is_array($right['properties'] ?? null)) {
-            $merged['properties'] = self::mergePropertySchemas(
-                is_array($left['properties'] ?? null) ? $left['properties'] : [],
-                is_array($right['properties'] ?? null) ? $right['properties'] : [],
-            );
-        }
-        if (is_array($left['required'] ?? null) || is_array($right['required'] ?? null)) {
-            $merged['required'] = array_values(array_unique(array_merge(
-                is_array($left['required'] ?? null) ? $left['required'] : [],
-                is_array($right['required'] ?? null) ? $right['required'] : [],
-            )));
-        }
-        if (isset($left['minimum'], $right['minimum'])) {
-            $merged['minimum'] = max($left['minimum'], $right['minimum']);
-        }
-        if (isset($left['maximum'], $right['maximum'])) {
-            $merged['maximum'] = min($left['maximum'], $right['maximum']);
-        }
-        if (isset($left['minLength'], $right['minLength'])) {
-            $merged['minLength'] = max($left['minLength'], $right['minLength']);
-        }
-        if (isset($left['maxLength'], $right['maxLength'])) {
-            $merged['maxLength'] = min($left['maxLength'], $right['maxLength']);
-        }
-        foreach (['minItems', 'minProperties'] as $minimumKeyword) {
-            if (isset($left[$minimumKeyword], $right[$minimumKeyword])) {
-                $merged[$minimumKeyword] = max($left[$minimumKeyword], $right[$minimumKeyword]);
-            }
-        }
-        foreach (['maxItems', 'maxProperties'] as $maximumKeyword) {
-            if (isset($left[$maximumKeyword], $right[$maximumKeyword])) {
-                $merged[$maximumKeyword] = min($left[$maximumKeyword], $right[$maximumKeyword]);
-            }
-        }
-        if ((is_int($left['multipleOf'] ?? null) || is_float($left['multipleOf'] ?? null)) &&
-            (is_int($right['multipleOf'] ?? null) || is_float($right['multipleOf'] ?? null))) {
-            $multipleOf = DecimalMultiple::leastCommonMultiple($left['multipleOf'], $right['multipleOf']);
-            if ($multipleOf === null) {
-                throw new InvalidArgumentException(
-                    'Cannot compose allOf multipleOf constraints within the platform numeric range.',
-                );
-            }
-            $merged['multipleOf'] = $multipleOf;
-        }
-
-        return $merged;
     }
 
     /**

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -140,16 +140,22 @@ final class SchemaDataGenerator
             $resolved = self::resolveBranchChoice($schema, $iteration, $plan, $pointer);
             [$base, $conditionals] = self::splitConditionals($resolved);
             if ($conditionals !== []) {
-                return self::generateConditionalNode(
-                    $resolved,
-                    $base,
-                    $conditionals,
-                    $pinnedConditional,
-                    $faker,
-                    $iteration,
-                    $plan,
-                    $pointer,
-                );
+                [$base, $choices, $unsatisfiable] = self::partitionConditionals($base, $conditionals);
+                if (!$unsatisfiable && $choices !== []) {
+                    return self::generateConditionalNode(
+                        $resolved,
+                        $base,
+                        $choices,
+                        $pinnedConditional,
+                        $faker,
+                        $iteration,
+                        $plan,
+                        $pointer,
+                    );
+                }
+                // No genuine choice remains (all folded, or the node is
+                // unsatisfiable): fall through to the normal pipeline, which
+                // re-partitions identically.
             }
         }
 
@@ -592,6 +598,73 @@ final class SchemaDataGenerator
     }
 
     /**
+     * Partition conditional `allOf` branches by their boolean consequents
+     * (valid Schema Objects in OpenAPI 3.1 / JSON Schema 2020-12):
+     * `then: false` means the if side is unsatisfiable, so the conditional
+     * is permanently suppressed (¬if and its else folded into the base);
+     * `else: false` means the if must always hold (if+then folded in). Both
+     * false makes the node unsatisfiable. Only the remaining conditionals
+     * are genuine choices. Shared with the enumerator so both sides fold
+     * identically.
+     *
+     * @param array<string, mixed> $base
+     * @param list<array<string, mixed>> $conditionals
+     *
+     * @return array{array<string, mixed>, list<array<string, mixed>>, bool} folded base, choice conditionals, unsatisfiable
+     */
+    public static function partitionConditionals(array $base, array $conditionals): array
+    {
+        $choices = [];
+        foreach ($conditionals as $conditional) {
+            $then = $conditional['then'] ?? null;
+            $else = $conditional['else'] ?? null;
+            if ($then === false && $else === false) {
+                return [$base, $choices, true];
+            }
+            if ($else === false) {
+                $base = self::mergeSchemas($base, $conditional['if']);
+                if (is_array($then)) {
+                    $base = self::mergeSchemas($base, $then);
+                }
+
+                continue;
+            }
+            if ($then === false) {
+                $base = self::suppressConditional($base, $conditional);
+
+                continue;
+            }
+            $choices[] = $conditional;
+        }
+
+        return [$base, $choices, false];
+    }
+
+    /**
+     * Fold the suppressed side of one conditional into a schema: its else
+     * applies and its if must fail — negated at the property itself for the
+     * single-property shape, at the node otherwise. mergeSchemas() combines
+     * `not` assertions conjunctively, so stacked suppressions accumulate.
+     *
+     * @param array<string, mixed> $schema
+     * @param array<string, mixed> $conditional
+     *
+     * @return array<string, mixed>
+     */
+    private static function suppressConditional(array $schema, array $conditional): array
+    {
+        if (isset($conditional['else']) && is_array($conditional['else'])) {
+            $schema = self::mergeSchemas($schema, $conditional['else']);
+        }
+        $condition = self::singlePropertyCondition($conditional['if']);
+        if ($condition !== null) {
+            return self::mergeSchemas($schema, ['properties' => [$condition[0] => ['not' => $condition[1]]]]);
+        }
+
+        return self::mergeSchemas($schema, ['not' => $conditional['if']]);
+    }
+
+    /**
      * Recognise an `if` of the shape `{properties: {p: s}, required: [p]}`
      * with no other assertions, and return `[p, s]`; null otherwise.
      *
@@ -787,6 +860,17 @@ final class SchemaDataGenerator
             if (($schema['items'] ?? true) === false) {
                 $size = min($size, $prefixCount);
             }
+            if ($plan !== null) {
+                // A `false` prefix item admits no value, so every array long
+                // enough to contain it is invalid: the first one is an
+                // effective maxItems, overriding even a forced size.
+                foreach (array_values($prefixItems) as $prefixIndex => $prefixItem) {
+                    if ($prefixItem === false) {
+                        $size = min($size, $prefixIndex);
+                        break;
+                    }
+                }
+            }
             $result = [];
             for ($index = 0; $index < $size; $index++) {
                 $item = $prefixItems[$index] ?? ($schema['items'] ?? []);
@@ -804,6 +888,12 @@ final class SchemaDataGenerator
         }
 
         $items = $schema['items'] ?? null;
+        if ($plan !== null && $items === true) {
+            // A boolean-true items schema admits any value; generate from
+            // the empty schema instead of degrading to an empty array that
+            // would violate minItems.
+            $items = [];
+        }
         if (!is_array($items)) {
             return [];
         }
@@ -1170,6 +1260,15 @@ final class SchemaDataGenerator
 
         if (isset($schema['allOf']) && is_array($schema['allOf'])) {
             [$schema, $conditionals] = self::splitConditionals($schema);
+            if ($conditionals !== [] && $plan !== null) {
+                // Boolean consequents leave no choice; fold them into the
+                // node first. An unsatisfiable node generates from the base
+                // and fails the self-check loudly.
+                [$schema, $conditionals, $unsatisfiable] = self::partitionConditionals($schema, $conditionals);
+                if ($unsatisfiable) {
+                    $conditionals = [];
+                }
+            }
             if ($conditionals !== []) {
                 // Rotation only ever satisfies a conditional's `if`+`then`;
                 // pinned conditional branches never reach this point — they

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -340,9 +340,13 @@ final class SchemaDataGenerator
         // previously generated values that failed the loud self-check.
         if (is_array($left['enum'] ?? null) && is_array($right['enum'] ?? null) &&
             $left['enum'] !== [] && $right['enum'] !== []) {
+            // Membership uses JSON Schema equality (2020-12 §4.2.2) via the
+            // validator — 1 and 1.0 are the same mathematical value, and
+            // object equality ignores key order — not PHP identity.
+            $leftEnum = ['enum' => $left['enum']];
             $merged['enum'] = array_values(array_filter(
                 $right['enum'],
-                static fn(mixed $value): bool => in_array($value, $left['enum'], true),
+                static fn(mixed $value): bool => SchemaValueValidator::isValid($value, $leftEnum),
             ));
         }
         $leftType = $left['type'] ?? null;
@@ -350,10 +354,18 @@ final class SchemaDataGenerator
         if ((is_string($leftType) || is_array($leftType)) && (is_string($rightType) || is_array($rightType))) {
             $leftTypes = is_string($leftType) ? [$leftType] : $leftType;
             $rightTypes = is_string($rightType) ? [$rightType] : $rightType;
-            $intersection = array_values(array_filter(
-                $rightTypes,
-                static fn(mixed $type): bool => in_array($type, $leftTypes, true),
-            ));
+            $intersection = [];
+            foreach ($rightTypes as $type) {
+                if (in_array($type, $leftTypes, true)) {
+                    $intersection[] = $type;
+                } elseif (($type === 'number' || $type === 'integer') &&
+                    (in_array('number', $leftTypes, true) || in_array('integer', $leftTypes, true))) {
+                    // integer is the zero-fraction subtype of number
+                    // (2020-12 §6.1.1): number ∧ integer = integer.
+                    $intersection[] = 'integer';
+                }
+            }
+            $intersection = array_values(array_unique($intersection));
             if ($intersection !== $rightTypes) {
                 $merged['type'] = $intersection;
             }
@@ -611,6 +623,17 @@ final class SchemaDataGenerator
             return $schema['const'];
         }
 
+        if ($plan !== null &&
+            (($schema['enum'] ?? null) === [] || ($schema['type'] ?? null) === [] || ($schema['not'] ?? null) === true)) {
+            // A statically empty domain — an enum/type intersection emptied
+            // by mergeSchemas(), or an absorbing `not` — admits no value.
+            // Return a deterministic sentinel so the target search sees the
+            // identical outcome on every attempt and classifies the dead
+            // end as proven, instead of chasing varying garbage; untargeted
+            // cases still fail the loud self-check.
+            return null;
+        }
+
         if (isset($schema['enum']) && is_array($schema['enum']) && $schema['enum'] !== []) {
             $values = array_values($schema['enum']);
             if ($plan !== null && isset($schema['not']) && is_array($schema['not'])) {
@@ -628,6 +651,12 @@ final class SchemaDataGenerator
                 if ($admissible !== []) {
                     return $admissible[$iteration % count($admissible)];
                 }
+
+                // The exclusion provably closes the finite domain: no
+                // rotation can escape it. Pick deterministically so the
+                // target search classifies the dead end as proven rather
+                // than reading iteration-rotated picks as an open search.
+                return $values[0];
             }
 
             return $values[$iteration % count($values)];
@@ -1388,6 +1417,19 @@ final class SchemaDataGenerator
             }
         }
 
+        if ($plan !== null && $plan->refineTarget) {
+            $refinement = $plan->observation->takeRefinement();
+            if ($refinement !== null) {
+                // Refinement attempt of the target search: non-conjunctive
+                // keywords (pattern, format) displaced by a later merge are
+                // restored by re-merging the target branch content last.
+                // Conjunctive keywords are idempotent under the re-merge,
+                // and the whole-schema check plus the branch observation
+                // still gate whatever this view generates.
+                $schema = self::mergeSchemas($schema, $refinement);
+            }
+        }
+
         return $schema;
     }
 
@@ -1438,6 +1480,9 @@ final class SchemaDataGenerator
                 $branch = $branches[$selected];
                 $plan->observation->expect($pointer, static fn(mixed $value): bool
                     => $branch === true || (is_array($branch) && SchemaValueValidator::isValid($value, $branch)));
+                if ($plan->refineTarget && is_array($branch)) {
+                    $plan->observation->stageRefinement($branch);
+                }
             }
             $schema = self::applyCompositionBranch($schema, $branches, $selected, $keyword);
             break;

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -543,6 +543,55 @@ final class SchemaDataGenerator
     }
 
     /**
+     * The generatable sides of an array-schema `if` under a plan: side 0
+     * satisfies the `if` (plus `then`), side 1 violates it (plus `else`). A
+     * boolean `false` consequent makes its side unsatisfiable — nothing
+     * matches `false` — so it is excluded; `true` and absent consequents
+     * assert nothing and stay generatable.
+     *
+     * @param array<string, mixed> $schema
+     *
+     * @return list<int>
+     */
+    public static function ifBranchSides(array $schema): array
+    {
+        $sides = [];
+        if (($schema['then'] ?? null) !== false) {
+            $sides[] = 0;
+        }
+        if (($schema['else'] ?? null) !== false) {
+            $sides[] = 1;
+        }
+
+        return $sides;
+    }
+
+    /**
+     * Materialise one side of an array-schema `if`: the condition (or its
+     * negation) merged with the matching consequent. Shared with the
+     * enumerator so descent and pinned generation see identical views.
+     *
+     * @param array<string, mixed> $schema node still carrying if/then/else
+     *
+     * @return array<string, mixed>
+     */
+    public static function applyIfSide(array $schema, int $side): array
+    {
+        $conditional = $side === 0
+            ? self::mergeSchemas(
+                is_array($schema['if']) ? $schema['if'] : [],
+                is_array($schema['then'] ?? null) ? $schema['then'] : [],
+            )
+            : self::mergeSchemas(
+                ['not' => $schema['if']],
+                is_array($schema['else'] ?? null) ? $schema['else'] : [],
+            );
+        unset($schema['if'], $schema['then'], $schema['else']);
+
+        return self::mergeSchemas($schema, $conditional);
+    }
+
+    /**
      * Recognise an `if` of the shape `{properties: {p: s}, required: [p]}`
      * with no other assertions, and return `[p, s]`; null otherwise.
      *
@@ -598,7 +647,14 @@ final class SchemaDataGenerator
 
         $result = [];
         foreach ($properties as $name => $propSchema) {
-            if (!is_string($name) || !is_array($propSchema)) {
+            if (!is_string($name)) {
+                continue;
+            }
+            // Boolean property schemas (OpenAPI 3.1 / JSON Schema 2020-12)
+            // participate under a plan: `true` admits any value, `false`
+            // admits none, so its presence is unreachable and the property
+            // is always omitted. Plan-less rotation keeps skipping them.
+            if (!is_array($propSchema) && !($plan !== null && $propSchema === true)) {
                 continue;
             }
 
@@ -619,7 +675,13 @@ final class SchemaDataGenerator
                 }
             }
 
-            $result[$name] = self::generateOne($propSchema, $faker, $iteration, $plan, $childPointer);
+            $result[$name] = self::generateOne(
+                $propSchema === true ? [] : $propSchema,
+                $faker,
+                $iteration,
+                $plan,
+                $childPointer,
+            );
         }
 
         $minProperties = isset($schema['minProperties']) && is_int($schema['minProperties'])
@@ -1132,16 +1194,26 @@ final class SchemaDataGenerator
                 $schema = self::mergeSchemas($schema, $branchSchema);
             }
         } elseif (isset($schema['if']) && is_array($schema['if'])) {
-            $pinned = $plan?->branchFor($pointer . '/if');
-            $useThen = (($pinned ?? $iteration) % 2) === 0;
-            $conditional = $useThen
-                ? self::mergeSchemas($schema['if'], is_array($schema['then'] ?? null) ? $schema['then'] : [])
-                : self::mergeSchemas(
-                    ['not' => $schema['if']],
-                    is_array($schema['else'] ?? null) ? $schema['else'] : [],
-                );
-            unset($schema['if'], $schema['then'], $schema['else']);
-            $schema = self::mergeSchemas($schema, $conditional);
+            if ($plan !== null) {
+                $sides = self::ifBranchSides($schema);
+                // No generatable side means both consequents are `false`;
+                // leave the keyword unresolved for the loud self-check.
+                if ($sides !== []) {
+                    $pinned = $plan->branchFor($pointer . '/if');
+                    $side = $sides[($pinned ?? $iteration) % count($sides)];
+                    $schema = self::applyIfSide($schema, $side);
+                }
+            } else {
+                $useThen = ($iteration % 2) === 0;
+                $conditional = $useThen
+                    ? self::mergeSchemas($schema['if'], is_array($schema['then'] ?? null) ? $schema['then'] : [])
+                    : self::mergeSchemas(
+                        ['not' => $schema['if']],
+                        is_array($schema['else'] ?? null) ? $schema['else'] : [],
+                    );
+                unset($schema['if'], $schema['then'], $schema['else']);
+                $schema = self::mergeSchemas($schema, $conditional);
+            }
         }
 
         return $schema;

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -136,108 +136,15 @@ final class SchemaDataGenerator
         ?CaseSelectionPlan $plan = null,
         string $pointer = '',
     ): mixed {
-        if ($plan !== null && ($pinnedConditional = $plan->branchFor($pointer . '/allOf')) !== null) {
-            $resolved = self::resolveBranchChoice($schema, $iteration, $plan, $pointer);
-            [$base, $conditionals] = self::splitConditionals($resolved);
-            if ($conditionals !== []) {
-                [$base, $choices, $unsatisfiable] = self::partitionConditionals($base, $conditionals);
-                if (!$unsatisfiable && $choices !== []) {
-                    return self::generateConditionalNode(
-                        $resolved,
-                        $base,
-                        $choices,
-                        $pinnedConditional,
-                        $faker,
-                        $iteration,
-                        $plan,
-                        $pointer,
-                    );
-                }
-                // No genuine choice remains (all folded, or the node is
-                // unsatisfiable): fall through to the normal pipeline, which
-                // re-partitions identically.
-            }
-        }
+        $value = self::generateNode($schema, $faker, $iteration, $plan, $pointer);
+        // The site that applied the plan's target registered its
+        // branch-level check while this node resolved; the value exists
+        // only now. Nested regenerations at the same pointer evaluated
+        // their own candidates first — this call ran last, so the final
+        // observation describes the returned value.
+        $plan?->observation->evaluate($pointer, $value);
 
-        $schema = self::resolveComposition($schema, $faker, $iteration, $plan, $pointer);
-
-        if (array_key_exists('const', $schema)) {
-            return $schema['const'];
-        }
-
-        if (isset($schema['enum']) && is_array($schema['enum']) && $schema['enum'] !== []) {
-            $values = array_values($schema['enum']);
-            if ($plan !== null && isset($schema['not']) && is_array($schema['not'])) {
-                // The enum domain is finite, so a `not` (e.g. suppressed
-                // discriminator values pushed down by conditionalSetView())
-                // is honoured by filtering the domain outright — complete
-                // and deterministic where iteration retries could miss the
-                // admissible tail of a long enum. An empty filter result
-                // means the exclusion genuinely closes the domain; fall
-                // through and let the self-check fail or drop the probe.
-                $admissible = array_values(array_filter(
-                    $values,
-                    static fn(mixed $value): bool => SchemaValueValidator::isValid($value, $schema),
-                ));
-                if ($admissible !== []) {
-                    return $admissible[$iteration % count($admissible)];
-                }
-            }
-
-            return $values[$iteration % count($values)];
-        }
-
-        if (is_array($schema['type'] ?? null) && in_array('null', $schema['type'], true)) {
-            $pinnedNull = $plan?->branchFor($pointer . '/type');
-            $emitNull = $pinnedNull !== null
-                ? $pinnedNull === SchemaChoicePoint::NULL_VALUE
-                : ($iteration % 3) === 2;
-            if ($emitNull) {
-                return null;
-            }
-        }
-
-        if (isset($schema['not']) && is_array($schema['not'])) {
-            $withoutNot = $schema;
-            unset($withoutNot['not']);
-            $candidate = self::generateOne($withoutNot, $faker, $iteration, $plan, $pointer);
-            if (!SchemaValueValidator::isValid($candidate, $schema)) {
-                if ($plan !== null) {
-                    // The `not` often excludes exactly the rotation pick — a
-                    // suppressed discriminator value landing on this case's
-                    // iteration. Nearby iterations re-rotate enums and
-                    // scalars before giving up, so one unlucky index is not
-                    // read as "unsatisfiable". Plan-less rotation keeps the
-                    // historical single-shot behaviour and output.
-                    for ($offset = 1; $offset <= self::NOT_GENERATION_RETRIES; $offset++) {
-                        $retried = self::generateOne($withoutNot, $faker, $iteration + $offset, $plan, $pointer);
-                        if (SchemaValueValidator::isValid($retried, $schema)) {
-                            return $retried;
-                        }
-                    }
-                }
-                foreach ([null, false, 0, 1, '', 'value', [], ['value' => true]] as $alternative) {
-                    if (SchemaValueValidator::isValid($alternative, $schema)) {
-                        return $alternative;
-                    }
-                }
-            }
-
-            return $candidate;
-        }
-
-        $type = self::resolveType($schema);
-
-        return match ($type) {
-            'object' => self::generateObject($schema, $faker, $iteration, $plan, $pointer),
-            'array' => self::generateArray($schema, $faker, $iteration, $plan, $pointer),
-            'string' => self::generateString($schema, $faker, $iteration),
-            'integer' => self::generateInteger($schema, $faker, $iteration),
-            'number' => self::generateNumber($schema, $faker, $iteration),
-            'boolean' => self::generateBoolean($iteration),
-            'null' => null,
-            default => null,
-        };
+        return $value;
     }
 
     /**
@@ -423,6 +330,33 @@ final class SchemaDataGenerator
                 is_array($left['required'] ?? null) ? $left['required'] : [],
                 is_array($right['required'] ?? null) ? $right['required'] : [],
             )));
+        }
+        // `enum` and `type` are assertions too: a value must satisfy both
+        // sides, so their domains intersect. Right-side order (and, for an
+        // unconflicted `type`, the right side verbatim) is preserved: when
+        // the right domain is already a subset of the left, the merge is
+        // byte-identical to the historical array_merge result, keeping
+        // plan-less rotation output bit-for-bit. Conflicting domains
+        // previously generated values that failed the loud self-check.
+        if (is_array($left['enum'] ?? null) && is_array($right['enum'] ?? null) &&
+            $left['enum'] !== [] && $right['enum'] !== []) {
+            $merged['enum'] = array_values(array_filter(
+                $right['enum'],
+                static fn(mixed $value): bool => in_array($value, $left['enum'], true),
+            ));
+        }
+        $leftType = $left['type'] ?? null;
+        $rightType = $right['type'] ?? null;
+        if ((is_string($leftType) || is_array($leftType)) && (is_string($rightType) || is_array($rightType))) {
+            $leftTypes = is_string($leftType) ? [$leftType] : $leftType;
+            $rightTypes = is_string($rightType) ? [$rightType] : $rightType;
+            $intersection = array_values(array_filter(
+                $rightTypes,
+                static fn(mixed $type): bool => in_array($type, $leftTypes, true),
+            ));
+            if ($intersection !== $rightTypes) {
+                $merged['type'] = $intersection;
+            }
         }
         // `not` is an assertion like the bound keywords below: both sides
         // must keep holding after a merge — ¬A ∧ ¬B ⟺ ¬(anyOf [A, B]).
@@ -640,6 +574,123 @@ final class SchemaDataGenerator
         return [$base, $choices, false];
     }
 
+    /** @param array<string, mixed> $schema */
+    private static function generateNode(
+        array $schema,
+        ?Generator $faker,
+        int $iteration,
+        ?CaseSelectionPlan $plan,
+        string $pointer,
+    ): mixed {
+        if ($plan !== null && ($pinnedConditional = $plan->branchFor($pointer . '/allOf')) !== null) {
+            $resolved = self::resolveBranchChoice($schema, $iteration, $plan, $pointer);
+            [$base, $conditionals] = self::splitConditionals($resolved);
+            if ($conditionals !== []) {
+                [$base, $choices, $unsatisfiable] = self::partitionConditionals($base, $conditionals);
+                if (!$unsatisfiable && $choices !== []) {
+                    return self::generateConditionalNode(
+                        $resolved,
+                        $base,
+                        $choices,
+                        $pinnedConditional,
+                        $faker,
+                        $iteration,
+                        $plan,
+                        $pointer,
+                    );
+                }
+                // No genuine choice remains (all folded, or the node is
+                // unsatisfiable): fall through to the normal pipeline, which
+                // re-partitions identically.
+            }
+        }
+
+        $schema = self::resolveComposition($schema, $faker, $iteration, $plan, $pointer);
+
+        if (array_key_exists('const', $schema)) {
+            return $schema['const'];
+        }
+
+        if (isset($schema['enum']) && is_array($schema['enum']) && $schema['enum'] !== []) {
+            $values = array_values($schema['enum']);
+            if ($plan !== null && isset($schema['not']) && is_array($schema['not'])) {
+                // The enum domain is finite, so a `not` (e.g. suppressed
+                // discriminator values pushed down by conditionalSetView())
+                // is honoured by filtering the domain outright — complete
+                // and deterministic where iteration retries could miss the
+                // admissible tail of a long enum. An empty filter result
+                // means the exclusion genuinely closes the domain; fall
+                // through and let the self-check fail or drop the probe.
+                $admissible = array_values(array_filter(
+                    $values,
+                    static fn(mixed $value): bool => SchemaValueValidator::isValid($value, $schema),
+                ));
+                if ($admissible !== []) {
+                    return $admissible[$iteration % count($admissible)];
+                }
+            }
+
+            return $values[$iteration % count($values)];
+        }
+
+        if (is_array($schema['type'] ?? null) && in_array('null', $schema['type'], true)) {
+            $pinnedNull = $plan?->branchFor($pointer . '/type');
+            if ($plan !== null && $pinnedNull !== null && $plan->targetPointer === $pointer . '/type') {
+                $wantNull = $pinnedNull === SchemaChoicePoint::NULL_VALUE;
+                $plan->observation->expect($pointer, static fn(mixed $value): bool
+                    => ($value === null) === $wantNull);
+            }
+            $emitNull = $pinnedNull !== null
+                ? $pinnedNull === SchemaChoicePoint::NULL_VALUE
+                : ($iteration % 3) === 2;
+            if ($emitNull) {
+                return null;
+            }
+        }
+
+        if (isset($schema['not']) && is_array($schema['not'])) {
+            $withoutNot = $schema;
+            unset($withoutNot['not']);
+            $candidate = self::generateOne($withoutNot, $faker, $iteration, $plan, $pointer);
+            if (!SchemaValueValidator::isValid($candidate, $schema)) {
+                if ($plan !== null) {
+                    // The `not` often excludes exactly the rotation pick — a
+                    // suppressed discriminator value landing on this case's
+                    // iteration. Nearby iterations re-rotate enums and
+                    // scalars before giving up, so one unlucky index is not
+                    // read as "unsatisfiable". Plan-less rotation keeps the
+                    // historical single-shot behaviour and output.
+                    for ($offset = 1; $offset <= self::NOT_GENERATION_RETRIES; $offset++) {
+                        $retried = self::generateOne($withoutNot, $faker, $iteration + $offset, $plan, $pointer);
+                        if (SchemaValueValidator::isValid($retried, $schema)) {
+                            return $retried;
+                        }
+                    }
+                }
+                foreach ([null, false, 0, 1, '', 'value', [], ['value' => true]] as $alternative) {
+                    if (SchemaValueValidator::isValid($alternative, $schema)) {
+                        return $alternative;
+                    }
+                }
+            }
+
+            return $candidate;
+        }
+
+        $type = self::resolveType($schema);
+
+        return match ($type) {
+            'object' => self::generateObject($schema, $faker, $iteration, $plan, $pointer),
+            'array' => self::generateArray($schema, $faker, $iteration, $plan, $pointer),
+            'string' => self::generateString($schema, $faker, $iteration),
+            'integer' => self::generateInteger($schema, $faker, $iteration),
+            'number' => self::generateNumber($schema, $faker, $iteration),
+            'boolean' => self::generateBoolean($iteration),
+            'null' => null,
+            default => null,
+        };
+    }
+
     /**
      * Fold the suppressed side of one conditional into a schema: its else
      * applies and its if must fail — negated at the property itself for the
@@ -719,6 +770,7 @@ final class SchemaDataGenerator
         }
 
         $result = [];
+        $presenceTarget = null;
         foreach ($properties as $name => $propSchema) {
             if (!is_string($name)) {
                 continue;
@@ -732,6 +784,12 @@ final class SchemaDataGenerator
             }
 
             $childPointer = $pointer . '/properties/' . SchemaChoicePointEnumerator::escapePointerSegment($name);
+            if ($plan !== null && $plan->targetPointer === $childPointer) {
+                // A presence target is decided by this object's final shape
+                // — the maxProperties trim may still remove the property —
+                // so it is reported once composition below has settled.
+                $presenceTarget = $name;
+            }
             $isRequired = in_array($name, $required, true);
             // Optional properties alternate inclusion across cases so the
             // suite exercises both "required-only" and "required+optional"
@@ -813,6 +871,12 @@ final class SchemaDataGenerator
                     unset($result[$name]);
                 }
             }
+        }
+        if ($presenceTarget !== null && $plan !== null) {
+            $present = array_key_exists($presenceTarget, $result);
+            $plan->observation->report(
+                $plan->targetBranch === SchemaChoicePoint::OMITTED ? !$present : $present,
+            );
         }
         if ($result === []) {
             if ($maxProperties === 0 || ($schema['additionalProperties'] ?? true) === false) {
@@ -1301,6 +1365,14 @@ final class SchemaDataGenerator
                 if ($sides !== []) {
                     $pinned = $plan->branchFor($pointer . '/if');
                     $side = $sides[($pinned ?? $iteration) % count($sides)];
+                    if ($plan->targetPointer === $pointer . '/if' && $pinned !== null) {
+                        // An else-targeted value that fires the `if` anyway
+                        // passes the whole schema through the then side; only
+                        // the condition itself tells the sides apart.
+                        $condition = $schema['if'];
+                        $plan->observation->expect($pointer, static fn(mixed $value): bool
+                            => SchemaValueValidator::isValid($value, $condition) === ($side === 0));
+                    }
                     $schema = self::applyIfSide($schema, $side);
                 }
             } else {
@@ -1359,6 +1431,14 @@ final class SchemaDataGenerator
             unset($schema[$keyword]);
             $pinned = $plan->branchFor($pointer . '/' . $keyword);
             $selected = $enumerable[($pinned ?? $iteration) % count($enumerable)];
+            if ($plan->targetPointer === $pointer . '/' . $keyword && $pinned !== null) {
+                // Whole-schema validity cannot tell this branch from a
+                // sibling that also matches; the case counts as covering
+                // the target only if the value satisfies the branch itself.
+                $branch = $branches[$selected];
+                $plan->observation->expect($pointer, static fn(mixed $value): bool
+                    => $branch === true || (is_array($branch) && SchemaValueValidator::isValid($value, $branch)));
+            }
             $schema = self::applyCompositionBranch($schema, $branches, $selected, $keyword);
             break;
         }
@@ -1427,6 +1507,26 @@ final class SchemaDataGenerator
         $count = count($conditionals);
         $branch = $pinned % ($count + 1);
         $satisfied = $branch < $count ? [$branch] : [];
+
+        if ($plan->targetPointer === $pointer . '/allOf') {
+            // Branch c is covered only if its `if` actually fires on the
+            // value; the none-match state only if no choice `if` does. A
+            // value can pass the whole node either way (e.g. a node const
+            // that satisfies a suppressed condition), so the state must be
+            // checked against the conditions themselves.
+            $plan->observation->expect($pointer, static function (mixed $value) use ($conditionals, $branch, $count): bool {
+                if ($branch < $count) {
+                    return SchemaValueValidator::isValid($value, $conditionals[$branch]['if']);
+                }
+                foreach ($conditionals as $conditional) {
+                    if (SchemaValueValidator::isValid($value, $conditional['if'])) {
+                        return false;
+                    }
+                }
+
+                return true;
+            });
+        }
 
         $value = null;
         for ($attempt = 0; $attempt <= $count; $attempt++) {

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -373,16 +373,18 @@ final class SchemaDataGenerator
                 $schema = self::mergeSchemas($schema, $conditional['else']);
             }
         }
+        // mergeSchemas() combines `not` assertions conjunctively, so any
+        // exclusion the target already carries — from the base schema or an
+        // earlier else merge — survives these merges.
         foreach ($negatedByProperty as $property => $negated) {
-            $existing = is_array($schema['properties'] ?? null) && is_array($schema['properties'][$property] ?? null)
-                ? ($schema['properties'][$property]['not'] ?? null)
-                : null;
             $schema = self::mergeSchemas($schema, ['properties' => [
-                $property => ['not' => self::negation($existing, $negated)],
+                $property => ['not' => count($negated) === 1 ? $negated[0] : ['anyOf' => $negated]],
             ]]);
         }
         if ($suppressedIfs !== []) {
-            $schema = self::mergeSchemas($schema, ['not' => self::negation($schema['not'] ?? null, $suppressedIfs)]);
+            $schema = self::mergeSchemas($schema, [
+                'not' => count($suppressedIfs) === 1 ? $suppressedIfs[0] : ['anyOf' => $suppressedIfs],
+            ]);
         }
 
         return $schema;
@@ -414,6 +416,13 @@ final class SchemaDataGenerator
                 is_array($left['required'] ?? null) ? $left['required'] : [],
                 is_array($right['required'] ?? null) ? $right['required'] : [],
             )));
+        }
+        // `not` is an assertion like the bound keywords below: both sides
+        // must keep holding after a merge — ¬A ∧ ¬B ⟺ ¬(anyOf [A, B]).
+        // Plain array_merge would let the right side displace the left and
+        // silently widen the admissible domain.
+        if (is_array($left['not'] ?? null) && is_array($right['not'] ?? null) && $left['not'] !== $right['not']) {
+            $merged['not'] = ['anyOf' => [$left['not'], $right['not']]];
         }
         if (isset($left['minimum'], $right['minimum'])) {
             $merged['minimum'] = max($left['minimum'], $right['minimum']);
@@ -449,27 +458,6 @@ final class SchemaDataGenerator
         }
 
         return $merged;
-    }
-
-    /**
-     * Build a `not` value that adds the synthesized exclusions to whatever
-     * exclusion already sits on the target: `¬A ∧ ¬B ⟺ ¬(anyOf [A, B])`.
-     * Merging would overwrite the pre-existing `not` and silently widen the
-     * admissible domain.
-     *
-     * @param list<mixed> $disjuncts
-     *
-     * @return array<string, mixed>
-     */
-    private static function negation(mixed $existingNot, array $disjuncts): array
-    {
-        if ($existingNot !== null) {
-            $disjuncts = [$existingNot, ...$disjuncts];
-        }
-
-        return count($disjuncts) === 1 && is_array($disjuncts[0])
-            ? $disjuncts[0]
-            : ['anyOf' => $disjuncts];
     }
 
     /**

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -135,8 +135,9 @@ final class SchemaDataGenerator
         int $iteration,
         ?CaseSelectionPlan $plan = null,
         string $pointer = '',
+        bool $forced = true,
     ): mixed {
-        $value = self::generateNode($schema, $faker, $iteration, $plan, $pointer);
+        $value = self::generateNode($schema, $faker, $iteration, $plan, $pointer, $forced);
         // The site that applied the plan's target registered its
         // branch-level check while this node resolved; the value exists
         // only now. Nested regenerations at the same pointer evaluated
@@ -348,6 +349,23 @@ final class SchemaDataGenerator
                 $right['enum'],
                 static fn(mixed $value): bool => SchemaValueValidator::isValid($value, $leftEnum),
             ));
+        }
+        // A `const` conflicting with the other side's `const` or `enum` is a
+        // static proof the conjunction admits no value; the empty-enum
+        // marker lets planned generation treat the dead end as proven. The
+        // marker is inert on the plan-less path: `const` is generated first
+        // and an empty `enum` is never consulted.
+        $leftConst = array_key_exists('const', $left);
+        $rightConst = array_key_exists('const', $right);
+        if ($leftConst && $rightConst &&
+            !SchemaValueValidator::isValid($left['const'], ['const' => $right['const']])) {
+            $merged['enum'] = [];
+        } elseif ($leftConst && is_array($right['enum'] ?? null) && $right['enum'] !== [] &&
+            !SchemaValueValidator::isValid($left['const'], ['enum' => $right['enum']])) {
+            $merged['enum'] = [];
+        } elseif ($rightConst && is_array($left['enum'] ?? null) && $left['enum'] !== [] &&
+            !SchemaValueValidator::isValid($right['const'], ['enum' => $left['enum']])) {
+            $merged['enum'] = [];
         }
         $leftType = $left['type'] ?? null;
         $rightType = $right['type'] ?? null;
@@ -586,16 +604,28 @@ final class SchemaDataGenerator
         return [$base, $choices, false];
     }
 
-    /** @param array<string, mixed> $schema */
+    /**
+     * `$forced` tracks whether every choice on the path from the root to
+     * this node was pinned by the plan or admitted no alternative — i.e.
+     * whether this node's constraints are unavoidable for any value of the
+     * whole case. A statically empty value domain found at a forced node is
+     * a schema-derived proof the pinned view admits no value at all
+     * (recorded via {@see PinnedBranchObservation::proveDeadEnd()}); the
+     * same emptiness under an unpinned rotation proves nothing, because a
+     * different rotation pick may avoid the node entirely.
+     *
+     * @param array<string, mixed> $schema
+     */
     private static function generateNode(
         array $schema,
         ?Generator $faker,
         int $iteration,
         ?CaseSelectionPlan $plan,
         string $pointer,
+        bool $forced,
     ): mixed {
         if ($plan !== null && ($pinnedConditional = $plan->branchFor($pointer . '/allOf')) !== null) {
-            $resolved = self::resolveBranchChoice($schema, $iteration, $plan, $pointer);
+            $resolved = self::resolveBranchChoice($schema, $iteration, $plan, $pointer, $forced);
             [$base, $conditionals] = self::splitConditionals($resolved);
             if ($conditionals !== []) {
                 [$base, $choices, $unsatisfiable] = self::partitionConditionals($base, $conditionals);
@@ -609,6 +639,7 @@ final class SchemaDataGenerator
                         $iteration,
                         $plan,
                         $pointer,
+                        $forced,
                     );
                 }
                 // No genuine choice remains (all folded, or the node is
@@ -617,46 +648,60 @@ final class SchemaDataGenerator
             }
         }
 
-        $schema = self::resolveComposition($schema, $faker, $iteration, $plan, $pointer);
-
-        if (array_key_exists('const', $schema)) {
-            return $schema['const'];
-        }
+        $schema = self::resolveComposition($schema, $faker, $iteration, $plan, $pointer, $forced);
 
         if ($plan !== null &&
             (($schema['enum'] ?? null) === [] || ($schema['type'] ?? null) === [] || ($schema['not'] ?? null) === true)) {
-            // A statically empty domain — an enum/type intersection emptied
-            // by mergeSchemas(), or an absorbing `not` — admits no value.
-            // Return a deterministic sentinel so the target search sees the
-            // identical outcome on every attempt and classifies the dead
-            // end as proven, instead of chasing varying garbage; untargeted
-            // cases still fail the loud self-check.
+            // A statically empty domain — an enum/type intersection or a
+            // const conflict emptied by mergeSchemas(), or an absorbing
+            // `not` — admits no value. This precedes the const shortcut:
+            // the conflict marker outranks whichever const survived the
+            // merge. At a forced node this is a schema-derived proof the
+            // pinned view is unsatisfiable; the deterministic sentinel
+            // keeps untargeted cases failing the loud self-check.
+            if ($forced) {
+                $plan->observation->proveDeadEnd();
+            }
+
             return null;
+        }
+
+        if (array_key_exists('const', $schema)) {
+            if ($plan !== null && $forced && !SchemaValueValidator::isValid($schema['const'], $schema)) {
+                // The node's domain is the single const value; if even that
+                // value violates the node's own view (a suppression `not`,
+                // an exclusivity constraint), the finite domain is
+                // exhausted — a static proof, not a failed sample.
+                $plan->observation->proveDeadEnd();
+            }
+
+            return $schema['const'];
         }
 
         if (isset($schema['enum']) && is_array($schema['enum']) && $schema['enum'] !== []) {
             $values = array_values($schema['enum']);
-            if ($plan !== null && isset($schema['not']) && is_array($schema['not'])) {
-                // The enum domain is finite, so a `not` (e.g. suppressed
-                // discriminator values pushed down by conditionalSetView())
-                // is honoured by filtering the domain outright — complete
-                // and deterministic where iteration retries could miss the
-                // admissible tail of a long enum. An empty filter result
-                // means the exclusion genuinely closes the domain; fall
-                // through and let the self-check fail or drop the probe.
+            if ($plan !== null) {
+                // The enum domain is finite, so admissibility against the
+                // node view (including any `not` pushed down by suppression)
+                // is decidable outright — complete and deterministic where
+                // iteration retries could miss the admissible tail of a
+                // long enum.
                 $admissible = array_values(array_filter(
                     $values,
                     static fn(mixed $value): bool => SchemaValueValidator::isValid($value, $schema),
                 ));
-                if ($admissible !== []) {
+                if ($admissible === []) {
+                    // The finite domain is provably exhausted; the
+                    // deterministic pick keeps untargeted cases loud.
+                    if ($forced) {
+                        $plan->observation->proveDeadEnd();
+                    }
+
+                    return $values[0];
+                }
+                if (isset($schema['not']) && is_array($schema['not'])) {
                     return $admissible[$iteration % count($admissible)];
                 }
-
-                // The exclusion provably closes the finite domain: no
-                // rotation can escape it. Pick deterministically so the
-                // target search classifies the dead end as proven rather
-                // than reading iteration-rotated picks as an open search.
-                return $values[0];
             }
 
             return $values[$iteration % count($values)];
@@ -675,12 +720,17 @@ final class SchemaDataGenerator
             if ($emitNull) {
                 return null;
             }
+            if ($plan !== null && $pinnedNull === null) {
+                // Rotation chose the non-null side; null remains a way to
+                // satisfy this node, so nothing below can prove a dead end.
+                $forced = false;
+            }
         }
 
         if (isset($schema['not']) && is_array($schema['not'])) {
             $withoutNot = $schema;
             unset($withoutNot['not']);
-            $candidate = self::generateOne($withoutNot, $faker, $iteration, $plan, $pointer);
+            $candidate = self::generateOne($withoutNot, $faker, $iteration, $plan, $pointer, $forced);
             if (!SchemaValueValidator::isValid($candidate, $schema)) {
                 if ($plan !== null) {
                     // The `not` often excludes exactly the rotation pick — a
@@ -690,7 +740,7 @@ final class SchemaDataGenerator
                     // read as "unsatisfiable". Plan-less rotation keeps the
                     // historical single-shot behaviour and output.
                     for ($offset = 1; $offset <= self::NOT_GENERATION_RETRIES; $offset++) {
-                        $retried = self::generateOne($withoutNot, $faker, $iteration + $offset, $plan, $pointer);
+                        $retried = self::generateOne($withoutNot, $faker, $iteration + $offset, $plan, $pointer, $forced);
                         if (SchemaValueValidator::isValid($retried, $schema)) {
                             return $retried;
                         }
@@ -709,8 +759,8 @@ final class SchemaDataGenerator
         $type = self::resolveType($schema);
 
         return match ($type) {
-            'object' => self::generateObject($schema, $faker, $iteration, $plan, $pointer),
-            'array' => self::generateArray($schema, $faker, $iteration, $plan, $pointer),
+            'object' => self::generateObject($schema, $faker, $iteration, $plan, $pointer, $forced),
+            'array' => self::generateArray($schema, $faker, $iteration, $plan, $pointer, $forced),
             'string' => self::generateString($schema, $faker, $iteration),
             'integer' => self::generateInteger($schema, $faker, $iteration),
             'number' => self::generateNumber($schema, $faker, $iteration),
@@ -783,6 +833,7 @@ final class SchemaDataGenerator
         int $iteration,
         ?CaseSelectionPlan $plan = null,
         string $pointer = '',
+        bool $forced = true,
     ): array|stdClass {
         $properties = $schema['properties'] ?? [];
         if (!is_array($properties)) {
@@ -820,6 +871,7 @@ final class SchemaDataGenerator
                 $presenceTarget = $name;
             }
             $isRequired = in_array($name, $required, true);
+            $pinnedPresence = null;
             // Optional properties alternate inclusion across cases so the
             // suite exercises both "required-only" and "required+optional"
             // shapes — mirrors Schemathesis' explore-omit toggle on a small
@@ -841,6 +893,9 @@ final class SchemaDataGenerator
                 $iteration,
                 $plan,
                 $childPointer,
+                // A rotation-included optional property is avoidable by
+                // omission, so its subtree can prove nothing.
+                $forced && ($isRequired || $pinnedPresence === SchemaChoicePoint::PRESENT),
             );
         }
 
@@ -859,6 +914,7 @@ final class SchemaDataGenerator
                     $iteration + count($result),
                     $plan,
                     $pointer . '/additionalProperties',
+                    false,
                 );
             }
         }
@@ -877,6 +933,7 @@ final class SchemaDataGenerator
                     $iteration + count($result),
                     $plan,
                     $pointer . '/additionalProperties',
+                    false,
                 );
             }
         }
@@ -906,6 +963,34 @@ final class SchemaDataGenerator
             $plan->observation->report(
                 $plan->targetBranch === SchemaChoicePoint::OMITTED ? !$present : $present,
             );
+            if ($forced) {
+                // Static presence arithmetic — schema-derived proofs that
+                // the pinned state is impossible, independent of what was
+                // generated. The merged view unions `properties` and
+                // `required` and maximises `minProperties`, so both counts
+                // only over-approximate what the real conjunction admits.
+                $includableOthers = 0;
+                foreach ($properties as $name => $propSchema) {
+                    if (is_string($name) && $name !== $presenceTarget && $propSchema !== false) {
+                        $includableOthers++;
+                    }
+                }
+                if ($plan->targetBranch === SchemaChoicePoint::OMITTED) {
+                    // Without the target property, at most the other named
+                    // properties can exist when additionalProperties is
+                    // false; fewer than minProperties means omission can
+                    // never satisfy the object.
+                    if (($schema['additionalProperties'] ?? true) === false && $includableOthers < $minProperties) {
+                        $plan->observation->proveDeadEnd();
+                    }
+                } elseif ($maxProperties !== null &&
+                    !in_array($presenceTarget, $required, true) &&
+                    count($required) + 1 > $maxProperties) {
+                    // Every valid object carries all required properties;
+                    // adding the target on top provably exceeds the budget.
+                    $plan->observation->proveDeadEnd();
+                }
+            }
         }
         if ($result === []) {
             if ($maxProperties === 0 || ($schema['additionalProperties'] ?? true) === false) {
@@ -928,7 +1013,13 @@ final class SchemaDataGenerator
         int $iteration,
         ?CaseSelectionPlan $plan = null,
         string $pointer = '',
+        bool $forced = true,
     ): array {
+        // Item subtrees never prove dead ends ($forced is deliberately not
+        // forwarded below): element count and content interact with
+        // minItems/maxItems/uniqueItems in ways the proof sites do not
+        // model, so stay conservative and loud.
+        unset($forced);
         // A pinned plan entry at `<pointer>/items` is a forced minimum size:
         // it makes items reachable in the pinned case (mirroring how optional
         // ancestors are forced present) without becoming a rotation strategy.
@@ -971,7 +1062,7 @@ final class SchemaDataGenerator
                     ? $pointer . '/prefixItems/' . $index
                     : $pointer . '/items';
                 if (is_array($item)) {
-                    $result[] = self::generateOne($item, $faker, $iteration + $index, $plan, $itemPointer);
+                    $result[] = self::generateOne($item, $faker, $iteration + $index, $plan, $itemPointer, false);
                 } else {
                     $result[] = 'item-' . $index;
                 }
@@ -1008,12 +1099,12 @@ final class SchemaDataGenerator
         $itemPointer = $pointer . '/items';
         $result = [];
         for ($i = 0; $i < $size; $i++) {
-            $item = self::generateOne($items, $faker, $iteration + $i, $plan, $itemPointer);
+            $item = self::generateOne($items, $faker, $iteration + $i, $plan, $itemPointer, false);
             if (($schema['uniqueItems'] ?? false) === true) {
                 $attempt = 0;
                 while (in_array($item, $result, true) && $attempt < 100) {
                     $attempt++;
-                    $item = self::generateOne($items, $faker, $iteration + $i + $attempt, $plan, $itemPointer);
+                    $item = self::generateOne($items, $faker, $iteration + $i + $attempt, $plan, $itemPointer, false);
                 }
             }
             $result[] = $item;
@@ -1349,8 +1440,9 @@ final class SchemaDataGenerator
         int $iteration,
         ?CaseSelectionPlan $plan = null,
         string $pointer = '',
+        bool &$forced = true,
     ): array {
-        $schema = self::resolveBranchChoice($schema, $iteration, $plan, $pointer);
+        $schema = self::resolveBranchChoice($schema, $iteration, $plan, $pointer, $forced);
 
         if (isset($schema['allOf']) && is_array($schema['allOf'])) {
             [$schema, $conditionals] = self::splitConditionals($schema);
@@ -1373,6 +1465,10 @@ final class SchemaDataGenerator
                 if (isset($selected['then']) && is_array($selected['then'])) {
                     $schema = self::mergeSchemas($schema, $selected['then']);
                 }
+                // An unpinned conditional state is a choice: another
+                // rotation may satisfy a different conditional (or none),
+                // so nothing merged here can prove a dead end.
+                $forced = false;
             }
         }
 
@@ -1394,6 +1490,11 @@ final class SchemaDataGenerator
                 if ($sides !== []) {
                     $pinned = $plan->branchFor($pointer . '/if');
                     $side = $sides[($pinned ?? $iteration) % count($sides)];
+                    if ($pinned === null && count($sides) > 1) {
+                        // An unpinned side is a choice; the other side may
+                        // avoid whatever this merge makes unsatisfiable.
+                        $forced = false;
+                    }
                     if ($plan->targetPointer === $pointer . '/if' && $pinned !== null) {
                         // An else-targeted value that fires the `if` anyway
                         // passes the whole schema through the then side; only
@@ -1448,6 +1549,7 @@ final class SchemaDataGenerator
         int $iteration,
         ?CaseSelectionPlan $plan,
         string $pointer,
+        bool &$forced = true,
     ): array {
         foreach (['oneOf', 'anyOf'] as $keyword) {
             if (!isset($schema[$keyword]) || !is_array($schema[$keyword]) || $schema[$keyword] === []) {
@@ -1473,6 +1575,11 @@ final class SchemaDataGenerator
             unset($schema[$keyword]);
             $pinned = $plan->branchFor($pointer . '/' . $keyword);
             $selected = $enumerable[($pinned ?? $iteration) % count($enumerable)];
+            if ($pinned === null && count($enumerable) > 1) {
+                // An unpinned branch pick is a choice; emptiness under this
+                // branch says nothing about its siblings.
+                $forced = false;
+            }
             if ($plan->targetPointer === $pointer . '/' . $keyword && $pinned !== null) {
                 // Whole-schema validity cannot tell this branch from a
                 // sibling that also matches; the case counts as covering
@@ -1548,6 +1655,7 @@ final class SchemaDataGenerator
         int $iteration,
         CaseSelectionPlan $plan,
         string $pointer,
+        bool $forced,
     ): mixed {
         $count = count($conditionals);
         $branch = $pinned % ($count + 1);
@@ -1576,7 +1684,10 @@ final class SchemaDataGenerator
         $value = null;
         for ($attempt = 0; $attempt <= $count; $attempt++) {
             $view = self::conditionalSetView($base, $conditionals, $satisfied);
-            $value = self::generateOne($view, $faker, $iteration, $plan, $pointer);
+            // Only the pinned starting view is forced: closure expansion is
+            // driven by the generated value, so an expanded satisfied set is
+            // one of several reachable states and proves nothing.
+            $value = self::generateOne($view, $faker, $iteration, $plan, $pointer, $forced && $attempt === 0);
             if ($branch === $count || SchemaValueValidator::isValid($value, $node)) {
                 return $value;
             }

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -72,6 +72,16 @@ final class SchemaDataGenerator
     private const MAX_SYNTHESIZED_PATTERN_LENGTH = 10_000;
 
     /**
+     * How many nearby iterations planned `not` generation probes before
+     * falling back to scalar alternatives. Bounds the search that keeps a
+     * rotation-misaligned enum (e.g. the excluded discriminator value) from
+     * being mistaken for an unsatisfiable constraint; deliberately larger
+     * than the 2/3-cycle rotation periods so every scalar rotation state is
+     * revisited.
+     */
+    private const NOT_GENERATION_RETRIES = 8;
+
+    /**
      * Per-process record of formats already announced as "faker missing".
      * Keyed by format name; we only warn once per format to avoid spamming
      * a long fuzz run that touches many `email` properties.
@@ -124,6 +134,23 @@ final class SchemaDataGenerator
         ?CaseSelectionPlan $plan = null,
         string $pointer = '',
     ): mixed {
+        if ($plan !== null && ($pinnedConditional = $plan->branchFor($pointer . '/allOf')) !== null) {
+            $resolved = self::resolveBranchChoice($schema, $iteration, $plan, $pointer);
+            [$base, $conditionals] = self::splitConditionals($resolved);
+            if ($conditionals !== []) {
+                return self::generateConditionalNode(
+                    $resolved,
+                    $base,
+                    $conditionals,
+                    $pinnedConditional,
+                    $faker,
+                    $iteration,
+                    $plan,
+                    $pointer,
+                );
+            }
+        }
+
         $schema = self::resolveComposition($schema, $faker, $iteration, $plan, $pointer);
 
         if (array_key_exists('const', $schema)) {
@@ -151,6 +178,20 @@ final class SchemaDataGenerator
             unset($withoutNot['not']);
             $candidate = self::generateOne($withoutNot, $faker, $iteration, $plan, $pointer);
             if (!SchemaValueValidator::isValid($candidate, $schema)) {
+                if ($plan !== null) {
+                    // The `not` often excludes exactly the rotation pick — a
+                    // suppressed discriminator value landing on this case's
+                    // iteration. Nearby iterations re-rotate enums and
+                    // scalars before giving up, so one unlucky index is not
+                    // read as "unsatisfiable". Plan-less rotation keeps the
+                    // historical single-shot behaviour and output.
+                    for ($offset = 1; $offset <= self::NOT_GENERATION_RETRIES; $offset++) {
+                        $retried = self::generateOne($withoutNot, $faker, $iteration + $offset, $plan, $pointer);
+                        if (SchemaValueValidator::isValid($retried, $schema)) {
+                            return $retried;
+                        }
+                    }
+                }
                 foreach ([null, false, 0, 1, '', 'value', [], ['value' => true]] as $alternative) {
                     if (SchemaValueValidator::isValid($alternative, $schema)) {
                         return $alternative;
@@ -251,15 +292,14 @@ final class SchemaDataGenerator
     }
 
     /**
-     * Materialise one branch of the conditional-`allOf` choice space.
-     *
-     * Branches `0..n-1` satisfy that conditional's `if`+`then` while
-     * suppressing every other conditional — their `if`s are excluded through
-     * a single synthesized `not`/`anyOf` and their `else`s applied — so the
-     * generated value satisfies the complete schema rather than just the
-     * selected slice. Branch `n` is the none-match state: no `if` holds and
-     * every `else` applies. Public within the internal fuzz family so
-     * {@see SchemaChoicePointEnumerator} descends exactly these views.
+     * Materialise the starting view of one branch of the conditional-`allOf`
+     * choice space: branches `0..n-1` satisfy that conditional's `if`+`then`,
+     * branch `n` is the none-match state where no `if` holds and every
+     * `else` applies. Generation may grow the satisfied set beyond this
+     * starting point when suppressed conditionals fire anyway — see
+     * {@see self::generateConditionalNode()}. Public within the internal
+     * fuzz family so {@see SchemaChoicePointEnumerator} descends exactly
+     * these views.
      *
      * @param array<string, mixed> $schema node with `allOf` removed and its non-conditional branches merged
      * @param list<array<string, mixed>> $conditionals
@@ -268,8 +308,27 @@ final class SchemaDataGenerator
      */
     public static function conditionalBranchView(array $schema, array $conditionals, int $branch): array
     {
-        if ($branch < count($conditionals)) {
-            $selected = $conditionals[$branch];
+        return self::conditionalSetView($schema, $conditionals, $branch < count($conditionals) ? [$branch] : []);
+    }
+
+    /**
+     * Materialise the conditional-`allOf` state where exactly the
+     * conditionals in `$satisfied` hold: their `if`+`then` merged, every
+     * other conditional suppressed through a single synthesized `not`/`anyOf`
+     * with its `else` applied. {@see self::generateConditionalNode()} starts
+     * from a singleton (or empty) set and grows it when a suppressed `if`
+     * turns out to fire anyway, so overlapping conditionals stay satisfiable.
+     *
+     * @param array<string, mixed> $schema node with `allOf` removed and its non-conditional branches merged
+     * @param list<array<string, mixed>> $conditionals
+     * @param list<int> $satisfied
+     *
+     * @return array<string, mixed>
+     */
+    public static function conditionalSetView(array $schema, array $conditionals, array $satisfied): array
+    {
+        foreach ($satisfied as $index) {
+            $selected = $conditionals[$index];
             $schema = self::mergeSchemas($schema, $selected['if']);
             if (isset($selected['then']) && is_array($selected['then'])) {
                 $schema = self::mergeSchemas($schema, $selected['then']);
@@ -278,7 +337,7 @@ final class SchemaDataGenerator
 
         $suppressedIfs = [];
         foreach ($conditionals as $index => $conditional) {
-            if ($index === $branch) {
+            if (in_array($index, $satisfied, true)) {
                 continue;
             }
             $suppressedIfs[] = $conditional['if'];
@@ -890,50 +949,19 @@ final class SchemaDataGenerator
         ?CaseSelectionPlan $plan = null,
         string $pointer = '',
     ): array {
-        foreach (['oneOf', 'anyOf'] as $keyword) {
-            if (!isset($schema[$keyword]) || !is_array($schema[$keyword]) || $schema[$keyword] === []) {
-                continue;
-            }
-            $branches = array_values(array_filter($schema[$keyword], is_array(...)));
-            if ($branches === []) {
-                continue;
-            }
-            unset($schema[$keyword]);
-            $pinned = $plan?->branchFor($pointer . '/' . $keyword);
-            $index = ($pinned ?? $iteration) % count($branches);
-            $schema = self::mergeSchemas($schema, $branches[$index]);
-            break;
-        }
+        $schema = self::resolveBranchChoice($schema, $iteration, $plan, $pointer);
 
         if (isset($schema['allOf']) && is_array($schema['allOf'])) {
-            $branches = $schema['allOf'];
-            unset($schema['allOf']);
-            $conditionals = [];
-            foreach ($branches as $branch) {
-                if (!is_array($branch)) {
-                    continue;
-                }
-                if (isset($branch['if']) && is_array($branch['if'])) {
-                    $conditionals[] = $branch;
-                } else {
-                    $schema = self::mergeSchemas($schema, $branch);
-                }
-            }
+            [$schema, $conditionals] = self::splitConditionals($schema);
             if ($conditionals !== []) {
-                // Rotation only ever satisfies a conditional's `if`+`then`.
-                // Pinned plans use the conditionalBranchView() branch space
-                // instead, which suppresses the unselected conditionals so
-                // the value satisfies the complete schema, and adds a
-                // trailing none-match branch.
-                $pinned = $plan?->branchFor($pointer . '/allOf');
-                if ($pinned !== null) {
-                    $schema = self::conditionalBranchView($schema, $conditionals, $pinned % (count($conditionals) + 1));
-                } else {
-                    $selected = $conditionals[$iteration % count($conditionals)];
-                    $schema = self::mergeSchemas($schema, $selected['if']);
-                    if (isset($selected['then']) && is_array($selected['then'])) {
-                        $schema = self::mergeSchemas($schema, $selected['then']);
-                    }
+                // Rotation only ever satisfies a conditional's `if`+`then`;
+                // pinned conditional branches never reach this point — they
+                // are resolved by generateConditionalNode() before the
+                // composition phases run.
+                $selected = $conditionals[$iteration % count($conditionals)];
+                $schema = self::mergeSchemas($schema, $selected['if']);
+                if (isset($selected['then']) && is_array($selected['then'])) {
+                    $schema = self::mergeSchemas($schema, $selected['then']);
                 }
             }
         }
@@ -952,6 +980,126 @@ final class SchemaDataGenerator
         }
 
         return $schema;
+    }
+
+    /**
+     * Resolve the first `oneOf`/`anyOf` on the node — composition phase one.
+     * Idempotent: the resolved keyword is consumed, so a second call is a
+     * no-op, which lets the pinned-conditional path pre-resolve it before
+     * splitting conditionals out of `allOf`.
+     *
+     * @param array<string, mixed> $schema
+     *
+     * @return array<string, mixed>
+     */
+    private static function resolveBranchChoice(
+        array $schema,
+        int $iteration,
+        ?CaseSelectionPlan $plan,
+        string $pointer,
+    ): array {
+        foreach (['oneOf', 'anyOf'] as $keyword) {
+            if (!isset($schema[$keyword]) || !is_array($schema[$keyword]) || $schema[$keyword] === []) {
+                continue;
+            }
+            $branches = array_values(array_filter($schema[$keyword], is_array(...)));
+            if ($branches === []) {
+                continue;
+            }
+            unset($schema[$keyword]);
+            $pinned = $plan?->branchFor($pointer . '/' . $keyword);
+            $index = ($pinned ?? $iteration) % count($branches);
+            $schema = self::mergeSchemas($schema, $branches[$index]);
+            break;
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Split a node's `allOf` into the node with every non-conditional branch
+     * merged in, and the list of conditional (`if`-carrying) branches —
+     * mirrored by the enumerator's traversal.
+     *
+     * @param array<string, mixed> $schema
+     *
+     * @return array{array<string, mixed>, list<array<string, mixed>>}
+     */
+    private static function splitConditionals(array $schema): array
+    {
+        if (!isset($schema['allOf']) || !is_array($schema['allOf'])) {
+            return [$schema, []];
+        }
+
+        $base = $schema;
+        unset($base['allOf']);
+        $conditionals = [];
+        foreach ($schema['allOf'] as $branch) {
+            if (!is_array($branch)) {
+                continue;
+            }
+            if (isset($branch['if']) && is_array($branch['if'])) {
+                $conditionals[] = $branch;
+            } else {
+                $base = self::mergeSchemas($base, $branch);
+            }
+        }
+
+        return [$base, $conditionals];
+    }
+
+    /**
+     * Generate a node whose conditional-`allOf` choice is pinned by the plan.
+     *
+     * Starts from the pinned branch's view — the selected conditional (or
+     * none) satisfied, all others suppressed — and validates the produced
+     * value against the complete node schema. Suppression is a starting
+     * point, not an assumption of exclusivity: when a suppressed `if` fires
+     * on the value anyway (overlapping conditionals), that conditional joins
+     * the satisfied set and the node regenerates, up to once per
+     * conditional. The none-match branch never grows the set — reaching a
+     * state where no `if` fires is exactly its target.
+     *
+     * @param array<string, mixed> $node phase-one-resolved node, conditionals still in `allOf`
+     * @param array<string, mixed> $base node with `allOf` removed and non-conditional branches merged
+     * @param list<array<string, mixed>> $conditionals
+     */
+    private static function generateConditionalNode(
+        array $node,
+        array $base,
+        array $conditionals,
+        int $pinned,
+        ?Generator $faker,
+        int $iteration,
+        CaseSelectionPlan $plan,
+        string $pointer,
+    ): mixed {
+        $count = count($conditionals);
+        $branch = $pinned % ($count + 1);
+        $satisfied = $branch < $count ? [$branch] : [];
+
+        $value = null;
+        for ($attempt = 0; $attempt <= $count; $attempt++) {
+            $view = self::conditionalSetView($base, $conditionals, $satisfied);
+            $value = self::generateOne($view, $faker, $iteration, $plan, $pointer);
+            if ($branch === $count || SchemaValueValidator::isValid($value, $node)) {
+                return $value;
+            }
+
+            $fired = false;
+            foreach ($conditionals as $index => $conditional) {
+                if (!in_array($index, $satisfied, true) &&
+                    SchemaValueValidator::isValid($value, $conditional['if'])) {
+                    $satisfied[] = $index;
+                    $fired = true;
+                }
+            }
+            if (!$fired) {
+                break;
+            }
+        }
+
+        return $value;
     }
 
     /**

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -37,6 +37,7 @@ use function max;
 use function min;
 use function preg_match;
 use function preg_match_all;
+use function preg_quote;
 use function round;
 use function sprintf;
 use function str_ends_with;
@@ -918,6 +919,39 @@ final class SchemaDataGenerator
                 );
             }
         }
+        if ($plan !== null && count($result) < $minProperties && ($schema['additionalProperties'] ?? true) === false) {
+            // `additionalProperties: false` only forbids names that neither
+            // `properties` nor `patternProperties` evaluates (JSON Schema
+            // 2020-12 §10.3.2.3), so a minProperties shortfall on a closed
+            // object can still be met with pattern-matched names. Plan-only:
+            // plan-less rotation output is frozen.
+            $patternProperties = $schema['patternProperties'] ?? null;
+            if (is_array($patternProperties)) {
+                foreach ($patternProperties as $patternKey => $patternSchema) {
+                    if (count($result) >= $minProperties) {
+                        break;
+                    }
+                    if (!is_string($patternKey) || (!is_array($patternSchema) && $patternSchema !== true)) {
+                        continue;
+                    }
+                    $name = self::synthesizePropertyName($patternKey, $faker, $iteration);
+                    // A name that collides with a declared property would
+                    // override that property's own presence rotation or pin,
+                    // so leave the shortfall to fail loudly instead.
+                    if ($name === null || array_key_exists($name, $result) || isset($properties[$name])) {
+                        continue;
+                    }
+                    $result[$name] = self::generateOne(
+                        $patternSchema === true ? [] : $patternSchema,
+                        $faker,
+                        $iteration + count($result),
+                        $plan,
+                        $pointer . '/patternProperties/' . SchemaChoicePointEnumerator::escapePointerSegment($patternKey),
+                        false,
+                    );
+                }
+            }
+        }
         $maxProperties = isset($schema['maxProperties']) && is_int($schema['maxProperties'])
             ? $schema['maxProperties']
             : null;
@@ -979,8 +1013,28 @@ final class SchemaDataGenerator
                     // Without the target property, at most the other named
                     // properties can exist when additionalProperties is
                     // false; fewer than minProperties means omission can
-                    // never satisfy the object.
-                    if (($schema['additionalProperties'] ?? true) === false && $includableOthers < $minProperties) {
+                    // never satisfy the object. The count argument breaks
+                    // down when any patternProperties entry admits values —
+                    // additionalProperties only governs names that neither
+                    // keyword evaluates — so a pattern-open object proves
+                    // nothing.
+                    $patternsAdmitNames = false;
+                    $patternProperties = $schema['patternProperties'] ?? null;
+                    if (is_array($patternProperties) && $patternProperties !== []) {
+                        foreach ($patternProperties as $patternSchema) {
+                            if ($patternSchema !== false) {
+                                $patternsAdmitNames = true;
+
+                                break;
+                            }
+                        }
+                    } elseif ($patternProperties !== null) {
+                        // Malformed node: stay conservative, no proof.
+                        $patternsAdmitNames = true;
+                    }
+                    if (($schema['additionalProperties'] ?? true) === false &&
+                        !$patternsAdmitNames &&
+                        $includableOthers < $minProperties) {
                         $plan->observation->proveDeadEnd();
                     }
                 } elseif ($maxProperties !== null &&
@@ -1725,6 +1779,31 @@ final class SchemaDataGenerator
         }
 
         return $merged;
+    }
+
+    /**
+     * Synthesize a property name matching a `patternProperties` pattern.
+     *
+     * Anchored literal patterns (`^name$`, no metacharacters) are read off
+     * directly; anything else goes through the common pattern synthesis
+     * subset with a final match check, since those synthesizers target
+     * value patterns. Null means the pattern is outside both — the caller
+     * leaves the shortfall unmet and generation fails loudly downstream.
+     */
+    private static function synthesizePropertyName(string $pattern, ?Generator $faker, int $iteration): ?string
+    {
+        if (preg_match('/^\^(.+)\$$/D', $pattern, $matches) === 1 && preg_quote($matches[1], '~') === $matches[1]) {
+            return $matches[1];
+        }
+
+        $name = self::generateCommonPattern($pattern, [], $faker, $iteration);
+        if ($name === null) {
+            return null;
+        }
+        $delimiter = '~';
+        $escaped = str_replace($delimiter, '\\' . $delimiter, $pattern);
+
+        return @preg_match($delimiter . $escaped . $delimiter . 'u', $name) === 1 ? $name : null;
     }
 
     /** @param array<string, mixed> $schema */

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -340,16 +340,22 @@ final class SchemaDataGenerator
         // byte-identical to the historical array_merge result, keeping
         // plan-less rotation output bit-for-bit. Conflicting domains
         // previously generated values that failed the loud self-check.
-        if (is_array($left['enum'] ?? null) && is_array($right['enum'] ?? null) &&
-            $left['enum'] !== [] && $right['enum'] !== []) {
-            // Membership uses JSON Schema equality (2020-12 §4.2.2) via the
-            // validator — 1 and 1.0 are the same mathematical value, and
-            // object equality ignores key order — not PHP identity.
-            $leftEnum = ['enum' => $left['enum']];
-            $merged['enum'] = array_values(array_filter(
-                $right['enum'],
-                static fn(mixed $value): bool => SchemaValueValidator::isValid($value, $leftEnum),
-            ));
+        if (is_array($left['enum'] ?? null) && is_array($right['enum'] ?? null)) {
+            if ($left['enum'] === [] || $right['enum'] === []) {
+                // An empty side — user-authored or a conflict marker from an
+                // earlier merge — states the conjunction is already empty;
+                // array_merge displacement must not resurrect the domain.
+                $merged['enum'] = [];
+            } else {
+                // Membership uses JSON Schema equality (2020-12 §4.2.2) via
+                // the validator — 1 and 1.0 are the same mathematical value,
+                // and object equality ignores key order — not PHP identity.
+                $leftEnum = ['enum' => $left['enum']];
+                $merged['enum'] = array_values(array_filter(
+                    $right['enum'],
+                    static fn(mixed $value): bool => SchemaValueValidator::isValid($value, $leftEnum),
+                ));
+            }
         }
         // A `const` conflicting with the other side's `const` or `enum` is a
         // static proof the conjunction admits no value; the empty-enum

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -472,6 +472,77 @@ final class SchemaDataGenerator
     }
 
     /**
+     * The generatable branch space of a `oneOf`/`anyOf` under a plan. Array
+     * branches and boolean schemas both participate (booleans are valid
+     * Schema Objects in OpenAPI 3.1 / JSON Schema 2020-12); branches that
+     * are statically unreachable do not: `false` never matches a value, and
+     * inside `oneOf` a `true` sibling means no other branch can ever be the
+     * sole match. Excluded branches still take part in exclusivity
+     * suppression via {@see self::applyCompositionBranch()}.
+     *
+     * @param list<mixed> $raw
+     *
+     * @return array{list<mixed>, list<int>} kept branches, enumerable indexes into them
+     */
+    public static function compositionBranchSpace(array $raw, string $keyword): array
+    {
+        $branches = array_values(array_filter(
+            $raw,
+            static fn(mixed $branch): bool => is_array($branch) || is_bool($branch),
+        ));
+
+        $hasTrue = in_array(true, $branches, true);
+        $enumerable = [];
+        foreach ($branches as $index => $branch) {
+            if ($branch === false) {
+                continue;
+            }
+            if ($keyword === 'oneOf' && $hasTrue && $branch !== true) {
+                continue;
+            }
+            $enumerable[] = $index;
+        }
+
+        return [$branches, $enumerable];
+    }
+
+    /**
+     * Materialise one branch of a planned `oneOf`/`anyOf` choice: the
+     * selected branch's assertions merged in and, for `oneOf`, every sibling
+     * suppressed through a single `not`/`anyOf` so the value matches exactly
+     * one branch by construction. Shared with the enumerator so descent and
+     * generation see identical views.
+     *
+     * @param array<string, mixed> $schema node with the composition keyword removed
+     * @param list<mixed> $branches
+     *
+     * @return array<string, mixed>
+     */
+    public static function applyCompositionBranch(array $schema, array $branches, int $selected, string $keyword): array
+    {
+        $branch = $branches[$selected];
+        if (is_array($branch)) {
+            $schema = self::mergeSchemas($schema, $branch);
+        }
+
+        if ($keyword !== 'oneOf') {
+            return $schema;
+        }
+
+        $siblings = [];
+        foreach ($branches as $index => $sibling) {
+            if ($index !== $selected && $sibling !== false) {
+                $siblings[] = $sibling;
+            }
+        }
+        if ($siblings !== []) {
+            $schema = self::mergeSchemas($schema, ['not' => ['anyOf' => $siblings]]);
+        }
+
+        return $schema;
+    }
+
+    /**
      * Recognise an `if` of the shape `{properties: {p: s}, required: [p]}`
      * with no other assertions, and return `[p, s]`; null otherwise.
      *
@@ -1050,7 +1121,17 @@ final class SchemaDataGenerator
             }
         }
 
-        if (isset($schema['if']) && is_array($schema['if'])) {
+        if ($plan !== null && is_bool($schema['if'] ?? null)) {
+            // Boolean Schema Objects (OpenAPI 3.1 / JSON Schema 2020-12):
+            // `if: true` makes the then unconditional, `if: false` the else
+            // — there is no branch to choose. Plan-less rotation keeps its
+            // historical output and ignores boolean ifs.
+            $branchSchema = $schema['if'] === true ? ($schema['then'] ?? null) : ($schema['else'] ?? null);
+            unset($schema['if'], $schema['then'], $schema['else']);
+            if (is_array($branchSchema)) {
+                $schema = self::mergeSchemas($schema, $branchSchema);
+            }
+        } elseif (isset($schema['if']) && is_array($schema['if'])) {
             $pinned = $plan?->branchFor($pointer . '/if');
             $useThen = (($pinned ?? $iteration) % 2) === 0;
             $conditional = $useThen
@@ -1086,14 +1167,27 @@ final class SchemaDataGenerator
             if (!isset($schema[$keyword]) || !is_array($schema[$keyword]) || $schema[$keyword] === []) {
                 continue;
             }
-            $branches = array_values(array_filter($schema[$keyword], is_array(...)));
-            if ($branches === []) {
+
+            if ($plan === null) {
+                // Documented rotation: array branches only, no exclusivity
+                // suppression, historical output bit-for-bit.
+                $branches = array_values(array_filter($schema[$keyword], is_array(...)));
+                if ($branches === []) {
+                    continue;
+                }
+                unset($schema[$keyword]);
+                $schema = self::mergeSchemas($schema, $branches[$iteration % count($branches)]);
+                break;
+            }
+
+            [$branches, $enumerable] = self::compositionBranchSpace(array_values($schema[$keyword]), $keyword);
+            if ($enumerable === []) {
                 continue;
             }
             unset($schema[$keyword]);
-            $pinned = $plan?->branchFor($pointer . '/' . $keyword);
-            $index = ($pinned ?? $iteration) % count($branches);
-            $schema = self::mergeSchemas($schema, $branches[$index]);
+            $pinned = $plan->branchFor($pointer . '/' . $keyword);
+            $selected = $enumerable[($pinned ?? $iteration) % count($enumerable)];
+            $schema = self::applyCompositionBranch($schema, $branches, $selected, $keyword);
             break;
         }
 

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -15,6 +15,7 @@ use Studio\Gesso\Spec\OpenApiSchemaConverter;
 
 use function array_filter;
 use function array_key_exists;
+use function array_key_first;
 use function array_keys;
 use function array_merge;
 use function array_slice;
@@ -73,11 +74,11 @@ final class SchemaDataGenerator
 
     /**
      * How many nearby iterations planned `not` generation probes before
-     * falling back to scalar alternatives. Bounds the search that keeps a
-     * rotation-misaligned enum (e.g. the excluded discriminator value) from
-     * being mistaken for an unsatisfiable constraint; deliberately larger
-     * than the 2/3-cycle rotation periods so every scalar rotation state is
-     * revisited.
+     * falling back to scalar alternatives. Finite domains do not rely on
+     * this: enums under a `not` are filtered exhaustively. The retries cover
+     * the remaining scalar rotations (boolean parity, string/number
+     * boundary cycles), and are deliberately larger than the 2/3-cycle
+     * rotation periods so every such rotation state is revisited.
      */
     private const NOT_GENERATION_RETRIES = 8;
 
@@ -159,6 +160,22 @@ final class SchemaDataGenerator
 
         if (isset($schema['enum']) && is_array($schema['enum']) && $schema['enum'] !== []) {
             $values = array_values($schema['enum']);
+            if ($plan !== null && isset($schema['not']) && is_array($schema['not'])) {
+                // The enum domain is finite, so a `not` (e.g. suppressed
+                // discriminator values pushed down by conditionalSetView())
+                // is honoured by filtering the domain outright — complete
+                // and deterministic where iteration retries could miss the
+                // admissible tail of a long enum. An empty filter result
+                // means the exclusion genuinely closes the domain; fall
+                // through and let the self-check fail or drop the probe.
+                $admissible = array_values(array_filter(
+                    $values,
+                    static fn(mixed $value): bool => SchemaValueValidator::isValid($value, $schema),
+                ));
+                if ($admissible !== []) {
+                    return $admissible[$iteration % count($admissible)];
+                }
+            }
 
             return $values[$iteration % count($values)];
         }
@@ -336,14 +353,30 @@ final class SchemaDataGenerator
         }
 
         $suppressedIfs = [];
+        $negatedByProperty = [];
         foreach ($conditionals as $index => $conditional) {
             if (in_array($index, $satisfied, true)) {
                 continue;
             }
-            $suppressedIfs[] = $conditional['if'];
+            // A single-property `if` — the discriminator-lowering shape —
+            // is negated equivalently at the property itself: `¬(p present
+            // ∧ s(p))` is exactly "when present, `p` fails `s`". That puts
+            // the exclusion where value generation can honour it (the enum
+            // domain filter); other shapes stay in a node-level not/anyOf.
+            $condition = self::singlePropertyCondition($conditional['if']);
+            if ($condition !== null) {
+                $negatedByProperty[$condition[0]][] = $condition[1];
+            } else {
+                $suppressedIfs[] = $conditional['if'];
+            }
             if (isset($conditional['else']) && is_array($conditional['else'])) {
                 $schema = self::mergeSchemas($schema, $conditional['else']);
             }
+        }
+        foreach ($negatedByProperty as $property => $negated) {
+            $schema = self::mergeSchemas($schema, ['properties' => [
+                $property => ['not' => count($negated) === 1 ? $negated[0] : ['anyOf' => $negated]],
+            ]]);
         }
         if ($suppressedIfs !== []) {
             $schema = self::mergeSchemas($schema, ['not' => ['anyOf' => $suppressedIfs]]);
@@ -413,6 +446,34 @@ final class SchemaDataGenerator
         }
 
         return $merged;
+    }
+
+    /**
+     * Recognise an `if` of the shape `{properties: {p: s}, required: [p]}`
+     * with no other assertions, and return `[p, s]`; null otherwise.
+     *
+     * @param array<string, mixed> $if
+     *
+     * @return null|array{string, array<string, mixed>}
+     */
+    private static function singlePropertyCondition(array $if): ?array
+    {
+        if (array_keys($if) !== ['properties', 'required'] && array_keys($if) !== ['required', 'properties']) {
+            return null;
+        }
+        if (!is_array($if['properties']) || count($if['properties']) !== 1) {
+            return null;
+        }
+        $property = array_key_first($if['properties']);
+        $subschema = $if['properties'][$property];
+        if (!is_string($property) || !is_array($subschema)) {
+            return null;
+        }
+        if ($if['required'] !== [$property]) {
+            return null;
+        }
+
+        return [$property, $subschema];
     }
 
     /**

--- a/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
+++ b/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
@@ -167,6 +167,53 @@ class BranchCompleteCaseGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function covers_the_else_branch_of_an_all_of_conditional(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'required' => ['kind'],
+            'properties' => ['kind' => ['type' => 'string']],
+            'allOf' => [
+                [
+                    'if' => ['properties' => ['kind' => ['const' => 'a']], 'required' => ['kind']],
+                    'then' => ['properties' => ['kind' => ['const' => 'a']]],
+                    'else' => ['properties' => ['kind' => ['const' => 'b']]],
+                ],
+            ],
+        ];
+
+        $kinds = [];
+        foreach (BranchCompleteCaseGenerator::generate($schema, seed: 1) as $case) {
+            $this->assertIsArray($case->value);
+            $kinds[$case->value['kind']] = true;
+        }
+
+        $this->assertArrayHasKey('a', $kinds, 'no case took the then branch');
+        $this->assertArrayHasKey('b', $kinds, 'no case took the else branch');
+    }
+
+    #[Test]
+    public function covers_branches_that_only_exist_under_a_later_composition_branch(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'required' => ['v'],
+            'anyOf' => [
+                ['properties' => ['v' => ['oneOf' => [['const' => 'x'], ['const' => 'y']]]]],
+                ['properties' => ['v' => ['oneOf' => [['const' => 'x'], ['const' => 'y'], ['const' => 'z']]]]],
+            ],
+        ];
+
+        $values = [];
+        foreach (BranchCompleteCaseGenerator::generate($schema, seed: 1) as $case) {
+            $this->assertIsArray($case->value);
+            $values[$case->value['v']] = true;
+        }
+
+        $this->assertArrayHasKey('z', $values, 'the third branch of the wider rediscovery was never generated');
+    }
+
+    #[Test]
     public function covers_a_choice_point_inside_an_empty_by_default_array(): void
     {
         // The pinned case must force at least one item so the branch under

--- a/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
+++ b/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
@@ -945,6 +945,96 @@ class BranchCompleteCaseGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function covers_a_pattern_branch_narrowed_by_an_all_of_pattern(): void
+    {
+        // `pattern` cannot be merged conjunctively, so the branch view loses
+        // the branch's own pattern to the allOf one; a single failed
+        // candidate must not be read as proof the branch is unreachable —
+        // "A" satisfies branch 0.
+        $cases = BranchCompleteCaseGenerator::generate([
+            'type' => 'string',
+            'anyOf' => [
+                ['pattern' => '^[A-Z]+$'],
+                ['const' => 'z'],
+            ],
+            'allOf' => [
+                ['pattern' => '^[A-Za-z]+$'],
+            ],
+        ], seed: 1);
+
+        $byBranch = [];
+        foreach ($cases as $case) {
+            if ($case->plan->targetPointer === '/anyOf') {
+                $byBranch[$case->plan->targetBranch] = $case->value;
+            }
+        }
+
+        $this->assertArrayHasKey(0, $byBranch, 'the reachable uppercase branch was silently dropped');
+        $this->assertMatchesRegularExpression('/^[A-Z]+$/', $byBranch[0]);
+        $this->assertSame('z', $byBranch[1] ?? null);
+    }
+
+    #[Test]
+    public function stays_loud_when_a_target_search_cannot_conclude(): void
+    {
+        // Digits and lowercase are disjoint, so branch 0 is unreachable —
+        // but the generator cannot prove that: its candidates vary without
+        // ever succeeding. That must fail explicitly, not drop silently.
+        $this->expectException(FuzzGenerationException::class);
+
+        BranchCompleteCaseGenerator::generate([
+            'type' => 'string',
+            'anyOf' => [
+                ['pattern' => '^[0-9]+$'],
+                ['const' => 'z'],
+            ],
+            'allOf' => [
+                ['pattern' => '^[a-z]+$'],
+            ],
+        ], seed: 1);
+    }
+
+    #[Test]
+    public function generates_integer_cases_for_an_integer_narrowed_by_number(): void
+    {
+        // integer is a subtype of number (2020-12 §6.1.1): the conjunction
+        // is integer, not the empty set.
+        $cases = BranchCompleteCaseGenerator::generate([
+            'type' => 'integer',
+            'allOf' => [['type' => 'number']],
+            'anyOf' => [['minimum' => 0], ['maximum' => -1]],
+        ], seed: 1);
+
+        $byBranch = [];
+        foreach ($cases as $case) {
+            $this->assertIsInt($case->value);
+            if ($case->plan->targetPointer === '/anyOf') {
+                $byBranch[$case->plan->targetBranch] = $case->value;
+            }
+        }
+
+        $this->assertGreaterThanOrEqual(0, $byBranch[0] ?? -1);
+        $this->assertLessThanOrEqual(-1, $byBranch[1] ?? 0);
+    }
+
+    #[Test]
+    public function covers_enum_branches_with_numerically_equal_values(): void
+    {
+        // 1 and 1.0 are the same mathematical value (2020-12 §4.2.2); the
+        // enum conjunction admits it.
+        $cases = BranchCompleteCaseGenerator::generate([
+            'allOf' => [['enum' => [1]], ['enum' => [1.0]]],
+        ], seed: 1);
+
+        $this->assertNotSame([], $cases);
+        foreach ($cases as $case) {
+            // JSON Schema equality, not PHP identity: the generated value
+            // may surface as int 1 or float 1.0 depending on merge order.
+            $this->assertTrue(SchemaValueValidator::isValid($case->value, ['const' => 1]));
+        }
+    }
+
+    #[Test]
     public function drops_a_present_case_whose_property_was_trimmed(): void
     {
         // maxProperties 1 with a required sibling means `b` can never be

--- a/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
+++ b/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\Gesso\Fuzz\BranchCompleteCaseGenerator;
+use Studio\Gesso\Fuzz\FuzzGenerationException;
 use Studio\Gesso\Fuzz\PlannedSchemaCase;
 use Studio\Gesso\Fuzz\SchemaValueValidator;
 
@@ -620,6 +621,107 @@ class BranchCompleteCaseGeneratorTest extends TestCase
         $this->assertNotSame([], $cases);
         foreach ($cases as $case) {
             $this->assertSame([], $case->value);
+        }
+    }
+
+    #[Test]
+    public function drops_a_one_of_branch_made_unreachable_by_exclusivity(): void
+    {
+        // `x` matches both branches, so the const branch can never be the
+        // sole match; its case is dropped, not a crash.
+        $cases = BranchCompleteCaseGenerator::generate([
+            'oneOf' => [['type' => 'string'], ['const' => 'x']],
+        ], seed: 1);
+
+        $this->assertNotSame([], $cases);
+        foreach ($cases as $case) {
+            $this->assertIsString($case->value);
+            $this->assertNotSame('x', $case->value);
+        }
+    }
+
+    #[Test]
+    public function drops_an_else_branch_made_unreachable_by_a_const(): void
+    {
+        $cases = BranchCompleteCaseGenerator::generate([
+            'const' => 'x',
+            'if' => ['const' => 'x'],
+            'then' => true,
+            'else' => ['const' => 'y'],
+        ], seed: 1);
+
+        $this->assertNotSame([], $cases);
+        foreach ($cases as $case) {
+            $this->assertSame('x', $case->value);
+        }
+    }
+
+    #[Test]
+    public function drops_an_omission_branch_made_unreachable_by_min_properties(): void
+    {
+        // minProperties: 1 with additionalProperties: false means the only
+        // optional property can never be omitted.
+        $cases = BranchCompleteCaseGenerator::generate([
+            'type' => 'object',
+            'minProperties' => 1,
+            'additionalProperties' => false,
+            'properties' => ['a' => ['type' => 'string']],
+        ], seed: 1);
+
+        $this->assertNotSame([], $cases);
+        foreach ($cases as $case) {
+            $this->assertIsArray($case->value);
+            $this->assertArrayHasKey('a', $case->value);
+        }
+    }
+
+    #[Test]
+    public function drops_a_conditional_branch_made_unreachable_by_a_folded_suppression(): void
+    {
+        // The first conditional's then: false permanently forbids x; the
+        // second conditional's satisfied side needs x and is unreachable.
+        $cases = BranchCompleteCaseGenerator::generate([
+            'type' => 'string',
+            'allOf' => [
+                ['if' => ['const' => 'x'], 'then' => false],
+                ['if' => ['const' => 'x'], 'then' => ['minLength' => 1]],
+            ],
+        ], seed: 1);
+
+        $this->assertNotSame([], $cases);
+        foreach ($cases as $case) {
+            $this->assertIsString($case->value);
+            $this->assertNotSame('x', $case->value);
+        }
+    }
+
+    #[Test]
+    public function stays_loud_when_the_schema_itself_is_unsatisfiable(): void
+    {
+        // Dropping unreachable-branch cases must not swallow a schema no
+        // value can satisfy: the fallback case still fails loudly.
+        $this->expectException(FuzzGenerationException::class);
+
+        BranchCompleteCaseGenerator::generate([
+            'type' => 'string',
+            'oneOf' => [['const' => 'x'], ['const' => 'x']],
+        ], seed: 1);
+    }
+
+    #[Test]
+    public function generates_items_when_the_items_keyword_is_omitted(): void
+    {
+        // Omitted items is the empty schema (2020-12 §10.3.1.2): elements
+        // are unconstrained, not forbidden.
+        $cases = BranchCompleteCaseGenerator::generate([
+            'type' => 'array',
+            'minItems' => 1,
+        ], seed: 1);
+
+        $this->assertNotSame([], $cases);
+        foreach ($cases as $case) {
+            $this->assertIsArray($case->value);
+            $this->assertNotSame([], $case->value);
         }
     }
 

--- a/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
+++ b/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
@@ -228,6 +228,65 @@ class BranchCompleteCaseGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function covers_overlapping_conditionals_without_forcing_exclusivity(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'required' => ['flag'],
+            'properties' => ['flag' => ['type' => 'boolean']],
+            'allOf' => [
+                [
+                    'if' => ['properties' => ['flag' => ['const' => true]], 'required' => ['flag']],
+                    'then' => ['required' => ['a'], 'properties' => ['a' => ['type' => 'string']]],
+                ],
+                [
+                    'if' => ['properties' => ['flag' => ['const' => true]], 'required' => ['flag']],
+                    'then' => ['required' => ['b'], 'properties' => ['b' => ['type' => 'string']]],
+                ],
+            ],
+        ];
+
+        $sawBothThens = false;
+        $sawNoneMatch = false;
+        foreach (BranchCompleteCaseGenerator::generate($schema, seed: 1) as $case) {
+            $this->assertIsArray($case->value);
+            $sawBothThens = $sawBothThens ||
+                (isset($case->value['a'], $case->value['b']));
+            $sawNoneMatch = $sawNoneMatch || $case->value['flag'] === false;
+        }
+
+        $this->assertTrue($sawBothThens, 'no case satisfied the jointly-firing conditionals');
+        $this->assertTrue($sawNoneMatch, 'no case exercised the none-match state');
+    }
+
+    #[Test]
+    public function keeps_a_reachable_none_match_probe_despite_rotation_misalignment(): void
+    {
+        // The probe case's iteration rotates the enum onto the excluded
+        // discriminator value; one failed generation must not be read as
+        // "the none-match state is unreachable".
+        $schema = [
+            'type' => 'object',
+            'required' => ['kind'],
+            'properties' => ['kind' => ['type' => 'string', 'enum' => ['other', 'cat']]],
+            'allOf' => [
+                [
+                    'if' => ['properties' => ['kind' => ['const' => 'cat']], 'required' => ['kind']],
+                    'then' => ['required' => ['meow'], 'properties' => ['meow' => ['type' => 'string']]],
+                ],
+            ],
+        ];
+
+        $kinds = [];
+        foreach (BranchCompleteCaseGenerator::generate($schema, seed: 1) as $case) {
+            $this->assertIsArray($case->value);
+            $kinds[$case->value['kind']] = true;
+        }
+
+        $this->assertArrayHasKey('other', $kinds, 'the reachable none-match probe was dropped');
+    }
+
+    #[Test]
     public function covers_the_none_match_state_when_it_is_reachable(): void
     {
         $schema = [

--- a/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
+++ b/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
@@ -193,6 +193,88 @@ class BranchCompleteCaseGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function covers_every_subtype_of_a_discriminator_style_conditional_all_of(): void
+    {
+        // Discriminator lowering produces this shape: a closed enum plus one
+        // if/then pair per subtype. The none-match branch is unsatisfiable
+        // here; its probe case must be dropped, not fail the whole run.
+        $schema = [
+            'type' => 'object',
+            'required' => ['petType'],
+            'properties' => ['petType' => ['type' => 'string', 'enum' => ['cat', 'dog']]],
+            'allOf' => [
+                [
+                    'if' => ['properties' => ['petType' => ['const' => 'cat']], 'required' => ['petType']],
+                    'then' => ['required' => ['meow'], 'properties' => ['meow' => ['type' => 'string']]],
+                ],
+                [
+                    'if' => ['properties' => ['petType' => ['const' => 'dog']], 'required' => ['petType']],
+                    'then' => ['required' => ['bark'], 'properties' => ['bark' => ['type' => 'string']]],
+                ],
+            ],
+        ];
+
+        $cases = BranchCompleteCaseGenerator::generate($schema, seed: 1);
+
+        $byType = [];
+        foreach ($cases as $case) {
+            $this->assertIsArray($case->value);
+            $byType[$case->value['petType']] = $case->value;
+        }
+
+        $this->assertCount(2, $cases);
+        $this->assertArrayHasKey('meow', $byType['cat']);
+        $this->assertArrayHasKey('bark', $byType['dog']);
+    }
+
+    #[Test]
+    public function covers_the_none_match_state_when_it_is_reachable(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'required' => ['petType'],
+            'properties' => ['petType' => ['type' => 'string']],
+            'allOf' => [
+                [
+                    'if' => ['properties' => ['petType' => ['const' => 'cat']], 'required' => ['petType']],
+                    'then' => ['required' => ['meow'], 'properties' => ['meow' => ['type' => 'string']]],
+                ],
+            ],
+        ];
+
+        $sawNonCat = false;
+        foreach (BranchCompleteCaseGenerator::generate($schema, seed: 1) as $case) {
+            $this->assertIsArray($case->value);
+            $sawNonCat = $sawNonCat || $case->value['petType'] !== 'cat';
+        }
+
+        $this->assertTrue($sawNonCat, 'no case exercised the none-match state of the conditional');
+    }
+
+    #[Test]
+    public function covers_same_pointer_choice_points_with_different_content_per_context(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'required' => ['v'],
+            'anyOf' => [
+                ['properties' => ['v' => ['oneOf' => [['const' => 'x'], ['const' => 'y']]]]],
+                ['properties' => ['v' => ['oneOf' => [['const' => 1], ['const' => 2]]]]],
+            ],
+        ];
+
+        $values = [];
+        foreach (BranchCompleteCaseGenerator::generate($schema, seed: 1) as $case) {
+            $this->assertIsArray($case->value);
+            $values[json_encode($case->value['v'])] = true;
+        }
+
+        foreach (['"x"', '"y"', '1', '2'] as $expected) {
+            $this->assertArrayHasKey($expected, $values, "branch producing {$expected} was never generated");
+        }
+    }
+
+    #[Test]
     public function covers_branches_that_only_exist_under_a_later_composition_branch(): void
     {
         $schema = [

--- a/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
+++ b/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
@@ -454,6 +454,53 @@ class BranchCompleteCaseGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function generates_valid_values_for_a_one_of_with_a_boolean_true_branch(): void
+    {
+        // OpenAPI 3.1 admits boolean Schema Objects. With a `true` sibling,
+        // no other oneOf branch can ever be the sole match, so the valid
+        // values are exactly those matching nothing else — here, any string
+        // except `x`.
+        $cases = BranchCompleteCaseGenerator::generate([
+            'type' => 'string',
+            'oneOf' => [true, ['const' => 'x']],
+        ], seed: 1);
+
+        $this->assertNotSame([], $cases);
+        foreach ($cases as $case) {
+            $this->assertIsString($case->value);
+            $this->assertNotSame('x', $case->value);
+        }
+    }
+
+    #[Test]
+    public function applies_a_boolean_true_if_and_covers_its_then_choice_points(): void
+    {
+        // `if: true` makes the `then` unconditional; ignoring it generates an
+        // empty object that fails the self-check, and the choice point inside
+        // the `then` would never be covered.
+        $schema = [
+            'type' => 'object',
+            'if' => true,
+            'then' => [
+                'required' => ['choice'],
+                'properties' => ['choice' => ['oneOf' => [['type' => 'string'], ['type' => 'integer']]]],
+            ],
+        ];
+
+        $sawString = false;
+        $sawInteger = false;
+        foreach (BranchCompleteCaseGenerator::generate($schema, seed: 1) as $case) {
+            $this->assertIsArray($case->value);
+            $this->assertArrayHasKey('choice', $case->value);
+            $sawString = $sawString || is_string($case->value['choice']);
+            $sawInteger = $sawInteger || is_int($case->value['choice']);
+        }
+
+        $this->assertTrue($sawString, 'no case pinned the string branch under the unconditional then');
+        $this->assertTrue($sawInteger, 'no case pinned the integer branch under the unconditional then');
+    }
+
+    #[Test]
     public function covers_the_none_match_state_when_it_is_reachable(): void
     {
         $schema = [

--- a/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
+++ b/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
@@ -559,6 +559,71 @@ class BranchCompleteCaseGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function folds_a_conditional_with_a_false_then_into_permanent_suppression(): void
+    {
+        // `then: false` means the if side is unsatisfiable: the conditional
+        // is not a choice at all — every valid value violates the if and
+        // satisfies the else.
+        $cases = BranchCompleteCaseGenerator::generate([
+            'type' => 'string',
+            'allOf' => [['if' => ['const' => 'x'], 'then' => false, 'else' => ['const' => 'y']]],
+        ], seed: 1);
+
+        $this->assertNotSame([], $cases);
+        foreach ($cases as $case) {
+            $this->assertSame('y', $case->value);
+        }
+    }
+
+    #[Test]
+    public function folds_a_conditional_with_a_false_else_into_a_mandatory_condition(): void
+    {
+        // `else: false` means the if must always hold — again no choice.
+        $cases = BranchCompleteCaseGenerator::generate([
+            'type' => 'string',
+            'allOf' => [['if' => ['const' => 'a'], 'then' => true, 'else' => false]],
+        ], seed: 1);
+
+        $this->assertNotSame([], $cases);
+        foreach ($cases as $case) {
+            $this->assertSame('a', $case->value);
+        }
+    }
+
+    #[Test]
+    public function generates_items_for_a_boolean_true_items_schema(): void
+    {
+        $cases = BranchCompleteCaseGenerator::generate([
+            'type' => 'array',
+            'minItems' => 1,
+            'items' => true,
+        ], seed: 1);
+
+        $this->assertNotSame([], $cases);
+        foreach ($cases as $case) {
+            $this->assertIsArray($case->value);
+            $this->assertNotSame([], $case->value);
+        }
+    }
+
+    #[Test]
+    public function does_not_reach_past_a_boolean_false_prefix_item(): void
+    {
+        // prefixItems[0] is false, so any array with one or more elements is
+        // invalid: the oneOf behind it is unreachable and must not produce a
+        // forced-size plan.
+        $cases = BranchCompleteCaseGenerator::generate([
+            'type' => 'array',
+            'prefixItems' => [false, ['oneOf' => [['const' => 'x'], ['const' => 'y']]]],
+        ], seed: 1);
+
+        $this->assertNotSame([], $cases);
+        foreach ($cases as $case) {
+            $this->assertSame([], $case->value);
+        }
+    }
+
+    #[Test]
     public function covers_the_none_match_state_when_it_is_reachable(): void
     {
         $schema = [

--- a/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
+++ b/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
@@ -16,6 +16,7 @@ use function is_array;
 use function is_int;
 use function is_string;
 use function json_encode;
+use function range;
 
 class BranchCompleteCaseGeneratorTest extends TestCase
 {
@@ -284,6 +285,72 @@ class BranchCompleteCaseGeneratorTest extends TestCase
         }
 
         $this->assertArrayHasKey('other', $kinds, 'the reachable none-match probe was dropped');
+    }
+
+    #[Test]
+    public function covers_a_none_match_probe_behind_a_long_enum(): void
+    {
+        // Ten enum values, nine conditionals, and a preceding choice point
+        // shifting the probe's iteration: blind retry windows cannot reach
+        // the one admissible value, so the excluded set must be filtered out
+        // of the enum domain deterministically instead.
+        $conditionals = [];
+        $excluded = [];
+        foreach (range(0, 8) as $i) {
+            $conditionals[] = [
+                'if' => ['properties' => ['kind' => ['const' => "v{$i}"]], 'required' => ['kind']],
+                'then' => ['required' => ["p{$i}"], 'properties' => ["p{$i}" => ['type' => 'string']]],
+            ];
+            $excluded[] = "v{$i}";
+        }
+        $schema = [
+            'type' => 'object',
+            'required' => ['kind'],
+            'oneOf' => [['type' => 'object']],
+            'properties' => ['kind' => ['type' => 'string', 'enum' => [...$excluded, 'other']]],
+            'allOf' => $conditionals,
+        ];
+
+        $kinds = [];
+        foreach (BranchCompleteCaseGenerator::generate($schema, seed: 1) as $case) {
+            $this->assertIsArray($case->value);
+            $kinds[$case->value['kind']] = true;
+        }
+
+        $this->assertArrayHasKey('other', $kinds, 'the reachable none-match state behind a long enum was dropped');
+    }
+
+    #[Test]
+    public function covers_choice_points_inside_a_suppressed_else(): void
+    {
+        // Overlapping ifs: whenever conditional 0 fires, conditional 1 fires
+        // too, so its else — and the optional fallback inside it — is only
+        // realizable in the none-match state. The fallback presence branch
+        // must be generated from that stable context.
+        $schema = [
+            'type' => 'object',
+            'required' => ['flag'],
+            'properties' => ['flag' => ['type' => 'boolean']],
+            'allOf' => [
+                [
+                    'if' => ['properties' => ['flag' => ['const' => true]], 'required' => ['flag']],
+                    'then' => ['required' => ['a'], 'properties' => ['a' => ['type' => 'string']]],
+                ],
+                [
+                    'if' => ['properties' => ['flag' => ['const' => true]], 'required' => ['flag']],
+                    'then' => ['required' => ['b'], 'properties' => ['b' => ['type' => 'string']]],
+                    'else' => ['properties' => ['fallback' => ['type' => 'string']]],
+                ],
+            ],
+        ];
+
+        $sawFallback = false;
+        foreach (BranchCompleteCaseGenerator::generate($schema, seed: 1) as $case) {
+            $this->assertIsArray($case->value);
+            $sawFallback = $sawFallback || isset($case->value['fallback']);
+        }
+
+        $this->assertTrue($sawFallback, 'no case realized the optional property inside the suppressed else');
     }
 
     #[Test]

--- a/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
+++ b/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
@@ -676,6 +676,32 @@ class BranchCompleteCaseGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function drops_a_presence_branch_made_unreachable_by_conflicting_consts(): void
+    {
+        // const: a ∧ const: b is a contradiction; the empty-enum marker
+        // must survive the later enum merge so the present branch is a
+        // proven dead end, not a loud search failure.
+        $cases = BranchCompleteCaseGenerator::generate([
+            'type' => 'object',
+            'properties' => [
+                'p' => [
+                    'allOf' => [
+                        ['const' => 'a'],
+                        ['const' => 'b'],
+                        ['enum' => ['a', 'b']],
+                    ],
+                ],
+            ],
+        ], seed: 1);
+
+        $this->assertNotSame([], $cases);
+        foreach ($cases as $case) {
+            $this->assertIsArray($case->value);
+            $this->assertArrayNotHasKey('p', $case->value);
+        }
+    }
+
+    #[Test]
     public function covers_an_omission_branch_reachable_through_pattern_properties(): void
     {
         // additionalProperties: false only forbids names that neither

--- a/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
+++ b/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
@@ -422,6 +422,38 @@ class BranchCompleteCaseGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function preserves_a_base_not_across_a_boolean_not_merge(): void
+    {
+        // `not: false` in the else is a semantic no-op (2020-12 boolean
+        // schema); it must not displace the base exclusion of `forbidden`.
+        $schema = [
+            'type' => 'object',
+            'required' => ['kind'],
+            'properties' => ['kind' => [
+                'type' => 'string',
+                'enum' => ['other', 'forbidden', 'cat'],
+                'not' => ['const' => 'forbidden'],
+            ]],
+            'allOf' => [
+                [
+                    'if' => ['properties' => ['kind' => ['const' => 'cat']], 'required' => ['kind']],
+                    'then' => ['required' => ['meow'], 'properties' => ['meow' => ['type' => 'string']]],
+                    'else' => ['properties' => ['kind' => ['not' => false]]],
+                ],
+            ],
+        ];
+
+        $kinds = [];
+        foreach (BranchCompleteCaseGenerator::generate($schema, seed: 1) as $case) {
+            $this->assertIsArray($case->value);
+            $kinds[$case->value['kind']] = true;
+        }
+
+        $this->assertArrayHasKey('other', $kinds, 'the none-match state lost the base not to a boolean no-op');
+        $this->assertArrayNotHasKey('forbidden', $kinds);
+    }
+
+    #[Test]
     public function covers_the_none_match_state_when_it_is_reachable(): void
     {
         $schema = [

--- a/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
+++ b/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
@@ -819,4 +819,153 @@ class BranchCompleteCaseGeneratorTest extends TestCase
         $this->assertTrue($sawString, 'no case exercised the string items branch');
         $this->assertTrue($sawInteger, 'no case exercised the integer items branch');
     }
+
+    #[Test]
+    public function covers_each_any_of_branch_constrained_by_an_all_of_enum(): void
+    {
+        // The allOf enum narrows each anyOf branch: branch 0 admits only
+        // `b`, branch 1 only `c`. A whole-schema check alone cannot tell a
+        // case that took branch 0 from one that merely passed via branch 1.
+        $cases = BranchCompleteCaseGenerator::generate([
+            'type' => 'string',
+            'anyOf' => [
+                ['enum' => ['a', 'b']],
+                ['const' => 'c'],
+            ],
+            'allOf' => [
+                ['enum' => ['c', 'b']],
+            ],
+        ], seed: 1);
+
+        $byBranch = [];
+        foreach ($cases as $case) {
+            if ($case->plan->targetPointer === '/anyOf') {
+                $byBranch[$case->plan->targetBranch] = $case->value;
+            }
+        }
+
+        $this->assertSame('b', $byBranch[0] ?? null, 'branch 0 never produced its only admissible value');
+        $this->assertSame('c', $byBranch[1] ?? null);
+    }
+
+    #[Test]
+    public function covers_each_any_of_branch_constrained_by_an_all_of_type(): void
+    {
+        // Both branches stay reachable under the allOf type union; each
+        // pinned case must produce a value of its own branch's type.
+        $cases = BranchCompleteCaseGenerator::generate([
+            'anyOf' => [
+                ['type' => 'string'],
+                ['type' => 'integer'],
+            ],
+            'allOf' => [
+                ['type' => ['string', 'integer']],
+            ],
+        ], seed: 1);
+
+        $byBranch = [];
+        foreach ($cases as $case) {
+            if ($case->plan->targetPointer === '/anyOf') {
+                $byBranch[$case->plan->targetBranch] = $case->value;
+            }
+        }
+
+        $this->assertIsString($byBranch[0] ?? null);
+        $this->assertIsInt($byBranch[1] ?? null, 'the integer branch was never actually taken');
+    }
+
+    #[Test]
+    public function drops_an_any_of_case_that_cannot_take_its_target_branch(): void
+    {
+        // The allOf forces strings, so the integer branch is unreachable;
+        // its case must be dropped, not kept mislabeled with a value that
+        // only passes through the string branch.
+        $cases = BranchCompleteCaseGenerator::generate([
+            'anyOf' => [
+                ['type' => 'integer'],
+                ['type' => 'string'],
+            ],
+            'allOf' => [
+                ['type' => 'string'],
+            ],
+        ], seed: 1);
+
+        $this->assertNotSame([], $cases);
+        foreach ($cases as $case) {
+            $this->assertIsString($case->value);
+            if ($case->plan->targetPointer === '/anyOf') {
+                $this->assertSame(1, $case->plan->targetBranch, 'the unreachable integer branch was kept');
+            }
+        }
+    }
+
+    #[Test]
+    public function drops_a_conditional_case_whose_value_matches_a_suppressed_if(): void
+    {
+        // The node const forces `x`, so the none-match state (no `if`
+        // firing) is unreachable — but `x` is valid for the whole schema,
+        // so only a per-branch check can tell the case was mislabeled.
+        $cases = BranchCompleteCaseGenerator::generate([
+            'type' => 'string',
+            'const' => 'x',
+            'allOf' => [
+                ['if' => ['const' => 'x'], 'then' => ['minLength' => 1]],
+            ],
+        ], seed: 1);
+
+        $this->assertNotSame([], $cases);
+        foreach ($cases as $case) {
+            $this->assertSame('x', $case->value);
+            if ($case->plan->targetPointer === '/allOf') {
+                $this->assertSame(0, $case->plan->targetBranch, 'the unreachable none-match state was kept');
+            }
+        }
+    }
+
+    #[Test]
+    public function drops_an_else_case_whose_value_satisfies_the_if(): void
+    {
+        // The node const forces the `if` to fire, so the else side is
+        // unreachable — yet its generated value `x` passes the whole
+        // schema through the then side.
+        $cases = BranchCompleteCaseGenerator::generate([
+            'type' => 'string',
+            'const' => 'x',
+            'if' => ['const' => 'x'],
+            'then' => ['minLength' => 1],
+        ], seed: 1);
+
+        $this->assertNotSame([], $cases);
+        foreach ($cases as $case) {
+            $this->assertSame('x', $case->value);
+            if ($case->plan->targetPointer === '/if') {
+                $this->assertSame(0, $case->plan->targetBranch, 'the unreachable else side was kept');
+            }
+        }
+    }
+
+    #[Test]
+    public function drops_a_present_case_whose_property_was_trimmed(): void
+    {
+        // maxProperties 1 with a required sibling means `b` can never be
+        // present; the trim removes it, so keeping the case would label a
+        // b-less object as covering b's presence.
+        $cases = BranchCompleteCaseGenerator::generate([
+            'type' => 'object',
+            'maxProperties' => 1,
+            'required' => ['a'],
+            'properties' => [
+                'a' => ['type' => 'string'],
+                'b' => ['type' => 'string'],
+            ],
+        ], seed: 1);
+
+        $this->assertNotSame([], $cases);
+        foreach ($cases as $case) {
+            $this->assertIsArray($case->value);
+            if ($case->plan->targetPointer === '/properties/b' && $case->plan->targetBranch === 0) {
+                $this->assertArrayHasKey('b', $case->value, 'a present-targeted case lost its property to the trim');
+            }
+        }
+    }
 }

--- a/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
+++ b/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
@@ -387,6 +387,41 @@ class BranchCompleteCaseGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function preserves_a_base_not_across_an_else_merge(): void
+    {
+        // The suppressed conditional's else carries its own kind.not; merging
+        // it must not displace the base exclusion of `forbidden`. Otherwise
+        // the none-match probe generates `forbidden`, fails validation, and
+        // is dropped even though `other` is admissible.
+        $schema = [
+            'type' => 'object',
+            'required' => ['kind'],
+            'properties' => ['kind' => [
+                'type' => 'string',
+                'enum' => ['other', 'forbidden', 'elseForbidden', 'cat'],
+                'not' => ['const' => 'forbidden'],
+            ]],
+            'allOf' => [
+                [
+                    'if' => ['properties' => ['kind' => ['const' => 'cat']], 'required' => ['kind']],
+                    'then' => ['required' => ['meow'], 'properties' => ['meow' => ['type' => 'string']]],
+                    'else' => ['properties' => ['kind' => ['not' => ['const' => 'elseForbidden']]]],
+                ],
+            ],
+        ];
+
+        $kinds = [];
+        foreach (BranchCompleteCaseGenerator::generate($schema, seed: 1) as $case) {
+            $this->assertIsArray($case->value);
+            $kinds[$case->value['kind']] = true;
+        }
+
+        $this->assertArrayHasKey('other', $kinds, 'the none-match state lost the base not across the else merge');
+        $this->assertArrayNotHasKey('forbidden', $kinds);
+        $this->assertArrayNotHasKey('elseForbidden', $kinds);
+    }
+
+    #[Test]
     public function covers_the_none_match_state_when_it_is_reachable(): void
     {
         $schema = [

--- a/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
+++ b/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
@@ -1035,6 +1035,44 @@ class BranchCompleteCaseGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function covers_a_presence_branch_gated_by_a_dependent_schema(): void
+    {
+        // dependentSchemas applies its subschema to the whole object when
+        // `a` is present (2020-12 §10.2.2.4): {a, b: 4} is valid, but only
+        // one of b's five untargeted rotations produces it. An identical
+        // presence observation across a too-narrow search must not be read
+        // as proof the present branch is unreachable.
+        $cases = BranchCompleteCaseGenerator::generate([
+            'type' => 'object',
+            'required' => ['b'],
+            'properties' => [
+                'a' => ['type' => 'string'],
+                'b' => ['anyOf' => [
+                    ['const' => 0],
+                    ['const' => 1],
+                    ['const' => 2],
+                    ['const' => 3],
+                    ['const' => 4],
+                ]],
+            ],
+            'dependentSchemas' => [
+                'a' => ['properties' => ['b' => ['const' => 4]]],
+            ],
+        ], seed: 1);
+
+        $present = null;
+        foreach ($cases as $case) {
+            $this->assertIsArray($case->value);
+            if (array_key_exists('a', $case->value)) {
+                $present = $case->value;
+            }
+        }
+
+        $this->assertNotNull($present, 'the reachable present branch of a was silently dropped');
+        $this->assertSame(4, $present['b']);
+    }
+
+    #[Test]
     public function drops_a_present_case_whose_property_was_trimmed(): void
     {
         // maxProperties 1 with a required sibling means `b` can never be

--- a/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
+++ b/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
@@ -11,6 +11,7 @@ use Studio\Gesso\Fuzz\BranchCompleteCaseGenerator;
 use Studio\Gesso\Fuzz\PlannedSchemaCase;
 use Studio\Gesso\Fuzz\SchemaValueValidator;
 
+use function array_key_exists;
 use function array_map;
 use function is_array;
 use function is_int;
@@ -498,6 +499,63 @@ class BranchCompleteCaseGeneratorTest extends TestCase
 
         $this->assertTrue($sawString, 'no case pinned the string branch under the unconditional then');
         $this->assertTrue($sawInteger, 'no case pinned the integer branch under the unconditional then');
+    }
+
+    #[Test]
+    public function skips_an_unsatisfiable_boolean_then_and_covers_the_else(): void
+    {
+        // `then: false` makes the if-holds side unsatisfiable (2020-12
+        // boolean schema); only the else branch is generatable. Pinning the
+        // then side would crash the run before the reachable else case.
+        $cases = BranchCompleteCaseGenerator::generate([
+            'type' => 'string',
+            'if' => ['const' => 'x'],
+            'then' => false,
+            'else' => ['const' => 'y'],
+        ], seed: 1);
+
+        $this->assertNotSame([], $cases);
+        foreach ($cases as $case) {
+            $this->assertSame('y', $case->value);
+        }
+    }
+
+    #[Test]
+    public function covers_presence_of_a_boolean_true_property(): void
+    {
+        // `properties: {x: true}` admits any value for x; both presence
+        // states are reachable and must each appear in a case.
+        $sawPresent = false;
+        $sawOmitted = false;
+        foreach (BranchCompleteCaseGenerator::generate([
+            'type' => 'object',
+            'properties' => ['x' => true],
+        ], seed: 1) as $case) {
+            $this->assertIsArray($case->value);
+            if (array_key_exists('x', $case->value)) {
+                $sawPresent = true;
+            } else {
+                $sawOmitted = true;
+            }
+        }
+
+        $this->assertTrue($sawPresent, 'no case included the boolean-true property');
+        $this->assertTrue($sawOmitted, 'no case omitted the boolean-true property');
+    }
+
+    #[Test]
+    public function never_includes_a_boolean_false_property(): void
+    {
+        // Nothing matches `false`, so presence is unreachable; the only
+        // valid shape omits x.
+        foreach (BranchCompleteCaseGenerator::generate([
+            'type' => 'object',
+            'required' => ['id'],
+            'properties' => ['id' => ['type' => 'integer'], 'x' => false],
+        ], seed: 1) as $case) {
+            $this->assertIsArray($case->value);
+            $this->assertArrayNotHasKey('x', $case->value);
+        }
     }
 
     #[Test]

--- a/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
+++ b/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
@@ -354,6 +354,39 @@ class BranchCompleteCaseGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function preserves_an_existing_property_not_when_suppressing_conditionals(): void
+    {
+        // The property already excludes `forbidden`; suppressing the cat
+        // conditional must add to that exclusion, not replace it — otherwise
+        // the none-match probe generates `forbidden`, fails validation, and
+        // is dropped even though `other` is admissible.
+        $schema = [
+            'type' => 'object',
+            'required' => ['kind'],
+            'properties' => ['kind' => [
+                'type' => 'string',
+                'enum' => ['other', 'forbidden', 'cat'],
+                'not' => ['const' => 'forbidden'],
+            ]],
+            'allOf' => [
+                [
+                    'if' => ['properties' => ['kind' => ['const' => 'cat']], 'required' => ['kind']],
+                    'then' => ['required' => ['meow'], 'properties' => ['meow' => ['type' => 'string']]],
+                ],
+            ],
+        ];
+
+        $kinds = [];
+        foreach (BranchCompleteCaseGenerator::generate($schema, seed: 1) as $case) {
+            $this->assertIsArray($case->value);
+            $kinds[$case->value['kind']] = true;
+        }
+
+        $this->assertArrayHasKey('other', $kinds, 'the none-match state lost the pre-existing not exclusion');
+        $this->assertArrayNotHasKey('forbidden', $kinds);
+    }
+
+    #[Test]
     public function covers_the_none_match_state_when_it_is_reachable(): void
     {
         $schema = [

--- a/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
+++ b/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
@@ -1073,6 +1073,30 @@ class BranchCompleteCaseGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function stays_loud_when_a_dependent_schema_gates_a_synthesized_pattern(): void
+    {
+        // {"host": "b.example.com"} is valid, but the pattern synthesizer
+        // deterministically produces a different label. Generator
+        // determinism is not a proof that no other value exists on the
+        // schema: without a static unreachability proof the present branch
+        // must fail loudly, never be dropped silently.
+        $this->expectException(FuzzGenerationException::class);
+
+        BranchCompleteCaseGenerator::generate([
+            'type' => 'object',
+            'properties' => [
+                'host' => [
+                    'type' => 'string',
+                    'pattern' => '^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\\.)+example\\.com$',
+                ],
+            ],
+            'dependentSchemas' => [
+                'host' => ['properties' => ['host' => ['const' => 'b.example.com']]],
+            ],
+        ], seed: 1);
+    }
+
+    #[Test]
     public function drops_a_present_case_whose_property_was_trimmed(): void
     {
         // maxProperties 1 with a required sibling means `b` can never be

--- a/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
+++ b/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Fuzz;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Fuzz\BranchCompleteCaseGenerator;
+use Studio\Gesso\Fuzz\PlannedSchemaCase;
+use Studio\Gesso\Fuzz\SchemaValueValidator;
+
+use function array_map;
+use function is_array;
+use function is_int;
+use function is_string;
+use function json_encode;
+
+class BranchCompleteCaseGeneratorTest extends TestCase
+{
+    /**
+     * The studio-auth#1520 incident shape: a primitive-only inline `oneOf`
+     * (`string | string[]`) inside an optional property. Rotation with an
+     * unlucky case count misses branches; branch-complete generation must
+     * cover both `oneOf` branches and both presence states.
+     *
+     * @var array<string, mixed>
+     */
+    private const INCIDENT_SHAPE = [
+        'type' => 'object',
+        'required' => ['active'],
+        'properties' => [
+            'active' => ['type' => 'boolean'],
+            'aud' => [
+                'oneOf' => [
+                    ['type' => 'string'],
+                    ['type' => 'array', 'items' => ['type' => 'string']],
+                ],
+            ],
+        ],
+    ];
+
+    #[Test]
+    public function covers_every_branch_of_an_optional_primitive_only_one_of(): void
+    {
+        $cases = BranchCompleteCaseGenerator::generate(self::INCIDENT_SHAPE, seed: 1);
+
+        $sawString = false;
+        $sawArray = false;
+        $sawOmitted = false;
+        foreach ($cases as $case) {
+            $this->assertIsArray($case->value);
+            if (!isset($case->value['aud'])) {
+                $sawOmitted = true;
+
+                continue;
+            }
+            $sawString = $sawString || is_string($case->value['aud']);
+            $sawArray = $sawArray || is_array($case->value['aud']);
+        }
+
+        $this->assertTrue($sawString, 'no case pinned the string branch of aud');
+        $this->assertTrue($sawArray, 'no case pinned the array branch of aud');
+        $this->assertTrue($sawOmitted, 'no case omitted the optional aud property');
+    }
+
+    #[Test]
+    public function derives_one_case_per_choice_point_branch_pair_plus_extras(): void
+    {
+        // Choice points: aud presence (2 branches) + aud oneOf (2 branches).
+        $this->assertCount(4, BranchCompleteCaseGenerator::generate(self::INCIDENT_SHAPE, seed: 1));
+        $this->assertCount(6, BranchCompleteCaseGenerator::generate(self::INCIDENT_SHAPE, seed: 1, extraCases: 2));
+    }
+
+    #[Test]
+    public function pinned_cases_carry_their_target_choice_point(): void
+    {
+        $cases = BranchCompleteCaseGenerator::generate(self::INCIDENT_SHAPE, seed: 1, extraCases: 1);
+
+        $targets = [];
+        foreach ($cases as $case) {
+            if ($case->plan->targetPointer !== null) {
+                $targets[] = $case->plan->targetPointer . '@' . $case->plan->targetBranch;
+            }
+        }
+
+        $this->assertSame([
+            '/properties/aud@0',
+            '/properties/aud@1',
+            '/properties/aud/oneOf@0',
+            '/properties/aud/oneOf@1',
+        ], $targets);
+        $this->assertNull($cases[4]->plan->targetPointer);
+    }
+
+    #[Test]
+    public function every_generated_case_satisfies_the_converted_schema(): void
+    {
+        $cases = BranchCompleteCaseGenerator::generate(self::INCIDENT_SHAPE, seed: 1, extraCases: 2);
+
+        foreach ($cases as $case) {
+            $this->assertTrue(SchemaValueValidator::isValid($case->value, self::INCIDENT_SHAPE));
+        }
+    }
+
+    #[Test]
+    public function covers_both_nullable_branches(): void
+    {
+        $cases = BranchCompleteCaseGenerator::generate(['type' => ['string', 'null']], seed: 1);
+
+        $values = array_map(static fn(PlannedSchemaCase $case): mixed => $case->value, $cases);
+
+        $this->assertContains(null, $values);
+        $sawString = false;
+        foreach ($values as $value) {
+            $sawString = $sawString || is_string($value);
+        }
+        $this->assertTrue($sawString, 'no case pinned the non-null branch');
+    }
+
+    #[Test]
+    public function is_deterministic_for_a_fixed_schema_and_seed(): void
+    {
+        $first = BranchCompleteCaseGenerator::generate(self::INCIDENT_SHAPE, seed: 7, extraCases: 3);
+        $second = BranchCompleteCaseGenerator::generate(self::INCIDENT_SHAPE, seed: 7, extraCases: 3);
+
+        $this->assertSame(
+            json_encode(array_map(static fn(PlannedSchemaCase $case): mixed => $case->value, $first)),
+            json_encode(array_map(static fn(PlannedSchemaCase $case): mixed => $case->value, $second)),
+        );
+    }
+
+    #[Test]
+    public function generates_a_single_case_for_a_schema_without_choice_points(): void
+    {
+        $cases = BranchCompleteCaseGenerator::generate([
+            'type' => 'object',
+            'required' => ['id'],
+            'properties' => ['id' => ['type' => 'integer']],
+        ], seed: 1);
+
+        $this->assertCount(1, $cases);
+        $this->assertNull($cases[0]->plan->targetPointer);
+    }
+
+    #[Test]
+    public function rejects_negative_extra_cases(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        BranchCompleteCaseGenerator::generate(self::INCIDENT_SHAPE, seed: 1, extraCases: -1);
+    }
+
+    #[Test]
+    public function propagates_loud_enumeration_failures(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('enumeration');
+
+        BranchCompleteCaseGenerator::generate([
+            'oneOf' => [
+                ['oneOf' => [['type' => 'string'], ['type' => 'integer']]],
+                ['type' => 'boolean'],
+            ],
+        ], seed: 1);
+    }
+
+    #[Test]
+    public function covers_a_choice_point_inside_an_empty_by_default_array(): void
+    {
+        // The pinned case must force at least one item so the branch under
+        // `items` is actually exercised even though minItems allows [].
+        $schema = [
+            'type' => 'array',
+            'minItems' => 0,
+            'items' => ['oneOf' => [['type' => 'string'], ['type' => 'integer']]],
+        ];
+
+        $cases = BranchCompleteCaseGenerator::generate($schema, seed: 1);
+
+        $sawString = false;
+        $sawInteger = false;
+        foreach ($cases as $case) {
+            $this->assertIsArray($case->value);
+            foreach ($case->value as $item) {
+                $sawString = $sawString || is_string($item);
+                $sawInteger = $sawInteger || is_int($item);
+            }
+        }
+
+        $this->assertTrue($sawString, 'no case exercised the string items branch');
+        $this->assertTrue($sawInteger, 'no case exercised the integer items branch');
+    }
+}

--- a/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
+++ b/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
@@ -676,6 +676,34 @@ class BranchCompleteCaseGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function covers_an_omission_branch_reachable_through_pattern_properties(): void
+    {
+        // additionalProperties: false only forbids names that neither
+        // `properties` nor `patternProperties` evaluates, so minProperties
+        // can be met by a pattern-matched name and omission stays reachable.
+        $schema = [
+            'type' => 'object',
+            'minProperties' => 1,
+            'properties' => ['a' => ['type' => 'string']],
+            'patternProperties' => ['^x$' => ['type' => 'string']],
+            'additionalProperties' => false,
+        ];
+
+        $sawOmitted = false;
+        foreach (BranchCompleteCaseGenerator::generate($schema, seed: 1) as $case) {
+            $this->assertTrue(
+                SchemaValueValidator::isValid($case->value, $schema),
+                'case ' . json_encode($case->value) . ' is invalid',
+            );
+            if (is_array($case->value) && !array_key_exists('a', $case->value)) {
+                $sawOmitted = true;
+            }
+        }
+
+        $this->assertTrue($sawOmitted, 'no case omitted the optional property');
+    }
+
+    #[Test]
     public function drops_a_conditional_branch_made_unreachable_by_a_folded_suppression(): void
     {
         // The first conditional's then: false permanently forbids x; the

--- a/tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
+++ b/tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
@@ -133,19 +133,46 @@ class SchemaChoicePointEnumeratorTest extends TestCase
         $this->assertArrayHasKey('/allOf', $points);
         $conditional = $points['/allOf'];
         $this->assertSame(SchemaChoicePointKind::AllOfConditional, $conditional->kind);
-        // Two branches per conditional: even takes if+then, odd takes else.
-        $this->assertSame(4, $conditional->branchCount);
+        // One branch per conditional (if+then, all others suppressed) plus
+        // the trailing none-match branch, which is a reachability probe.
+        $this->assertSame(3, $conditional->branchCount);
+        $this->assertSame(2, $conditional->probeBranch);
     }
 
     #[Test]
-    public function records_supplemental_branches_when_a_pointer_reappears_with_more_branches(): void
+    public function flags_choice_points_discovered_under_the_none_match_view_as_probes(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'allOf' => [
+                [
+                    'if' => ['required' => ['kind']],
+                    'then' => ['properties' => ['kind' => ['const' => 'a']]],
+                    'else' => ['properties' => ['fallback' => ['type' => 'string']]],
+                ],
+            ],
+        ];
+
+        $points = $this->indexByPointer(SchemaChoicePointEnumerator::enumerate($schema));
+
+        $this->assertArrayHasKey('/properties/fallback', $points);
+        $fallback = $points['/properties/fallback'];
+        $this->assertSame(['/allOf' => 1], $fallback->ancestors);
+        // Reachable only when no conditional matches, which cannot be
+        // pre-determined — its cases are dropped, not failed, when the
+        // schema forbids that state.
+        $this->assertTrue($fallback->probeContext);
+    }
+
+    #[Test]
+    public function records_rediscoveries_with_different_content_as_separate_choice_points(): void
     {
         $schema = [
             'type' => 'object',
             'required' => ['v'],
             'anyOf' => [
                 ['properties' => ['v' => ['oneOf' => [['const' => 'x'], ['const' => 'y']]]]],
-                ['properties' => ['v' => ['oneOf' => [['const' => 'x'], ['const' => 'y'], ['const' => 'z']]]]],
+                ['properties' => ['v' => ['oneOf' => [['const' => 1], ['const' => 2]]]]],
             ],
         ];
 
@@ -156,15 +183,35 @@ class SchemaChoicePointEnumeratorTest extends TestCase
             }
         }
 
+        // Same pointer and branch count, but different branch content: both
+        // contexts keep their own full coverage under their own ancestors.
         $this->assertCount(2, $entries);
-        $this->assertSame(0, $entries[0]->firstBranch);
         $this->assertSame(2, $entries[0]->branchCount);
         $this->assertSame(['/anyOf' => 0], $entries[0]->ancestors);
-        // The wider rediscovery keeps only its uncovered branches, under the
-        // ancestors that actually make the third branch reachable.
-        $this->assertSame(2, $entries[1]->firstBranch);
-        $this->assertSame(3, $entries[1]->branchCount);
+        $this->assertSame(2, $entries[1]->branchCount);
         $this->assertSame(['/anyOf' => 1], $entries[1]->ancestors);
+    }
+
+    #[Test]
+    public function still_dedupes_rediscoveries_with_identical_content(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'required' => ['v'],
+            'anyOf' => [
+                ['properties' => ['v' => ['oneOf' => [['const' => 'x'], ['const' => 'y']]]]],
+                ['properties' => ['v' => ['oneOf' => [['const' => 'x'], ['const' => 'y']]]]],
+            ],
+        ];
+
+        $entries = [];
+        foreach (SchemaChoicePointEnumerator::enumerate($schema) as $point) {
+            if ($point->pointer === '/properties/v/oneOf') {
+                $entries[] = $point;
+            }
+        }
+
+        $this->assertCount(1, $entries);
     }
 
     #[Test]

--- a/tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
+++ b/tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
@@ -162,6 +162,40 @@ class SchemaChoicePointEnumeratorTest extends TestCase
     }
 
     #[Test]
+    public function excludes_statically_unreachable_boolean_branches_from_the_one_of_space(): void
+    {
+        $points = SchemaChoicePointEnumerator::enumerate([
+            'type' => 'string',
+            'oneOf' => [true, ['const' => 'x']],
+        ]);
+
+        $this->assertCount(1, $points);
+        $this->assertSame('/oneOf', $points[0]->pointer);
+        // With a `true` sibling no other branch can be the sole match; only
+        // the `true` branch is generatable.
+        $this->assertSame(1, $points[0]->branchCount);
+    }
+
+    #[Test]
+    public function resolves_a_boolean_if_without_recording_a_choice_point(): void
+    {
+        $points = $this->indexByPointer(SchemaChoicePointEnumerator::enumerate([
+            'type' => 'object',
+            'if' => true,
+            'then' => [
+                'required' => ['choice'],
+                'properties' => ['choice' => ['oneOf' => [['type' => 'string'], ['type' => 'integer']]]],
+            ],
+        ]));
+
+        // `if: true` has no else side to choose — the then is unconditional,
+        // and its content is enumerated without an /if ancestor.
+        $this->assertArrayNotHasKey('/if', $points);
+        $this->assertArrayHasKey('/properties/choice/oneOf', $points);
+        $this->assertSame([], $points['/properties/choice/oneOf']->ancestors);
+    }
+
+    #[Test]
     public function records_rediscoveries_with_different_content_as_separate_choice_points(): void
     {
         $schema = [

--- a/tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
+++ b/tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
@@ -196,6 +196,35 @@ class SchemaChoicePointEnumeratorTest extends TestCase
     }
 
     #[Test]
+    public function excludes_an_unsatisfiable_boolean_consequent_from_the_if_space(): void
+    {
+        $points = $this->indexByPointer(SchemaChoicePointEnumerator::enumerate([
+            'type' => 'string',
+            'if' => ['const' => 'x'],
+            'then' => false,
+            'else' => ['const' => 'y'],
+        ]));
+
+        $this->assertArrayHasKey('/if', $points);
+        // Only the else side is generatable: nothing satisfies `then: false`.
+        $this->assertSame(1, $points['/if']->branchCount);
+    }
+
+    #[Test]
+    public function records_presence_for_boolean_true_properties_and_skips_false_ones(): void
+    {
+        $points = $this->indexByPointer(SchemaChoicePointEnumerator::enumerate([
+            'type' => 'object',
+            'properties' => ['x' => true, 'y' => false],
+        ]));
+
+        $this->assertArrayHasKey('/properties/x', $points);
+        $this->assertSame(SchemaChoicePointKind::OptionalProperty, $points['/properties/x']->kind);
+        // Presence of a `false` property is unreachable — no choice.
+        $this->assertArrayNotHasKey('/properties/y', $points);
+    }
+
+    #[Test]
     public function records_rediscoveries_with_different_content_as_separate_choice_points(): void
     {
         $schema = [

--- a/tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
+++ b/tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
@@ -11,9 +11,6 @@ use Studio\Gesso\Fuzz\SchemaChoicePoint;
 use Studio\Gesso\Fuzz\SchemaChoicePointEnumerator;
 use Studio\Gesso\Fuzz\SchemaChoicePointKind;
 
-use function array_unique;
-use function array_values;
-
 class SchemaChoicePointEnumeratorTest extends TestCase
 {
     #[Test]
@@ -193,7 +190,7 @@ class SchemaChoicePointEnumeratorTest extends TestCase
     }
 
     #[Test]
-    public function still_dedupes_rediscoveries_with_identical_content(): void
+    public function keeps_identical_content_rediscoveries_from_different_contexts(): void
     {
         $schema = [
             'type' => 'object',
@@ -204,14 +201,14 @@ class SchemaChoicePointEnumeratorTest extends TestCase
             ],
         ];
 
-        $entries = [];
+        $contexts = [];
         foreach (SchemaChoicePointEnumerator::enumerate($schema) as $point) {
             if ($point->pointer === '/properties/v/oneOf') {
-                $entries[] = $point;
+                $contexts[] = $point->ancestors;
             }
         }
 
-        $this->assertCount(1, $entries);
+        $this->assertSame([['/anyOf' => 0], ['/anyOf' => 1]], $contexts);
     }
 
     #[Test]
@@ -260,7 +257,7 @@ class SchemaChoicePointEnumeratorTest extends TestCase
     }
 
     #[Test]
-    public function dedupes_choice_points_rediscovered_across_one_of_branches(): void
+    public function records_rediscoveries_per_branch_context(): void
     {
         $schema = [
             'type' => 'object',
@@ -273,20 +270,27 @@ class SchemaChoicePointEnumeratorTest extends TestCase
             ],
         ];
 
-        $points = SchemaChoicePointEnumerator::enumerate($schema);
-        $pointers = [];
-        foreach ($points as $point) {
-            $pointers[] = $point->pointer;
+        $contexts = [];
+        $presenceContexts = [];
+        foreach (SchemaChoicePointEnumerator::enumerate($schema) as $point) {
+            if ($point->pointer === '/properties/shared/oneOf') {
+                $contexts[] = $point->ancestors;
+            }
+            if ($point->pointer === '/properties/shared') {
+                $presenceContexts[] = $point->ancestors;
+            }
         }
 
-        $this->assertSame($pointers, array_values(array_unique($pointers)));
-
-        $indexed = $this->indexByPointer($points);
-        $this->assertArrayHasKey('/oneOf', $indexed);
-        // Discovered first under branch 0, where `shared` is required.
-        $this->assertSame(['/oneOf' => 0], $indexed['/properties/shared/oneOf']->ancestors);
+        // Generation may leave a claimed branch context (closure expansion),
+        // so every discovery context keeps its own entry; at least one of
+        // them is stable under generation. Under branch 1 `shared` is
+        // optional, so that context also forces its presence.
+        $this->assertSame([
+            ['/oneOf' => 0],
+            ['/oneOf' => 1, '/properties/shared' => SchemaChoicePoint::PRESENT],
+        ], $contexts);
         // Presence is only a choice under branch 1, where `shared` is optional.
-        $this->assertSame(['/oneOf' => 1], $indexed['/properties/shared']->ancestors);
+        $this->assertSame([['/oneOf' => 1]], $presenceContexts);
     }
 
     #[Test]

--- a/tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
+++ b/tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
@@ -1,0 +1,316 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Fuzz;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Fuzz\SchemaChoicePoint;
+use Studio\Gesso\Fuzz\SchemaChoicePointEnumerator;
+use Studio\Gesso\Fuzz\SchemaChoicePointKind;
+
+use function array_unique;
+use function array_values;
+
+class SchemaChoicePointEnumeratorTest extends TestCase
+{
+    #[Test]
+    public function collects_optional_property_presence_and_nested_one_of_for_the_incident_shape(): void
+    {
+        // studio-auth#1520: a primitive-only inline oneOf inside an *optional*
+        // property of the response model, not at the schema root.
+        $schema = [
+            'type' => 'object',
+            'required' => ['active'],
+            'properties' => [
+                'active' => ['type' => 'boolean'],
+                'aud' => [
+                    'oneOf' => [
+                        ['type' => 'string'],
+                        ['type' => 'array', 'items' => ['type' => 'string']],
+                    ],
+                ],
+            ],
+        ];
+
+        $points = $this->indexByPointer(SchemaChoicePointEnumerator::enumerate($schema));
+
+        $this->assertArrayHasKey('/properties/aud', $points);
+        $presence = $points['/properties/aud'];
+        $this->assertSame(SchemaChoicePointKind::OptionalProperty, $presence->kind);
+        $this->assertSame(2, $presence->branchCount);
+        $this->assertSame([], $presence->ancestors);
+
+        $this->assertArrayHasKey('/properties/aud/oneOf', $points);
+        $oneOf = $points['/properties/aud/oneOf'];
+        $this->assertSame(SchemaChoicePointKind::OneOf, $oneOf->kind);
+        $this->assertSame(2, $oneOf->branchCount);
+        $this->assertSame(
+            ['/properties/aud' => SchemaChoicePoint::PRESENT],
+            $oneOf->ancestors,
+        );
+    }
+
+    #[Test]
+    public function does_not_record_presence_for_required_properties(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'required' => ['status'],
+            'properties' => [
+                'status' => ['anyOf' => [['type' => 'string'], ['type' => 'integer']]],
+            ],
+        ];
+
+        $points = $this->indexByPointer(SchemaChoicePointEnumerator::enumerate($schema));
+
+        $this->assertArrayNotHasKey('/properties/status', $points);
+        $this->assertArrayHasKey('/properties/status/anyOf', $points);
+        $anyOf = $points['/properties/status/anyOf'];
+        $this->assertSame(SchemaChoicePointKind::AnyOf, $anyOf->kind);
+        $this->assertSame(2, $anyOf->branchCount);
+        $this->assertSame([], $anyOf->ancestors);
+    }
+
+    #[Test]
+    public function collects_nullable_type_choice_and_constrains_descendants_to_the_value_branch(): void
+    {
+        $schema = [
+            'type' => ['object', 'null'],
+            'properties' => [
+                'name' => ['type' => 'string'],
+            ],
+        ];
+
+        $points = $this->indexByPointer(SchemaChoicePointEnumerator::enumerate($schema));
+
+        $this->assertArrayHasKey('/type', $points);
+        $nullable = $points['/type'];
+        $this->assertSame(SchemaChoicePointKind::Nullable, $nullable->kind);
+        $this->assertSame(2, $nullable->branchCount);
+
+        $this->assertArrayHasKey('/properties/name', $points);
+        $this->assertSame(
+            ['/type' => SchemaChoicePoint::VALUE],
+            $points['/properties/name']->ancestors,
+        );
+    }
+
+    #[Test]
+    public function collects_if_then_else_choice(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'if' => ['required' => ['kind']],
+            'then' => ['required' => ['a'], 'properties' => ['a' => ['type' => 'string']]],
+            'else' => ['required' => ['b'], 'properties' => ['b' => ['type' => 'integer']]],
+        ];
+
+        $points = $this->indexByPointer(SchemaChoicePointEnumerator::enumerate($schema));
+
+        $this->assertArrayHasKey('/if', $points);
+        $conditional = $points['/if'];
+        $this->assertSame(SchemaChoicePointKind::IfThenElse, $conditional->kind);
+        $this->assertSame(2, $conditional->branchCount);
+    }
+
+    #[Test]
+    public function collects_all_of_conditional_choice(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'allOf' => [
+                ['properties' => ['base' => ['type' => 'string']]],
+                ['if' => ['required' => ['x']], 'then' => ['properties' => ['x' => ['type' => 'string']]]],
+                ['if' => ['required' => ['y']], 'then' => ['properties' => ['y' => ['type' => 'integer']]]],
+            ],
+        ];
+
+        $points = $this->indexByPointer(SchemaChoicePointEnumerator::enumerate($schema));
+
+        $this->assertArrayHasKey('/allOf', $points);
+        $conditional = $points['/allOf'];
+        $this->assertSame(SchemaChoicePointKind::AllOfConditional, $conditional->kind);
+        $this->assertSame(2, $conditional->branchCount);
+    }
+
+    #[Test]
+    public function stops_at_const_and_enum_schemas(): void
+    {
+        $this->assertSame([], SchemaChoicePointEnumerator::enumerate([
+            'const' => 'fixed',
+            'properties' => ['a' => ['oneOf' => [['type' => 'string'], ['type' => 'integer']]]],
+        ]));
+        $this->assertSame([], SchemaChoicePointEnumerator::enumerate([
+            'type' => ['string', 'null'],
+            'enum' => ['a', 'b', null],
+        ]));
+    }
+
+    #[Test]
+    public function collects_choice_points_under_array_items_with_forced_item_presence(): void
+    {
+        $schema = [
+            'type' => 'array',
+            'minItems' => 0,
+            'items' => ['oneOf' => [['type' => 'string'], ['type' => 'integer']]],
+        ];
+
+        $points = $this->indexByPointer(SchemaChoicePointEnumerator::enumerate($schema));
+
+        $this->assertArrayHasKey('/items/oneOf', $points);
+        $this->assertSame(['/items' => 1], $points['/items/oneOf']->ancestors);
+    }
+
+    #[Test]
+    public function collects_choice_points_under_prefix_items(): void
+    {
+        $schema = [
+            'type' => 'array',
+            'prefixItems' => [
+                ['type' => 'string'],
+                ['oneOf' => [['type' => 'string'], ['type' => 'integer']]],
+            ],
+        ];
+
+        $points = $this->indexByPointer(SchemaChoicePointEnumerator::enumerate($schema));
+
+        $this->assertArrayHasKey('/prefixItems/1/oneOf', $points);
+        $this->assertSame(['/items' => 2], $points['/prefixItems/1/oneOf']->ancestors);
+    }
+
+    #[Test]
+    public function dedupes_choice_points_rediscovered_across_one_of_branches(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'shared' => ['oneOf' => [['type' => 'string'], ['type' => 'integer']]],
+            ],
+            'oneOf' => [
+                ['required' => ['shared']],
+                ['properties' => ['extra' => ['type' => 'string']]],
+            ],
+        ];
+
+        $points = SchemaChoicePointEnumerator::enumerate($schema);
+        $pointers = [];
+        foreach ($points as $point) {
+            $pointers[] = $point->pointer;
+        }
+
+        $this->assertSame($pointers, array_values(array_unique($pointers)));
+
+        $indexed = $this->indexByPointer($points);
+        $this->assertArrayHasKey('/oneOf', $indexed);
+        // Discovered first under branch 0, where `shared` is required.
+        $this->assertSame(['/oneOf' => 0], $indexed['/properties/shared/oneOf']->ancestors);
+        // Presence is only a choice under branch 1, where `shared` is optional.
+        $this->assertSame(['/oneOf' => 1], $indexed['/properties/shared']->ancestors);
+    }
+
+    #[Test]
+    public function escapes_property_names_in_json_pointers(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'a/b' => ['type' => 'string'],
+                'c~d' => ['type' => 'string'],
+            ],
+        ];
+
+        $points = $this->indexByPointer(SchemaChoicePointEnumerator::enumerate($schema));
+
+        $this->assertArrayHasKey('/properties/a~1b', $points);
+        $this->assertArrayHasKey('/properties/c~0d', $points);
+    }
+
+    #[Test]
+    public function returns_empty_for_a_schema_without_choice_points(): void
+    {
+        $this->assertSame([], SchemaChoicePointEnumerator::enumerate([
+            'type' => 'object',
+            'required' => ['id'],
+            'properties' => ['id' => ['type' => 'integer']],
+        ]));
+    }
+
+    #[Test]
+    public function throws_on_a_composition_nested_directly_inside_a_branch(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('enumeration');
+
+        SchemaChoicePointEnumerator::enumerate([
+            'oneOf' => [
+                ['oneOf' => [['type' => 'string'], ['type' => 'integer']]],
+                ['type' => 'boolean'],
+            ],
+        ]);
+    }
+
+    #[Test]
+    public function throws_when_one_of_and_any_of_share_a_node(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('enumeration');
+
+        SchemaChoicePointEnumerator::enumerate([
+            'oneOf' => [['type' => 'string'], ['type' => 'integer']],
+            'anyOf' => [['minLength' => 1], ['maxLength' => 3]],
+        ]);
+    }
+
+    #[Test]
+    public function throws_beyond_the_documented_depth_bound(): void
+    {
+        $schema = ['oneOf' => [['type' => 'string'], ['type' => 'integer']]];
+        for ($i = 0; $i < 40; $i++) {
+            $schema = [
+                'type' => 'object',
+                'required' => ['nested'],
+                'properties' => ['nested' => $schema],
+            ];
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('depth');
+
+        SchemaChoicePointEnumerator::enumerate($schema);
+    }
+
+    #[Test]
+    public function throws_beyond_the_documented_choice_point_budget(): void
+    {
+        $properties = [];
+        for ($i = 0; $i < 300; $i++) {
+            $properties['p' . $i] = ['type' => 'string'];
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('choice point');
+
+        SchemaChoicePointEnumerator::enumerate([
+            'type' => 'object',
+            'properties' => $properties,
+        ]);
+    }
+
+    /**
+     * @param list<SchemaChoicePoint> $points
+     *
+     * @return array<string, SchemaChoicePoint>
+     */
+    private function indexByPointer(array $points): array
+    {
+        $indexed = [];
+        foreach ($points as $point) {
+            $indexed[$point->pointer] = $point;
+        }
+
+        return $indexed;
+    }
+}

--- a/tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
+++ b/tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
@@ -133,7 +133,38 @@ class SchemaChoicePointEnumeratorTest extends TestCase
         $this->assertArrayHasKey('/allOf', $points);
         $conditional = $points['/allOf'];
         $this->assertSame(SchemaChoicePointKind::AllOfConditional, $conditional->kind);
-        $this->assertSame(2, $conditional->branchCount);
+        // Two branches per conditional: even takes if+then, odd takes else.
+        $this->assertSame(4, $conditional->branchCount);
+    }
+
+    #[Test]
+    public function records_supplemental_branches_when_a_pointer_reappears_with_more_branches(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'required' => ['v'],
+            'anyOf' => [
+                ['properties' => ['v' => ['oneOf' => [['const' => 'x'], ['const' => 'y']]]]],
+                ['properties' => ['v' => ['oneOf' => [['const' => 'x'], ['const' => 'y'], ['const' => 'z']]]]],
+            ],
+        ];
+
+        $entries = [];
+        foreach (SchemaChoicePointEnumerator::enumerate($schema) as $point) {
+            if ($point->pointer === '/properties/v/oneOf') {
+                $entries[] = $point;
+            }
+        }
+
+        $this->assertCount(2, $entries);
+        $this->assertSame(0, $entries[0]->firstBranch);
+        $this->assertSame(2, $entries[0]->branchCount);
+        $this->assertSame(['/anyOf' => 0], $entries[0]->ancestors);
+        // The wider rediscovery keeps only its uncovered branches, under the
+        // ancestors that actually make the third branch reachable.
+        $this->assertSame(2, $entries[1]->firstBranch);
+        $this->assertSame(3, $entries[1]->branchCount);
+        $this->assertSame(['/anyOf' => 1], $entries[1]->ancestors);
     }
 
     #[Test]

--- a/tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
+++ b/tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
@@ -131,13 +131,12 @@ class SchemaChoicePointEnumeratorTest extends TestCase
         $conditional = $points['/allOf'];
         $this->assertSame(SchemaChoicePointKind::AllOfConditional, $conditional->kind);
         // One branch per conditional (if+then, all others suppressed) plus
-        // the trailing none-match branch, which is a reachability probe.
+        // the trailing none-match branch.
         $this->assertSame(3, $conditional->branchCount);
-        $this->assertSame(2, $conditional->probeBranch);
     }
 
     #[Test]
-    public function flags_choice_points_discovered_under_the_none_match_view_as_probes(): void
+    public function enumerates_choice_points_under_the_none_match_view(): void
     {
         $schema = [
             'type' => 'object',
@@ -153,12 +152,8 @@ class SchemaChoicePointEnumeratorTest extends TestCase
         $points = $this->indexByPointer(SchemaChoicePointEnumerator::enumerate($schema));
 
         $this->assertArrayHasKey('/properties/fallback', $points);
-        $fallback = $points['/properties/fallback'];
-        $this->assertSame(['/allOf' => 1], $fallback->ancestors);
-        // Reachable only when no conditional matches, which cannot be
-        // pre-determined — its cases are dropped, not failed, when the
-        // schema forbids that state.
-        $this->assertTrue($fallback->probeContext);
+        // Reachable only when no conditional matches.
+        $this->assertSame(['/allOf' => 1], $points['/properties/fallback']->ancestors);
     }
 
     #[Test]

--- a/tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
+++ b/tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
@@ -225,6 +225,32 @@ class SchemaChoicePointEnumeratorTest extends TestCase
     }
 
     #[Test]
+    public function records_no_choice_for_conditionals_with_boolean_consequents(): void
+    {
+        // then: false → always suppressed; else: false → always satisfied.
+        // Neither leaves a branch to choose.
+        $this->assertSame([], SchemaChoicePointEnumerator::enumerate([
+            'type' => 'string',
+            'allOf' => [['if' => ['const' => 'x'], 'then' => false, 'else' => ['const' => 'y']]],
+        ]));
+        $this->assertSame([], SchemaChoicePointEnumerator::enumerate([
+            'type' => 'string',
+            'allOf' => [['if' => ['const' => 'a'], 'then' => true, 'else' => false]],
+        ]));
+    }
+
+    #[Test]
+    public function does_not_enumerate_past_a_boolean_false_prefix_item(): void
+    {
+        // Any array with elements is invalid once prefixItems[0] is false;
+        // choice points behind it are unreachable.
+        $this->assertSame([], SchemaChoicePointEnumerator::enumerate([
+            'type' => 'array',
+            'prefixItems' => [false, ['oneOf' => [['const' => 'x'], ['const' => 'y']]]],
+        ]));
+    }
+
+    #[Test]
     public function records_rediscoveries_with_different_content_as_separate_choice_points(): void
     {
         $schema = [

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -1362,6 +1362,49 @@ class SchemaDataGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function merge_intersects_enum_domains(): void
+    {
+        // Both enums are assertions; plain array_merge would let the right
+        // side displace the left and silently widen the admissible domain.
+        $this->assertSame(
+            ['b'],
+            SchemaDataGenerator::mergeSchemas(['enum' => ['a', 'b']], ['enum' => ['c', 'b']])['enum'],
+        );
+        // Right-side order is preserved so unconflicted merges keep the
+        // historical rotation picks bit-for-bit.
+        $this->assertSame(
+            ['b', 'a'],
+            SchemaDataGenerator::mergeSchemas(['enum' => ['a', 'b']], ['enum' => ['b', 'a']])['enum'],
+        );
+        $this->assertSame(
+            [],
+            SchemaDataGenerator::mergeSchemas(['enum' => ['a']], ['enum' => ['c']])['enum'],
+        );
+    }
+
+    #[Test]
+    public function merge_intersects_type_constraints(): void
+    {
+        $this->assertSame(
+            ['integer'],
+            SchemaDataGenerator::mergeSchemas(
+                ['type' => 'integer'],
+                ['type' => ['string', 'integer']],
+            )['type'],
+        );
+        // An unconflicted merge keeps the right side verbatim, string form
+        // included, so historical output is untouched.
+        $this->assertSame(
+            'string',
+            SchemaDataGenerator::mergeSchemas(['type' => ['string', 'null']], ['type' => 'string'])['type'],
+        );
+        $this->assertSame(
+            [],
+            SchemaDataGenerator::mergeSchemas(['type' => 'integer'], ['type' => 'string'])['type'],
+        );
+    }
+
+    #[Test]
     public function planned_enum_generation_filters_values_excluded_by_not(): void
     {
         // Rotation alone cannot escape a long excluded prefix; the planned

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -1427,6 +1427,35 @@ class SchemaDataGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function merge_marks_conflicting_value_domains_empty(): void
+    {
+        // A const conflicting with the other side's const or enum is a
+        // static proof the conjunction is empty; the marker lets planned
+        // generation prove a dead end instead of guessing from failures.
+        $this->assertSame(
+            [],
+            SchemaDataGenerator::mergeSchemas(['const' => 'a'], ['const' => 'b'])['enum'],
+        );
+        $this->assertSame(
+            [],
+            SchemaDataGenerator::mergeSchemas(['const' => 'a'], ['enum' => ['b', 'c']])['enum'],
+        );
+        $this->assertSame(
+            [],
+            SchemaDataGenerator::mergeSchemas(['enum' => ['b', 'c']], ['const' => 'a'])['enum'],
+        );
+        // Compatible const/enum pairs stay untouched.
+        $this->assertArrayNotHasKey(
+            'enum',
+            SchemaDataGenerator::mergeSchemas(['const' => 'a'], ['const' => 'a']),
+        );
+        $this->assertSame(
+            ['a', 'b'],
+            SchemaDataGenerator::mergeSchemas(['const' => 'a'], ['enum' => ['a', 'b']])['enum'],
+        );
+    }
+
+    #[Test]
     public function merge_intersects_enum_domains_by_json_equality(): void
     {
         // JSON Schema equality is mathematical for numbers (2020-12

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -1330,6 +1330,18 @@ class SchemaDataGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function merge_combines_not_constraints_conjunctively(): void
+    {
+        $merged = SchemaDataGenerator::mergeSchemas(
+            ['type' => 'string', 'not' => ['const' => 'a']],
+            ['not' => ['const' => 'b']],
+        );
+
+        // ¬A ∧ ¬B ⟺ ¬(A ∨ B): both exclusions must survive the merge.
+        $this->assertSame(['anyOf' => [['const' => 'a'], ['const' => 'b']]], $merged['not']);
+    }
+
+    #[Test]
     public function planned_enum_generation_filters_values_excluded_by_not(): void
     {
         // Rotation alone cannot escape a long excluded prefix; the planned

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -1342,6 +1342,26 @@ class SchemaDataGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function merge_treats_boolean_not_schemas_as_conjunction_operands(): void
+    {
+        // JSON Schema 2020-12 booleans: `not: false` is a no-op (nothing
+        // matches false), `not: true` rejects everything. Neither may
+        // displace or be displaced by a real exclusion.
+        $exclusion = ['const' => 'forbidden'];
+
+        $this->assertSame(
+            $exclusion,
+            SchemaDataGenerator::mergeSchemas(['not' => $exclusion], ['not' => false])['not'],
+        );
+        $this->assertSame(
+            $exclusion,
+            SchemaDataGenerator::mergeSchemas(['not' => false], ['not' => $exclusion])['not'],
+        );
+        $this->assertTrue(SchemaDataGenerator::mergeSchemas(['not' => $exclusion], ['not' => true])['not']);
+        $this->assertFalse(SchemaDataGenerator::mergeSchemas(['not' => false], ['not' => false])['not']);
+    }
+
+    #[Test]
     public function planned_enum_generation_filters_values_excluded_by_not(): void
     {
         // Rotation alone cannot escape a long excluded prefix; the planned

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -1299,6 +1299,55 @@ class SchemaDataGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function pinned_conditional_branch_keeps_overlapping_conditionals_satisfiable(): void
+    {
+        // Two conditionals fire on the same `if`; the only valid state with
+        // flag=true satisfies BOTH thens. Pinning one branch must not force
+        // the other conditional out of existence.
+        $schema = [
+            'type' => 'object',
+            'required' => ['flag'],
+            'properties' => ['flag' => ['type' => 'boolean']],
+            'allOf' => [
+                [
+                    'if' => ['properties' => ['flag' => ['const' => true]], 'required' => ['flag']],
+                    'then' => ['required' => ['a'], 'properties' => ['a' => ['type' => 'string']]],
+                ],
+                [
+                    'if' => ['properties' => ['flag' => ['const' => true]], 'required' => ['flag']],
+                    'then' => ['required' => ['b'], 'properties' => ['b' => ['type' => 'string']]],
+                ],
+            ],
+        ];
+
+        $value = SchemaDataGenerator::generateOne($schema, null, 0, new CaseSelectionPlan(['/allOf' => 0]));
+
+        $this->assertIsArray($value);
+        $this->assertArrayHasKey('a', $value);
+        $this->assertArrayHasKey('b', $value);
+        $this->assertTrue(SchemaValueValidator::isValid($value, $schema));
+    }
+
+    #[Test]
+    public function planned_not_generation_retries_nearby_iterations_before_falling_back(): void
+    {
+        // Iteration 1 rotates the enum onto the excluded value; the planned
+        // path must probe nearby iterations instead of giving up on the
+        // first miss.
+        $schema = [
+            'type' => 'object',
+            'required' => ['kind'],
+            'properties' => ['kind' => ['type' => 'string', 'enum' => ['other', 'cat']]],
+            'not' => ['properties' => ['kind' => ['const' => 'cat']], 'required' => ['kind']],
+        ];
+
+        $value = SchemaDataGenerator::generateOne($schema, null, 1, new CaseSelectionPlan([]));
+
+        $this->assertIsArray($value);
+        $this->assertSame('other', $value['kind']);
+    }
+
+    #[Test]
     public function pinned_none_match_branch_avoids_every_conditional(): void
     {
         $schema = [

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -1405,6 +1405,44 @@ class SchemaDataGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function merge_narrows_number_and_integer_to_integer(): void
+    {
+        // integer is the zero-fraction subtype of number (2020-12 §6.1.1):
+        // the conjunction is integer in either direction, never empty.
+        $this->assertSame(
+            ['integer'],
+            SchemaDataGenerator::mergeSchemas(['type' => 'integer'], ['type' => 'number'])['type'],
+        );
+        $this->assertSame(
+            'integer',
+            SchemaDataGenerator::mergeSchemas(['type' => 'number'], ['type' => 'integer'])['type'],
+        );
+        $this->assertSame(
+            ['string', 'integer'],
+            SchemaDataGenerator::mergeSchemas(
+                ['type' => ['string', 'integer']],
+                ['type' => ['string', 'number']],
+            )['type'],
+        );
+    }
+
+    #[Test]
+    public function merge_intersects_enum_domains_by_json_equality(): void
+    {
+        // JSON Schema equality is mathematical for numbers (2020-12
+        // §4.2.2): 1 and 1.0 are the same value, so neither enum empties
+        // the other.
+        $this->assertSame(
+            [1.0],
+            SchemaDataGenerator::mergeSchemas(['enum' => [1]], ['enum' => [1.0]])['enum'],
+        );
+        $this->assertSame(
+            [1],
+            SchemaDataGenerator::mergeSchemas(['enum' => [1.0]], ['enum' => [1]])['enum'],
+        );
+    }
+
+    #[Test]
     public function planned_enum_generation_filters_values_excluded_by_not(): void
     {
         // Rotation alone cannot escape a long excluded prefix; the planned

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -30,6 +30,7 @@ use function fmod;
 use function json_decode;
 use function json_encode;
 use function preg_match;
+use function range;
 use function restore_error_handler;
 use function set_error_handler;
 use function str_repeat;
@@ -1326,6 +1327,26 @@ class SchemaDataGeneratorTest extends TestCase
         $this->assertArrayHasKey('a', $value);
         $this->assertArrayHasKey('b', $value);
         $this->assertTrue(SchemaValueValidator::isValid($value, $schema));
+    }
+
+    #[Test]
+    public function planned_enum_generation_filters_values_excluded_by_not(): void
+    {
+        // Rotation alone cannot escape a long excluded prefix; the planned
+        // path must restrict the finite enum domain to admissible values.
+        $excluded = [];
+        foreach (range(0, 8) as $i) {
+            $excluded[] = ['const' => "v{$i}"];
+        }
+        $schema = [
+            'type' => 'string',
+            'enum' => ['v0', 'v1', 'v2', 'v3', 'v4', 'v5', 'v6', 'v7', 'v8', 'other'],
+            'not' => ['anyOf' => $excluded],
+        ];
+
+        $value = SchemaDataGenerator::generateOne($schema, null, 10, new CaseSelectionPlan([]));
+
+        $this->assertSame('other', $value);
     }
 
     #[Test]

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -11,6 +11,8 @@ use Opis\JsonSchema\Validator;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+use Studio\Gesso\Fuzz\CaseSelectionPlan;
+use Studio\Gesso\Fuzz\SchemaChoicePoint;
 use Studio\Gesso\Fuzz\SchemaDataGenerator;
 use Studio\Gesso\Fuzz\SchemaMutationGenerator;
 use Studio\Gesso\Fuzz\SchemaValueValidator;
@@ -1097,5 +1099,148 @@ class SchemaDataGeneratorTest extends TestCase
         foreach ($values as $value) {
             $this->assertLessThanOrEqual(1, count($value));
         }
+    }
+
+    #[Test]
+    public function pinned_plan_overrides_one_of_branch_rotation(): void
+    {
+        $schema = ['oneOf' => [['type' => 'string'], ['type' => 'integer']]];
+        $plan = new CaseSelectionPlan(['/oneOf' => 1]);
+
+        // Iteration 0 rotation would pick branch 0 (string).
+        $value = SchemaDataGenerator::generateOne($schema, null, 0, $plan);
+
+        $this->assertIsInt($value);
+    }
+
+    #[Test]
+    public function pinned_plan_forces_optional_property_presence_and_absence(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'required' => ['id'],
+            'properties' => [
+                'id' => ['type' => 'integer'],
+                'aud' => ['type' => 'string'],
+            ],
+        ];
+
+        // Iteration 0 parity would omit optional properties.
+        $present = SchemaDataGenerator::generateOne(
+            $schema,
+            null,
+            0,
+            new CaseSelectionPlan(['/properties/aud' => SchemaChoicePoint::PRESENT]),
+        );
+        $this->assertIsArray($present);
+        $this->assertArrayHasKey('aud', $present);
+
+        // Iteration 1 parity would include optional properties.
+        $absent = SchemaDataGenerator::generateOne(
+            $schema,
+            null,
+            1,
+            new CaseSelectionPlan(['/properties/aud' => SchemaChoicePoint::OMITTED]),
+        );
+        $this->assertIsArray($absent);
+        $this->assertArrayNotHasKey('aud', $absent);
+    }
+
+    #[Test]
+    public function pinned_plan_selects_nullable_branches(): void
+    {
+        $schema = ['type' => ['string', 'null']];
+
+        // Iteration 0 rotation would produce a string.
+        $null = SchemaDataGenerator::generateOne(
+            $schema,
+            null,
+            0,
+            new CaseSelectionPlan(['/type' => SchemaChoicePoint::NULL_VALUE]),
+        );
+        $this->assertNull($null);
+
+        // Iteration 2 rotation would produce null.
+        $value = SchemaDataGenerator::generateOne(
+            $schema,
+            null,
+            2,
+            new CaseSelectionPlan(['/type' => SchemaChoicePoint::VALUE]),
+        );
+        $this->assertIsString($value);
+    }
+
+    #[Test]
+    public function pinned_plan_selects_the_else_branch_of_a_conditional(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'required' => ['kind'],
+            'properties' => ['kind' => ['type' => 'string']],
+            'if' => ['properties' => ['kind' => ['const' => 'a']], 'required' => ['kind']],
+            'then' => ['properties' => ['kind' => ['const' => 'a']]],
+            'else' => ['properties' => ['kind' => ['const' => 'b']]],
+        ];
+
+        // Iteration 0 parity would take the `then` branch.
+        $value = SchemaDataGenerator::generateOne(
+            $schema,
+            null,
+            0,
+            new CaseSelectionPlan(['/if' => 1]),
+        );
+
+        $this->assertIsArray($value);
+        $this->assertSame('b', $value['kind']);
+    }
+
+    #[Test]
+    public function pinned_plan_forces_minimum_array_sizes(): void
+    {
+        $schema = [
+            'type' => 'array',
+            'minItems' => 0,
+            'items' => ['type' => 'string'],
+        ];
+
+        // Iteration 0 rotation would produce the minItems=0 empty array.
+        $value = SchemaDataGenerator::generateOne(
+            $schema,
+            null,
+            0,
+            new CaseSelectionPlan(['/items' => 1]),
+        );
+
+        $this->assertIsArray($value);
+        $this->assertNotSame([], $value);
+    }
+
+    #[Test]
+    public function pinned_plan_reaches_a_nested_choice_point_through_pointers(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'aud' => [
+                    'oneOf' => [
+                        ['type' => 'string'],
+                        ['type' => 'array', 'items' => ['type' => 'string']],
+                    ],
+                ],
+            ],
+        ];
+
+        $value = SchemaDataGenerator::generateOne(
+            $schema,
+            null,
+            0,
+            new CaseSelectionPlan([
+                '/properties/aud' => SchemaChoicePoint::PRESENT,
+                '/properties/aud/oneOf' => 1,
+            ]),
+        );
+
+        $this->assertIsArray($value);
+        $this->assertIsArray($value['aud']);
     }
 }

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -1456,6 +1456,28 @@ class SchemaDataGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function merge_keeps_an_empty_enum_marker_through_later_merges(): void
+    {
+        // enum: [] states the conjunction is empty — whether user-authored
+        // or a conflict marker from an earlier merge. Intersecting with any
+        // later enum must stay empty; array_merge displacement would erase
+        // the contradiction and forfeit the dead-end proof.
+        $conflicted = SchemaDataGenerator::mergeSchemas(['const' => 'a'], ['const' => 'b']);
+        $this->assertSame(
+            [],
+            SchemaDataGenerator::mergeSchemas($conflicted, ['enum' => ['a', 'b']])['enum'],
+        );
+        $this->assertSame(
+            [],
+            SchemaDataGenerator::mergeSchemas(['enum' => []], ['enum' => ['a']])['enum'],
+        );
+        $this->assertSame(
+            [],
+            SchemaDataGenerator::mergeSchemas(['enum' => ['a']], ['enum' => []])['enum'],
+        );
+    }
+
+    #[Test]
     public function merge_intersects_enum_domains_by_json_equality(): void
     {
         // JSON Schema equality is mathematical for numbers (2020-12

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -1216,6 +1216,58 @@ class SchemaDataGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function max_properties_trimming_spares_pinned_present_properties(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'required' => ['kind'],
+            'maxProperties' => 2,
+            'properties' => [
+                'kind' => ['type' => 'string'],
+                'a' => ['type' => 'integer'],
+                'b' => ['type' => 'string'],
+            ],
+        ];
+
+        // Odd parity includes both optionals; the maxProperties trim must
+        // drop the unpinned one, not the pinned target.
+        $value = SchemaDataGenerator::generateOne(
+            $schema,
+            null,
+            3,
+            new CaseSelectionPlan(['/properties/a' => SchemaChoicePoint::PRESENT]),
+        );
+
+        $this->assertIsArray($value);
+        $this->assertArrayHasKey('a', $value);
+        $this->assertLessThanOrEqual(2, count($value));
+    }
+
+    #[Test]
+    public function pinned_plan_selects_the_else_branch_of_an_all_of_conditional(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'required' => ['kind'],
+            'properties' => ['kind' => ['type' => 'string']],
+            'allOf' => [
+                [
+                    'if' => ['properties' => ['kind' => ['const' => 'a']], 'required' => ['kind']],
+                    'then' => ['properties' => ['kind' => ['const' => 'a']]],
+                    'else' => ['properties' => ['kind' => ['const' => 'b']]],
+                ],
+            ],
+        ];
+
+        // Rotation only ever takes the if+then side of an allOf conditional;
+        // odd pinned branches select the not-if+else side.
+        $value = SchemaDataGenerator::generateOne($schema, null, 0, new CaseSelectionPlan(['/allOf' => 1]));
+
+        $this->assertIsArray($value);
+        $this->assertSame('b', $value['kind']);
+    }
+
+    #[Test]
     public function pinned_plan_reaches_a_nested_choice_point_through_pointers(): void
     {
         $schema = [

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -1260,11 +1260,68 @@ class SchemaDataGeneratorTest extends TestCase
         ];
 
         // Rotation only ever takes the if+then side of an allOf conditional;
-        // odd pinned branches select the not-if+else side.
+        // the trailing pinned branch selects the none-match state, where
+        // every conditional's else applies.
         $value = SchemaDataGenerator::generateOne($schema, null, 0, new CaseSelectionPlan(['/allOf' => 1]));
 
         $this->assertIsArray($value);
         $this->assertSame('b', $value['kind']);
+    }
+
+    #[Test]
+    public function pinned_conditional_branch_suppresses_the_other_conditionals(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'required' => ['petType'],
+            'properties' => ['petType' => ['type' => 'string', 'enum' => ['cat', 'dog']]],
+            'allOf' => [
+                [
+                    'if' => ['properties' => ['petType' => ['const' => 'cat']], 'required' => ['petType']],
+                    'then' => ['required' => ['meow'], 'properties' => ['meow' => ['type' => 'string']]],
+                ],
+                [
+                    'if' => ['properties' => ['petType' => ['const' => 'dog']], 'required' => ['petType']],
+                    'then' => ['required' => ['bark'], 'properties' => ['bark' => ['type' => 'string']]],
+                ],
+            ],
+        ];
+
+        // Iteration 1 rotation would select the dog conditional; the pin must
+        // hold the cat branch AND keep the value out of the dog `if`, so the
+        // result satisfies the complete schema, not just the pinned slice.
+        $value = SchemaDataGenerator::generateOne($schema, null, 1, new CaseSelectionPlan(['/allOf' => 0]));
+
+        $this->assertIsArray($value);
+        $this->assertSame('cat', $value['petType']);
+        $this->assertArrayHasKey('meow', $value);
+        $this->assertTrue(SchemaValueValidator::isValid($value, $schema));
+    }
+
+    #[Test]
+    public function pinned_none_match_branch_avoids_every_conditional(): void
+    {
+        $schema = [
+            'type' => 'object',
+            'required' => ['petType'],
+            'properties' => ['petType' => ['type' => 'string']],
+            'allOf' => [
+                [
+                    'if' => ['properties' => ['petType' => ['const' => 'cat']], 'required' => ['petType']],
+                    'then' => ['required' => ['meow'], 'properties' => ['meow' => ['type' => 'string']]],
+                ],
+                [
+                    'if' => ['properties' => ['petType' => ['const' => 'dog']], 'required' => ['petType']],
+                    'then' => ['required' => ['bark'], 'properties' => ['bark' => ['type' => 'string']]],
+                ],
+            ],
+        ];
+
+        $value = SchemaDataGenerator::generateOne($schema, null, 0, new CaseSelectionPlan(['/allOf' => 2]));
+
+        $this->assertIsArray($value);
+        $this->assertNotContains($value['petType'], ['cat', 'dog']);
+        $this->assertTrue(SchemaValueValidator::isValid($value, $schema));
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Adds internal branch-complete case generation for the fuzz family: a pre-pass enumerator collects every composition choice point of a converted schema (`oneOf`/`anyOf` branches, conditional branches, nullable and optional-property presence) with its JSON Pointer and reachability ancestors, and `BranchCompleteCaseGenerator` derives one pinned case per (choice point, branch) pair plus caller-requested extras. For a fixed (schema, seed), every branch of every reachable choice point appears in at least one generated case, deterministically.

## Why

Phase 2 of ADR 0003 (#441). Rotation resolves branches with the shared case index, so an unlucky case count can miss a branch entirely — the exact gap behind studio-design/studio-auth#1520, where the defective `oneOf` (`string | string[]`) sat inside an optional property. #441 requires branch coverage as a documented guarantee, not best-effort rotation.

Closes #443

## Verification

- Unit tests pin the incident shape (an optional property whose value is a primitive-only inline `oneOf`): both branches and both presence states are covered, deterministically for a fixed seed.
- Enumerator tests cover pointers/ancestors for each choice-point kind, dedupe across branch contexts, and loud failures for shapes generation cannot resolve (multiple compositions per node, reintroduced keywords, depth/size bounds).
- With no plan, `SchemaDataGenerator` reproduces rotation output bit-for-bit; existing seeds and request explorers are unchanged (full suite green).

- [x] `composer test` passes
- [x] `composer stan` passes
- [x] `composer cs-check` passes

## Notes for reviewers

- Internal only: every new class is `@internal`; the public explorer surface and `docs/fuzzing.md` strategy matrix are untouched until the phase-3 facade adopts the pinned-plan generator.
- Choice-point pointers address the *effective* schema — the view after `allOf`/branch merging — so the enumerator mirrors `resolveComposition` phase order exactly and rejects anything the generator would leave unresolved rather than silently dropping branches.
- A pinned entry at `<pointer>/items` is a forced minimum array size (not a rotation strategy): it makes a choice point under `items` reachable when `minItems: 0` would otherwise produce `[]`, mirroring how optional ancestors are forced present.
- `mergeSchemas()`/`resolveType()` were widened to `public` on the already-`@internal` `SchemaDataGenerator` so the enumerator shares merge semantics by construction instead of duplicating them.
- Enumeration bounds (depth 32, 256 choice points, 10k node visits) throw loud `InvalidArgumentException`s; recursive/`contains`/`patternProperties` shapes stay validator-only features as before.