### PR TITLE
docs(coverage): note deliberate enum_spec_base_path omission in merge

### DIFF
--- a/src/Coverage/CoverageMergeCommand.php
+++ b/src/Coverage/CoverageMergeCommand.php
@@ -367,6 +367,14 @@ final class CoverageMergeCommand
         }
 
         OpenApiSpecLoader::reset();
+        // Issue #172: $enumBasePath is deliberately left unwired. The merge
+        // command never invokes EnumDriftAsserter, so #[BoundToOpenApiEnum]
+        // resolution never runs here and the omission is inert. If enum-drift
+        // responsibilities are ever added to this command, plumb an
+        // `--enum-spec-base-path` flag through to the `enumBasePath:` argument
+        // and mirror the validation in
+        // OpenApiCoverageExtension::resolveEnumSpecBasePathParameter()
+        // (empty / orphaned value => FATAL, EnumSpecBasePathOrphaned).
         OpenApiSpecLoader::configure($specBasePath, $stripPrefixes);
 
         // Issue #229: each merge invocation owns its trackers. Installing


### PR DESCRIPTION
## Summary

Add a call-site comment at `CoverageMergeCommand`'s `OpenApiSpecLoader::configure()` recording that the `enumBasePath` argument is deliberately unwired, and what to do if that changes. Comment only — no behavior change.

## Why

Issue #172 tracks the fact that `gesso coverage:merge` does not propagate `enum_spec_base_path` the way `OpenApiCoverageExtension` does. The gap is inert: the merge command never invokes `EnumDriftAsserter`, so `#[BoundToOpenApiEnum]` resolution never runs there, and no open issue plans to add enum-drift responsibilities to the command.

Adding `--enum-spec-base-path` now would pin a new CLI flag — a v1.x compatibility surface per `docs/versioning.md` — for a feature with no consumer, and no end-to-end test could exercise it. A note where the next person will edit is the cheaper way to keep the awareness. Closes #172 as not-planned once this lands.

## Verification

- Comment-only change; behavior verified unchanged by the full suite.

- [x] `composer test` passes (2858 tests, 10287 assertions)
- [x] `composer stan` passes
- [x] `composer cs-check` passes

## Notes for reviewers

The alternative — implementing the flag now — is written up in #172 step 1–4 and stays valid if enum-drift ever moves into `coverage:merge`; the comment points at `OpenApiCoverageExtension::resolveEnumSpecBasePathParameter()` as the validation shape to mirror.
