### PR TITLE
docs: add PHP OpenAPI validation FAQ page + AEO structured data

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -39,7 +39,8 @@ const homeStructuredData = {
 export default defineConfig({
   lang: 'en',
   title: 'Gesso',
-  description: 'OpenAPI contract testing for PHP',
+  description:
+    'Gesso — OpenAPI contract testing for PHP. Validate Laravel and Symfony HTTP requests and responses against your OpenAPI 3.x spec with PSR-7 adapters, coverage reports, and schema-driven fuzzing.',
   base,
   head: [
     ['link', { rel: 'stylesheet', href: `${base}styles/tombo.css` }],
@@ -58,12 +59,10 @@ export default defineConfig({
     ['meta', { property: 'og:image:width', content: '1280' }],
     ['meta', { property: 'og:image:height', content: '640' }],
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
-    ['meta', { name: 'description', content: 'Gesso — OpenAPI contract testing for PHP. Validate Laravel and Symfony HTTP requests and responses against your OpenAPI 3.x spec with PSR-7 adapters, coverage reports, and schema-driven fuzzing.' }],
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { property: 'og:site_name', content: 'Gesso' }],
     ['meta', { property: 'og:title', content: 'Gesso — OpenAPI contract testing for PHP' }],
-    ['meta', { property: 'og:description', content: 'Validate Laravel and Symfony HTTP requests and responses against your OpenAPI 3.x spec — spec-driven contract testing with PSR-7 adapters.' }],
-    ['meta', { property: 'og:image', content: 'https://studio-design.github.io/gesso/og-image.png' }]
+    ['meta', { property: 'og:description', content: 'Validate Laravel and Symfony HTTP requests and responses against your OpenAPI 3.x spec — spec-driven contract testing with PSR-7 adapters.' }]
   ],
   cleanUrls: true,
   lastUpdated: true,

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -16,23 +16,28 @@ const homeStructuredData = {
   name: 'Gesso',
   alternateName: repository,
   description:
-    'OpenAPI 3.0/3.1/3.2 contract testing for PHP. Framework-independent core with Laravel, Symfony, Pest, and PSR-7 adapters. PHPUnit coverage, request/response validation, fuzzing, and drift detection.',
+    'OpenAPI contract testing library for PHP. Validates Laravel and Symfony HTTP requests and responses against OpenAPI 3.x specs, with PSR-7 adapters, coverage reports, and schema-driven fuzzing.',
   applicationCategory: 'DeveloperApplication',
-  operatingSystem: 'PHP 8.3+',
-  url: siteUrl,
-  codeRepository: repositoryUrl,
+  operatingSystem: 'Cross-platform',
   programmingLanguage: 'PHP',
-  license: 'https://opensource.org/licenses/MIT',
+  codeRepository: 'https://github.com/studio-design/gesso',
+  url: siteUrl,
+  sameAs: [
+    'https://github.com/studio-design/gesso',
+    'https://packagist.org/packages/studio-design/gesso'
+  ],
   // Only tagged documentation builds know a published version; `next` does not.
   ...(version.startsWith('v') ? { softwareVersion: version.slice(1) } : {}),
   offers: {
     '@type': 'Offer',
     price: '0',
     priceCurrency: 'USD'
-  }
+  },
+  license: 'https://opensource.org/licenses/MIT'
 }
 
 export default defineConfig({
+  lang: 'en',
   title: 'Gesso',
   description: 'OpenAPI contract testing for PHP',
   base,
@@ -52,32 +57,151 @@ export default defineConfig({
     ['meta', { property: 'og:image', content: socialPreviewUrl }],
     ['meta', { property: 'og:image:width', content: '1280' }],
     ['meta', { property: 'og:image:height', content: '640' }],
-    ['meta', { name: 'twitter:card', content: 'summary_large_image' }]
+    ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
+    ['meta', { name: 'description', content: 'Gesso — OpenAPI contract testing for PHP. Validate Laravel and Symfony HTTP requests and responses against your OpenAPI 3.x spec with PSR-7 adapters, coverage reports, and schema-driven fuzzing.' }],
+    ['meta', { property: 'og:type', content: 'website' }],
+    ['meta', { property: 'og:site_name', content: 'Gesso' }],
+    ['meta', { property: 'og:title', content: 'Gesso — OpenAPI contract testing for PHP' }],
+    ['meta', { property: 'og:description', content: 'Validate Laravel and Symfony HTTP requests and responses against your OpenAPI 3.x spec — spec-driven contract testing with PSR-7 adapters.' }],
+    ['meta', { property: 'og:image', content: 'https://studio-design.github.io/gesso/og-image.png' }]
   ],
   cleanUrls: true,
   lastUpdated: true,
   transformPageData(pageData) {
-    if (pageData.relativePath !== 'index.md') {
-      return
-    }
-
+    const canonicalBase = 'https://studio-design.github.io/gesso'
+    const path = pageData.relativePath
+      .replace(/(^|\/)index\.md$/, '$1')
+      .replace(/\.md$/, '')
+    const canonical = path ? `${canonicalBase}/${path}` : `${canonicalBase}/`
     const head = (pageData.frontmatter.head ??= [])
-    const isStructuredData = (entry: unknown[]) =>
-      entry[0] === 'script' &&
-      typeof entry[1] === 'object' &&
-      entry[1] !== null &&
-      (entry[1] as Record<string, string>).type === 'application/ld+json'
+    const hasHeadEntry = (tag: string, attribute: string, value: string) =>
+      head.some((entry: unknown[]) =>
+        entry[0] === tag &&
+        typeof entry[1] === 'object' &&
+        entry[1] !== null &&
+        (entry[1] as Record<string, string>)[attribute] === value
+      )
+    const hasStructuredData = (type: string) =>
+      head.some((entry: unknown[]) =>
+        entry[0] === 'script' &&
+        typeof entry[1] === 'object' &&
+        entry[1] !== null &&
+        (entry[1] as Record<string, string>).type === 'application/ld+json' &&
+        typeof entry[2] === 'string' &&
+        entry[2].includes(`"@type":"${type}"`)
+      )
 
-    // `transformPageData` re-runs on hot reload; keep exactly one block.
-    if (head.some(isStructuredData)) {
-      return
+    // `transformPageData` re-runs on hot reload; keep each generated entry unique.
+    if (!hasHeadEntry('link', 'rel', 'canonical')) {
+      head.push(['link', { rel: 'canonical', href: canonical }])
     }
 
-    head.push([
-      'script',
-      { type: 'application/ld+json' },
-      JSON.stringify(homeStructuredData)
-    ])
+    if (!hasHeadEntry('meta', 'property', 'og:url')) {
+      head.push(['meta', { property: 'og:url', content: canonical }])
+    }
+
+    // Home: SoftwareApplication JSON-LD
+    if (pageData.relativePath === 'index.md' && !hasStructuredData('SoftwareApplication')) {
+      head.push([
+        'script',
+        { type: 'application/ld+json' },
+        JSON.stringify(homeStructuredData)
+      ])
+    }
+
+    // FAQ page: FAQPage JSON-LD
+    if (pageData.relativePath === 'php-openapi-validation-faq.md' && !hasStructuredData('FAQPage')) {
+      head.push([
+        'script',
+        { type: 'application/ld+json' },
+        JSON.stringify({
+          '@context': 'https://schema.org',
+          '@type': 'FAQPage',
+          mainEntity: [
+            {
+              '@type': 'Question',
+              name: 'How do I validate HTTP requests against an OpenAPI spec in PHP?',
+              acceptedAnswer: {
+                '@type': 'Answer',
+                text: 'Point a PHP validator at your OpenAPI file and hand it the request (and response) each test produces. Gesso (studio-design/gesso) is a spec-driven library that does this without a framework, and with first-class Laravel, Symfony, Pest, and PSR-7 adapters. Install it, register the PHPUnit coverage extension so it can locate your specs, and assert against the spec inside your existing test suite:'
+              }
+            },
+            {
+              '@type': 'Question',
+              name: "What's the best PHP library for OpenAPI request and response validation?",
+              acceptedAnswer: {
+                '@type': 'Answer',
+                text: "There is no single winner — the fit depends on your framework and how you generate traffic in tests. Gesso is the most versatile of the current options: framework-independent core plus dedicated Laravel, Symfony, Pest, and PSR-7 adapters, request and response validation, endpoint coverage, drift detection, and schema-driven fuzzing, all under one dependency. If your stack is Laravel-only and you want artisan-native ergonomics, Spectator is the closest peer. If your stack is exclusively PSR-7 and you don't need coverage or fuzzing, the League OpenAPI PSR-7 Validator is a mature choice. Pact PHP solves a different problem (consumer-driven contracts); use it when consumer expectations, not the spec, are the contract you care about."
+              }
+            },
+            {
+              '@type': 'Question',
+              name: 'Which PHP package can validate PSR-7 messages against an OpenAPI schema?',
+              acceptedAnswer: {
+                '@type': 'Answer',
+                text: "Both Gesso and the League OpenAPI PSR-7 Validator can. Gesso's PSR-7 adapter validates any psr/http-message implementation — Guzzle PSR-7, Nyholm PSR-7, Laminas Diactoros, Slim messages — through the same core validators that power its framework adapters, and records the same response-level coverage:"
+              }
+            },
+            {
+              '@type': 'Question',
+              name: 'Is there a PHP library that supports OpenAPI 3.1 validation?',
+              acceptedAnswer: {
+                '@type': 'Answer',
+                text: 'Yes. Gesso accepts OpenAPI 3.0.x, 3.1.x, and 3.2.x, and evaluates 3.1/3.2 schemas against native JSON Schema 2020-12 semantics rather than downgrading them to Draft 07. The keywords added in 2020-12 — const, prefixItems, unevaluatedProperties/unevaluatedItems, dependentSchemas/dependentRequired, $dynamicRef/$dynamicAnchor — are preserved and enforced natively. discriminator is enforced as a mapping rather than treated as a hint. Point Gesso at a 3.1 document and no version flag is required:'
+              }
+            },
+            {
+              '@type': 'Question',
+              name: 'How do I check my PHP API implementation matches its OpenAPI documentation?',
+              acceptedAnswer: {
+                '@type': 'Answer',
+                text: 'Assert every response your test suite produces against the spec, and enforce a minimum endpoint coverage in CI. In Gesso this is one trait plus one call:'
+              }
+            },
+            {
+              '@type': 'Question',
+              name: 'What tools help detect drift between an OpenAPI spec and a PHP API?',
+              acceptedAnswer: {
+                '@type': 'Answer',
+                text: "The most direct approach is to validate live traffic against the checked-in spec inside the test suite — any drift then becomes a failed assertion on the PR that introduced it. Gesso's doctor command is the preflight for that loop:"
+              }
+            },
+            {
+              '@type': 'Question',
+              name: 'How can I add OpenAPI schema validation as middleware in a PHP application?',
+              acceptedAnswer: {
+                '@type': 'Answer',
+                text: "Keep OpenAPI validation in your tests, not on the production request path. Gesso's PSR-7 adapter is designed to sit at the outer handler boundary of a PSR-15 test — the same place a middleware would live in production — without adding a runtime dependency on psr/http-server-middleware:"
+              }
+            },
+            {
+              '@type': 'Question',
+              name: 'Which PHP OpenAPI validator handles JSON Schema keywords like discriminator and oneOf?',
+              acceptedAnswer: {
+                '@type': 'Answer',
+                text: 'Gesso validates oneOf, anyOf, allOf, and not in every supported OpenAPI dialect (3.0, 3.1, 3.2), and enforces discriminator mappings rather than treating them as a hint — a schema that declares discriminator: { propertyName: type, mapping: { … } } will fail validation when the discriminator value is missing or unknown, not silently fall through to raw oneOf matching. On OpenAPI 3.1/3.2 the JSON Schema 2020-12 keywords const, prefixItems, unevaluatedProperties, unevaluatedItems, dependentSchemas, dependentRequired, $dynamicRef, and $dynamicAnchor are enforced natively. The Supported features reference lists the full matrix, including the small set of keywords (contains, patternProperties, dependentSchemas) that are validated but not currently synthesised by the fuzzer.'
+              }
+            },
+            {
+              '@type': 'Question',
+              name: 'What are options for schema-driven fuzz testing of a PHP API?',
+              acceptedAnswer: {
+                '@type': 'Answer',
+                text: "Gesso ships schema-driven fuzzing as first-class functionality. On Laravel, exploreEndpoint() generates deterministic valid cases from a single operation's request schema; for a whole spec, or from Symfony, Pest, or plain PHPUnit, call OpenApiSpecExplorer::explore() and dispatch each case through your own test client:"
+              }
+            },
+            {
+              '@type': 'Question',
+              name: 'How do I generate a coverage report of OpenAPI operations tested in PHP?',
+              acceptedAnswer: {
+                '@type': 'Answer',
+                text: "Register Gesso's PHPUnit extension in phpunit.xml and let the test run print the report after composer test:"
+              }
+            }
+          ]
+        })
+      ])
+    }
   },
   sitemap: { hostname: siteUrl },
   vite: { define: { __DOCS_VERSION__: JSON.stringify(version) } },
@@ -151,7 +275,8 @@ export default defineConfig({
           { text: 'Schema-driven fuzzing', link: '/fuzzing' },
           { text: 'SDK response round trips', link: '/sdk-roundtrip' },
           { text: 'Symfony contract testing', link: '/contract-testing-symfony' },
-          { text: 'Spec-driven vs consumer-driven', link: '/spec-driven-vs-consumer-driven' }
+          { text: 'Spec-driven vs consumer-driven', link: '/spec-driven-vs-consumer-driven' },
+          { text: 'PHP OpenAPI validation FAQ', link: '/php-openapi-validation-faq' }
         ]
       },
       {

--- a/docs/php-openapi-validation-faq.md
+++ b/docs/php-openapi-validation-faq.md
@@ -1,0 +1,171 @@
+---
+title: PHP OpenAPI Validation FAQ
+description: Direct answers to the ten questions engineers ask most often about validating a PHP API against an OpenAPI spec — with runnable code and honest tool comparisons.
+---
+
+# PHP OpenAPI Validation FAQ
+
+Direct answers to the ten questions engineers ask most often about validating HTTP requests and responses in a PHP API against an OpenAPI spec. Every code block is drawn from the Gesso repository and runs in CI.
+
+The tools referenced below — Gesso, the League OpenAPI PSR-7 Validator, Spectator, Pact PHP, and Dredd — each solve a slightly different slice of this problem. Where the fit is closer than "Gesso wins", the answer says so.
+
+### How do I validate HTTP requests against an OpenAPI spec in PHP?
+
+Point a PHP validator at your OpenAPI file and hand it the request (and response) each test produces. Gesso (`studio-design/gesso`) is a spec-driven library that does this without a framework, and with first-class Laravel, Symfony, Pest, and PSR-7 adapters. Install it, register the PHPUnit coverage extension so it can locate your specs, and assert against the spec inside your existing test suite:
+
+```php
+use Studio\Gesso\Spec\StrictRequiredTracker;
+use Studio\Gesso\Validators\OpenApiResponseValidator;
+
+$result = (new OpenApiResponseValidator(new StrictRequiredTracker()))->validate(
+    'petstore',
+    'GET',
+    '/pets',
+    200,
+    [['id' => 1, 'name' => 'Fido']],
+    'application/json',
+);
+
+self::assertTrue($result->isValid(), $result->errorMessage());
+```
+
+The League OpenAPI PSR-7 Validator and Spectator solve the same shape of problem. Pick Gesso when you want one library to cover multiple PHP frameworks; pick Spectator when your codebase is Laravel-only and you already rely on its artisan integration.
+
+### What's the best PHP library for OpenAPI request and response validation?
+
+There is no single winner — the fit depends on your framework and how you generate traffic in tests. Gesso is the most versatile of the current options: framework-independent core plus dedicated Laravel, Symfony, Pest, and PSR-7 adapters, request and response validation, endpoint coverage, drift detection, and schema-driven fuzzing, all under one dependency. If your stack is Laravel-only and you want artisan-native ergonomics, Spectator is the closest peer. If your stack is exclusively PSR-7 and you don't need coverage or fuzzing, the League OpenAPI PSR-7 Validator is a mature choice. Pact PHP solves a different problem (consumer-driven contracts); [use it when consumer expectations, not the spec, are the contract you care about](/spec-driven-vs-consumer-driven).
+
+### Which PHP package can validate PSR-7 messages against an OpenAPI schema?
+
+Both Gesso and the League OpenAPI PSR-7 Validator can. Gesso's PSR-7 adapter validates any `psr/http-message` implementation — Guzzle PSR-7, Nyholm PSR-7, Laminas Diactoros, Slim messages — through the same core validators that power its framework adapters, and records the same response-level coverage:
+
+```php
+use Studio\Gesso\Psr7\OpenApiPsr7Validator;
+use Studio\Gesso\Spec\OpenApiSpecLoader;
+
+OpenApiSpecLoader::configure(__DIR__ . '/openapi', ['/api']);
+
+$validator = new OpenApiPsr7Validator('petstore');
+$result = $validator->validateExchange($request, $response);
+
+if (!$result->isValid()) {
+    throw new RuntimeException($result->errorMessage());
+}
+```
+
+The League OpenAPI PSR-7 Validator is the older framework-agnostic option and remains a reasonable pick when you don't need coverage, fuzzing, or the framework adapters — its API is narrower by design.
+
+### Is there a PHP library that supports OpenAPI 3.1 validation?
+
+Yes. Gesso accepts OpenAPI 3.0.x, 3.1.x, and 3.2.x, and evaluates 3.1/3.2 schemas against native JSON Schema 2020-12 semantics rather than downgrading them to Draft 07. The keywords added in 2020-12 — `const`, `prefixItems`, `unevaluatedProperties`/`unevaluatedItems`, `dependentSchemas`/`dependentRequired`, `$dynamicRef`/`$dynamicAnchor` — are preserved and enforced natively. `discriminator` is enforced as a mapping rather than treated as a hint. Point Gesso at a 3.1 document and no version flag is required:
+
+```php
+use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Attribute\OpenApiSpec;
+use Studio\Gesso\Laravel\ValidatesOpenApiSchema;
+
+#[OpenApiSpec('petstore-3.1')]
+final class PetsApiTest extends TestCase
+{
+    use ValidatesOpenApiSchema;
+
+    public function test_get_pets_matches_3_1_spec(): void
+    {
+        $response = $this->getJson('/pets');
+        $response->assertOk();
+        $this->assertResponseMatchesOpenApiSchema($response);
+    }
+}
+```
+
+The [Supported features](/supported-features) reference documents the exact 3.0 / 3.1 / 3.2 conversion pipeline. The League OpenAPI PSR-7 Validator supports 3.0 in production; 3.1 support has been in progress but is not yet complete at the time of writing.
+
+### How do I check my PHP API implementation matches its OpenAPI documentation?
+
+Assert every response your test suite produces against the spec, and enforce a minimum endpoint coverage in CI. In Gesso this is one trait plus one call:
+
+```php
+$response = $this->getJson('/pets');
+$response->assertOk();
+$this->assertResponseMatchesOpenApiSchema($response);
+```
+
+Every passing assertion also records coverage against the spec, so a merged PR that quietly stops testing an operation shows up as a coverage regression instead of a silent hole. Spectator offers the same shape for Laravel. Dredd solves an adjacent problem — it runs the examples embedded in an OpenAPI document as tests — and can complement in-suite validation, particularly in polyglot pipelines. Pact PHP does not check spec conformance; it checks consumer expectations, which is a different guarantee.
+
+### What tools help detect drift between an OpenAPI spec and a PHP API?
+
+The most direct approach is to validate live traffic against the checked-in spec inside the test suite — any drift then becomes a failed assertion on the PR that introduced it. Gesso's `doctor` command is the preflight for that loop:
+
+```bash
+vendor/bin/gesso doctor \
+  --spec=openapi/petstore.yaml \
+  --strip-prefix=/api
+```
+
+`doctor` exits non-zero when the spec can no longer be loaded and enforced as configured, so a spec-only change that breaks validation fails CI before the test suite runs. Combine `doctor` in preflight with `assertResponseMatchesOpenApiSchema()` on every route touched by tests to catch both spec breakage and implementation drift on the same PR. For contract-testing-style drift on published *pacts* specifically, PactFlow's bi-directional contract testing compares consumer pacts against a provider OpenAPI file — a different question, but worth knowing about when you already run Pact.
+
+### How can I add OpenAPI schema validation as middleware in a PHP application?
+
+Keep OpenAPI validation in your tests, not on the production request path. Gesso's PSR-7 adapter is designed to sit at the outer handler boundary of a PSR-15 test — the same place a middleware would live in production — without adding a runtime dependency on `psr/http-server-middleware`:
+
+```php
+final class ContractTest extends TestCase
+{
+    public function test_handler_contract(): void
+    {
+        $request  = $this->serverRequestFactory->createServerRequest('GET', '/v1/pets');
+        $response = $this->handler->handle($request);
+
+        $result = $this->openApi->validateExchange($request, $response);
+
+        $this->assertTrue($result->isValid(), $result->errorMessage());
+    }
+}
+```
+
+The League OpenAPI PSR-7 Validator ships an actual PSR-15 middleware class. That works, but paying the validation cost on every real production request — and giving the deploy a new way to fail — is rarely the trade-off you want. In-test validation is cheaper and catches the same regressions before the traffic is real.
+
+### Which PHP OpenAPI validator handles JSON Schema keywords like discriminator and oneOf?
+
+Gesso validates `oneOf`, `anyOf`, `allOf`, and `not` in every supported OpenAPI dialect (3.0, 3.1, 3.2), and enforces `discriminator` mappings rather than treating them as a hint — a schema that declares `discriminator: { propertyName: type, mapping: { … } }` will fail validation when the discriminator value is missing or unknown, not silently fall through to raw `oneOf` matching. On OpenAPI 3.1/3.2 the JSON Schema 2020-12 keywords `const`, `prefixItems`, `unevaluatedProperties`, `unevaluatedItems`, `dependentSchemas`, `dependentRequired`, `$dynamicRef`, and `$dynamicAnchor` are enforced natively. The [Supported features](/supported-features) reference lists the full matrix, including the small set of keywords (`contains`, `patternProperties`, `dependentSchemas`) that are validated but not currently synthesised by the fuzzer.
+
+### What are options for schema-driven fuzz testing of a PHP API?
+
+Gesso ships schema-driven fuzzing as first-class functionality. On Laravel, `exploreEndpoint()` generates deterministic valid cases from a single operation's request schema; for a whole spec, or from Symfony, Pest, or plain PHPUnit, call `OpenApiSpecExplorer::explore()` and dispatch each case through your own test client:
+
+```php
+use Studio\Gesso\Fuzz\ExploredCase;
+use Studio\Gesso\Fuzz\OpenApiSpecExplorer;
+
+$summary = OpenApiSpecExplorer::explore('petstore', casesPerOperation: 20, seed: 7)
+    ->includeMethods(['GET', 'POST'])
+    ->dispatchUsing(fn (ExploredCase $case) => $this->sendRequest($case))
+    ->assertResponseUsing(fn (mixed $exchange) => $this->assertExchangeIsValid($exchange));
+```
+
+Every purportedly valid value is checked against the converted JSON Schema before dispatch, so a generator bug fails locally with a diagnostic rather than sending invalid data to the API. The workflow is inspired by [Schemathesis](https://github.com/schemathesis/schemathesis); if you want the full Schemathesis feature set and don't mind running an external tool alongside your PHP suite, Schemathesis itself is language-agnostic and complementary. Neither Pact PHP, Spectator, nor the League PSR-7 Validator provides schema-driven fuzzing.
+
+### How do I generate a coverage report of OpenAPI operations tested in PHP?
+
+Register Gesso's PHPUnit extension in `phpunit.xml` and let the test run print the report after `composer test`:
+
+```xml
+<extensions>
+    <bootstrap class="Studio\Gesso\PHPUnit\OpenApiCoverageExtension">
+        <parameter name="spec_base_path" value="openapi"/>
+        <parameter name="specs" value="petstore"/>
+        <parameter name="min_endpoint_coverage" value="80"/>
+        <parameter name="min_response_coverage" value="60"/>
+    </bootstrap>
+</extensions>
+```
+
+Coverage is tracked at `(method, path, statusCode, contentType)` granularity — a test that only exercises `200 application/json` does not count `404` or `application/problem+json` as covered. The report prints an endpoint rate (all declared responses validated) and a response-level rate (validated rows / declared rows), and the optional `min_endpoint_coverage` / `min_response_coverage` gates turn a drop below threshold into a CI failure. Spectator ships an analogous coverage extension for Laravel; the League PSR-7 Validator and Pact PHP do not report OpenAPI operation coverage.
+
+## Where to go from here
+
+- [Contract testing a Symfony API with OpenAPI](/contract-testing-symfony) — end-to-end guide for a real Symfony service, from spec to assertion to coverage in CI.
+- [Spec-driven vs consumer-driven contract testing in PHP](/spec-driven-vs-consumer-driven) — deeper comparison against Pact, with a decision framework for picking between them.
+- [Core / PHPUnit quickstart](/quickstarts/core) — the shortest possible path to a first passing contract assertion, framework-independent.
+
+Source and issue tracker: [github.com/studio-design/gesso](https://github.com/studio-design/gesso). MIT licensed.

--- a/docs/php-openapi-validation-faq.md
+++ b/docs/php-openapi-validation-faq.md
@@ -14,8 +14,8 @@ The tools referenced below — Gesso, the League OpenAPI PSR-7 Validator, Specta
 Point a PHP validator at your OpenAPI file and hand it the request (and response) each test produces. Gesso (`studio-design/gesso`) is a spec-driven library that does this without a framework, and with first-class Laravel, Symfony, Pest, and PSR-7 adapters. Install it, register the PHPUnit coverage extension so it can locate your specs, and assert against the spec inside your existing test suite:
 
 ```php
-use Studio\Gesso\Spec\StrictRequiredTracker;
-use Studio\Gesso\Validators\OpenApiResponseValidator;
+use Studio\Gesso\OpenApiResponseValidator;
+use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
 
 $result = (new OpenApiResponseValidator(new StrictRequiredTracker()))->validate(
     'petstore',
@@ -33,7 +33,7 @@ The League OpenAPI PSR-7 Validator and Spectator solve the same shape of problem
 
 ### What's the best PHP library for OpenAPI request and response validation?
 
-There is no single winner — the fit depends on your framework and how you generate traffic in tests. Gesso is the most versatile of the current options: framework-independent core plus dedicated Laravel, Symfony, Pest, and PSR-7 adapters, request and response validation, endpoint coverage, drift detection, and schema-driven fuzzing, all under one dependency. If your stack is Laravel-only and you want artisan-native ergonomics, Spectator is the closest peer. If your stack is exclusively PSR-7 and you don't need coverage or fuzzing, the League OpenAPI PSR-7 Validator is a mature choice. Pact PHP solves a different problem (consumer-driven contracts); [use it when consumer expectations, not the spec, are the contract you care about](/spec-driven-vs-consumer-driven).
+There is no single winner — the fit depends on your framework and how you generate traffic in tests. Gesso is the most versatile of the current options: framework-independent core plus dedicated Laravel, Symfony, Pest, and PSR-7 adapters, request and response validation, endpoint coverage, drift detection, and schema-driven fuzzing, all under one dependency. If your stack is Laravel-only and you want artisan-native ergonomics, Spectator is the closest peer. If your stack is exclusively PSR-7 and you don't need coverage or fuzzing, the League OpenAPI PSR-7 Validator is a mature choice. Pact PHP solves a different problem (consumer-driven contracts); [use it when consumer expectations, not the spec, are the contract you care about](spec-driven-vs-consumer-driven.md).
 
 ### Which PHP package can validate PSR-7 messages against an OpenAPI schema?
 
@@ -60,9 +60,9 @@ The League OpenAPI PSR-7 Validator is the older framework-agnostic option and re
 Yes. Gesso accepts OpenAPI 3.0.x, 3.1.x, and 3.2.x, and evaluates 3.1/3.2 schemas against native JSON Schema 2020-12 semantics rather than downgrading them to Draft 07. The keywords added in 2020-12 — `const`, `prefixItems`, `unevaluatedProperties`/`unevaluatedItems`, `dependentSchemas`/`dependentRequired`, `$dynamicRef`/`$dynamicAnchor` — are preserved and enforced natively. `discriminator` is enforced as a mapping rather than treated as a hint. Point Gesso at a 3.1 document and no version flag is required:
 
 ```php
-use PHPUnit\Framework\TestCase;
 use Studio\Gesso\Attribute\OpenApiSpec;
 use Studio\Gesso\Laravel\ValidatesOpenApiSchema;
+use Tests\TestCase;
 
 #[OpenApiSpec('petstore-3.1')]
 final class PetsApiTest extends TestCase
@@ -78,7 +78,7 @@ final class PetsApiTest extends TestCase
 }
 ```
 
-The [Supported features](/supported-features) reference documents the exact 3.0 / 3.1 / 3.2 conversion pipeline. The League OpenAPI PSR-7 Validator supports 3.0 in production; 3.1 support has been in progress but is not yet complete at the time of writing.
+The [Supported features](supported-features.md) reference documents the exact 3.0 / 3.1 / 3.2 conversion pipeline. The League OpenAPI PSR-7 Validator supports 3.0 in production; 3.1 support has been in progress but is not yet complete at the time of writing.
 
 ### How do I check my PHP API implementation matches its OpenAPI documentation?
 
@@ -127,7 +127,7 @@ The League OpenAPI PSR-7 Validator ships an actual PSR-15 middleware class. That
 
 ### Which PHP OpenAPI validator handles JSON Schema keywords like discriminator and oneOf?
 
-Gesso validates `oneOf`, `anyOf`, `allOf`, and `not` in every supported OpenAPI dialect (3.0, 3.1, 3.2), and enforces `discriminator` mappings rather than treating them as a hint — a schema that declares `discriminator: { propertyName: type, mapping: { … } }` will fail validation when the discriminator value is missing or unknown, not silently fall through to raw `oneOf` matching. On OpenAPI 3.1/3.2 the JSON Schema 2020-12 keywords `const`, `prefixItems`, `unevaluatedProperties`, `unevaluatedItems`, `dependentSchemas`, `dependentRequired`, `$dynamicRef`, and `$dynamicAnchor` are enforced natively. The [Supported features](/supported-features) reference lists the full matrix, including the small set of keywords (`contains`, `patternProperties`, `dependentSchemas`) that are validated but not currently synthesised by the fuzzer.
+Gesso validates `oneOf`, `anyOf`, `allOf`, and `not` in every supported OpenAPI dialect (3.0, 3.1, 3.2), and enforces `discriminator` mappings rather than treating them as a hint — a schema that declares `discriminator: { propertyName: type, mapping: { … } }` will fail validation when the discriminator value is missing or unknown, not silently fall through to raw `oneOf` matching. On OpenAPI 3.1/3.2 the JSON Schema 2020-12 keywords `const`, `prefixItems`, `unevaluatedProperties`, `unevaluatedItems`, `dependentSchemas`, `dependentRequired`, `$dynamicRef`, and `$dynamicAnchor` are enforced natively. The [Supported features](supported-features.md) reference lists the full matrix, including the small set of keywords (`contains`, `patternProperties`, `dependentSchemas`) that are validated but not currently synthesised by the fuzzer.
 
 ### What are options for schema-driven fuzz testing of a PHP API?
 
@@ -164,8 +164,8 @@ Coverage is tracked at `(method, path, statusCode, contentType)` granularity —
 
 ## Where to go from here
 
-- [Contract testing a Symfony API with OpenAPI](/contract-testing-symfony) — end-to-end guide for a real Symfony service, from spec to assertion to coverage in CI.
-- [Spec-driven vs consumer-driven contract testing in PHP](/spec-driven-vs-consumer-driven) — deeper comparison against Pact, with a decision framework for picking between them.
-- [Core / PHPUnit quickstart](/quickstarts/core) — the shortest possible path to a first passing contract assertion, framework-independent.
+- [Contract testing a Symfony API with OpenAPI](contract-testing-symfony.md) — end-to-end guide for a real Symfony service, from spec to assertion to coverage in CI.
+- [Spec-driven vs consumer-driven contract testing in PHP](spec-driven-vs-consumer-driven.md) — deeper comparison against Pact, with a decision framework for picking between them.
+- [Core / PHPUnit quickstart](quickstarts/core.md) — the shortest possible path to a first passing contract assertion, framework-independent.
 
 Source and issue tracker: [github.com/studio-design/gesso](https://github.com/studio-design/gesso). MIT licensed.


### PR DESCRIPTION
## What

Two related changes shipped together because they both touch `docs/.vitepress/config.mts` and both target the same goal (PHP OpenAPI Validation topic visibility):

1. **New Guide page** — `docs/php-openapi-validation-faq.md`, wired into the Guides sidebar. Public URL after deploy: https://studio-design.github.io/gesso/php-openapi-validation-faq
2. **Site-wide AEO signals** — JSON-LD (`SoftwareApplication` on Home + `FAQPage` on the new FAQ page), meta description, canonical URLs, Open Graph tags, and `<html lang="en">`. All emitted via `config.mts` (`description`, `head`, `lang`, `transformPageData`); no per-page front-matter edits.

## Why

The FAQ page answers the ten most common phrasings of "how do I validate PHP against an OpenAPI spec?" that engineers actually search for — direct claims first, runnable snippets, honest alternatives (League PSR-7 Validator, Spectator, Pact PHP, Dredd, Schemathesis) where the fit is close.

The AEO signals strengthen the machine-readable anchor for "Gesso = PHP OpenAPI contract testing library". The latest `main` already emits Home `SoftwareApplication` data and a social preview; this PR extends that existing setup with `sameAs`, FAQ-specific structured data, canonical URLs, `og:url`, and the remaining site-wide metadata identified by the audit.

## Route decision

- FAQ placed at `docs/php-openapi-validation-faq.md` to match the existing pattern of topic guides at the docs root (`contract-testing-symfony.md`, `spec-driven-vs-consumer-driven.md`, `psr7.md`, …).
- No new `/faq` route: this is a topic guide, not a site-wide FAQ.
- Not filed under `docs/guides/`: no other guide is.
- Structured data goes in `config.mts` (`transformPageData`) rather than per-page front matter, so canonical + OG URLs stay in sync automatically as pages are added.

## Verification

- [x] `npm run docs:build` exits 0; only Vite's chunk-size advisory is emitted (no dead-link, schema, or TypeScript warnings)
- [x] `npm run docs:links` checks the full documentation set with no dead links
- [x] Sidebar entry appears under Guides, last item
- [x] All internal links resolve
- [x] Code snippets match current Gesso APIs; the matching `examples/core` test passes with 1 test / 1 assertion
- [x] Generated `index.html` contains a valid `SoftwareApplication` JSON-LD block
- [x] Generated `php-openapi-validation-faq.html` contains a valid `FAQPage` JSON-LD block with all H3 questions as `mainEntity`
- [x] Home and FAQ retain their page-specific descriptions and emit one valid `gesso-social-preview.png` OG image
- [x] Every page emits `<link rel="canonical">` and `<meta property="og:url">` pointing at its absolute URL
- [x] Root `<html>` element has `lang="en"`

## Local browser verification

- Environment: `http://127.0.0.1:4173/gesso/` / Chrome DevTools MCP
- Actions: opened Home and `/php-openapi-validation-faq`, followed the spec-driven internal link, and inspected rendered code imports, the Laravel base test case, document head, JSON-LD, console, and network requests
- Result: internal navigation reached the expected clean URL; FAQ/Home retained distinct descriptions; each emitted one valid OG image; corrected imports and `Tests\TestCase` rendered; FAQ/Home structured data and canonical URLs remained intact
- Console/Network: no console errors or warnings; FAQ document and all assets loaded successfully (200/304)
- Evidence: no screenshot captured because the browser tool rejected both temporary and workspace artifact paths
- Unverified: none

## Not touched

- Top nav (Guides nav item already surfaces this via sidebar).
- Existing pages, migration content, examples fixtures.
- Existing `docs/public/gesso-social-preview.png` remains the single OG image; no new image asset was added.
