### PR TITLE
docs(fuzz): complete branch enumeration bounds contract

### DIFF
--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -241,6 +241,11 @@ currently strategies. Those keywords remain validator features; an operation
 whose valid value cannot be synthesized fails locally with a supported-subset
 diagnostic or is an explicit whole-spec skip carrying that reason.
 
+Branch-complete response enumeration is bounded to 32 nested property/item
+levels, 256 collected choice points, and 10,000 visited schema nodes across all
+branch contexts. Exceeding any limit fails locally with a supported-subset
+diagnostic; Gesso never returns partial branch coverage.
+
 - Request cases alternate optional object properties between included and omitted. Response payload exploration pins both presence branches for every reachable optional property.
 - Required keys are always emitted.
 - Path resolution accepts both the spec template form (`/v1/pets/{petId}`) and concrete URIs that match it (`/api/v1/pets/123` with `strip_prefixes=/api`). Captured URI values are intentionally discarded — `pathParams` is always regenerated from the operation spec for consistency.

--- a/docs/superpowers/plans/2026-08-03-branch-enumeration-bounds-contract.md
+++ b/docs/superpowers/plans/2026-08-03-branch-enumeration-bounds-contract.md
@@ -1,0 +1,161 @@
+# Branch-complete Enumeration Bounds Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete issue #443's finite-enumeration contract by documenting all exact bounds, directly protecting the node-visit guard, and correcting obsolete dead-end guidance.
+
+**Architecture:** Preserve the existing internal enumerator and all public behavior. Add one boundary test against the real `SchemaChoicePointEnumerator`, then align user-facing and internal documentation with the already-implemented limits and static-proof-only dead-end policy.
+
+**Tech Stack:** PHP 8.3+, PHPUnit, Markdown, PHP-CS-Fixer, PHPStan.
+
+## Global Constraints
+
+- Keep `MAX_DEPTH = 32`, `MAX_CHOICE_POINTS = 256`, and `MAX_NODE_VISITS = 10_000` unchanged.
+- Do not add public API or dependencies.
+- Exceeding a bound must remain loud; partial branch-coverage results are forbidden.
+- Preserve unrelated worktree files and changes.
+
+---
+
+### Task 1: Protect the node-visit budget
+
+**Files:**
+- Test: `tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php`
+- Temporarily mutate and restore: `src/Fuzz/SchemaChoicePointEnumerator.php:68`
+
+**Interfaces:**
+- Consumes: `SchemaChoicePointEnumerator::enumerate(array $schema): array`
+- Produces: a regression test for the existing 10,000-node visit limit
+
+- [ ] **Step 1: Add the real-behavior boundary test**
+
+Add this test beside the existing depth and choice-point budget tests:
+
+```php
+#[Test]
+public function throws_beyond_the_documented_node_visit_budget(): void
+{
+    $prefixItems = [];
+    for ($i = 0; $i < 10_000; $i++) {
+        $prefixItems[] = ['type' => 'string'];
+    }
+
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessage('node-visit budget of 10000');
+
+    SchemaChoicePointEnumerator::enumerate([
+        'type' => 'array',
+        'prefixItems' => $prefixItems,
+    ]);
+}
+```
+
+- [ ] **Step 2: Run the focused test against current behavior**
+
+Run:
+
+```bash
+vendor/bin/phpunit --filter throws_beyond_the_documented_node_visit_budget tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
+```
+
+Expected: PASS because the production guard already exists.
+
+- [ ] **Step 3: Prove the regression test catches a weakened guard**
+
+Temporarily change only `MAX_NODE_VISITS` from `10_000` to `10_001`, rerun the
+same focused command, and confirm it FAILS because the expected exception is not
+thrown. Restore `MAX_NODE_VISITS` to `10_000` immediately afterward.
+
+- [ ] **Step 4: Run the focused suite after restoration**
+
+Run:
+
+```bash
+vendor/bin/phpunit tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
+```
+
+Expected: PASS with the new budget test included.
+
+- [ ] **Step 5: Commit the regression test**
+
+```bash
+git add tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
+git commit -m "test(fuzz): cover enumeration node budget"
+```
+
+### Task 2: Publish and align the bounds contract
+
+**Files:**
+- Modify: `docs/fuzzing.md:238-246`
+- Modify: `src/Fuzz/PinnedBranchObservation.php:21-25`
+- Modify: `docs/superpowers/specs/2026-08-03-branch-enumeration-bounds-contract-design.md`
+
+**Interfaces:**
+- Consumes: the internal constants and `PinnedBranchObservation::$provenDeadEnd` policy
+- Produces: accurate user-facing bounds and accurate internal dead-end guidance
+
+- [ ] **Step 1: Document exact finite-enumeration limits**
+
+After the supported-subset paragraph in `docs/fuzzing.md`, add that response
+branch enumeration accepts at most 32 nested property/item levels, 256 choice
+points, and 10,000 visited nodes across branch contexts. State that exceeding a
+limit fails locally with a supported-subset diagnostic and never returns
+partial branch coverage.
+
+- [ ] **Step 2: Correct the dead-end policy comment**
+
+Replace the obsolete deterministic-outcome paragraph in
+`PinnedBranchObservation` with wording that `targetLocal` is diagnostic state
+only and that a case may be dropped solely after `proveDeadEnd()` records a
+schema-derived empty-domain proof. Search exhaustion or repeated output remains
+loud.
+
+- [ ] **Step 3: Format and inspect the scoped diff**
+
+Run:
+
+```bash
+composer cs
+git diff --check
+git diff -- docs/fuzzing.md src/Fuzz/PinnedBranchObservation.php tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php docs/superpowers/specs/2026-08-03-branch-enumeration-bounds-contract-design.md
+```
+
+Expected: formatter succeeds, no whitespace errors, and no production behavior changes.
+
+- [ ] **Step 4: Commit the contract documentation**
+
+```bash
+git add docs/fuzzing.md src/Fuzz/PinnedBranchObservation.php docs/superpowers/specs/2026-08-03-branch-enumeration-bounds-contract-design.md docs/superpowers/plans/2026-08-03-branch-enumeration-bounds-contract.md
+git commit -m "docs(fuzz): publish enumeration bounds"
+```
+
+### Task 3: Verify the completed contract
+
+**Files:**
+- Verify only; no planned edits
+
+**Interfaces:**
+- Consumes: Tasks 1 and 2
+- Produces: fresh evidence for issue #441's final acceptance audit
+
+- [ ] **Step 1: Run the focused enumerator suite**
+
+```bash
+vendor/bin/phpunit tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
+```
+
+- [ ] **Step 2: Run the full repository gate**
+
+```bash
+NPM_CONFIG_CACHE=/tmp/gesso-npm-cache composer ci
+```
+
+- [ ] **Step 3: Verify repository scope**
+
+```bash
+git diff main...HEAD --check
+git status --short --branch
+```
+
+Expected: all checks pass; only the known unrelated `.claude/` and
+`docs/adr/0002-arazzo-workflow-execution.md` remain untracked.

--- a/docs/superpowers/specs/2026-08-03-branch-enumeration-bounds-contract-design.md
+++ b/docs/superpowers/specs/2026-08-03-branch-enumeration-bounds-contract-design.md
@@ -1,0 +1,44 @@
+# Branch-complete enumeration bounds contract
+
+## Context
+
+Issue #443 requires branch-complete response generation to document its finite
+enumeration bounds and to fail loudly when a schema exceeds them. The current
+implementation enforces maximum depth, choice-point count, and node visits, but
+the exact values are only visible on the internal enumerator. The node-visit
+budget also lacks a direct regression test.
+
+`PinnedBranchObservation` additionally contains an obsolete class-level
+description saying repeated deterministic failures prove a dead end. The
+current safety rule is stricter: only a schema-derived proof may mark a target
+unreachable; an unsuccessful search must fail loudly.
+
+## Design
+
+- Keep generation behavior and the public PHP API unchanged.
+- Document the exact branch-complete enumeration limits in `docs/fuzzing.md`:
+  32 nested property/item levels, 256 collected choice points, and 10,000 node
+  visits across branch contexts.
+- State that exceeding any limit throws a supported-subset diagnostic instead
+  of returning partial branch coverage.
+- Add a direct `SchemaChoicePointEnumeratorTest` case that constructs a shallow
+  schema with enough rediscovered branch contexts to exceed the node-visit
+  budget. Assert the exception type and stable diagnostic category rather than
+  the complete message prose.
+- Replace the obsolete `PinnedBranchObservation` explanation with the current
+  static-proof-only policy already expressed by `provenDeadEnd`.
+
+## Testing
+
+The regression test must first fail because no direct node-budget assertion is
+present, then pass without changing production behavior because the loud bound
+already exists. Run the focused enumerator suite, affected fuzz suites if the
+fixture reveals shared behavior, formatting/static analysis, and the full
+`composer ci` gate.
+
+## Non-goals
+
+- Changing any enumeration limit.
+- Adding a configurable limit or new public API.
+- Broadening the supported schema-generation subset.
+- Changing how unreachable branches are proven or searched.

--- a/docs/superpowers/specs/2026-08-03-branch-enumeration-bounds-contract-design.md
+++ b/docs/superpowers/specs/2026-08-03-branch-enumeration-bounds-contract-design.md
@@ -30,11 +30,12 @@ unreachable; an unsuccessful search must fail loudly.
 
 ## Testing
 
-The regression test must first fail because no direct node-budget assertion is
-present, then pass without changing production behavior because the loud bound
-already exists. Run the focused enumerator suite, affected fuzz suites if the
-fixture reveals shared behavior, formatting/static analysis, and the full
-`composer ci` gate.
+The loud node-budget guard already exists, so the new regression test will pass
+against the current implementation. Prove that the test protects the guard by
+temporarily raising the production threshold, observing the test fail because
+no exception is thrown, restoring the threshold, and observing it pass. Run the
+focused enumerator suite, formatting/static analysis, and the full `composer ci`
+gate.
 
 ## Non-goals
 

--- a/src/Fuzz/PinnedBranchObservation.php
+++ b/src/Fuzz/PinnedBranchObservation.php
@@ -19,10 +19,10 @@ use Closure;
  * spot (property presence after the maxProperties trim) report directly.
  *
  * `targetLocal` keeps the node-level outcome at the target site — the value
- * the check ran on, or the reported state. The target search compares it
- * across attempts: identical failing outcomes mean generation is
- * deterministic for this case and the branch is a proven dead end; varying
- * outcomes mean the search cannot conclude and must fail loudly.
+ * the check ran on, or the reported state — for diagnostics only. A case may
+ * be dropped solely when generation records a schema-derived empty-domain
+ * proof through {@see self::proveDeadEnd()}. Search exhaustion, repeated
+ * output, or deterministic failure without that proof must stay loud.
  *
  * A composition site also stages its branch content here when the plan asks
  * for a refinement attempt ({@see CaseSelectionPlan::$refineTarget}); the

--- a/tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
+++ b/tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
@@ -11,6 +11,8 @@ use Studio\Gesso\Fuzz\SchemaChoicePoint;
 use Studio\Gesso\Fuzz\SchemaChoicePointEnumerator;
 use Studio\Gesso\Fuzz\SchemaChoicePointKind;
 
+use function array_fill;
+
 class SchemaChoicePointEnumeratorTest extends TestCase
 {
     #[Test]
@@ -494,10 +496,7 @@ class SchemaChoicePointEnumeratorTest extends TestCase
     #[Test]
     public function throws_beyond_the_documented_node_visit_budget(): void
     {
-        $prefixItems = [];
-        for ($i = 0; $i < 10_000; $i++) {
-            $prefixItems[] = ['type' => 'string'];
-        }
+        $prefixItems = array_fill(0, 10_000, ['type' => 'string']);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('node-visit budget of 10000');

--- a/tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
+++ b/tests/Unit/Fuzz/SchemaChoicePointEnumeratorTest.php
@@ -491,6 +491,23 @@ class SchemaChoicePointEnumeratorTest extends TestCase
         ]);
     }
 
+    #[Test]
+    public function throws_beyond_the_documented_node_visit_budget(): void
+    {
+        $prefixItems = [];
+        for ($i = 0; $i < 10_000; $i++) {
+            $prefixItems[] = ['type' => 'string'];
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('node-visit budget of 10000');
+
+        SchemaChoicePointEnumerator::enumerate([
+            'type' => 'array',
+            'prefixItems' => $prefixItems,
+        ]);
+    }
+
     /**
      * @param list<SchemaChoicePoint> $points
      *


### PR DESCRIPTION
## Summary

Documents the exact finite bounds for branch-complete response enumeration and adds direct regression coverage for the node-visit budget. It also aligns the internal dead-end explanation with the existing static-proof-only policy.

## Why

Issue #443 requires enumeration depth and size bounds to be explicit and loud on excess. This completes the remaining acceptance evidence needed before the final #441 audit.

Related to #441 and #443.

## Verification

- [x] `composer test` passes
- [x] `composer stan` passes
- [x] `composer cs-check` passes
- [x] Raising the node-visit threshold from 10,000 to 10,001 makes the focused regression test fail because no exception is thrown

## Notes for reviewers

No enumeration limits, generation behavior, public API, or dependencies change.