### PR TITLE
fix(fuzz): cover nullable enum branches

### DIFF
--- a/docs/superpowers/plans/2026-08-03-nullable-enum-branch-coverage.md
+++ b/docs/superpowers/plans/2026-08-03-nullable-enum-branch-coverage.md
@@ -1,0 +1,374 @@
+# Nullable Enum Branch Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generate both reachable null and non-null response cases when a nullable converted JSON Schema has an enum spanning both sides, without inventing branches for single-value or one-sided finite domains.
+
+**Architecture:** Keep nullable enum classification in the existing pre-pass enumerator and honor the resulting `/type` selection in the existing schema generator. The enumerator filters enum members through `SchemaValueValidator` before deciding whether two branches exist; the generator partitions its already-admissible planned enum domain by the pinned null/value selection. Public explorer APIs, choice-point pointers, and plan-less enum rotation remain unchanged.
+
+**Tech Stack:** PHP 8.3+, PHPUnit 12/13 attributes, existing internal fuzzing classes, Composer CI scripts.
+
+## Global Constraints
+
+- Preserve compatibility with the PHP 8.3 floor and the existing public API inventory.
+- Add no production dependency, public symbol, configuration option, or wire-format change.
+- Keep request exploration without a `CaseSelectionPlan` bit-for-bit on its existing enum rotation path.
+- Enumerate a nullable finite domain only when valid null and non-null members are both reachable.
+- Treat `const` and one-sided enums as terminal domains without synthetic nullable branches.
+- Preserve unrelated worktree changes, including `.claude/` and `docs/adr/0002-arazzo-workflow-execution.md`.
+
+---
+
+## File Structure
+
+- Modify `src/Fuzz/SchemaChoicePointEnumerator.php`: classify admissible enum members before terminating exact-value leaf traversal.
+- Modify `src/Fuzz/SchemaDataGenerator.php`: apply a pinned `/type` selection to planned enum generation.
+- Modify `tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php`: pin two-sided and one-sided finite-domain enumeration behavior.
+- Modify `tests/Unit/Fuzz/SchemaDataGeneratorTest.php`: prove pinned nullable selections override enum rotation.
+- Modify `tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php`: prove the end-to-end case set contains both reachable sides.
+
+### Task 1: Enumerate only reachable nullable enum sides
+
+**Files:**
+- Modify: `src/Fuzz/SchemaChoicePointEnumerator.php:318-342`
+- Test: `tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php:297-312`
+
+**Interfaces:**
+- Consumes: `SchemaChoicePointEnumerator::enumerate(array<string, mixed>): list<SchemaChoicePoint>` and `SchemaValueValidator::isValid(mixed, array<string, mixed>): bool`.
+- Produces: an existing `SchemaChoicePointKind::Nullable` at `<pointer>/type`, with branch `SchemaChoicePoint::VALUE` equal to `0` and `SchemaChoicePoint::NULL_VALUE` equal to `1`, only for enum domains admitting both categories.
+
+- [ ] **Step 1: Replace the overly broad exact-domain regression test**
+
+Replace `stops_at_const_and_enum_schemas()` with focused tests that describe the finite-domain contract:
+
+```php
+#[Test]
+public function collects_nullable_choice_for_an_enum_spanning_both_reachable_sides(): void
+{
+    $points = SchemaChoicePointEnumerator::enumerate([
+        'type' => ['string', 'null'],
+        'enum' => ['member', null],
+    ]);
+
+    $this->assertCount(1, $points);
+    $this->assertSame(SchemaChoicePointKind::Nullable, $points[0]->kind);
+    $this->assertSame('/type', $points[0]->pointer);
+    $this->assertSame(2, $points[0]->branchCount);
+    $this->assertSame([], $points[0]->ancestors);
+}
+
+#[Test]
+public function stops_at_exact_domains_that_reach_only_one_nullable_side(): void
+{
+    $schemas = [
+        ['type' => ['string', 'null'], 'const' => 'fixed'],
+        ['type' => ['string', 'null'], 'const' => null],
+        ['type' => ['string', 'null'], 'enum' => ['fixed']],
+        ['type' => ['string', 'null'], 'enum' => [null]],
+        [
+            'type' => ['string', 'null'],
+            'enum' => ['fixed', null],
+            'not' => ['const' => null],
+        ],
+    ];
+
+    foreach ($schemas as $schema) {
+        $this->assertSame([], SchemaChoicePointEnumerator::enumerate($schema));
+    }
+}
+```
+
+- [ ] **Step 2: Run the enumerator tests and verify RED**
+
+Run:
+
+```bash
+vendor/bin/phpunit tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
+```
+
+Expected: FAIL in `collects_nullable_choice_for_an_enum_spanning_both_reachable_sides()` because the current early enum return produces zero points. The one-sided exact-domain assertions remain green.
+
+- [ ] **Step 3: Classify the admissible enum domain before returning**
+
+Keep `const` terminal. In the non-empty enum branch of `visitLeaf()`, filter members against the effective schema and record the existing nullable choice only when the filtered domain contains both null and non-null values:
+
+```php
+if (array_key_exists('const', $schema)) {
+    return;
+}
+if (isset($schema['enum']) && is_array($schema['enum']) && $schema['enum'] !== []) {
+    $admissible = array_values(array_filter(
+        $schema['enum'],
+        static fn(mixed $value): bool => SchemaValueValidator::isValid($value, $schema),
+    ));
+    $hasNull = in_array(null, $admissible, true);
+    $hasValue = array_filter($admissible, static fn(mixed $value): bool => $value !== null) !== [];
+    if (self::isNullableTypeArray($schema) && $hasNull && $hasValue) {
+        $this->record(
+            SchemaChoicePointKind::Nullable,
+            $pointer . '/type',
+            2,
+            $ancestors,
+            null,
+        );
+    }
+
+    return;
+}
+```
+
+Do not descend into properties or items after an enum: the finite values remain terminal and already determine their entire shape.
+
+- [ ] **Step 4: Run the enumerator tests and verify GREEN**
+
+Run:
+
+```bash
+vendor/bin/phpunit tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
+```
+
+Expected: PASS with both the two-sided enum and all one-sided finite domains classified correctly.
+
+- [ ] **Step 5: Commit the enumerator slice**
+
+```bash
+git add src/Fuzz/SchemaChoicePointEnumerator.php tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
+git commit -m "fix(fuzz): enumerate nullable enum branches"
+```
+
+### Task 2: Honor nullable pins during enum generation
+
+**Files:**
+- Modify: `src/Fuzz/SchemaDataGenerator.php:676-716`
+- Test: `tests/Unit/Fuzz/SchemaDataGeneratorTest.php:1148-1172`
+- Test: `tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php:109-126`
+
+**Interfaces:**
+- Consumes: `CaseSelectionPlan::branchFor(string): ?int`, the `/type` pointer emitted by Task 1, and the existing enum admissibility filter.
+- Produces: planned enum generation that returns null for `SchemaChoicePoint::NULL_VALUE` and an admissible non-null member for `SchemaChoicePoint::VALUE`, while registering the existing `PinnedBranchObservation` target predicate.
+
+- [ ] **Step 1: Add a direct pinned-generation regression test**
+
+Add next to `pinned_plan_selects_nullable_branches()`:
+
+```php
+#[Test]
+public function pinned_plan_partitions_nullable_enum_values(): void
+{
+    $schema = [
+        'type' => ['string', 'null'],
+        'enum' => [null, 'member', 'alternate'],
+    ];
+
+    $null = SchemaDataGenerator::generateOne(
+        $schema,
+        null,
+        2,
+        new CaseSelectionPlan(['/type' => SchemaChoicePoint::NULL_VALUE]),
+    );
+    $this->assertNull($null);
+
+    $value = SchemaDataGenerator::generateOne(
+        $schema,
+        null,
+        0,
+        new CaseSelectionPlan(['/type' => SchemaChoicePoint::VALUE]),
+    );
+    $this->assertSame('member', $value);
+}
+```
+
+The chosen iterations deliberately contradict normal enum rotation: iteration `2` would select `alternate`, while iteration `0` would select `null`.
+
+- [ ] **Step 2: Add the branch-complete end-to-end regression test**
+
+Add next to `covers_both_nullable_branches()`:
+
+```php
+#[Test]
+public function covers_both_reachable_nullable_enum_branches(): void
+{
+    $schema = [
+        'type' => ['string', 'null'],
+        'enum' => [null, 'member', 'alternate'],
+    ];
+
+    $cases = BranchCompleteCaseGenerator::generate($schema, seed: 1);
+    $values = array_map(static fn(PlannedSchemaCase $case): mixed => $case->value, $cases);
+
+    $this->assertCount(2, $cases);
+    $this->assertContains(null, $values);
+    $this->assertContains('member', $values);
+    foreach ($cases as $case) {
+        $this->assertTrue(SchemaValueValidator::isValid($case->value, $schema));
+        $this->assertSame('/type', $case->plan->targetPointer);
+    }
+}
+```
+
+- [ ] **Step 3: Run both new behavior tests and verify RED**
+
+Run:
+
+```bash
+vendor/bin/phpunit tests/Unit/Fuzz/SchemaDataGeneratorTest.php --filter pinned_plan_partitions_nullable_enum_values
+vendor/bin/phpunit tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php --filter covers_both_reachable_nullable_enum_branches
+```
+
+Expected: the direct test fails because enum rotation ignores the pin. The branch-complete test fails because target observation is never registered and the target search cannot prove either requested branch.
+
+- [ ] **Step 4: Partition admissible enum values by the nullable pin**
+
+In `SchemaDataGenerator::generateNode()`, derive the nullable pointer and pin before the enum return. Inside planned enum generation, register the normal target predicate and restrict the admissible finite domain when a pin exists:
+
+```php
+$nullablePointer = $pointer . '/type';
+$pinnedNullable = $plan?->branchFor($nullablePointer);
+
+// Existing const branch remains here.
+
+if (isset($schema['enum']) && is_array($schema['enum']) && $schema['enum'] !== []) {
+    $values = array_values($schema['enum']);
+    if ($plan !== null) {
+        $admissible = array_values(array_filter(
+            $values,
+            static fn(mixed $value): bool => SchemaValueValidator::isValid($value, $schema),
+        ));
+        if ($pinnedNullable !== null) {
+            $wantNull = $pinnedNullable === SchemaChoicePoint::NULL_VALUE;
+            if ($plan->targetPointer === $nullablePointer) {
+                $plan->observation->expect(
+                    $pointer,
+                    static fn(mixed $value): bool => ($value === null) === $wantNull,
+                );
+            }
+            $admissible = array_values(array_filter(
+                $admissible,
+                static fn(mixed $value): bool => ($value === null) === $wantNull,
+            ));
+        }
+        if ($admissible === []) {
+            if ($forced) {
+                $plan->observation->proveDeadEnd();
+            }
+
+            return $values[0];
+        }
+        if ((isset($schema['not']) && is_array($schema['not'])) || $pinnedNullable !== null) {
+            return $admissible[$iteration % count($admissible)];
+        }
+    }
+
+    return $values[$iteration % count($values)];
+}
+```
+
+Reuse `$nullablePointer` and `$pinnedNullable` in the existing generic nullable block below the enum branch. Do not change the plan-less return, so request generation keeps rotating over the original enum order.
+
+- [ ] **Step 5: Run focused generator tests and verify GREEN**
+
+Run:
+
+```bash
+vendor/bin/phpunit tests/Unit/Fuzz/SchemaDataGeneratorTest.php --filter pinned_plan_partitions_nullable_enum_values
+vendor/bin/phpunit tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php --filter covers_both_reachable_nullable_enum_branches
+vendor/bin/phpunit tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php --filter covers_both_nullable_branches
+```
+
+Expected: all focused tests PASS; the generic nullable test confirms the non-enum path remains intact.
+
+- [ ] **Step 6: Run all affected fuzzing suites**
+
+Run:
+
+```bash
+vendor/bin/phpunit \
+  tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php \
+  tests/Unit/Fuzz/SchemaDataGeneratorTest.php \
+  tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
+```
+
+Expected: PASS with no warnings or failures.
+
+- [ ] **Step 7: Commit the generation slice**
+
+```bash
+git add \
+  src/Fuzz/SchemaDataGenerator.php \
+  tests/Unit/Fuzz/SchemaDataGeneratorTest.php \
+  tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
+git commit -m "fix(fuzz): honor nullable enum branch plans"
+```
+
+### Task 3: Verify and publish the fix
+
+**Files:**
+- Verify: all tracked changes on `fix/nullable-enum-branch-coverage`
+- Preserve: `.claude/`, `docs/adr/0002-arazzo-workflow-execution.md`
+
+**Interfaces:**
+- Consumes: the two implementation commits from Tasks 1 and 2.
+- Produces: a verified draft pull request targeting `main`, with the documented nullable enum example and test evidence.
+
+- [ ] **Step 1: Apply repository formatting and inspect its scope**
+
+Run:
+
+```bash
+composer cs
+git status --short
+git diff --check
+```
+
+Expected: only the plan, design, two fuzzing classes, and three focused test files are tracked changes or branch commits; unrelated untracked paths remain untouched.
+
+- [ ] **Step 2: Run the repository CI gate fresh**
+
+Run:
+
+```bash
+NPM_CONFIG_CACHE=/tmp/gesso-npm-cache composer ci
+```
+
+Expected: both PHP-CS-Fixer checks, PHPStan, and the complete PHPUnit suite PASS.
+
+- [ ] **Step 3: Inspect the final branch and commit any formatter-only adjustment**
+
+Run:
+
+```bash
+git diff main...HEAD --check
+git diff --stat main...HEAD
+git status --short --branch
+```
+
+If `composer cs` changed any implementation/test file, stage only the fixed
+in-scope paths (Git ignores unchanged paths) and commit the adjustment:
+
+```bash
+git add \
+  src/Fuzz/SchemaChoicePointEnumerator.php \
+  src/Fuzz/SchemaDataGenerator.php \
+  tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php \
+  tests/Unit/Fuzz/SchemaDataGeneratorTest.php \
+  tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
+git commit -m "style: format nullable enum coverage fix"
+```
+
+Do not stage `.claude/` or `docs/adr/0002-arazzo-workflow-execution.md`.
+
+- [ ] **Step 4: Push and create the draft pull request**
+
+Run:
+
+```bash
+git push -u origin fix/nullable-enum-branch-coverage
+```
+
+Create a draft PR targeting `main` with title:
+
+```text
+fix(fuzz): cover nullable enum branches
+```
+
+The PR body must summarize the finite-domain partition, `const`/one-sided enum behavior, RED-to-GREEN evidence, affected focused suites, and the fresh `composer ci` result.

--- a/docs/superpowers/specs/2026-08-03-nullable-enum-branch-coverage-design.md
+++ b/docs/superpowers/specs/2026-08-03-nullable-enum-branch-coverage-design.md
@@ -1,0 +1,129 @@
+# Nullable enum branch coverage design
+
+- Date: 2026-08-03
+- Status: Approved for implementation
+
+## Goal
+
+Make response payload exploration generate both reachable sides of a nullable
+type when the converted JSON Schema also constrains the value with `enum`, while
+preserving exact-value semantics for `const` and one-sided enums.
+
+For example, this schema must produce both `"member"` and `null` cases:
+
+```json
+{
+  "type": ["string", "null"],
+  "enum": ["member", null]
+}
+```
+
+This restores the documented branch-complete guarantee for every reachable
+nullable choice point.
+
+## Current behavior
+
+`SchemaChoicePointEnumerator::visitLeaf()` returns immediately when it sees a
+non-empty `enum` or any `const`. It therefore records no `/type` nullable choice
+for an enum containing both null and non-null values.
+
+`SchemaDataGenerator::generateNode()` also resolves `const` and `enum` before
+its nullable-plan handling. Even if the enumerator reported the choice point,
+the generator would rotate through the exact-value domain without honoring a
+pinned null or non-null branch.
+
+The combined effect is a silent coverage gap: a fixed schema and seed can
+exercise only one side even though both are valid and reachable.
+
+## Decision
+
+Treat a non-empty enum as a finite value domain and partition its admissible
+members into null and non-null groups.
+
+The enumerator records the existing `SchemaChoicePointKind::Nullable` choice at
+`<pointer>/type` only when all of the following hold:
+
+1. `type` is an array containing `null` and at least one non-null type;
+2. at least one enum member is valid against the effective leaf schema and is
+   null; and
+3. at least one enum member is valid against the effective leaf schema and is
+   non-null.
+
+The generator applies a pinned nullable selection to the admissible enum
+members before choosing by iteration. The null branch selects only null; the
+value branch selects only non-null members. The existing target observation
+continues to prove that the returned value realized the requested branch.
+
+`const` remains a terminal single-value domain. Whether its sole value is null
+or non-null, it exposes no choice and therefore must not create a two-branch
+nullable target. Enums whose admissible values all fall on one side follow the
+same rule and remain terminal without a nullable choice point.
+
+## Alternatives considered
+
+### Move nullable handling before `const` and `enum`
+
+Rejected. It would invent a null target for schemas such as
+`{"type":["string","null"],"const":"fixed"}` even though `const` makes that
+branch unreachable. Target search would then need to rediscover a fact already
+decidable from the finite domain.
+
+### Normalize nullable enums into synthetic composition branches
+
+Rejected. Rewriting the schema as an implicit `anyOf` would change choice-point
+pointers, case counts, and merge behavior for a narrow bug. The existing
+nullable kind and `/type` selection contract already model the desired choice.
+
+### Partition the finite enum domain
+
+Accepted. It is local to the two components that currently disagree, preserves
+existing pointers and public behavior, and lets the generator choose only
+values that satisfy the exact-value constraint.
+
+## Implementation
+
+Keep the change inside the internal fuzzing boundary:
+
+- `SchemaChoicePointEnumerator` determines whether an enum has admissible
+  members on both nullable sides before returning from the exact-value leaf.
+- `SchemaDataGenerator` filters its already-computed admissible enum values by
+  a pinned nullable selection and installs the normal target observation before
+  returning the selected member.
+- The generic nullable generation path remains unchanged for schemas without
+  an exact-value domain.
+
+No new public class, method, configuration option, wire-format field, or
+production dependency is introduced. Request exploration without a selection
+plan retains its existing enum rotation.
+
+## Tests
+
+Follow test-driven development:
+
+1. Change the enumerator regression coverage so a nullable enum with valid null
+   and non-null members reports a two-branch `/type` choice.
+2. Prove that `const`, null-only enums, non-null-only enums, and enum members
+   excluded by sibling constraints do not create unreachable nullable targets.
+3. Add a branch-complete generator test proving both sides of a nullable enum
+   are emitted and every case satisfies the schema.
+4. Retain the existing generic nullable test to guard schemas without `enum`.
+5. Run the focused enumerator, branch-complete generator, and schema data
+   generator suites, followed by the repository CI command.
+
+## Documentation and compatibility
+
+No user-guide change is required. `docs/fuzzing.md` already promises coverage
+of every reachable nullable choice point; this change makes enum-constrained
+schemas satisfy that existing contract.
+
+The affected types are internal. Exact public APIs, generated coverage formats,
+and deterministic plan-less request generation remain unchanged.
+
+## Non-goals
+
+- Do not enumerate every enum member as its own branch; the contract is null
+  versus non-null coverage, not exhaustive enum-value coverage.
+- Do not create nullable targets for finite domains that admit only one side.
+- Do not change composition, conditional, optional-property, or array-presence
+  enumeration.
+- Do not alter public response-explorer or coverage-reporting APIs.

--- a/src/Fuzz/SchemaChoicePointEnumerator.php
+++ b/src/Fuzz/SchemaChoicePointEnumerator.php
@@ -329,6 +329,22 @@ final class SchemaChoicePointEnumerator
             return;
         }
         if (isset($schema['enum']) && is_array($schema['enum']) && $schema['enum'] !== []) {
+            $admissible = array_values(array_filter(
+                $schema['enum'],
+                static fn(mixed $value): bool => SchemaValueValidator::isValid($value, $schema),
+            ));
+            $hasNull = in_array(null, $admissible, true);
+            $hasValue = array_filter($admissible, static fn(mixed $value): bool => $value !== null) !== [];
+            if (self::isNullableTypeArray($schema) && $hasNull && $hasValue) {
+                $this->record(
+                    SchemaChoicePointKind::Nullable,
+                    $pointer . '/type',
+                    2,
+                    $ancestors,
+                    null,
+                );
+            }
+
             return;
         }
 

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -673,6 +673,9 @@ final class SchemaDataGenerator
             return null;
         }
 
+        $nullablePointer = $pointer . '/type';
+        $pinnedNullable = $plan?->branchFor($nullablePointer);
+
         if (array_key_exists('const', $schema)) {
             if ($plan !== null && $forced && !SchemaValueValidator::isValid($schema['const'], $schema)) {
                 // The node's domain is the single const value; if even that
@@ -706,7 +709,27 @@ final class SchemaDataGenerator
 
                     return $values[0];
                 }
-                if (isset($schema['not']) && is_array($schema['not'])) {
+                if ($pinnedNullable !== null) {
+                    $wantNull = $pinnedNullable === SchemaChoicePoint::NULL_VALUE;
+                    if ($plan->targetPointer === $nullablePointer) {
+                        $plan->observation->expect(
+                            $pointer,
+                            static fn(mixed $value): bool => ($value === null) === $wantNull,
+                        );
+                    }
+                    $admissible = array_values(array_filter(
+                        $admissible,
+                        static fn(mixed $value): bool => ($value === null) === $wantNull,
+                    ));
+                    if ($admissible === []) {
+                        if ($forced) {
+                            $plan->observation->proveDeadEnd();
+                        }
+
+                        return $values[0];
+                    }
+                }
+                if ((isset($schema['not']) && is_array($schema['not'])) || $pinnedNullable !== null) {
                     return $admissible[$iteration % count($admissible)];
                 }
             }
@@ -715,19 +738,18 @@ final class SchemaDataGenerator
         }
 
         if (is_array($schema['type'] ?? null) && in_array('null', $schema['type'], true)) {
-            $pinnedNull = $plan?->branchFor($pointer . '/type');
-            if ($plan !== null && $pinnedNull !== null && $plan->targetPointer === $pointer . '/type') {
-                $wantNull = $pinnedNull === SchemaChoicePoint::NULL_VALUE;
+            if ($plan !== null && $pinnedNullable !== null && $plan->targetPointer === $nullablePointer) {
+                $wantNull = $pinnedNullable === SchemaChoicePoint::NULL_VALUE;
                 $plan->observation->expect($pointer, static fn(mixed $value): bool
                     => ($value === null) === $wantNull);
             }
-            $emitNull = $pinnedNull !== null
-                ? $pinnedNull === SchemaChoicePoint::NULL_VALUE
+            $emitNull = $pinnedNullable !== null
+                ? $pinnedNullable === SchemaChoicePoint::NULL_VALUE
                 : ($iteration % 3) === 2;
             if ($emitNull) {
                 return null;
             }
-            if ($plan !== null && $pinnedNull === null) {
+            if ($plan !== null && $pinnedNullable === null) {
                 // Rotation chose the non-null side; null remains a way to
                 // satisfy this node, so nothing below can prove a dead end.
                 $forced = false;

--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -691,46 +691,18 @@ final class SchemaDataGenerator
         if (isset($schema['enum']) && is_array($schema['enum']) && $schema['enum'] !== []) {
             $values = array_values($schema['enum']);
             if ($plan !== null) {
-                // The enum domain is finite, so admissibility against the
-                // node view (including any `not` pushed down by suppression)
-                // is decidable outright — complete and deterministic where
-                // iteration retries could miss the admissible tail of a
-                // long enum.
-                $admissible = array_values(array_filter(
+                [$handled, $plannedValue] = self::plannedEnumValue(
+                    $schema,
                     $values,
-                    static fn(mixed $value): bool => SchemaValueValidator::isValid($value, $schema),
-                ));
-                if ($admissible === []) {
-                    // The finite domain is provably exhausted; the
-                    // deterministic pick keeps untargeted cases loud.
-                    if ($forced) {
-                        $plan->observation->proveDeadEnd();
-                    }
-
-                    return $values[0];
-                }
-                if ($pinnedNullable !== null) {
-                    $wantNull = $pinnedNullable === SchemaChoicePoint::NULL_VALUE;
-                    if ($plan->targetPointer === $nullablePointer) {
-                        $plan->observation->expect(
-                            $pointer,
-                            static fn(mixed $value): bool => ($value === null) === $wantNull,
-                        );
-                    }
-                    $admissible = array_values(array_filter(
-                        $admissible,
-                        static fn(mixed $value): bool => ($value === null) === $wantNull,
-                    ));
-                    if ($admissible === []) {
-                        if ($forced) {
-                            $plan->observation->proveDeadEnd();
-                        }
-
-                        return $values[0];
-                    }
-                }
-                if ((isset($schema['not']) && is_array($schema['not'])) || $pinnedNullable !== null) {
-                    return $admissible[$iteration % count($admissible)];
+                    $iteration,
+                    $plan,
+                    $pinnedNullable,
+                    $nullablePointer,
+                    $pointer,
+                    $forced,
+                );
+                if ($handled) {
+                    return $plannedValue;
                 }
             }
 
@@ -797,6 +769,75 @@ final class SchemaDataGenerator
             'null' => null,
             default => null,
         };
+    }
+
+    /**
+     * Restrict a finite enum domain for planned generation while leaving
+     * plan-less rotation untouched.
+     *
+     * @param array<string, mixed> $schema
+     * @param list<mixed> $values
+     *
+     * @return array{bool, mixed} Whether the caller should return the value.
+     */
+    private static function plannedEnumValue(
+        array $schema,
+        array $values,
+        int $iteration,
+        CaseSelectionPlan $plan,
+        ?int $pinnedNullable,
+        string $nullablePointer,
+        string $pointer,
+        bool $forced,
+    ): array {
+        // The enum domain is finite, so admissibility against the node view
+        // (including any `not` pushed down by suppression) is decidable
+        // outright — complete and deterministic where iteration retries
+        // could miss the admissible tail of a long enum.
+        $admissible = array_values(array_filter(
+            $values,
+            static fn(mixed $value): bool => SchemaValueValidator::isValid($value, $schema),
+        ));
+        if ($admissible === []) {
+            // The finite domain is provably exhausted; the deterministic pick
+            // keeps untargeted cases loud.
+            if ($forced) {
+                $plan->observation->proveDeadEnd();
+            }
+
+            return [true, $values[0]];
+        }
+
+        if ($pinnedNullable !== null) {
+            $wantNull = $pinnedNullable === SchemaChoicePoint::NULL_VALUE;
+            if ($plan->targetPointer === $nullablePointer) {
+                $plan->observation->expect(
+                    $pointer,
+                    static fn(mixed $value): bool => ($value === null) === $wantNull,
+                );
+            }
+            $partition = [];
+            foreach ($admissible as $value) {
+                if (($value === null) === $wantNull) {
+                    $partition[] = $value;
+                }
+            }
+            if ($partition === []) {
+                if ($forced) {
+                    $plan->observation->proveDeadEnd();
+                }
+
+                return [true, $values[0]];
+            }
+
+            return [true, $partition[$iteration % count($partition)]];
+        }
+
+        if (isset($schema['not']) && is_array($schema['not'])) {
+            return [true, $admissible[$iteration % count($admissible)]];
+        }
+
+        return [false, null];
     }
 
     /**

--- a/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
+++ b/tests/Unit/Fuzz/BranchCompleteCaseGeneratorTest.php
@@ -123,6 +123,26 @@ class BranchCompleteCaseGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function covers_both_reachable_nullable_enum_branches(): void
+    {
+        $schema = [
+            'type' => ['string', 'null'],
+            'enum' => [null, 'member', 'alternate'],
+        ];
+
+        $cases = BranchCompleteCaseGenerator::generate($schema, seed: 1);
+        $values = array_map(static fn(PlannedSchemaCase $case): mixed => $case->value, $cases);
+
+        $this->assertCount(2, $cases);
+        $this->assertContains(null, $values);
+        $this->assertContains('member', $values);
+        foreach ($cases as $case) {
+            $this->assertTrue(SchemaValueValidator::isValid($case->value, $schema));
+            $this->assertSame('/type', $case->plan->targetPointer);
+        }
+    }
+
+    #[Test]
     public function is_deterministic_for_a_fixed_schema_and_seed(): void
     {
         $first = BranchCompleteCaseGenerator::generate(self::INCIDENT_SHAPE, seed: 7, extraCases: 3);

--- a/tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
+++ b/tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
@@ -296,16 +296,42 @@ class SchemaChoicePointEnumeratorTest extends TestCase
     }
 
     #[Test]
-    public function stops_at_const_and_enum_schemas(): void
+    public function collects_nullable_choice_for_an_enum_spanning_both_reachable_sides(): void
     {
-        $this->assertSame([], SchemaChoicePointEnumerator::enumerate([
-            'const' => 'fixed',
-            'properties' => ['a' => ['oneOf' => [['type' => 'string'], ['type' => 'integer']]]],
-        ]));
-        $this->assertSame([], SchemaChoicePointEnumerator::enumerate([
+        $points = SchemaChoicePointEnumerator::enumerate([
             'type' => ['string', 'null'],
-            'enum' => ['a', 'b', null],
-        ]));
+            'enum' => ['member', null],
+        ]);
+
+        $this->assertCount(1, $points);
+        $this->assertSame(SchemaChoicePointKind::Nullable, $points[0]->kind);
+        $this->assertSame('/type', $points[0]->pointer);
+        $this->assertSame(2, $points[0]->branchCount);
+        $this->assertSame([], $points[0]->ancestors);
+    }
+
+    #[Test]
+    public function stops_at_exact_domains_that_reach_only_one_nullable_side(): void
+    {
+        $schemas = [
+            [
+                'const' => 'fixed',
+                'properties' => ['a' => ['oneOf' => [['type' => 'string'], ['type' => 'integer']]]],
+            ],
+            ['type' => ['string', 'null'], 'const' => 'fixed'],
+            ['type' => ['string', 'null'], 'const' => null],
+            ['type' => ['string', 'null'], 'enum' => ['fixed']],
+            ['type' => ['string', 'null'], 'enum' => [null]],
+            [
+                'type' => ['string', 'null'],
+                'enum' => ['fixed', null],
+                'not' => ['const' => null],
+            ],
+        ];
+
+        foreach ($schemas as $schema) {
+            $this->assertSame([], SchemaChoicePointEnumerator::enumerate($schema));
+        }
     }
 
     #[Test]

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -1172,6 +1172,31 @@ class SchemaDataGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function pinned_plan_partitions_nullable_enum_values(): void
+    {
+        $schema = [
+            'type' => ['string', 'null'],
+            'enum' => [null, 'member', 'alternate'],
+        ];
+
+        $null = SchemaDataGenerator::generateOne(
+            $schema,
+            null,
+            2,
+            new CaseSelectionPlan(['/type' => SchemaChoicePoint::NULL_VALUE]),
+        );
+        $this->assertNull($null);
+
+        $value = SchemaDataGenerator::generateOne(
+            $schema,
+            null,
+            0,
+            new CaseSelectionPlan(['/type' => SchemaChoicePoint::VALUE]),
+        );
+        $this->assertSame('member', $value);
+    }
+
+    #[Test]
     public function pinned_plan_selects_the_else_branch_of_a_conditional(): void
     {
         $schema = [


### PR DESCRIPTION
## Summary

- enumerate `/type` as a nullable choice when an enum has admissible null and non-null members
- honor pinned null/value selections during planned enum generation while preserving plan-less rotation
- keep `const`, one-sided enums, and sibling-constrained one-sided domains terminal

## Root cause

The choice-point enumerator and schema generator both returned through
`const`/`enum` handling before nullable branch planning. A schema such as
`{"type":["string","null"],"enum":["member",null]}` could therefore exercise
only one reachable side for a fixed seed.

## Validation

- RED: enumerator returned zero `/type` points; pinned generation returned the rotation value; branch-complete generation could not observe the target
- GREEN: affected fuzz suites pass with 156 tests and 999 assertions
- `NPM_CONFIG_CACHE=/tmp/gesso-npm-cache composer ci`: PHP-CS-Fixer clean, PHPStan 411 files with no errors, PHPUnit 2,857 tests and 10,285 assertions

Related to #441.
