### PR TITLE
chore(deps-dev): bump undici to 7.29.0 and postcss to 8.5.25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2934,9 +2934,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -3304,9 +3304,9 @@
       "license": "0BSD"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

Bump two transitive dev-only dependencies in `package-lock.json` to clear the open
Dependabot alerts: `undici` 7.28.0 → 7.29.0 and `postcss` 8.5.20 → 8.5.25.
No `package.json` change — both resolve within existing semver ranges.

## Why

Dependabot reports 6 open alerts against the docs toolchain lockfile:

- `undici` < 7.29.0 (alerts #3–#7, one high / four medium): private-cache directive
  parse crash and cross-user disclosure, retry-interceptor response desync,
  cookie attribute injection, Cache-Control whitespace disclosure, CRLF injection
  via blob-like body `type`. Pulled in via `markdown-link-check → cheerio`.
- `postcss` <= 8.5.22 (alert #2, medium): incomplete fix of GHSA-6g55-p6wh-862q,
  attacker-controlled `sourceMappingURL` reads arbitrary `.map` files when `from`
  is unset. Pulled in via `vitepress → vite / vue`.

Both are `devDependencies` used only by the docs site build and the Markdown link
checker, so there is no runtime exposure for library consumers.

## Verification

- `npm audit`: 0 vulnerabilities after the bump (6 before).
- `npm run docs:build`: succeeds on Node 24 (same major CI uses).
- Not run: `composer test` / `stan` / `cs-check` — no PHP files touched.

## Notes for reviewers

Lockfile regenerated with npm 11 (Node 24) to match CI; the diff is only the three
version/resolved/integrity lines per package, no `libc` metadata churn.
