### PR TITLE
feat(fuzz): explore named component schemas

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -154,8 +154,32 @@ $cases->each(function (GeneratedResponseCase $case): void {
 });
 ```
 
+To exercise an SDK model by its exact, case-sensitive
+`components.schemas` name without inventing an operation, use the same facade:
+
+```php
+$cases = OpenApiResponseExplorer::exploreComponent(
+    specName: 'front',
+    schemaName: 'IntrospectResponse',
+    seed: 1,
+    extraCases: 2,
+);
+
+$cases->each(function (GeneratedResponseCase $case): void {
+    $decoded = sdk_decode($case->bodyAsObject());
+    $case->assertRoundTrip(sdk_encode($decoded));
+});
+```
+
+Named components are converted with the spec's OpenAPI version and JSON Schema
+dialect, response-side read/write semantics, and discriminator context. Their
+cases have `null` `status` and `contentType` because no operation was selected;
+`replaySnippet()` renders the corresponding `exploreComponent()` call.
+Unknown, malformed, recursive, and otherwise unsupported schemas throw loudly
+instead of returning an empty collection.
+
 The collection is `Countable` and `IteratorAggregate`. Each readonly case
-exposes `body`, `status`, `contentType`, `seed`, `caseIndex`, and
+exposes `body`, nullable `status` and `contentType`, `seed`, `caseIndex`, and
 `pinnedBranch`; `bodyAsObject()` supplies decoded JSON shapes to SDKs,
 `bodyAsArray()` supports array-typed consumers, and `replaySnippet()` renders a
 focused reproduction. `assertRoundTrip()` first validates the SDK output

--- a/docs/sdk-roundtrip.md
+++ b/docs/sdk-roundtrip.md
@@ -43,6 +43,35 @@ Omit `contentType` to select the first JSON-compatible media type exactly as
 response validation does. Status resolution also shares validator behavior:
 an exact response key wins, followed by an `X00` range key and `default`.
 
+## Named component models
+
+Some generated SDK models map directly to `components.schemas` entries and are
+not reachable through one useful operation/status pair. Select those models by
+their exact, case-sensitive component name:
+
+```php
+OpenApiResponseExplorer::exploreComponent(
+    specName: 'front',
+    schemaName: 'IntrospectResponse',
+    seed: 1,
+)->each(function (GeneratedResponseCase $case): void {
+    $model = ObjectSerializer::deserialize(
+        $case->bodyAsObject(),
+        IntrospectResponse::class,
+    );
+
+    $case->assertRoundTrip(
+        ObjectSerializer::sanitizeForSerialization($model),
+    );
+});
+```
+
+Component schemas use the spec's OpenAPI version, JSON Schema dialect,
+response-side read/write semantics, and discriminator context. The returned
+cases have `null` `status` and `contentType`, while `replaySnippet()` records an
+`exploreComponent()` call. Unknown, malformed, recursive, and otherwise
+unsupported component schemas throw instead of producing an empty green run.
+
 ## Laravel
 
 The `ExploresOpenApiEndpoint` trait uses the same spec-name precedence as the
@@ -108,10 +137,10 @@ effective seed is stored on every case and included in `replaySnippet()`.
 | `body` | Raw generated PHP value |
 | `bodyAsObject()` | JSON round-trip with objects decoded as `stdClass`; arrays and scalars retain their JSON shape |
 | `bodyAsArray()` | Associative decoded form for object/array bodies; scalar bodies throw |
-| `status`, `contentType` | Selected wire status and declared media-type key |
+| `status`, `contentType` | Selected wire status and declared media-type key; both are `null` for named components |
 | `seed`, `caseIndex` | Deterministic replay identity |
 | `pinnedBranch` | Target JSON Pointer plus zero-based branch, for example `/properties/aud/oneOf@0`; `null` for an extra case |
-| `replaySnippet()` | Minimal `OpenApiResponseExplorer::explore(...)` reproduction |
+| `replaySnippet()` | Minimal `explore(...)` or `exploreComponent(...)` reproduction |
 
 `assertRoundTrip()` makes two assertions in order:
 
@@ -138,6 +167,6 @@ shapes that cannot represent one buffered JSON document throw
 - selected non-JSON schemas; and
 - OpenAPI 3.2 streaming responses using `itemSchema`.
 
-Named component exploration, spec-wide SDK mapping, and SDK exercise coverage
-are separate follow-up phases; this entry point intentionally targets one
-resolved operation response at a time.
+Spec-wide SDK mapping and SDK exercise coverage remain separate follow-up
+phases. Use `explore()` for one resolved operation response or
+`exploreComponent()` for one named model schema.

--- a/docs/superpowers/plans/2026-08-03-named-component-schema-explorer.md
+++ b/docs/superpowers/plans/2026-08-03-named-component-schema-explorer.md
@@ -1,0 +1,408 @@
+# Named Component Schema Explorer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `OpenApiResponseExplorer::exploreComponent()` so SDK models can be exercised by a named `components.schemas` entry with the existing branch-complete and round-trip guarantees.
+
+**Architecture:** Keep component lookup and operation-response lookup as separate public paths in `OpenApiResponseExplorer`, then funnel both converted schemas through one private case builder. Reuse `GeneratedResponseCase` and `GeneratedResponseCases`; make only operation metadata nullable and choose the correct replay call from stored source metadata.
+
+**Tech Stack:** PHP 8.3+, PHPUnit, opis/json-schema through the existing validation boundary, PHPStan level 6, PHP-CS-Fixer.
+
+## Global Constraints
+
+- Keep PHP compatibility at the repository's PHP 8.3 floor.
+- Add no production dependency; generation must keep working without optional Faker.
+- Convert component schemas with the document's OpenAPI version, JSON Schema dialect, `SchemaContext::Response`, and current discriminator-enforcement gate.
+- Unknown, malformed, recursive, or otherwise unsupported schemas must throw; no empty or skipped green run is allowed.
+- Preserve existing operation-response behavior and replay strings.
+- Public symbols and constructor/property types are v2 compatibility surfaces; update the checked-in public API inventory for intentional changes.
+- Follow PER-CS2.0 and snake_case PHPUnit test method naming.
+- Preserve the unrelated untracked `.claude/` and `docs/adr/0002-arazzo-workflow-execution.md` paths.
+
+---
+
+## File Structure
+
+- Modify `src/Fuzz/OpenApiResponseExplorer.php`: resolve named components, convert them in response context, and centralize case construction.
+- Modify `src/Fuzz/GeneratedResponseCase.php`: represent absent operation metadata and render component replay snippets.
+- Modify `tests/Unit/Fuzz/OpenApiResponseExplorerTest.php`: cover generation, conversion context, malformed/unknown/recursive failures, replay metadata, and round-trip fidelity through the public facade.
+- Modify `tests/fixtures/specs/sdk-roundtrip.json`: add branch-complete and malformed named component fixtures.
+- Modify `tests/fixtures/specs/dialect-draft07.json`: add a Draft 07 tuple component proving document dialect propagation.
+- Create `tests/fixtures/specs/component-malformed-components.json`: malformed `components` boundary.
+- Create `tests/fixtures/specs/component-malformed-schemas.json`: malformed `components.schemas` boundary.
+- Modify `docs/api-reference.md`: document the new public method and nullable component-case metadata.
+- Modify `docs/sdk-roundtrip.md`: add named-model usage and remove the obsolete follow-up statement.
+- Modify `tests/fixtures/compatibility/v2-public-api.json`: record the public method and intentional nullable metadata.
+
+---
+
+### Task 1: Public component explorer and reusable cases
+
+**Files:**
+- Modify: `tests/fixtures/specs/sdk-roundtrip.json`
+- Modify: `tests/fixtures/specs/dialect-draft07.json`
+- Create: `tests/fixtures/specs/component-malformed-components.json`
+- Create: `tests/fixtures/specs/component-malformed-schemas.json`
+- Modify: `tests/Unit/Fuzz/OpenApiResponseExplorerTest.php`
+- Modify: `src/Fuzz/OpenApiResponseExplorer.php`
+- Modify: `src/Fuzz/GeneratedResponseCase.php`
+
+**Interfaces:**
+- Consumes: `OpenApiSpecLoader::load(string): array`, `OpenApiVersion::fromSpec(array): OpenApiVersion`, `OpenApiSchemaDialect::fromSpec(array, OpenApiVersion): string`, `OpenApiSchemaConverter::convert(array, OpenApiVersion, SchemaContext, ?DiscriminatorContext, ?string): array`, and `BranchCompleteCaseGenerator::generate(array, ?int, int): list<PlannedSchemaCase>`.
+- Produces: `OpenApiResponseExplorer::exploreComponent(string $specName, string $schemaName, ?int $seed = null, int $extraCases = 0): GeneratedResponseCases` and component cases whose `status`/`contentType` are `null`.
+
+- [ ] **Step 1: Add representative named-component fixtures**
+
+Add these component entries to `tests/fixtures/specs/sdk-roundtrip.json`:
+
+```json
+"components": {
+  "schemas": {
+    "IntrospectResponse": {
+      "type": "object",
+      "required": ["active"],
+      "properties": {
+        "active": {"type": "boolean"},
+        "aud": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
+          ]
+        },
+        "secret": {"type": "string", "writeOnly": true}
+      }
+    },
+    "JsonWebKey": {
+      "type": "object",
+      "required": ["kty"],
+      "properties": {"kty": {"type": "string", "enum": ["RSA", "EC"]}},
+      "discriminator": {
+        "propertyName": "kty",
+        "mapping": {
+          "RSA": "#/components/schemas/RsaJsonWebKey",
+          "EC": "#/components/schemas/EcJsonWebKey"
+        }
+      }
+    },
+    "RsaJsonWebKey": {
+      "type": "object",
+      "required": ["n"],
+      "properties": {"n": {"type": "string"}}
+    },
+    "EcJsonWebKey": {
+      "type": "object",
+      "required": ["x"],
+      "properties": {"x": {"type": "string"}}
+    },
+    "MalformedSchema": "not a schema object"
+  }
+}
+```
+
+Add a `Tuple` component to `tests/fixtures/specs/dialect-draft07.json` using the fixture's existing Draft 07 tuple schema:
+
+```json
+"components": {
+  "schemas": {
+    "Tuple": {
+      "type": "array",
+      "items": [{"type": "string"}, {"type": "integer"}],
+      "additionalItems": false
+    }
+  }
+}
+```
+
+Create the two malformed-boundary fixtures as minimal OpenAPI 3.1 documents, one with `"components": "invalid"` and one with `"components": {"schemas": "invalid"}`.
+
+- [ ] **Step 2: Write public-behavior tests before production changes**
+
+In `OpenApiResponseExplorerTest`, add tests using only real specs and the public facade. The primary generation test must assert literal branch descriptors, metadata, and replay shape:
+
+```php
+#[Test]
+public function explores_a_named_component_with_branch_complete_cases_and_no_operation_metadata(): void
+{
+    $cases = OpenApiResponseExplorer::exploreComponent(
+        'sdk-roundtrip',
+        'IntrospectResponse',
+        seed: 1,
+        extraCases: 1,
+    );
+
+    $this->assertSame(
+        [
+            '/properties/aud@0',
+            '/properties/aud@1',
+            '/properties/aud/oneOf@0',
+            '/properties/aud/oneOf@1',
+        ],
+        array_values(array_filter(array_map(
+            static fn(GeneratedResponseCase $case): ?string => $case->pinnedBranch,
+            $cases->cases,
+        ))),
+    );
+    foreach ($cases as $case) {
+        $this->assertNull($case->status);
+        $this->assertNull($case->contentType);
+        $this->assertArrayNotHasKey('secret', $case->bodyAsArray() ?? []);
+    }
+    $this->assertStringContainsString(
+        "OpenApiResponseExplorer::exploreComponent('sdk-roundtrip', 'IntrospectResponse', seed: 1, extraCases: 1)",
+        $cases->cases[0]->replaySnippet(),
+    );
+}
+```
+
+Add separate tests whose named break is:
+
+```php
+#[Test]
+public function component_cases_keep_the_existing_round_trip_fidelity_assertion(): void
+{
+    $case = OpenApiResponseExplorer::exploreComponent('sdk-roundtrip', 'IntrospectResponse', seed: 1)->cases[2];
+    $body = $case->bodyAsArray();
+    $this->assertIsArray($body);
+    $case->assertRoundTrip($body);
+
+    unset($body['aud']);
+    $this->expectException(AssertionFailedError::class);
+    $this->expectExceptionMessage("missing generated key 'aud'");
+    $case->assertRoundTrip($body);
+}
+
+#[Test]
+public function component_conversion_uses_the_document_json_schema_dialect(): void
+{
+    $case = OpenApiResponseExplorer::exploreComponent('dialect-draft07', 'Tuple', seed: 1)->cases[0];
+    $this->assertIsArray($case->body);
+    $this->assertCount(2, $case->body);
+    $this->assertIsString($case->body[0]);
+    $this->assertIsInt($case->body[1]);
+}
+
+#[Test]
+public function component_discriminator_mapping_resolves_against_the_document_root(): void
+{
+    $cases = OpenApiResponseExplorer::exploreComponent('sdk-roundtrip', 'JsonWebKey', seed: 1);
+    $encoded = json_encode(array_map(static fn(GeneratedResponseCase $case): mixed => $case->body, $cases->cases));
+    $this->assertIsString($encoded);
+    $this->assertStringContainsString('RSA', $encoded);
+    $this->assertStringContainsString('EC', $encoded);
+}
+```
+
+Add a data provider for unknown and malformed boundaries asserting `InvalidArgumentException` and stable context fragments (`components`, `components.schemas`, exact schema name, and spec name). Add a negative-`extraCases` test naming `exploreComponent()`. Add a recursive-schema test that calls `exploreComponent('refs-circular', 'Node')` and expects `InvalidOpenApiSpecException` containing `Circular $ref`.
+
+Before running, name the mutations these tests catch: operation metadata accidentally retained, response context omitted, dialect hard-coded, discriminator root omitted, missing structural guards, silent unknown-name handling, and recursion swallowed.
+
+- [ ] **Step 3: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+vendor/bin/phpunit tests/Unit/Fuzz/OpenApiResponseExplorerTest.php
+```
+
+Expected: test collection fails because `OpenApiResponseExplorer::exploreComponent()` does not exist. Confirm the failure is not fixture JSON syntax or test setup.
+
+- [ ] **Step 4: Implement `exploreComponent()` and shared case construction**
+
+In `OpenApiResponseExplorer.php`, import the existing version, dialect, loader, converter, schema context, discriminator, enforcement, malformed-node, and array helpers. Add the public method with the approved signature. Use `array_key_exists()` for exact component lookup and `MalformedSpecNode::isMalformed()` at all three structural boundaries. Convert using:
+
+```php
+$version = OpenApiVersion::fromSpec($spec);
+$schema = OpenApiSchemaConverter::convert(
+    $componentSchema,
+    $version,
+    SchemaContext::Response,
+    new DiscriminatorContext($spec, DiscriminatorEnforcement::isEnabled()),
+    OpenApiSchemaDialect::fromSpec($spec, $version),
+);
+```
+
+Extract the existing `BranchCompleteCaseGenerator` plus `array_map()` loop into a private method that takes the converted schema, effective seed, extra cases, spec name, and nullable replay metadata. Operation `explore()` must pass its existing status, content type, method, and matched path; component exploration must pass `schemaName` and null operation metadata.
+
+Emit contextual errors with this form:
+
+```php
+throw new InvalidArgumentException(sprintf(
+    "Component schema '%s' is not defined in '%s' spec.",
+    $schemaName,
+    $specName,
+));
+```
+
+For malformed boundaries, include the exact location and `MalformedSpecNode::describe($node)`; reject negative `extraCases` before loading the spec.
+
+- [ ] **Step 5: Make existing cases represent either replay source**
+
+In `GeneratedResponseCase.php`, change public `status` to `?int`, public `contentType` to `?string`, private `method` and `matchedPath` to `?string`, and add a final private optional `?string $schemaName = null` constructor parameter. Keep all existing parameter names and the existing `extraCases` default.
+
+Branch in `replaySnippet()`:
+
+```php
+if ($this->schemaName !== null) {
+    return sprintf(
+        'OpenApiResponseExplorer::exploreComponent(%s, %s, seed: %d%s)->cases[%d]',
+        var_export($this->specName, true),
+        var_export($this->schemaName, true),
+        $this->seed,
+        $extraCases,
+        $this->caseIndex,
+    );
+}
+```
+
+For the operation branch, guard impossible null metadata with `LogicException`, then leave the current replay format byte-for-byte unchanged. Do not alter `bodyAsObject()`, `bodyAsArray()`, `assertRoundTrip()`, or fidelity comparison.
+
+- [ ] **Step 6: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+vendor/bin/phpunit tests/Unit/Fuzz/OpenApiResponseExplorerTest.php tests/Unit/Fuzz/GeneratedResponseCaseTest.php tests/Unit/Fuzz/GeneratedResponseCasesTest.php
+```
+
+Expected: all tests pass with no warnings. If a discriminator fixture exposes a generator limitation, stop and determine whether the fixture or implementation violated the existing supported subset; do not weaken the discriminator-context assertion.
+
+- [ ] **Step 7: Format and commit the behavior slice**
+
+Run:
+
+```bash
+composer cs
+vendor/bin/phpunit tests/Unit/Fuzz/OpenApiResponseExplorerTest.php tests/Unit/Fuzz/GeneratedResponseCaseTest.php tests/Unit/Fuzz/GeneratedResponseCasesTest.php
+git diff --check
+```
+
+Commit only Task 1 files:
+
+```bash
+git add src/Fuzz/OpenApiResponseExplorer.php src/Fuzz/GeneratedResponseCase.php tests/Unit/Fuzz/OpenApiResponseExplorerTest.php tests/fixtures/specs/sdk-roundtrip.json tests/fixtures/specs/dialect-draft07.json tests/fixtures/specs/component-malformed-components.json tests/fixtures/specs/component-malformed-schemas.json
+git commit -m "feat(fuzz): explore named component schemas"
+```
+
+---
+
+### Task 2: Public compatibility record and user documentation
+
+**Files:**
+- Modify: `tests/fixtures/compatibility/v2-public-api.json`
+- Modify: `docs/api-reference.md`
+- Modify: `docs/sdk-roundtrip.md`
+
+**Interfaces:**
+- Consumes: the Task 1 signature and nullable `GeneratedResponseCase::$status` / `$contentType`.
+- Produces: a passing public API compatibility gate and documented plain-PHPUnit usage.
+
+- [ ] **Step 1: Confirm the public API gate detects the intentional change**
+
+Run:
+
+```bash
+vendor/bin/phpunit tests/Unit/Compatibility/PublicApiBaselineTest.php
+```
+
+Expected: `public_php_api_matches_the_v2_baseline` fails and its diff includes `exploreComponent`, nullable metadata, and the optional `schemaName` constructor parameter.
+
+- [ ] **Step 2: Regenerate and inspect the compatibility inventory**
+
+Run:
+
+```bash
+php scripts/export-public-api.php --write
+git diff -- tests/fixtures/compatibility/v2-public-api.json
+```
+
+Accept only these changes: the new static `exploreComponent()` signature, `status` from `int` to `?int`, `contentType` from `string` to `?string`, constructor method/path nullable types, and the final optional nullable `schemaName`. Investigate any unrelated inventory change.
+
+- [ ] **Step 3: Document named component exploration**
+
+In `docs/api-reference.md`, extend the `OpenApiResponseExplorer` section with the exact call:
+
+```php
+$cases = OpenApiResponseExplorer::exploreComponent(
+    specName: 'front',
+    schemaName: 'IntrospectResponse',
+    seed: 1,
+    extraCases: 2,
+);
+```
+
+State that it uses response conversion semantics, cases have null `status` and `contentType`, and unknown or unsupported schemas throw rather than returning an empty collection.
+
+In `docs/sdk-roundtrip.md`, add a short “Named component models” section showing SDK decode and `assertRoundTrip()`. Replace the final sentence that calls named components a follow-up with text reserving only spec-wide mapping and exercise coverage for later phases.
+
+- [ ] **Step 4: Verify docs-adjacent and compatibility checks**
+
+Run:
+
+```bash
+vendor/bin/phpunit tests/Unit/Compatibility/PublicApiBaselineTest.php
+composer cs-check
+git diff --check
+```
+
+Expected: the compatibility test passes, both PHP-CS-Fixer configurations report clean, and no whitespace errors remain.
+
+- [ ] **Step 5: Commit the compatibility and documentation slice**
+
+```bash
+git add tests/fixtures/compatibility/v2-public-api.json docs/api-reference.md docs/sdk-roundtrip.md
+git commit -m "docs(fuzz): document component schema exploration"
+```
+
+---
+
+### Task 3: Requirement audit and repository verification
+
+**Files:**
+- Review: `docs/superpowers/specs/2026-08-03-named-component-schema-explorer-design.md`
+- Review: all Task 1 and Task 2 diffs
+
+**Interfaces:**
+- Consumes: the complete implementation and documentation.
+- Produces: evidence for every issue #446 requirement and repository gate.
+
+- [ ] **Step 1: Run narrow static analysis and unit tests**
+
+```bash
+composer stan
+vendor/bin/phpunit --testsuite Unit
+```
+
+Expected: PHPStan reports no errors and the Unit suite has zero failures/errors/warnings.
+
+- [ ] **Step 2: Run repository formatting and test gates**
+
+```bash
+composer cs-check
+composer test
+```
+
+Expected: both commands exit 0. If environment constraints prevent a gate, record the exact command and reason rather than claiming it passed.
+
+- [ ] **Step 3: Audit issue requirements against evidence**
+
+Read issue #446 and the design again, then confirm:
+
+- `exploreComponent()` is public and branch-complete for exact named components.
+- conversion uses the loaded document's version/dialect, response context, and discriminator root/gate;
+- existing case and collection types are reused with operation metadata absent;
+- `assertRoundTrip()` behavior is unchanged and covered through a component case;
+- unknown names and recursive/unsupported schemas throw loudly;
+- API reference and SDK round-trip guide document the feature;
+- the operation-based `explore()` tests still pass;
+- unrelated worktree files are untouched.
+
+- [ ] **Step 4: Inspect final repository state**
+
+```bash
+git status --short --branch
+git log --oneline --decorate -5
+git diff main...HEAD --stat
+git diff main...HEAD --check
+```
+
+Expected: only issue #446 design, implementation, tests, fixtures, compatibility inventory, and docs are committed; unrelated pre-existing untracked files remain unmodified.

--- a/docs/superpowers/specs/2026-08-03-named-component-schema-explorer-design.md
+++ b/docs/superpowers/specs/2026-08-03-named-component-schema-explorer-design.md
@@ -1,0 +1,140 @@
+# Named component schema explorer design
+
+- Date: 2026-08-03
+- Issue: [#446](https://github.com/studio-design/gesso/issues/446)
+- Parent design: [ADR 0003](../../adr/0003-sdk-roundtrip-harness.md)
+
+## Goal
+
+Allow a generated SDK model to be exercised directly from a named
+`components.schemas` entry without inventing an OpenAPI operation. The entry
+point must retain the existing branch-complete generation and round-trip
+fidelity guarantees, and must fail loudly when the name or schema cannot be
+used.
+
+## Public API
+
+Add a second entry point to the existing response-payload facade:
+
+```php
+OpenApiResponseExplorer::exploreComponent(
+    string $specName,
+    string $schemaName,
+    ?int $seed = null,
+    int $extraCases = 0,
+): GeneratedResponseCases
+```
+
+The method name makes component lookup explicit while keeping both ways of
+obtaining an SDK response payload on the same facade:
+
+- `explore()` resolves a schema through operation, status, and content type.
+- `exploreComponent()` resolves a schema through `components.schemas`.
+
+Both methods return the existing `GeneratedResponseCases` collection
+containing existing `GeneratedResponseCase` values. No component-specific case
+or collection type is introduced.
+
+## Component resolution and conversion
+
+`exploreComponent()` loads the named spec through `OpenApiSpecLoader`, then
+validates each structural boundary before indexing it:
+
+1. `components`, when present, must be an object.
+2. `components.schemas`, when present, must be an object.
+3. `$schemaName` must exist as an exact, case-sensitive key.
+4. The selected entry must be a Schema Object.
+
+An absent name throws `InvalidArgumentException` and identifies the requested
+schema and spec. Malformed document nodes use the repository's existing
+malformed-node descriptions so scalar, null, and list-shaped nodes fail at the
+boundary instead of producing a type error or an empty run.
+
+The selected Schema Object is converted with:
+
+- `OpenApiVersion::fromSpec()`;
+- `OpenApiSchemaDialect::fromSpec()`;
+- `SchemaContext::Response`; and
+- `DiscriminatorContext` rooted at the loaded document and using the same
+  `DiscriminatorEnforcement` gate as operation response resolution.
+
+This preserves OpenAPI 3.0 compatibility lowering, OpenAPI 3.1/3.2 JSON Schema
+dialects, response-side `readOnly`/`writeOnly` semantics, and discriminator
+mapping enforcement. The converted schema is then passed to the same
+`BranchCompleteCaseGenerator` used by `explore()`; unsupported schemas such as
+recursive schemas therefore retain the generator's existing loud exceptions.
+
+## Shared case construction
+
+Extract only the post-resolution case-construction loop inside
+`OpenApiResponseExplorer`. It receives a converted schema and replay metadata,
+runs `BranchCompleteCaseGenerator`, and creates the existing cases. Schema
+resolution remains separate because operation responses and components have
+different lookup rules and diagnostics.
+
+Operation-specific metadata is absent for component cases:
+
+- public `status` and `contentType` become nullable and are `null`;
+- private `method` and `matchedPath` become nullable and are `null`;
+- component cases carry the selected schema name for replay generation.
+
+Existing operation cases retain their current non-null values and replay text.
+`replaySnippet()` emits `OpenApiResponseExplorer::exploreComponent(...)` for a
+component case and `OpenApiResponseExplorer::explore(...)` for an operation
+case. `assertRoundTrip()` remains unchanged and validates against the converted
+schema stored in either case shape.
+
+Constructor changes preserve the existing parameter names and operation call
+sites. The intentional nullable metadata and new entry point are recorded in
+the v2 public API compatibility baseline.
+
+## Validation and error behavior
+
+The public boundary rejects negative `extraCases` before loading or generating,
+with a diagnostic naming `exploreComponent()`. A valid schema always produces a
+non-empty `GeneratedResponseCases` collection. There is no skip or empty-success
+path.
+
+Failures remain exceptions rather than collection entries:
+
+- unknown component schema: `InvalidArgumentException`;
+- malformed `components`, `schemas`, or selected schema: loud malformed-spec
+  exception or `InvalidArgumentException` with the exact location;
+- unsupported version, dialect, or discriminator: existing converter/spec
+  exception;
+- recursive or otherwise unsupported generation: existing generator
+  `InvalidArgumentException`.
+
+## Tests
+
+Add focused tests that prove:
+
+- a named component produces every reachable branch and requested extra case;
+- generated component cases have null operation metadata and a replayable
+  `exploreComponent()` snippet;
+- `assertRoundTrip()` accepts fidelity-preserving SDK output and rejects a
+  swallowed value for component-generated cases;
+- OpenAPI 3.0 response conversion removes `writeOnly` properties;
+- OpenAPI 3.1/3.2 document dialect selection is retained;
+- discriminator mappings resolve against the document root;
+- unknown names, malformed component boundaries, negative `extraCases`, and a
+  recursive schema fail loudly;
+- existing operation-response exploration behavior remains unchanged; and
+- the public API inventory reflects the intentional additive/widening changes.
+
+## Documentation
+
+Extend the `OpenApiResponseExplorer` API reference with
+`exploreComponent()`. Add a short named-model example to the SDK round-trip
+guide and remove the statement that named component exploration is a future
+phase. The documentation will state that component cases have no status or
+content-type metadata and retain the same branch-complete and round-trip
+guarantees.
+
+## Non-goals
+
+- No Laravel convenience method is added; issue #446 requests the public core
+  entry point and documentation only.
+- No generic request-context or arbitrary JSON Schema explorer is introduced.
+- No schema-to-SDK-class naming convention is inferred.
+- No production dependency or coverage wire-format change is required.

--- a/src/Fuzz/GeneratedResponseCase.php
+++ b/src/Fuzz/GeneratedResponseCase.php
@@ -31,16 +31,17 @@ final readonly class GeneratedResponseCase
      */
     public function __construct(
         public mixed $body,
-        public int $status,
-        public string $contentType,
+        public ?int $status,
+        public ?string $contentType,
         public int $seed,
         public int $caseIndex,
         public ?string $pinnedBranch,
         private string $specName,
-        private string $method,
-        private string $matchedPath,
+        private ?string $method,
+        private ?string $matchedPath,
         private array $schema,
         private int $extraCases = 0,
+        private ?string $schemaName = null,
     ) {}
 
     /**
@@ -119,6 +120,21 @@ final readonly class GeneratedResponseCase
     public function replaySnippet(): string
     {
         $extraCases = $this->extraCases > 0 ? sprintf(', extraCases: %d', $this->extraCases) : '';
+
+        if ($this->schemaName !== null) {
+            return sprintf(
+                'OpenApiResponseExplorer::exploreComponent(%s, %s, seed: %d%s)->cases[%d]',
+                var_export($this->specName, true),
+                var_export($this->schemaName, true),
+                $this->seed,
+                $extraCases,
+                $this->caseIndex,
+            );
+        }
+
+        if ($this->status === null || $this->contentType === null || $this->method === null || $this->matchedPath === null) {
+            throw new LogicException('GeneratedResponseCase replay metadata does not identify an operation response or component schema.');
+        }
 
         return sprintf(
             'OpenApiResponseExplorer::explore(%s, %s, %s, %d, %s, seed: %d%s)->cases[%d]',

--- a/src/Fuzz/OpenApiResponseExplorer.php
+++ b/src/Fuzz/OpenApiResponseExplorer.php
@@ -5,11 +5,20 @@ declare(strict_types=1);
 namespace Studio\Gesso\Fuzz;
 
 use InvalidArgumentException;
+use Studio\Gesso\OpenApiVersion;
+use Studio\Gesso\SchemaContext;
 use Studio\Gesso\Spec\OpenApiOperationResolver;
+use Studio\Gesso\Spec\OpenApiSchemaConverter;
+use Studio\Gesso\Spec\OpenApiSchemaDialect;
+use Studio\Gesso\Spec\OpenApiSpecLoader;
 use Studio\Gesso\Validation\Response\ResponseSchemaResolution;
 use Studio\Gesso\Validation\Response\ResponseSchemaResolutionOutcome;
 use Studio\Gesso\Validation\Response\ResponseSchemaResolver;
+use Studio\Gesso\Validation\Support\DiscriminatorContext;
+use Studio\Gesso\Validation\Support\DiscriminatorEnforcement;
+use Studio\Gesso\Validation\Support\MalformedSpecNode;
 
+use function array_key_exists;
 use function array_keys;
 use function array_map;
 use function sprintf;
@@ -51,23 +60,105 @@ final class OpenApiResponseExplorer
             throw self::unsupportedResolution($specName, $method, $path, $status, $resolution);
         }
 
-        $schema = $resolution->convertedSchema();
-        $matchedPath = $resolution->matchedPath;
-        $resolvedContentType = $resolution->contentType;
-        $replayMethod = OpenApiOperationResolver::normalizeMethodForKey($method);
-        $effectiveSeed = $seed ?? 0;
+        return self::buildCases(
+            schema: $resolution->convertedSchema(),
+            effectiveSeed: $seed ?? 0,
+            extraCases: $extraCases,
+            specName: $specName,
+            status: $status,
+            contentType: $resolution->contentType,
+            method: OpenApiOperationResolver::normalizeMethodForKey($method),
+            matchedPath: $resolution->matchedPath,
+        );
+    }
+
+    /**
+     * Generate deterministic, branch-complete valid payloads for one named
+     * `components.schemas` entry, converted with response-side semantics.
+     */
+    public static function exploreComponent(
+        string $specName,
+        string $schemaName,
+        ?int $seed = null,
+        int $extraCases = 0,
+    ): GeneratedResponseCases {
+        if ($extraCases < 0) {
+            throw new InvalidArgumentException(sprintf(
+                'OpenApiResponseExplorer::exploreComponent() requires extraCases >= 0, got %d.',
+                $extraCases,
+            ));
+        }
+
+        $spec = OpenApiSpecLoader::load($specName);
+        $components = array_key_exists('components', $spec) ? $spec['components'] : [];
+        self::assertComponentNode($components, 'components', $specName);
+
+        /** @var array<array-key, mixed> $components */
+        $schemas = array_key_exists('schemas', $components) ? $components['schemas'] : [];
+        self::assertComponentNode($schemas, 'components.schemas', $specName);
+
+        /** @var array<array-key, mixed> $schemas */
+        if (!array_key_exists($schemaName, $schemas)) {
+            throw new InvalidArgumentException(sprintf(
+                "Component schema '%s' is not defined in '%s' spec.",
+                $schemaName,
+                $specName,
+            ));
+        }
+
+        $componentSchema = $schemas[$schemaName];
+        self::assertComponentNode(
+            $componentSchema,
+            sprintf('components.schemas["%s"]', $schemaName),
+            $specName,
+        );
+
+        /** @var array<string, mixed> $componentSchema */
+        $version = OpenApiVersion::fromSpec($spec);
+        $convertedSchema = OpenApiSchemaConverter::convert(
+            $componentSchema,
+            $version,
+            SchemaContext::Response,
+            new DiscriminatorContext($spec, DiscriminatorEnforcement::isEnabled()),
+            OpenApiSchemaDialect::fromSpec($spec, $version),
+        );
+
+        return self::buildCases(
+            schema: $convertedSchema,
+            effectiveSeed: $seed ?? 0,
+            extraCases: $extraCases,
+            specName: $specName,
+            schemaName: $schemaName,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $schema
+     */
+    private static function buildCases(
+        array $schema,
+        int $effectiveSeed,
+        int $extraCases,
+        string $specName,
+        ?int $status = null,
+        ?string $contentType = null,
+        ?string $method = null,
+        ?string $matchedPath = null,
+        ?string $schemaName = null,
+    ): GeneratedResponseCases {
         $plannedCases = BranchCompleteCaseGenerator::generate($schema, $effectiveSeed, $extraCases);
 
         return new GeneratedResponseCases(array_map(
             static function (PlannedSchemaCase $planned, int $caseIndex) use (
                 $status,
-                $resolvedContentType,
+                $contentType,
                 $effectiveSeed,
                 $specName,
-                $replayMethod,
+                $method,
                 $matchedPath,
                 $schema,
                 $extraCases,
+                $schemaName,
             ): GeneratedResponseCase {
                 $pointer = $planned->plan->targetPointer;
                 $branch = $planned->plan->targetBranch;
@@ -75,19 +166,34 @@ final class OpenApiResponseExplorer
                 return new GeneratedResponseCase(
                     body: $planned->value,
                     status: $status,
-                    contentType: $resolvedContentType,
+                    contentType: $contentType,
                     seed: $effectiveSeed,
                     caseIndex: $caseIndex,
                     pinnedBranch: $pointer !== null && $branch !== null ? $pointer . '@' . $branch : null,
                     specName: $specName,
-                    method: $replayMethod,
+                    method: $method,
                     matchedPath: $matchedPath,
                     schema: $schema,
                     extraCases: $extraCases,
+                    schemaName: $schemaName,
                 );
             },
             $plannedCases,
             array_keys($plannedCases),
+        ));
+    }
+
+    private static function assertComponentNode(mixed $node, string $location, string $specName): void
+    {
+        if (!MalformedSpecNode::isMalformed($node)) {
+            return;
+        }
+
+        throw new InvalidArgumentException(sprintf(
+            "Malformed '%s' in '%s' spec: expected object, got %s.",
+            $location,
+            $specName,
+            MalformedSpecNode::describe($node),
         ));
     }
 

--- a/tests/Unit/Fuzz/OpenApiResponseExplorerTest.php
+++ b/tests/Unit/Fuzz/OpenApiResponseExplorerTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Studio\Gesso\Tests\Unit\Fuzz;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\Fuzz\GeneratedResponseCase;
 use Studio\Gesso\Fuzz\GeneratedResponseCases;
 use Studio\Gesso\Fuzz\OpenApiResponseExplorer;
@@ -53,6 +55,152 @@ class OpenApiResponseExplorerTest extends TestCase
         yield 'unknown path' => ['/unknown', 'GET', 200, 'PathNotFound'];
         yield 'unknown method' => ['/oauth/introspect', 'GET', 200, 'MethodNotDefined'];
         yield 'unknown status' => ['/oauth/introspect', 'POST', 201, 'StatusNotDeclared'];
+    }
+
+    /**
+     * @return iterable<string, array{string, string, string}>
+     */
+    public static function provideRejects_unknown_or_malformed_component_schemas_loudlyCases(): iterable
+    {
+        yield 'unknown schema name' => [
+            'sdk-roundtrip',
+            'MissingSchema',
+            "Component schema 'MissingSchema' is not defined in 'sdk-roundtrip' spec",
+        ];
+        yield 'malformed components' => [
+            'component-malformed-components',
+            'Model',
+            "Malformed 'components' in 'component-malformed-components' spec: expected object, got string",
+        ];
+        yield 'malformed schemas' => [
+            'component-malformed-schemas',
+            'Model',
+            "Malformed 'components.schemas' in 'component-malformed-schemas' spec: expected object, got string",
+        ];
+        yield 'malformed selected schema' => [
+            'sdk-roundtrip',
+            'MalformedSchema',
+            "Malformed 'components.schemas[\"MalformedSchema\"]' in 'sdk-roundtrip' spec: expected object, got string",
+        ];
+    }
+
+    #[Test]
+    public function explores_a_named_component_with_branch_complete_cases_and_no_operation_metadata(): void
+    {
+        $cases = OpenApiResponseExplorer::exploreComponent(
+            'sdk-roundtrip',
+            'IntrospectResponse',
+            seed: 1,
+            extraCases: 1,
+        );
+
+        $this->assertSame(
+            [
+                '/properties/aud@0',
+                '/properties/aud@1',
+                '/properties/aud/oneOf@0',
+                '/properties/aud/oneOf@1',
+            ],
+            array_values(array_filter(array_map(
+                static fn(GeneratedResponseCase $case): ?string => $case->pinnedBranch,
+                $cases->cases,
+            ))),
+        );
+        foreach ($cases as $case) {
+            $this->assertNull($case->status);
+            $this->assertNull($case->contentType);
+            $this->assertArrayNotHasKey('secret', $case->bodyAsArray() ?? []);
+        }
+        $this->assertStringContainsString(
+            "OpenApiResponseExplorer::exploreComponent('sdk-roundtrip', 'IntrospectResponse', seed: 1, extraCases: 1)",
+            $cases->cases[0]->replaySnippet(),
+        );
+    }
+
+    #[Test]
+    public function component_cases_keep_the_existing_round_trip_fidelity_assertion(): void
+    {
+        $case = OpenApiResponseExplorer::exploreComponent(
+            'sdk-roundtrip',
+            'IntrospectResponse',
+            seed: 1,
+        )->cases[2];
+        $body = $case->bodyAsArray();
+        $this->assertIsArray($body);
+        $case->assertRoundTrip($body);
+
+        unset($body['aud']);
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage("missing generated key 'aud'");
+        $case->assertRoundTrip($body);
+    }
+
+    #[Test]
+    public function component_conversion_uses_the_document_json_schema_dialect(): void
+    {
+        $case = OpenApiResponseExplorer::exploreComponent(
+            'dialect-draft07',
+            'DialectProbe',
+            seed: 1,
+        )->cases[0];
+        $body = $case->bodyAsArray();
+
+        $this->assertIsArray($body);
+        $case->assertRoundTrip([...$body, 'sdkExtra' => 'allowed by Draft 07']);
+        $this->addToAssertionCount(1);
+    }
+
+    #[Test]
+    public function component_discriminator_mapping_resolves_against_the_document_root(): void
+    {
+        $cases = OpenApiResponseExplorer::exploreComponent(
+            'sdk-roundtrip',
+            'JsonWebKey',
+            seed: 1,
+        );
+        $encoded = json_encode(array_map(
+            static fn(GeneratedResponseCase $case): mixed => $case->body,
+            $cases->cases,
+        ));
+
+        $this->assertIsString($encoded);
+        $this->assertStringContainsString('RSA', $encoded);
+        $this->assertStringContainsString('EC', $encoded);
+    }
+
+    #[Test]
+    #[DataProvider('provideRejects_unknown_or_malformed_component_schemas_loudlyCases')]
+    public function rejects_unknown_or_malformed_component_schemas_loudly(
+        string $specName,
+        string $schemaName,
+        string $message,
+    ): void {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($message);
+
+        OpenApiResponseExplorer::exploreComponent($specName, $schemaName);
+    }
+
+    #[Test]
+    public function rejects_negative_component_extra_cases_at_the_public_boundary(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('OpenApiResponseExplorer::exploreComponent() requires extraCases >= 0');
+
+        OpenApiResponseExplorer::exploreComponent(
+            'sdk-roundtrip',
+            'IntrospectResponse',
+            extraCases: -1,
+        );
+    }
+
+    #[Test]
+    public function rejects_recursive_component_schemas_loudly(): void
+    {
+        $this->expectException(InvalidOpenApiSpecException::class);
+        $this->expectExceptionMessage('Circular $ref');
+
+        OpenApiResponseExplorer::exploreComponent('refs-circular', 'Node');
     }
 
     #[Test]

--- a/tests/fixtures/compatibility/v2-public-api.json
+++ b/tests/fixtures/compatibility/v2-public-api.json
@@ -3503,7 +3503,7 @@
                 }
             },
             "contentType": {
-                "type": "string",
+                "type": "?string",
                 "static": false,
                 "readonly": true,
                 "default": {
@@ -3527,7 +3527,7 @@
                 }
             },
             "status": {
-                "type": "int",
+                "type": "?int",
                 "static": false,
                 "readonly": true,
                 "default": {
@@ -3557,7 +3557,7 @@
                     },
                     {
                         "name": "status",
-                        "type": "int",
+                        "type": "?int",
                         "optional": false,
                         "variadic": false,
                         "by_reference": false,
@@ -3568,7 +3568,7 @@
                     },
                     {
                         "name": "contentType",
-                        "type": "string",
+                        "type": "?string",
                         "optional": false,
                         "variadic": false,
                         "by_reference": false,
@@ -3623,7 +3623,7 @@
                     },
                     {
                         "name": "method",
-                        "type": "string",
+                        "type": "?string",
                         "optional": false,
                         "variadic": false,
                         "by_reference": false,
@@ -3634,7 +3634,7 @@
                     },
                     {
                         "name": "matchedPath",
-                        "type": "string",
+                        "type": "?string",
                         "optional": false,
                         "variadic": false,
                         "by_reference": false,
@@ -3661,6 +3661,15 @@
                         "variadic": false,
                         "by_reference": false,
                         "default": 0,
+                        "attributes": []
+                    },
+                    {
+                        "name": "schemaName",
+                        "type": "?string",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
                         "attributes": []
                     }
                 ]
@@ -4092,6 +4101,56 @@
                         "variadic": false,
                         "by_reference": false,
                         "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "seed",
+                        "type": "?int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": null,
+                        "attributes": []
+                    },
+                    {
+                        "name": "extraCases",
+                        "type": "int",
+                        "optional": true,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": 0,
+                        "attributes": []
+                    }
+                ]
+            },
+            "exploreComponent": {
+                "static": true,
+                "final": false,
+                "abstract": false,
+                "returns_reference": false,
+                "return_type": "Studio\\Gesso\\Fuzz\\GeneratedResponseCases",
+                "attributes": [],
+                "parameters": [
+                    {
+                        "name": "specName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
+                        "attributes": []
+                    },
+                    {
+                        "name": "schemaName",
+                        "type": "string",
+                        "optional": false,
+                        "variadic": false,
+                        "by_reference": false,
+                        "default": {
+                            "unavailable": true
+                        },
                         "attributes": []
                     },
                     {

--- a/tests/fixtures/specs/component-malformed-components.json
+++ b/tests/fixtures/specs/component-malformed-components.json
@@ -1,0 +1,9 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Malformed components fixture",
+    "version": "1.0.0"
+  },
+  "paths": {},
+  "components": "invalid"
+}

--- a/tests/fixtures/specs/component-malformed-schemas.json
+++ b/tests/fixtures/specs/component-malformed-schemas.json
@@ -1,0 +1,11 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Malformed component schemas fixture",
+    "version": "1.0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": "invalid"
+  }
+}

--- a/tests/fixtures/specs/dialect-draft07.json
+++ b/tests/fixtures/specs/dialect-draft07.json
@@ -24,5 +24,17 @@
         }
       }
     }
+  },
+  "components": {
+    "schemas": {
+      "DialectProbe": {
+        "type": "object",
+        "required": ["id"],
+        "properties": {
+          "id": {"type": "string"}
+        },
+        "unevaluatedProperties": false
+      }
+    }
   }
 }

--- a/tests/fixtures/specs/sdk-roundtrip.json
+++ b/tests/fixtures/specs/sdk-roundtrip.json
@@ -125,5 +125,55 @@
         }
       }
     }
+  },
+  "components": {
+    "schemas": {
+      "IntrospectResponse": {
+        "type": "object",
+        "required": ["active"],
+        "properties": {
+          "active": {"type": "boolean"},
+          "aud": {
+            "oneOf": [
+              {"type": "string"},
+              {
+                "type": "array",
+                "items": {"type": "string"}
+              }
+            ]
+          },
+          "secret": {"type": "string", "writeOnly": true}
+        }
+      },
+      "JsonWebKey": {
+        "type": "object",
+        "required": ["kty"],
+        "properties": {
+          "kty": {"type": "string", "enum": ["RSA", "EC"]}
+        },
+        "discriminator": {
+          "propertyName": "kty",
+          "mapping": {
+            "RSA": "#/components/schemas/RsaJsonWebKey",
+            "EC": "#/components/schemas/EcJsonWebKey"
+          }
+        }
+      },
+      "RsaJsonWebKey": {
+        "type": "object",
+        "required": ["n"],
+        "properties": {
+          "n": {"type": "string"}
+        }
+      },
+      "EcJsonWebKey": {
+        "type": "object",
+        "required": ["x"],
+        "properties": {
+          "x": {"type": "string"}
+        }
+      },
+      "MalformedSchema": "not a schema object"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds named `components.schemas` exploration to `OpenApiResponseExplorer` through a new `exploreComponent()` entry point. Generated component cases reuse the response explorer's deterministic, branch-complete generation and round-trip validation while exposing nullable operation metadata when no endpoint is involved.

## Why

SDK model types are often generated directly from named component schemas, including models that are not currently reachable from an operation response. The existing response-only explorer could therefore miss decode/encode regressions in those generated models.

Closes #446

## Verification

- [x] `composer test` passes (2,768 tests, 10,007 assertions)
- [x] PHPStan passes with `vendor/bin/phpstan analyse --memory-limit=512M`
- [x] `composer cs-check` passes
- [x] Focused fuzz tests pass (40 tests, 157 assertions)
- [x] Public API compatibility tests pass (6 tests, 26 assertions)
- [x] `npm run docs:build` passes
- [x] SDK round-trip and API-reference documentation verified in the local VitePress site

## Notes for reviewers

- Component lookup is exact and case-sensitive, and malformed `components` / `components.schemas` nodes fail loudly.
- Conversion preserves the document's OpenAPI version, JSON Schema dialect, response context, and discriminator enforcement.
- Existing operation-based replay snippets and `assertRoundTrip()` behavior remain compatible; component cases replay through `exploreComponent()`.
- No production dependencies were added.
