### PR TITLE
docs: accept sdk round-trip harness adr

### DIFF
--- a/docs/adr/0003-sdk-roundtrip-harness.md
+++ b/docs/adr/0003-sdk-roundtrip-harness.md
@@ -1,6 +1,6 @@
 # ADR 0003: branch-complete response payloads and an SDK round-trip harness
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-07-31
 - Issue: [#441](https://github.com/studio-design/gesso/issues/441)
 - Related: [#403](https://github.com/studio-design/gesso/issues/403)


### PR DESCRIPTION
## Summary

Marks ADR 0003 as Accepted now that all six SDK round-trip harness phases and the final branch-enumeration contract follow-up have landed.

## Why

The ADR still reported Proposed even though its design is implemented and verified. This aligns the decision record before closing #441.

Related to #441.

## Verification

- [x] `composer test` passes
- [x] `composer stan` passes
- [x] `composer cs-check` passes

## Notes for reviewers

Only the ADR status changes; no runtime behavior or public API changes.