### PR TITLE
fix(validation): reject null response content

### DIFF
--- a/docs/superpowers/plans/2026-08-03-response-content-null-consistency.md
+++ b/docs/superpowers/plans/2026-08-03-response-content-null-consistency.md
@@ -1,0 +1,185 @@
+# Response `content: null` Consistency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make runtime response validation reject an explicitly null Response Object `content` field while preserving no-content behavior when the field is omitted.
+
+**Architecture:** Keep `ResponseSchemaResolver` as the shared runtime boundary. Add one malformed fixture consumed by resolver and public-validator regression tests, then replace the resolver's non-null presence check with an explicit key-presence check so the existing `MalformedSpecNode` guard handles null.
+
+**Tech Stack:** PHP 8.3+, PHPUnit, Composer, JSON OpenAPI fixtures.
+
+## Global Constraints
+
+- Preserve PHP 8.3 compatibility and existing public APIs.
+- Add no production dependency.
+- Keep omitted `content` resolving to `NoContent`.
+- Keep doctor behavior unchanged.
+- Do not modify unrelated nullable-enum or exploration behavior.
+
+---
+
+### Task 1: Reject explicit null response content at runtime
+
+**Files:**
+- Modify: `tests/fixtures/specs/malformed.json`
+- Modify: `tests/Unit/Validation/Response/ResponseSchemaResolverTest.php`
+- Modify: `tests/Unit/OpenApiResponseValidatorTest.php`
+- Modify: `src/Validation/Response/ResponseSchemaResolver.php`
+
+**Interfaces:**
+- Consumes: `ResponseSchemaResolver::resolve(string $specName, string $method, string $path, int $statusCode, ?string $contentType = null): ResponseSchemaResolution`
+- Produces: existing `ResponseSchemaResolutionOutcome::MalformedContent` for a present `content` key whose value is null; no new interface.
+
+- [ ] **Step 1: Add the malformed OpenAPI fixture**
+
+Add this path to `tests/fixtures/specs/malformed.json` beside the existing
+response-content malformed cases:
+
+```json
+"/response-null-content": {
+    "get": {
+        "summary": "responses[200].content is null",
+        "operationId": "responseNullContent",
+        "responses": {
+            "200": {
+                "description": "OK",
+                "content": null
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Write resolver and public-validator regression tests**
+
+Extend `resolve_reports_malformed_content_nodes()` in
+`ResponseSchemaResolverTest` with:
+
+```php
+$nullContent = $this->resolver->resolve('malformed', 'GET', '/response-null-content', 200, 'application/json');
+$this->assertSame(ResponseSchemaResolutionOutcome::MalformedContent, $nullContent->outcome);
+$this->assertStringContainsString("Malformed 'responses[200].content'", (string) $nullContent->message);
+$this->assertStringContainsString('expected object, got null', (string) $nullContent->message);
+```
+
+Add this test to `OpenApiResponseValidatorTest`:
+
+```php
+#[Test]
+public function null_response_content_block_returns_failure(): void
+{
+    $result = $this->validator->validate(
+        'malformed',
+        'GET',
+        '/response-null-content',
+        200,
+        ['id' => 1],
+        'application/json',
+    );
+
+    $this->assertFalse($result->isValid());
+    $this->assertStringContainsString(
+        "Malformed 'responses[200].content'",
+        $result->errors()[0],
+    );
+    $this->assertStringContainsString('expected object, got null', $result->errors()[0]);
+}
+```
+
+- [ ] **Step 3: Run the tests to verify RED**
+
+Run:
+
+```bash
+vendor/bin/phpunit tests/Unit/Validation/Response/ResponseSchemaResolverTest.php --filter resolve_reports_malformed_content_nodes
+vendor/bin/phpunit tests/Unit/OpenApiResponseValidatorTest.php --filter null_response_content_block_returns_failure
+```
+
+Expected: both fail because explicit null currently resolves through
+`ResponseSchemaResolutionOutcome::NoContent` and public validation succeeds.
+
+- [ ] **Step 4: Make the minimal resolver change**
+
+In `ResponseSchemaResolver`, replace the historical `isset()` branch and its
+comment with:
+
+```php
+// 204 No Content (and similar) declare no `content` block. Check key
+// presence so an explicit `content: null` reaches the malformed-node guard.
+if (!array_key_exists('content', $responseSpec)) {
+    return ResponseSchemaResolution::noContent($matchedPath, $matchedResponseKey, $responseSpec);
+}
+```
+
+- [ ] **Step 5: Run focused verification to confirm GREEN**
+
+Run:
+
+```bash
+vendor/bin/phpunit tests/Unit/Validation/Response/ResponseSchemaResolverTest.php
+vendor/bin/phpunit tests/Unit/OpenApiResponseValidatorTest.php
+vendor/bin/phpunit tests/Unit/Cli/DoctorCommandTest.php --filter rejects_nested_response_nodes_using_runtime_malformed_node_rules
+```
+
+Expected: all tests pass, including the doctor's existing explicit-null case.
+
+- [ ] **Step 6: Run repository checks**
+
+Run:
+
+```bash
+composer ci
+```
+
+Expected: PHP-CS-Fixer checks, PHPStan, and PHPUnit all pass.
+
+- [ ] **Step 7: Commit the implementation**
+
+```bash
+git add tests/fixtures/specs/malformed.json \
+  tests/Unit/Validation/Response/ResponseSchemaResolverTest.php \
+  tests/Unit/OpenApiResponseValidatorTest.php \
+  src/Validation/Response/ResponseSchemaResolver.php
+git commit -m "fix(validation): reject null response content"
+```
+
+### Task 2: Publish the draft pull request
+
+**Files:**
+- Modify: none
+
+**Interfaces:**
+- Consumes: the complete feature-branch commit history and repository PR conventions.
+- Produces: a draft GitHub pull request targeting the repository default branch.
+
+- [ ] **Step 1: Confirm publish scope and authentication**
+
+Run:
+
+```bash
+git status --short --branch
+git diff main...HEAD --stat
+gh --version
+gh auth status
+```
+
+Expected: only the design, plan, fixture, tests, and resolver change are in the
+branch diff; unrelated untracked files remain unstaged; GitHub CLI is authenticated.
+
+- [ ] **Step 2: Push the feature branch**
+
+```bash
+git push -u origin fix/response-content-null-consistency
+```
+
+- [ ] **Step 3: Open a draft PR**
+
+Use the title:
+
+```text
+fix(validation): reject null response content
+```
+
+The body must explain the runtime/doctor inconsistency, the `isset()` root
+cause, the explicit key-presence fix, unchanged omitted-content behavior, and
+the successful focused and repository checks.

--- a/docs/superpowers/specs/2026-08-03-response-content-null-consistency-design.md
+++ b/docs/superpowers/specs/2026-08-03-response-content-null-consistency-design.md
@@ -1,0 +1,86 @@
+# Response `content: null` consistency design
+
+- Date: 2026-08-03
+- Status: Approved for implementation
+
+## Goal
+
+Make response validation and `gesso doctor` agree when an OpenAPI Response
+Object explicitly declares `content: null`, while preserving the existing
+no-content behavior when the `content` field is omitted.
+
+OpenAPI 3.0 and 3.1 define `content` as a map of media types to Media Type
+Objects, and OpenAPI 3.2 defines it as a map of media types to Media Type or
+Reference Objects. None permits `null` as the value of the fixed field:
+
+- [OpenAPI 3.0.4 Response Object](https://spec.openapis.org/oas/v3.0.4.html#response-object)
+- [OpenAPI 3.1.1 Response Object](https://spec.openapis.org/oas/v3.1.1.html#response-object)
+- [OpenAPI 3.2.0 Response Object](https://spec.openapis.org/oas/v3.2.0.html#response-object)
+
+## Current inconsistency
+
+`ResponseSchemaResolver` uses `isset()` to test for `content`. PHP therefore
+treats an explicitly null value as absent, and runtime response validation
+returns the normal no-content resolution.
+
+`DoctorCommand` uses an explicit key-presence check before validating the node.
+It therefore reports `content: null` as malformed. The same document currently
+passes one path and fails the other.
+
+## Decision
+
+Use field presence, rather than non-nullness, to distinguish an omitted
+`content` field from an invalid declared value at the runtime resolution
+boundary.
+
+| Response Object shape | Runtime resolution |
+| --- | --- |
+| `content` omitted | `NoContent` |
+| `content: null` | `MalformedContent` |
+| scalar or list-shaped `content` | `MalformedContent` (unchanged) |
+| map-shaped `content` | Existing media-type resolution behavior |
+
+The doctor remains unchanged because its strict behavior already matches the
+OpenAPI field type. Schema loading must not normalize explicit null to absence;
+doing so would erase the distinction needed for useful malformed-spec
+diagnostics.
+
+## Implementation
+
+Change only the response resolver's initial `content` presence check. Once an
+explicit null value reaches the existing malformed-node guard, the resolver
+will return `MalformedContent` through its current diagnostic path. Omitted
+`content` continues to return `NoContent` before that guard.
+
+No new public symbol, exception type, CLI option, wire-format field, or
+production dependency is introduced. The observable change applies only to an
+invalid OpenAPI document shape.
+
+## Tests
+
+Follow test-driven development:
+
+1. Add a focused resolver regression test proving that explicit `content: null`
+   resolves to `MalformedContent`.
+2. Add or extend a public response-validator test proving that the malformed
+   node becomes a validation failure rather than a no-content success.
+3. Retain the existing doctor test for `content: null` as the other side of the
+   consistency contract.
+4. Run the focused resolver, response-validator, and doctor tests, followed by
+   the repository CI command.
+
+Assertions should verify the result kind and useful location context without
+coupling to incidental third-party validator prose.
+
+## Documentation and compatibility
+
+No user guide change is required: `content: null` is not valid OpenAPI, and
+valid no-content responses remain represented by omitting `content`. This
+design document records the intentional malformed-spec behavior change.
+
+## Non-goals
+
+- Do not change request-body handling or unrelated malformed-node boundaries.
+- Do not change empty-map or media-type selection behavior.
+- Do not address the separately identified nullable-enum exploration issue.
+- Do not change doctor diagnostics beyond preserving their current strictness.

--- a/src/Validation/Response/ResponseSchemaResolver.php
+++ b/src/Validation/Response/ResponseSchemaResolver.php
@@ -244,10 +244,10 @@ final class ResponseSchemaResolver
         }
 
         /** @var array<string, mixed> $responseSpec */
-        // 204 No Content (and similar) declare no `content` block. `isset`
-        // (not `array_key_exists`) is the historical validator behavior: an
-        // explicit `content: null` also lands here.
-        if (!isset($responseSpec['content'])) {
+        // 204 No Content (and similar) declare no `content` block. Check key
+        // presence so an explicit `content: null` reaches the malformed-node
+        // guard below.
+        if (!array_key_exists('content', $responseSpec)) {
             return ResponseSchemaResolution::noContent($matchedPath, $matchedResponseKey, $responseSpec);
         }
 

--- a/tests/Unit/OpenApiResponseValidatorTest.php
+++ b/tests/Unit/OpenApiResponseValidatorTest.php
@@ -2313,6 +2313,26 @@ class OpenApiResponseValidatorTest extends TestCase
     }
 
     #[Test]
+    public function null_response_content_block_returns_failure(): void
+    {
+        $result = $this->validator->validate(
+            'malformed',
+            'GET',
+            '/response-null-content',
+            200,
+            ['id' => 1],
+            'application/json',
+        );
+
+        $this->assertFalse($result->isValid());
+        $this->assertStringContainsString(
+            "Malformed 'responses[200].content'",
+            $result->errors()[0],
+        );
+        $this->assertStringContainsString('expected object, got null', $result->errors()[0]);
+    }
+
+    #[Test]
     public function malformed_response_content_media_type_entry_returns_failure(): void
     {
         // `responses.200.content["application/json"]` is a scalar. The

--- a/tests/Unit/Validation/Response/ResponseSchemaResolverTest.php
+++ b/tests/Unit/Validation/Response/ResponseSchemaResolverTest.php
@@ -174,6 +174,11 @@ class ResponseSchemaResolverTest extends TestCase
         $this->assertSame(ResponseSchemaResolutionOutcome::MalformedContent, $contentBlock->outcome);
         $this->assertStringContainsString("Malformed 'responses[200].content'", (string) $contentBlock->message);
 
+        $nullContent = $this->resolver->resolve('malformed', 'GET', '/response-null-content', 200, 'application/json');
+        $this->assertSame(ResponseSchemaResolutionOutcome::MalformedContent, $nullContent->outcome);
+        $this->assertStringContainsString("Malformed 'responses[200].content'", (string) $nullContent->message);
+        $this->assertStringContainsString('expected object, got null', (string) $nullContent->message);
+
         $mediaType = $this->resolver->resolve('malformed', 'GET', '/response-scalar-content-media-type', 200, 'application/json');
         $this->assertSame(ResponseSchemaResolutionOutcome::MalformedContent, $mediaType->outcome);
         $this->assertStringContainsString(

--- a/tests/fixtures/specs/malformed.json
+++ b/tests/fixtures/specs/malformed.json
@@ -131,6 +131,18 @@
                 }
             }
         },
+        "/response-null-content": {
+            "get": {
+                "summary": "responses[200].content is null",
+                "operationId": "responseNullContent",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": null
+                    }
+                }
+            }
+        },
         "/response-scalar-content-media-type": {
             "get": {
                 "summary": "responses[200].content[mediaType] is a scalar (not an object)",


### PR DESCRIPTION
## Summary

Make runtime response validation reject an explicitly null Response Object
`content` field as malformed.

The resolver now distinguishes an omitted `content` key from a present null
value, and regression coverage verifies both the shared resolver outcome and
the public validator failure.

## Why

`ResponseSchemaResolver` used `isset()`, so `content: null` was treated as if
the field were omitted and returned `NoContent`. Meanwhile, `gesso doctor`
used an explicit key-presence check and correctly diagnosed the same OpenAPI
document as malformed.

Using `array_key_exists()` at the shared runtime boundary makes both paths
consistent while preserving valid content-less responses that omit the field.

## Verification

The regression tests were run before the fix and failed with `NoContent` / a
successful public validation result. They pass after the resolver change.

- [x] `composer test` passes
- [x] `composer stan` passes
- [x] `composer cs-check` passes
- [x] `NPM_CONFIG_CACHE=/tmp/gesso-npm-cache composer ci` passes (2854 tests,
  10267 assertions)

## Notes for reviewers

- No public API, dependency, CLI, or wire-format change.
- Omitted `content` continues to resolve to `NoContent`.
- The behavior change is limited to the invalid explicit-null OpenAPI shape.
- The branch includes the design and implementation plan used for this fix.
