### PR TITLE
test(conformance): pin the JSON Schema conversion delta against the official suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,10 @@ maintenance cost.
 - `bin/gesso`: Composer-installed CLI for `doctor` and `coverage:merge`.
 - `tests/Unit`, `tests/Integration`, `tests/fixtures`: tests and representative
   OpenAPI fixtures. Pest integration tests run through a separate command.
+- `tests/Integration/Conformance`: runs the official JSON Schema Test Suite
+  (pinned by commit SHA in `composer.json`) through the schema converter and
+  pins the resulting verdict delta. See `docs/conformance.md` before changing
+  `OpenApiSchemaConverter`.
 - `docs/`: focused guides. Start with `docs/setup.md`,
   `docs/supported-features.md`, `docs/coverage.md`, and `docs/versioning.md`.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ when upgrading from `studio-design/openapi-contract-testing` v1.10.
 - **Multi-format reports** — Markdown / JUnit XML / JSON / HTML output with one-click GitHub Step Summary
 - **Zero runtime overhead** — Only used in test suites
 
+**Conformance evidence**: the schema rewriting behind those claims is pinned against the official [JSON Schema Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite). Of 3,820 cases, conversion changes the verdict on **11**, each recorded with a reason and enforced in CI. See [`docs/conformance.md`](docs/conformance.md).
+
 ## Why this library?
 
 Choose based on the workflow you need rather than on a single yes/no feature count:
@@ -242,6 +244,7 @@ To validate every response automatically, set `'auto_assert' => true` and drop t
 | CI integration (GitHub Actions, PR comments, output formats, partial-run handling) | [`docs/ci.md`](docs/ci.md) |
 | API reference (`OpenApiResponseValidator`, `OpenApiSpecLoader`, `OpenApiCoverageTracker`) | [`docs/api-reference.md`](docs/api-reference.md) |
 | Supported features, known limitations, warning channel | [`docs/supported-features.md`](docs/supported-features.md) |
+| JSON Schema conformance result (conversion delta vs the official test suite) | [`docs/conformance.md`](docs/conformance.md) |
 | Versioning policy & support matrix | [`docs/versioning.md`](docs/versioning.md) |
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ when upgrading from `studio-design/openapi-contract-testing` v1.10.
 - **Multi-format reports** — Markdown / JUnit XML / JSON / HTML output with one-click GitHub Step Summary
 - **Zero runtime overhead** — Only used in test suites
 
-**Conformance evidence**: the schema rewriting behind those claims is pinned against the official [JSON Schema Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite). Of 3,820 cases, conversion changes the verdict on 126 — 115 of them one tracked defect ([#478](https://github.com/studio-design/gesso/issues/478)), the other 11 deliberate. Each is recorded with a reason and enforced in CI. See [`docs/conformance.md`](docs/conformance.md).
+**Conformance evidence**: the schema rewriting behind those claims is pinned against the official [JSON Schema Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite). Of 3,784 cases compared, conversion changes the verdict on 126 — 115 of them one tracked defect ([#478](https://github.com/studio-design/gesso/issues/478)), the other 11 deliberate. Each is recorded with a reason and enforced in CI. See [`docs/conformance.md`](docs/conformance.md).
 
 ## Why this library?
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ when upgrading from `studio-design/openapi-contract-testing` v1.10.
 - **Multi-format reports** — Markdown / JUnit XML / JSON / HTML output with one-click GitHub Step Summary
 - **Zero runtime overhead** — Only used in test suites
 
-**Conformance evidence**: the schema rewriting behind those claims is pinned against the official [JSON Schema Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite). Of 3,820 cases, conversion changes the verdict on **11**, each recorded with a reason and enforced in CI. See [`docs/conformance.md`](docs/conformance.md).
+**Conformance evidence**: the schema rewriting behind those claims is pinned against the official [JSON Schema Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite). Of 3,820 cases, conversion changes the verdict on 126 — 115 of them one tracked defect ([#478](https://github.com/studio-design/gesso/issues/478)), the other 11 deliberate. Each is recorded with a reason and enforced in CI. See [`docs/conformance.md`](docs/conformance.md).
 
 ## Why this library?
 

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,32 @@
     "conflict": {
         "studio-design/openapi-contract-testing": "*"
     },
+    "repositories": [
+        {
+            "comment": "The JSON Schema Test Suite has no usable upstream tags and is not on Packagist, so it is pinned by commit SHA here. composer.lock is not committed for a library, so this file is the pin. See docs/conformance.md.",
+            "type": "package",
+            "package": {
+                "name": "json-schema-org/json-schema-test-suite",
+                "version": "2026.08.04",
+                "license": "MIT",
+                "dist": {
+                    "type": "zip",
+                    "url": "https://codeload.github.com/json-schema-org/JSON-Schema-Test-Suite/zip/cf2e5e0ff2e3d90239c3b59e68ac4c080bd4ac92",
+                    "reference": "cf2e5e0ff2e3d90239c3b59e68ac4c080bd4ac92"
+                },
+                "source": {
+                    "type": "git",
+                    "url": "https://github.com/json-schema-org/JSON-Schema-Test-Suite.git",
+                    "reference": "cf2e5e0ff2e3d90239c3b59e68ac4c080bd4ac92"
+                }
+            }
+        }
+    ],
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.94",
         "guzzlehttp/guzzle": "^7.12.1",
         "guzzlehttp/psr7": "^2.12.1",
+        "json-schema-org/json-schema-test-suite": "2026.08.04",
         "nyholm/psr7": "^1.8",
         "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
         "phpstan/phpstan": "^2.1.13",

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -299,6 +299,7 @@ export default defineConfig({
           { text: 'Setup', link: '/setup' },
           { text: 'Coverage', link: '/coverage' },
           { text: 'Supported features', link: '/supported-features' },
+          { text: 'JSON Schema conformance', link: '/conformance' },
           { text: 'API reference', link: '/api-reference' }
         ]
       }

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -6,7 +6,10 @@ is lowered to Draft 07, `discriminator` becomes `if`/`then` conditionals,
 `readOnly` / `writeOnly` become boolean subschemas. That rewriting is the part
 of a contract-testing tool most likely to quietly change what your spec means.
 
-This page is the evidence that it does not.
+This page measures exactly where it does. Of 3,820 official test-suite cases,
+conversion changes the verdict on 126 — 115 of them one tracked defect, the
+other 11 deliberate. Every one is listed with a reason and pinned in CI, so the
+number can only move when someone updates the record.
 
 ## What is measured
 
@@ -39,36 +42,50 @@ Corpus: [`json-schema-org/JSON-Schema-Test-Suite`][suite] at
 
 | Suite | OAS pipeline | Cases | Verdict changed | Excluded |
 | --- | --- | ---: | ---: | ---: |
-| `draft7` | 3.0 → Draft 07 | 1,657 | **0** | 0 |
-| `draft2020-12` | 3.1 / 3.2 → 2020-12 | 2,163 | **11** | 4 |
+| `draft7` | 3.0 → Draft 07 | 1,657 | 56 | 0 |
+| `draft2020-12` | 3.1 / 3.2 → 2020-12 | 2,163 | 70 | 4 |
 
 Required and `optional/` cases are both included, `optional/format/` among
-them. 18 cases per suite use a boolean (`true` / `false`) root schema, which a
-Schema Object cannot express and the converter therefore never sees; they are
-counted in the baseline rather than dropped.
+them. The suite's `remotes/` directory is served at `http://localhost:1234/` as
+the suite expects, so remote `$ref` cases genuinely resolve instead of failing
+identically on both sides. 18 cases per suite use a boolean (`true` / `false`)
+root schema, which a Schema Object cannot express and the converter therefore
+never sees; they are counted in the baseline rather than dropped.
 
 OAS 3.2 shares the 3.1 conversion pipeline, so running it would reproduce the
 3.1 numbers exactly and it is not run twice.
 
-### The 11 differences
+### The 126 differences
 
-All eleven are in OAS 3.1/3.2 and fall into two groups. Every one produces a
-**loud error**, never a silent pass — which is the outcome this library prefers
-when it cannot evaluate something precisely.
+Three causes. Each recorded case cites one of them by key in the baseline's
+`reasons` map.
 
-**Custom `$schema` metaschemas (9 cases** — `vocabulary.json`,
-`format-assertion.json`**)**. These declare a metaschema URI Gesso does not
-recognize. `OpenApiSchemaDialect::assertSupported()` rejects unknown dialects
-with `InvalidOpenApiSpecException` instead of falling back to a dialect with
-different semantics. This is deliberate and documented in
+**`empty-schema-object` — 115 cases. A real defect, tracked in
+[#478](https://github.com/studio-design/gesso/issues/478).** An empty Schema
+Object `{}` is indistinguishable from an empty array once a spec is decoded
+with `json_decode(..., true)`, so it reaches opis as a JSON array and is
+rejected as not-a-schema. `additionalProperties: {}`, `properties: {x: {}}`,
+`items: {}` and `not: {}` are ordinary OpenAPI and all hit it. 114 of these
+surface as a loud `InvalidKeywordException`; one degrades further —
+`{"items": {}, "additionalItems": false}` becomes tuple-form `items: []`, so a
+compliant array is reported as a contract violation with no error at all. That
+last case is the reason this harness was worth building: it is a false failure
+that no existing test caught.
+
+**`unsupported-dialect` — 9 cases** (`vocabulary.json`,
+`format-assertion.json`). These declare a custom metaschema URI in `$schema`.
+`OpenApiSchemaDialect::assertSupported()` rejects unknown dialects with
+`InvalidOpenApiSpecException` instead of falling back to one with different
+semantics. Deliberate, and documented in
 [supported features](supported-features.md#openapi-30-31-and-32).
 
-**`$ref` into a stripped annotation (2 cases** — `refOfUnknownKeyword.json`**)**.
-The schema points `$ref` at `#/examples/0`. The converter strips `examples` as
-an OAS annotation keyword, so the reference target no longer exists and opis
+**`stripped-annotation-ref` — 2 cases** (`refOfUnknownKeyword.json`). The
+schema points `$ref` at `#/examples/0`. The converter strips `examples` as an
+OAS annotation keyword, so the reference target no longer exists and opis
 reports an unresolved reference. A spec that references into an `examples`
-array is unsupported. Referencing annotation internals is not something OpenAPI
-sanctions, so this is documented rather than fixed.
+array is unsupported; the outcome is a loud error, never a silent pass.
+Referencing annotation internals is not something OpenAPI sanctions, so this is
+documented rather than fixed.
 
 ### The 4 exclusions
 
@@ -99,9 +116,10 @@ Packagist and carries no usable upstream tags.
 2. `composer update json-schema-org/json-schema-test-suite`.
 3. Run the test. It will report the new case counts and any verdict that moved.
 4. Update `corpus.commit`, `suites`, and any `deltas` entries in the
-   baseline — **with a reason for each new entry** — and update the
-   table above. An entry without a reason fails a second assertion, so an
-   unexplained regression cannot be papered over by regenerating the file.
+   baseline — **each citing a key in the `reasons` map** — and update the
+   table above. A delta citing an unknown reason, or a published reason no
+   longer cited by anything, fails a second assertion, so an unexplained
+   regression cannot be papered over by regenerating the file.
 
 If a newly added corpus group triggers the same unbounded opis recursion, the
 test process will die with a fatal error rather than fail cleanly. Add the

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -6,20 +6,26 @@ is lowered to Draft 07, `discriminator` becomes `if`/`then` conditionals,
 `readOnly` / `writeOnly` become boolean subschemas. That rewriting is the part
 of a contract-testing tool most likely to quietly change what your spec means.
 
-This page measures exactly where it does. Of 3,820 official test-suite cases,
-conversion changes the verdict on 126 — 115 of them one tracked defect, the
-other 11 deliberate. Every one is listed with a reason and pinned in CI, so the
-number can only move when someone updates the record.
+This page measures exactly where it does. Of 3,784 official test-suite cases put
+through both pipelines, conversion changes the verdict on 126 — 115 of them one
+tracked defect, the other 11 deliberate. Every one is listed with a reason and
+pinned in CI, so the number can only move when someone updates the record.
 
 ## What is measured
 
-Every case in the [official JSON Schema Test Suite][suite] is validated twice:
+Each case from the [official JSON Schema Test Suite][suite] is validated twice:
 
 1. **bare** — the schema exactly as the suite wrote it, through
    [opis/json-schema][opis] alone;
 2. **converted** — the same schema after
    `Studio\Gesso\Spec\OpenApiSchemaConverter::convert()`, through the same
    validator.
+
+Not every corpus case can go through both. Of the 3,824 cases in the two suites,
+4 are excluded outright (see below) and 36 use a boolean `true` / `false` root
+schema, which a Schema Object cannot express and `convert()` therefore never
+sees. Those 36 are counted and reported rather than dropped, but they are
+validated once, not twice. That leaves **3,784 cases actually compared**.
 
 Only the cases where the two verdicts differ are recorded. The recorded set is
 committed as
@@ -40,17 +46,16 @@ Corpus: [`json-schema-org/JSON-Schema-Test-Suite`][suite] at
 `composer.json`. `composer.lock` is not committed for a library, so
 `composer.json` is the pin.
 
-| Suite | OAS pipeline | Cases | Verdict changed | Excluded |
-| --- | --- | ---: | ---: | ---: |
-| `draft7` | 3.0 → Draft 07 | 1,657 | 56 | 0 |
-| `draft2020-12` | 3.1 / 3.2 → 2020-12 | 2,163 | 70 | 4 |
+| Suite | OAS pipeline | In corpus | Excluded | Boolean root | Compared | Verdict changed |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| `draft7` | 3.0 → Draft 07 | 1,657 | 0 | 18 | 1,639 | 56 |
+| `draft2020-12` | 3.1 / 3.2 → 2020-12 | 2,167 | 4 | 18 | 2,145 | 70 |
+| **Total** | | **3,824** | **4** | **36** | **3,784** | **126** |
 
 Required and `optional/` cases are both included, `optional/format/` among
 them. The suite's `remotes/` directory is served at `http://localhost:1234/` as
 the suite expects, so remote `$ref` cases genuinely resolve instead of failing
-identically on both sides. 18 cases per suite use a boolean (`true` / `false`)
-root schema, which a Schema Object cannot express and the converter therefore
-never sees; they are counted in the baseline rather than dropped.
+identically on both sides.
 
 OAS 3.2 shares the 3.1 conversion pipeline, so running it would reproduce the
 3.1 numbers exactly and it is not run twice.

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -1,0 +1,112 @@
+# JSON Schema conformance
+
+Gesso rewrites your OpenAPI Schema Objects before validating anything: OAS 3.0
+is lowered to Draft 07, `discriminator` becomes `if`/`then` conditionals,
+`nullable` becomes a type array, annotation keywords are stripped, and
+`readOnly` / `writeOnly` become boolean subschemas. That rewriting is the part
+of a contract-testing tool most likely to quietly change what your spec means.
+
+This page is the evidence that it does not.
+
+## What is measured
+
+Every case in the [official JSON Schema Test Suite][suite] is validated twice:
+
+1. **bare** — the schema exactly as the suite wrote it, through
+   [opis/json-schema][opis] alone;
+2. **converted** — the same schema after
+   `Studio\Gesso\Spec\OpenApiSchemaConverter::convert()`, through the same
+   validator.
+
+Only the cases where the two verdicts differ are recorded. The recorded set is
+committed as
+`tests/fixtures/compatibility/v1-json-schema-conversion-delta.json`
+and asserted by `tests/Integration/Conformance/JsonSchemaConversionDeltaTest.php`
+on every CI run. A new entry fails the build; so does a disappeared one.
+
+**This page does not claim that Gesso is a conformant JSON Schema validator.**
+That claim belongs to opis, and it is measured independently by
+[Bowtie][bowtie] via the `php-opis-json-schema` harness — a report Gesso has no
+hand in producing. What is measured here is the delta Gesso adds on top of
+opis, because that is the part no external report covers.
+
+## Current result
+
+Corpus: [`json-schema-org/JSON-Schema-Test-Suite`][suite] at
+`cf2e5e0ff2e3d90239c3b59e68ac4c080bd4ac92` (MIT), pinned by commit SHA in
+`composer.json`. `composer.lock` is not committed for a library, so
+`composer.json` is the pin.
+
+| Suite | OAS pipeline | Cases | Verdict changed | Excluded |
+| --- | --- | ---: | ---: | ---: |
+| `draft7` | 3.0 → Draft 07 | 1,657 | **0** | 0 |
+| `draft2020-12` | 3.1 / 3.2 → 2020-12 | 2,163 | **11** | 4 |
+
+Required and `optional/` cases are both included, `optional/format/` among
+them. 18 cases per suite use a boolean (`true` / `false`) root schema, which a
+Schema Object cannot express and the converter therefore never sees; they are
+counted in the baseline rather than dropped.
+
+OAS 3.2 shares the 3.1 conversion pipeline, so running it would reproduce the
+3.1 numbers exactly and it is not run twice.
+
+### The 11 differences
+
+All eleven are in OAS 3.1/3.2 and fall into two groups. Every one produces a
+**loud error**, never a silent pass — which is the outcome this library prefers
+when it cannot evaluate something precisely.
+
+**Custom `$schema` metaschemas (9 cases** — `vocabulary.json`,
+`format-assertion.json`**)**. These declare a metaschema URI Gesso does not
+recognize. `OpenApiSchemaDialect::assertSupported()` rejects unknown dialects
+with `InvalidOpenApiSpecException` instead of falling back to a dialect with
+different semantics. This is deliberate and documented in
+[supported features](supported-features.md#openapi-30-31-and-32).
+
+**`$ref` into a stripped annotation (2 cases** — `refOfUnknownKeyword.json`**)**.
+The schema points `$ref` at `#/examples/0`. The converter strips `examples` as
+an OAS annotation keyword, so the reference target no longer exists and opis
+reports an unresolved reference. A spec that references into an `examples`
+array is unsupported. Referencing annotation internals is not something OpenAPI
+sanctions, so this is documented rather than fixed.
+
+### The 4 exclusions
+
+`unevaluatedItems with $dynamicRef` and `unevaluatedProperties with $dynamicRef`
+(2020-12) are skipped before they run. Bare opis recurses without bound on them
+and exhausts the stack — the conversion layer is not involved, and the
+resulting fatal error is not catchable from PHP, so the groups have to be
+excluded statically. They are listed in the baseline with that reason so the
+exclusion stays visible instead of silently shrinking the corpus.
+
+## Running it
+
+```bash
+composer install   # fetches the pinned corpus into vendor/
+vendor/bin/phpunit tests/Integration/Conformance/JsonSchemaConversionDeltaTest.php
+```
+
+The corpus is a normal dev dependency, declared as an inline
+`repositories` entry in `composer.json` because the suite is not published to
+Packagist and carries no usable upstream tags.
+
+## Updating the pinned corpus
+
+1. Bump `dist.url`, `dist.reference`, and `source.reference` in the
+   `composer.json` repository entry to the new commit SHA, and bump the
+   package `version` (Composer will not refresh a package repository unless the
+   version changes).
+2. `composer update json-schema-org/json-schema-test-suite`.
+3. Run the test. It will report the new case counts and any verdict that moved.
+4. Update `corpus.commit`, `suites`, and any `deltas` entries in the
+   baseline — **with a reason for each new entry** — and update the
+   table above. An entry without a reason fails a second assertion, so an
+   unexplained regression cannot be papered over by regenerating the file.
+
+If a newly added corpus group triggers the same unbounded opis recursion, the
+test process will die with a fatal error rather than fail cleanly. Add the
+group to `EXCLUDED_GROUPS` in the test and to `excluded_groups` in the baseline.
+
+[suite]: https://github.com/json-schema-org/JSON-Schema-Test-Suite
+[opis]: https://opis.io/json-schema
+[bowtie]: https://bowtie.report

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -13,7 +13,8 @@ pinned in CI, so the number can only move when someone updates the record.
 
 ## What is measured
 
-Each case from the [official JSON Schema Test Suite][suite] is validated twice:
+3,784 of the 3,824 cases in the [official JSON Schema Test Suite][suite] are
+validated twice:
 
 1. **bare** — the schema exactly as the suite wrote it, through
    [opis/json-schema][opis] alone;
@@ -21,11 +22,11 @@ Each case from the [official JSON Schema Test Suite][suite] is validated twice:
    `Studio\Gesso\Spec\OpenApiSchemaConverter::convert()`, through the same
    validator.
 
-Not every corpus case can go through both. Of the 3,824 cases in the two suites,
-4 are excluded outright (see below) and 36 use a boolean `true` / `false` root
-schema, which a Schema Object cannot express and `convert()` therefore never
-sees. Those 36 are counted and reported rather than dropped, but they are
-validated once, not twice. That leaves **3,784 cases actually compared**.
+The remaining 40 are not compared at all. 4 are excluded outright (see below),
+and 36 use a boolean `true` / `false` root schema, which a Schema Object cannot
+express — `convert()` has no counterpart to produce, so there is no second
+verdict to compare against. Both counts are published in the baseline rather
+than silently dropped.
 
 Only the cases where the two verdicts differ are recorded. The recorded set is
 committed as

--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -2,6 +2,8 @@
 
 This is a contract-testing tool: where we can't enforce a constraint precisely, we prefer a loud failure or an explicit "skipped" outcome over silently accepting non-compliant data. The list below pins down what does and does not get checked so you can decide whether the gaps matter for your spec.
 
+The schema-conversion behaviour described here is measured against the official JSON Schema Test Suite on every CI run — see [JSON Schema conformance](conformance.md) for the current result.
+
 - [OpenAPI 3.0, 3.1, and 3.2](#openapi-30-31-and-32)
   - [`readOnly` / `writeOnly` enforcement](#readonly--writeonly-enforcement)
 - [Body validation](#body-validation)

--- a/tests/Integration/Conformance/JsonSchemaConversionDeltaTest.php
+++ b/tests/Integration/Conformance/JsonSchemaConversionDeltaTest.php
@@ -35,11 +35,18 @@ use function sprintf;
  * Conformance signal for the OpenAPI-to-JSON-Schema conversion layer
  * (issue #283).
  *
- * Every case in the official JSON Schema Test Suite is validated twice: once
+ * Cases from the official JSON Schema Test Suite are validated twice: once
  * against the bare schema with opis alone, and once after
  * {@see OpenApiSchemaConverter::convert()} has rewritten it. Only the cases
  * where the two verdicts differ are recorded, and that recorded set is pinned
  * by a committed baseline.
+ *
+ * Two kinds of case are never compared: the groups in
+ * {@see self::EXCLUDED_GROUPS}, and boolean (`true` / `false`) root schemas,
+ * which a Schema Object cannot express, so `convert()` has no counterpart to
+ * produce and there is no second verdict. Both are counted and published in the
+ * baseline rather than dropped — 3,784 of the corpus's 3,824 cases are actually
+ * compared.
  *
  * This deliberately does NOT re-measure how conformant opis is — that is
  * published independently at https://bowtie.report via the

--- a/tests/Integration/Conformance/JsonSchemaConversionDeltaTest.php
+++ b/tests/Integration/Conformance/JsonSchemaConversionDeltaTest.php
@@ -24,9 +24,11 @@ use function in_array;
 use function is_array;
 use function is_dir;
 use function json_decode;
+use function json_encode;
 use function ksort;
 use function restore_error_handler;
 use function set_error_handler;
+use function sort;
 use function sprintf;
 
 /**
@@ -140,13 +142,40 @@ final class JsonSchemaConversionDeltaTest extends TestCase
     {
         $baseline = $this->baseline();
 
+        // Reasons are shared: 114 of the recorded deltas are one defect, and
+        // repeating its explanation per entry would make the file unreadable
+        // without making it more precise. Keys stay per case, so a genuinely
+        // new case still fails the comparison above.
+        foreach ($baseline['reasons'] as $key => $reason) {
+            $this->assertNotSame('', $reason['summary'] ?? '', sprintf('Reason "%s" has no summary.', $key));
+        }
+
+        $referenced = [];
         foreach ($baseline['deltas'] as $key => $entry) {
-            $this->assertNotSame('', $entry['reason'] ?? '', sprintf('Delta "%s" has no reason.', $key));
+            $reason = $entry['reason'] ?? '';
+            $this->assertArrayHasKey(
+                $reason,
+                $baseline['reasons'],
+                sprintf('Delta "%s" cites unknown reason "%s".', $key, $reason),
+            );
+            $referenced[$reason] = true;
         }
 
         foreach ($baseline['excluded_groups'] as $entry) {
             $this->assertNotSame('', $entry['reason'] ?? '', sprintf('Exclusion "%s" has no reason.', $entry['group']));
         }
+
+        $published = array_keys($baseline['reasons']);
+        $cited = array_keys($referenced);
+        sort($published);
+        sort($cited);
+
+        $this->assertSame(
+            $published,
+            $cited,
+            'A published reason is no longer cited by any delta. Remove reasons that no longer apply '
+            . 'instead of leaving them to rot.',
+        );
 
         $this->assertSame(
             self::EXCLUDED_GROUPS,
@@ -167,8 +196,7 @@ final class JsonSchemaConversionDeltaTest extends TestCase
         $suites = [];
 
         foreach (self::SUITES as $suiteName => $suite) {
-            $validator = new Validator();
-            $validator->parser()->setDefaultDraftVersion($suite['draft']);
+            $validator = $this->validatorFor($suite['draft']);
 
             $cases = 0;
             $booleanRootSchemas = 0;
@@ -179,40 +207,65 @@ final class JsonSchemaConversionDeltaTest extends TestCase
                 $contents = file_get_contents($file);
                 $this->assertIsString($contents, sprintf('Unreadable corpus file: %s.', $file));
 
-                /** @var list<array{description: string, schema: mixed, tests: list<array{description: string, data: mixed, valid: bool}>}> $groups */
-                $groups = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+                // Decoded twice on purpose. The object form is the faithful
+                // JSON: `{}` stays an object and `[]` stays a list, a
+                // distinction PHP associative arrays cannot carry. It is what
+                // the bare reference run and both data instances are built
+                // from, so the reference side is never distorted by the way
+                // this test reads the corpus.
+                //
+                // The array form exists only because `convert()` takes a
+                // Schema Object as an array — the same shape
+                // `OpenApiSpecLoader` produces with `json_decode(..., true)`.
+                // Any object/list information the OAS pipeline loses is
+                // therefore lost here too, and shows up as a recorded delta
+                // instead of being hidden behind an identical exception on
+                // both sides.
+                /** @var list<object{description: string, schema: mixed, tests: list<object{description: string, data: mixed, valid: bool}>}> $groups */
+                $groups = json_decode($contents, false, flags: JSON_THROW_ON_ERROR);
+                /** @var list<array{description: string, schema: mixed, tests: list<array{description: string, data: mixed, valid: bool}>}> $arrayGroups */
+                $arrayGroups = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
 
-                foreach ($groups as $group) {
-                    $groupKey = $suiteName . '::' . basename($file) . '::' . $group['description'];
+                foreach ($groups as $groupIndex => $group) {
+                    $groupKey = $suiteName . '::' . basename($file) . '::' . $group->description;
 
                     if (in_array($groupKey, self::EXCLUDED_GROUPS, true)) {
-                        $excludedCases += count($group['tests']);
+                        $excludedCases += count($group->tests);
                         continue;
                     }
 
-                    foreach ($group['tests'] as $case) {
+                    foreach ($group->tests as $case) {
                         $cases++;
 
                         // `convert()` takes a Schema Object; a bare `true` /
                         // `false` root schema has nothing for it to rewrite,
                         // so there is no delta to measure. Counted rather than
                         // dropped.
-                        if (!is_array($group['schema'])) {
+                        if (!is_array($arrayGroups[$groupIndex]['schema'])) {
                             $booleanRootSchemas++;
                             continue;
                         }
 
-                        $data = ObjectConverter::convert($case['data']);
-                        $bare = $this->verdict($validator, ObjectConverter::convert($group['schema']), $data);
-                        $converted = $this->convertedVerdict($validator, $group['schema'], $suite['version'], $data);
+                        // A separate instance per run. opis writes `default`
+                        // values into the instance it validates, so sharing
+                        // one would let the bare run's mutation reach the
+                        // converted run and register as a delta conversion
+                        // never caused.
+                        $bare = $this->verdict($validator, $group->schema, $this->instance($case->data));
+                        $converted = $this->convertedVerdict(
+                            $validator,
+                            $arrayGroups[$groupIndex]['schema'],
+                            $suite['version'],
+                            $this->instance($case->data),
+                        );
 
                         if ($bare === $converted) {
                             continue;
                         }
 
                         $suiteDeltas++;
-                        $deltas[$groupKey . '::' . $case['description']] = [
-                            'expected' => $case['valid'] ? 'valid' : 'invalid',
+                        $deltas[$groupKey . '::' . $case->description] = [
+                            'expected' => $case->valid ? 'valid' : 'invalid',
                             'bare' => $bare,
                             'converted' => $converted,
                         ];
@@ -278,6 +331,32 @@ final class JsonSchemaConversionDeltaTest extends TestCase
     }
 
     /**
+     * The suite expects `remotes/` to be served at `http://localhost:1234/`;
+     * without that mapping every remote `$ref` raises the same unresolved-
+     * reference error on both sides and 54 cases across `refRemote.json`
+     * assert nothing at all.
+     */
+    private function validatorFor(string $draft): Validator
+    {
+        $validator = new Validator();
+        $validator->parser()->setDefaultDraftVersion($draft);
+        $validator->resolver()?->registerPrefix('http://localhost:1234/', $this->corpusPath() . '/remotes');
+
+        return $validator;
+    }
+
+    /**
+     * A private copy of the case data, decoded from the faithful object form
+     * so `{}` and `[]` stay distinct. opis mutates the instance it validates
+     * (it writes `default` values into it), so each verdict has to own its
+     * own.
+     */
+    private function instance(mixed $data): mixed
+    {
+        return json_decode(json_encode($data, flags: JSON_THROW_ON_ERROR), false, flags: JSON_THROW_ON_ERROR);
+    }
+
+    /**
      * Required cases plus the suite's `optional/` and `optional/format/`
      * directories. `optional/` is where `format`, big numbers, and unknown
      * keywords live — all areas the converter actively rewrites — so leaving
@@ -337,6 +416,7 @@ final class JsonSchemaConversionDeltaTest extends TestCase
     /**
      * @return array{
      *     corpus: array{commit: string},
+     *     reasons: array<string, array{summary?: string}>,
      *     deltas: array<string, array{expected: string, bare: string, converted: string, reason?: string}>,
      *     excluded_groups: array<string, array{group: string, reason?: string}>,
      *     suites: array<string, array{cases: int, boolean_root_schemas: int, excluded_cases: int, deltas: int}>

--- a/tests/Integration/Conformance/JsonSchemaConversionDeltaTest.php
+++ b/tests/Integration/Conformance/JsonSchemaConversionDeltaTest.php
@@ -1,0 +1,353 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Integration\Conformance;
+
+use const E_USER_WARNING;
+use const JSON_THROW_ON_ERROR;
+
+use Opis\JsonSchema\Validator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\Gesso\OpenApiVersion;
+use Studio\Gesso\Spec\OpenApiSchemaConverter;
+use Studio\Gesso\Validation\Support\ObjectConverter;
+use Throwable;
+
+use function array_keys;
+use function basename;
+use function count;
+use function file_get_contents;
+use function glob;
+use function in_array;
+use function is_array;
+use function is_dir;
+use function json_decode;
+use function ksort;
+use function restore_error_handler;
+use function set_error_handler;
+use function sprintf;
+
+/**
+ * Conformance signal for the OpenAPI-to-JSON-Schema conversion layer
+ * (issue #283).
+ *
+ * Every case in the official JSON Schema Test Suite is validated twice: once
+ * against the bare schema with opis alone, and once after
+ * {@see OpenApiSchemaConverter::convert()} has rewritten it. Only the cases
+ * where the two verdicts differ are recorded, and that recorded set is pinned
+ * by a committed baseline.
+ *
+ * This deliberately does NOT re-measure how conformant opis is — that is
+ * published independently at https://bowtie.report via the
+ * `bowtie-json-schema/php-opis-json-schema` harness. What it measures is the
+ * delta this package introduces on top of opis, which is the part no external
+ * report covers. An unexplained entry in the delta set is, by construction, a
+ * conversion bug; an intentional one is recorded with its reason.
+ *
+ * The corpus is pinned by commit SHA in `composer.json` (the lock file is not
+ * committed for a library, so `composer.json` is the pin). See
+ * `docs/conformance.md`.
+ */
+final class JsonSchemaConversionDeltaTest extends TestCase
+{
+    /**
+     * Suite directory => the OAS version whose conversion pipeline targets
+     * that JSON Schema draft, plus the draft opis assumes for the bare run.
+     *
+     * OAS 3.0 lowers to Draft 07; 3.1/3.2 stay on 2020-12 and share one
+     * pipeline, so 3.2 would produce an identical delta set and is not run
+     * twice.
+     */
+    private const SUITES = [
+        'draft7' => ['version' => OpenApiVersion::V3_0, 'draft' => '07'],
+        'draft2020-12' => ['version' => OpenApiVersion::V3_1, 'draft' => '2020-12'],
+    ];
+
+    /**
+     * Groups skipped before they run, because bare opis — with no involvement
+     * from this package — recurses without bound on them and exhausts the
+     * stack. That is a fatal error PHP cannot catch, so it has to be excluded
+     * statically rather than handled. Both are `$dynamicRef` inside an
+     * `unevaluated*` applicator.
+     *
+     * Recorded in the baseline as well, so the exclusion is visible in the
+     * published result instead of silently shrinking the corpus.
+     */
+    private const EXCLUDED_GROUPS = [
+        'draft2020-12::unevaluatedItems.json::unevaluatedItems with $dynamicRef',
+        'draft2020-12::unevaluatedProperties.json::unevaluatedProperties with $dynamicRef',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        OpenApiSchemaConverter::resetWarningStateForTesting();
+    }
+
+    protected function tearDown(): void
+    {
+        OpenApiSchemaConverter::resetWarningStateForTesting();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function conversion_changes_no_json_schema_verdict_beyond_the_recorded_baseline(): void
+    {
+        $baseline = $this->baseline();
+        $observed = $this->measure();
+
+        $this->assertSame(
+            $baseline['corpus']['commit'],
+            $this->installedCorpusCommit(),
+            'The installed corpus does not match the commit the baseline was recorded against. '
+            . 'Re-pin composer.json or regenerate the baseline.',
+        );
+
+        // Compare only the verdict triple. `reason` is prose maintained by
+        // hand next to each entry and is asserted separately, so rewording an
+        // explanation cannot turn into a false conformance regression.
+        $expectedDeltas = [];
+        foreach ($baseline['deltas'] as $key => $entry) {
+            $expectedDeltas[$key] = [
+                'expected' => $entry['expected'],
+                'bare' => $entry['bare'],
+                'converted' => $entry['converted'],
+            ];
+        }
+
+        $this->assertSame(
+            $expectedDeltas,
+            $observed['deltas'],
+            'The set of JSON Schema cases whose verdict changes under OpenAPI schema conversion has moved. '
+            . 'A new entry is a conversion regression unless it is deliberate; a disappeared entry means a '
+            . 'documented limitation was fixed. Either way, update '
+            . 'tests/fixtures/compatibility/v1-json-schema-conversion-delta.json and docs/conformance.md.',
+        );
+
+        $this->assertSame(
+            $baseline['suites'],
+            $observed['suites'],
+            'The corpus case counts moved without the pinned commit changing.',
+        );
+    }
+
+    #[Test]
+    public function every_recorded_delta_and_exclusion_carries_a_reason(): void
+    {
+        $baseline = $this->baseline();
+
+        foreach ($baseline['deltas'] as $key => $entry) {
+            $this->assertNotSame('', $entry['reason'] ?? '', sprintf('Delta "%s" has no reason.', $key));
+        }
+
+        foreach ($baseline['excluded_groups'] as $entry) {
+            $this->assertNotSame('', $entry['reason'] ?? '', sprintf('Exclusion "%s" has no reason.', $entry['group']));
+        }
+
+        $this->assertSame(
+            self::EXCLUDED_GROUPS,
+            array_keys($baseline['excluded_groups']),
+            'The statically excluded groups and the published exclusion list have drifted apart.',
+        );
+    }
+
+    /**
+     * @return array{
+     *     deltas: array<string, array{expected: string, bare: string, converted: string}>,
+     *     suites: array<string, array{cases: int, boolean_root_schemas: int, excluded_cases: int, deltas: int}>
+     * }
+     */
+    private function measure(): array
+    {
+        $deltas = [];
+        $suites = [];
+
+        foreach (self::SUITES as $suiteName => $suite) {
+            $validator = new Validator();
+            $validator->parser()->setDefaultDraftVersion($suite['draft']);
+
+            $cases = 0;
+            $booleanRootSchemas = 0;
+            $excludedCases = 0;
+            $suiteDeltas = 0;
+
+            foreach ($this->suiteFiles($suiteName) as $file) {
+                $contents = file_get_contents($file);
+                $this->assertIsString($contents, sprintf('Unreadable corpus file: %s.', $file));
+
+                /** @var list<array{description: string, schema: mixed, tests: list<array{description: string, data: mixed, valid: bool}>}> $groups */
+                $groups = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+
+                foreach ($groups as $group) {
+                    $groupKey = $suiteName . '::' . basename($file) . '::' . $group['description'];
+
+                    if (in_array($groupKey, self::EXCLUDED_GROUPS, true)) {
+                        $excludedCases += count($group['tests']);
+                        continue;
+                    }
+
+                    foreach ($group['tests'] as $case) {
+                        $cases++;
+
+                        // `convert()` takes a Schema Object; a bare `true` /
+                        // `false` root schema has nothing for it to rewrite,
+                        // so there is no delta to measure. Counted rather than
+                        // dropped.
+                        if (!is_array($group['schema'])) {
+                            $booleanRootSchemas++;
+                            continue;
+                        }
+
+                        $data = ObjectConverter::convert($case['data']);
+                        $bare = $this->verdict($validator, ObjectConverter::convert($group['schema']), $data);
+                        $converted = $this->convertedVerdict($validator, $group['schema'], $suite['version'], $data);
+
+                        if ($bare === $converted) {
+                            continue;
+                        }
+
+                        $suiteDeltas++;
+                        $deltas[$groupKey . '::' . $case['description']] = [
+                            'expected' => $case['valid'] ? 'valid' : 'invalid',
+                            'bare' => $bare,
+                            'converted' => $converted,
+                        ];
+                    }
+                }
+            }
+
+            $suites[$suiteName] = [
+                'cases' => $cases,
+                'boolean_root_schemas' => $booleanRootSchemas,
+                'excluded_cases' => $excludedCases,
+                'deltas' => $suiteDeltas,
+            ];
+        }
+
+        ksort($deltas);
+
+        return ['deltas' => $deltas, 'suites' => $suites];
+    }
+
+    /**
+     * Run the schema through the OpenAPI conversion pipeline, then validate.
+     *
+     * The converter uses `E_USER_WARNING` as its loud-signal channel (unknown
+     * `format` values, 3.0-only keywords). Under `failOnWarning="true"` those
+     * would abort the run, and they are not what this test measures — the
+     * verdict is. They are swallowed here and the dedup state is reset per
+     * schema so one early warning cannot mask a later case.
+     *
+     * @param array<string, mixed> $schema
+     */
+    private function convertedVerdict(Validator $validator, array $schema, OpenApiVersion $version, mixed $data): string
+    {
+        set_error_handler(static fn(): bool => true, E_USER_WARNING);
+
+        try {
+            $converted = OpenApiSchemaConverter::convert($schema, $version);
+        } catch (Throwable $exception) {
+            return 'convert-error:' . $exception::class;
+        } finally {
+            restore_error_handler();
+            OpenApiSchemaConverter::resetWarningStateForTesting();
+        }
+
+        return $this->verdict($validator, ObjectConverter::convert($converted), $data);
+    }
+
+    private function verdict(Validator $validator, mixed $schema, mixed $data): string
+    {
+        try {
+            // opis registers every `$id`-bearing schema in a process-wide
+            // loader cache. Without clearing it, validating the converted form
+            // of a case whose bare form was just registered collides on the
+            // same `$id` (DuplicateSchemaIdException) and would be reported as
+            // a conversion delta that does not exist. opis's own suite runner
+            // clears between schema groups for the same reason.
+            $validator->loader()->clearCache();
+
+            return $validator->validate($data, $schema)->isValid() ? 'valid' : 'invalid';
+        } catch (Throwable $exception) {
+            return 'error:' . $exception::class;
+        }
+    }
+
+    /**
+     * Required cases plus the suite's `optional/` and `optional/format/`
+     * directories. `optional/` is where `format`, big numbers, and unknown
+     * keywords live — all areas the converter actively rewrites — so leaving
+     * them out would hide exactly the behavior this test exists to pin.
+     *
+     * @return list<string>
+     */
+    private function suiteFiles(string $suite): array
+    {
+        $root = $this->corpusPath() . '/tests/' . $suite;
+        $this->assertDirectoryExists($root, sprintf('Corpus suite "%s" is missing.', $suite));
+
+        $files = [];
+        foreach (['', '/optional', '/optional/format'] as $subdirectory) {
+            $directory = $root . $subdirectory;
+            if (!is_dir($directory)) {
+                continue;
+            }
+
+            $matches = glob($directory . '/*.json');
+            $this->assertIsArray($matches);
+            foreach ($matches as $match) {
+                $files[] = $match;
+            }
+        }
+
+        $this->assertNotEmpty($files, sprintf('Corpus suite "%s" yielded no files.', $suite));
+
+        return $files;
+    }
+
+    private function installedCorpusCommit(): string
+    {
+        $installed = file_get_contents($this->corpusPath() . '/../../composer/installed.json');
+        $this->assertIsString($installed, 'Cannot read vendor/composer/installed.json.');
+
+        /** @var array{packages: list<array{name: string, dist?: array{reference?: string}}>} $decoded */
+        $decoded = json_decode($installed, true, flags: JSON_THROW_ON_ERROR);
+
+        foreach ($decoded['packages'] as $package) {
+            if ($package['name'] === 'json-schema-org/json-schema-test-suite') {
+                return $package['dist']['reference'] ?? '';
+            }
+        }
+
+        $this->fail('The JSON Schema Test Suite corpus is not installed.');
+    }
+
+    private function corpusPath(): string
+    {
+        $path = __DIR__ . '/../../../vendor/json-schema-org/json-schema-test-suite';
+        $this->assertDirectoryExists($path, 'Run `composer install` to fetch the pinned JSON Schema Test Suite.');
+
+        return $path;
+    }
+
+    /**
+     * @return array{
+     *     corpus: array{commit: string},
+     *     deltas: array<string, array{expected: string, bare: string, converted: string, reason?: string}>,
+     *     excluded_groups: array<string, array{group: string, reason?: string}>,
+     *     suites: array<string, array{cases: int, boolean_root_schemas: int, excluded_cases: int, deltas: int}>
+     * }
+     */
+    private function baseline(): array
+    {
+        $path = __DIR__ . '/../../fixtures/compatibility/v1-json-schema-conversion-delta.json';
+        $contents = file_get_contents($path);
+        $this->assertIsString($contents, 'Missing conformance baseline.');
+
+        return json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+    }
+}

--- a/tests/Integration/Conformance/JsonSchemaConversionDeltaTest.php
+++ b/tests/Integration/Conformance/JsonSchemaConversionDeltaTest.php
@@ -142,7 +142,7 @@ final class JsonSchemaConversionDeltaTest extends TestCase
     {
         $baseline = $this->baseline();
 
-        // Reasons are shared: 114 of the recorded deltas are one defect, and
+        // Reasons are shared: 115 of the recorded deltas are one defect, and
         // repeating its explanation per entry would make the file unreadable
         // without making it more precise. Keys stay per case, so a genuinely
         // new case still fails the comparison above.

--- a/tests/fixtures/compatibility/v1-json-schema-conversion-delta.json
+++ b/tests/fixtures/compatibility/v1-json-schema-conversion-delta.json
@@ -13,13 +13,25 @@
             "cases": 1657,
             "boolean_root_schemas": 18,
             "excluded_cases": 0,
-            "deltas": 0
+            "deltas": 56
         },
         "draft2020-12": {
             "cases": 2163,
             "boolean_root_schemas": 18,
             "excluded_cases": 4,
-            "deltas": 11
+            "deltas": 70
+        }
+    },
+    "reasons": {
+        "empty-schema-object": {
+            "summary": "Known defect. An empty Schema Object `{}` is indistinguishable from an empty array once the spec is decoded with json_decode(..., true), so it reaches opis as a JSON array and is rejected as not-a-schema. Legal OpenAPI (`additionalProperties: {}`, `properties: {x: {}}`, `items: {}`, `not: {}`) is affected. One case — draft7 additionalItems.json \"when items is schema, boolean additionalItems does nothing\" — degrades further into a wrong `invalid` verdict rather than an error, because `items: {}` becomes tuple-form `items: []`.",
+            "issue": "https://github.com/studio-design/gesso/issues/478"
+        },
+        "unsupported-dialect": {
+            "summary": "Deliberate. The schema declares a custom metaschema URI in `$schema`. OpenApiSchemaDialect::assertSupported() rejects dialects it cannot evaluate instead of falling back to one with different semantics, which for a contract-testing tool is the safer failure. See docs/supported-features.md. Note that on vocabulary.json \"no validation: invalid number, but it still validates\" bare opis also disagrees with the suite: opis does not honour a metaschema that drops the validation vocabulary, a gap that belongs to opis and is visible on https://bowtie.report."
+        },
+        "stripped-annotation-ref": {
+            "summary": "Known limitation. The schema points `$ref` at `#/examples/0`. The converter strips `examples` as an OAS annotation keyword, so the reference target no longer exists and opis reports an unresolved reference. A spec that references into an `examples` array is unsupported; the outcome is a loud error, never a silent pass. Referencing annotation internals is not something OpenAPI sanctions, so this is documented rather than fixed."
         }
     },
     "excluded_groups": {
@@ -33,71 +45,761 @@
         }
     },
     "deltas": {
+        "draft2020-12::additionalProperties.json::additionalProperties are allowed by default::additional properties are allowed": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::additionalProperties.json::additionalProperties being false does not allow other properties::an additional property is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::additionalProperties.json::additionalProperties being false does not allow other properties::ignores arrays": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::additionalProperties.json::additionalProperties being false does not allow other properties::ignores other non-objects": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::additionalProperties.json::additionalProperties being false does not allow other properties::ignores strings": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::additionalProperties.json::additionalProperties being false does not allow other properties::no additional properties is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::additionalProperties.json::additionalProperties being false does not allow other properties::patternProperties are not additional properties": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::additionalProperties.json::additionalProperties with schema::an additional invalid property is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::additionalProperties.json::additionalProperties with schema::an additional valid property is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::additionalProperties.json::additionalProperties with schema::no additional properties is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::additionalProperties.json::dependentSchemas with additionalProperties::additionalProperties can't see bar": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::additionalProperties.json::dependentSchemas with additionalProperties::additionalProperties can't see bar even when foo2 is present": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::additionalProperties.json::dependentSchemas with additionalProperties::additionalProperties doesn't consider dependentSchemas": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::additionalProperties.json::non-ASCII pattern with additionalProperties::matching the pattern is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::additionalProperties.json::non-ASCII pattern with additionalProperties::not matching the pattern is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::allOf.json::allOf with one empty schema::any data is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::allOf.json::allOf with the first empty schema::number is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::allOf.json::allOf with the first empty schema::string is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::allOf.json::allOf with the last empty schema::number is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::allOf.json::allOf with the last empty schema::string is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::allOf.json::allOf with two empty schemas::any data is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::anyOf.json::anyOf with one empty schema::number is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::anyOf.json::anyOf with one empty schema::string is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::dependentSchemas.json::dependent subschema incompatible with root::matches both": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::dependentSchemas.json::dependent subschema incompatible with root::matches dependency": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::dependentSchemas.json::dependent subschema incompatible with root::matches root": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::dependentSchemas.json::dependent subschema incompatible with root::no dependency": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
         "draft2020-12::format-assertion.json::schema that uses custom metaschema with format-assertion: false::format-assertion: false: invalid string": {
             "expected": "invalid",
             "bare": "invalid",
             "converted": "convert-error:Studio\\Gesso\\Exception\\InvalidOpenApiSpecException",
-            "reason": "Deliberate. The schema declares a custom metaschema URI in $schema. OpenApiSchemaDialect::assertSupported() rejects dialects it cannot evaluate instead of silently falling back to a dialect with different semantics, which for a contract-testing tool is the safer failure. See docs/supported-features.md."
+            "reason": "unsupported-dialect"
         },
         "draft2020-12::format-assertion.json::schema that uses custom metaschema with format-assertion: false::format-assertion: false: valid string": {
             "expected": "valid",
             "bare": "valid",
             "converted": "convert-error:Studio\\Gesso\\Exception\\InvalidOpenApiSpecException",
-            "reason": "Deliberate. Custom metaschema URI in $schema; unsupported dialects fail loudly rather than falling back."
+            "reason": "unsupported-dialect"
         },
         "draft2020-12::format-assertion.json::schema that uses custom metaschema with format-assertion: true::format-assertion: true: invalid string": {
             "expected": "invalid",
             "bare": "invalid",
             "converted": "convert-error:Studio\\Gesso\\Exception\\InvalidOpenApiSpecException",
-            "reason": "Deliberate. Custom metaschema URI in $schema; unsupported dialects fail loudly rather than falling back."
+            "reason": "unsupported-dialect"
         },
         "draft2020-12::format-assertion.json::schema that uses custom metaschema with format-assertion: true::format-assertion: true: valid string": {
             "expected": "valid",
             "bare": "valid",
             "converted": "convert-error:Studio\\Gesso\\Exception\\InvalidOpenApiSpecException",
-            "reason": "Deliberate. Custom metaschema URI in $schema; unsupported dialects fail loudly rather than falling back."
+            "reason": "unsupported-dialect"
+        },
+        "draft2020-12::items.json::items with heterogeneous array::heterogeneous invalid instance": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::items.json::items with heterogeneous array::valid instance": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::items.json::prefixItems with no additional items allowed::additional items are not permitted": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::items.json::prefixItems with no additional items allowed::empty array": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::items.json::prefixItems with no additional items allowed::equal number of items present": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::items.json::prefixItems with no additional items allowed::fewer number of items present (1)": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::items.json::prefixItems with no additional items allowed::fewer number of items present (2)": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::not.json::double negation::any value is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::not.json::forbid everything with empty schema::array is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::not.json::forbid everything with empty schema::boolean false is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::not.json::forbid everything with empty schema::boolean true is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::not.json::forbid everything with empty schema::empty array is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::not.json::forbid everything with empty schema::empty object is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::not.json::forbid everything with empty schema::null is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::not.json::forbid everything with empty schema::number is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::not.json::forbid everything with empty schema::object is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::not.json::forbid everything with empty schema::string is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::not.json::forbidden property::property present": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::oneOf.json::oneOf with empty schema::both valid - invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::oneOf.json::oneOf with empty schema::one valid - valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
         },
         "draft2020-12::refOfUnknownKeyword.json::reference internals of known non-applicator::match": {
             "expected": "valid",
             "bare": "valid",
             "converted": "error:Opis\\JsonSchema\\Exceptions\\UnresolvedReferenceException",
-            "reason": "Known limitation. The schema points $ref at \"#/examples/0\". The converter strips OAS annotation keywords including examples, so the reference target no longer exists and opis reports an unresolved reference. A spec that references into an examples array is unsupported; the outcome is a loud error, never a silent pass. Referencing annotation internals is not something OpenAPI sanctions, so this is documented rather than fixed."
+            "reason": "stripped-annotation-ref"
         },
         "draft2020-12::refOfUnknownKeyword.json::reference internals of known non-applicator::mismatch": {
             "expected": "invalid",
             "bare": "invalid",
             "converted": "error:Opis\\JsonSchema\\Exceptions\\UnresolvedReferenceException",
-            "reason": "Known limitation. Same stripped-examples reference target as the match case above."
+            "reason": "stripped-annotation-ref"
+        },
+        "draft2020-12::required.json::required default validation::not required by default": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::required.json::required validation::ignores arrays": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::required.json::required validation::ignores boolean": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::required.json::required validation::ignores null": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::required.json::required validation::ignores other non-objects": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::required.json::required validation::ignores strings": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::required.json::required validation::non-present required property is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::required.json::required validation::present required property is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::required.json::required with empty array::property not required": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::unevaluatedProperties.json::dependentSchemas with unevaluatedProperties::unevaluatedProperties doesn't consider dependentSchemas": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::unevaluatedProperties.json::dependentSchemas with unevaluatedProperties::unevaluatedProperties doesn't see bar when foo2 is absent": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft2020-12::unevaluatedProperties.json::dependentSchemas with unevaluatedProperties::unevaluatedProperties sees bar when foo2 is present": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
         },
         "draft2020-12::vocabulary.json::ignore unrecognized optional vocabulary::number value": {
             "expected": "valid",
             "bare": "valid",
             "converted": "convert-error:Studio\\Gesso\\Exception\\InvalidOpenApiSpecException",
-            "reason": "Deliberate. Custom metaschema URI in $schema; unsupported dialects fail loudly rather than falling back."
+            "reason": "unsupported-dialect"
         },
         "draft2020-12::vocabulary.json::ignore unrecognized optional vocabulary::string value": {
             "expected": "invalid",
             "bare": "invalid",
             "converted": "convert-error:Studio\\Gesso\\Exception\\InvalidOpenApiSpecException",
-            "reason": "Deliberate. Custom metaschema URI in $schema; unsupported dialects fail loudly rather than falling back."
+            "reason": "unsupported-dialect"
         },
         "draft2020-12::vocabulary.json::schema that uses custom metaschema with with no validation vocabulary::applicator vocabulary still works": {
             "expected": "invalid",
             "bare": "invalid",
             "converted": "convert-error:Studio\\Gesso\\Exception\\InvalidOpenApiSpecException",
-            "reason": "Deliberate. Custom metaschema URI in $schema; unsupported dialects fail loudly rather than falling back."
+            "reason": "unsupported-dialect"
         },
         "draft2020-12::vocabulary.json::schema that uses custom metaschema with with no validation vocabulary::no validation: invalid number, but it still validates": {
             "expected": "valid",
             "bare": "invalid",
             "converted": "convert-error:Studio\\Gesso\\Exception\\InvalidOpenApiSpecException",
-            "reason": "Deliberate. Custom metaschema URI in $schema; unsupported dialects fail loudly rather than falling back. Note that bare opis also disagrees with the suite here (expected valid, opis says invalid): opis does not honour a metaschema that drops the validation vocabulary. That gap belongs to opis and is visible on https://bowtie.report; conversion only turns it into a loud error."
+            "reason": "unsupported-dialect"
         },
         "draft2020-12::vocabulary.json::schema that uses custom metaschema with with no validation vocabulary::no validation: valid number": {
             "expected": "valid",
             "bare": "valid",
             "converted": "convert-error:Studio\\Gesso\\Exception\\InvalidOpenApiSpecException",
-            "reason": "Deliberate. Custom metaschema URI in $schema; unsupported dialects fail loudly rather than falling back."
+            "reason": "unsupported-dialect"
+        },
+        "draft7::additionalItems.json::additionalItems as schema::additional items do not match schema": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::additionalItems.json::additionalItems as schema::additional items match schema": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::additionalItems.json::additionalItems with heterogeneous array::heterogeneous invalid instance": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::additionalItems.json::additionalItems with heterogeneous array::valid instance": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::additionalItems.json::array of items with no additionalItems permitted::additional items are not permitted": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::additionalItems.json::array of items with no additionalItems permitted::empty array": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::additionalItems.json::array of items with no additionalItems permitted::equal number of items present": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::additionalItems.json::array of items with no additionalItems permitted::fewer number of items present (1)": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::additionalItems.json::array of items with no additionalItems permitted::fewer number of items present (2)": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::additionalItems.json::when items is schema, boolean additionalItems does nothing::all items match schema": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "invalid",
+            "reason": "empty-schema-object"
+        },
+        "draft7::additionalProperties.json::additionalProperties are allowed by default::additional properties are allowed": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::additionalProperties.json::additionalProperties being false does not allow other properties::an additional property is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::additionalProperties.json::additionalProperties being false does not allow other properties::ignores arrays": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::additionalProperties.json::additionalProperties being false does not allow other properties::ignores other non-objects": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::additionalProperties.json::additionalProperties being false does not allow other properties::ignores strings": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::additionalProperties.json::additionalProperties being false does not allow other properties::no additional properties is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::additionalProperties.json::additionalProperties being false does not allow other properties::patternProperties are not additional properties": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::additionalProperties.json::additionalProperties with schema::an additional invalid property is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::additionalProperties.json::additionalProperties with schema::an additional valid property is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::additionalProperties.json::additionalProperties with schema::no additional properties is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::additionalProperties.json::non-ASCII pattern with additionalProperties::matching the pattern is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::additionalProperties.json::non-ASCII pattern with additionalProperties::not matching the pattern is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::allOf.json::allOf with one empty schema::any data is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::allOf.json::allOf with the first empty schema::number is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::allOf.json::allOf with the first empty schema::string is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::allOf.json::allOf with the last empty schema::number is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::allOf.json::allOf with the last empty schema::string is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::allOf.json::allOf with two empty schemas::any data is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::anyOf.json::anyOf with one empty schema::number is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::anyOf.json::anyOf with one empty schema::string is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::dependencies.json::dependent subschema incompatible with root::matches both": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::dependencies.json::dependent subschema incompatible with root::matches dependency": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::dependencies.json::dependent subschema incompatible with root::matches root": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::dependencies.json::dependent subschema incompatible with root::no dependency": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::not.json::double negation::any value is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::not.json::forbid everything with empty schema::array is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::not.json::forbid everything with empty schema::boolean false is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::not.json::forbid everything with empty schema::boolean true is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::not.json::forbid everything with empty schema::empty array is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::not.json::forbid everything with empty schema::empty object is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::not.json::forbid everything with empty schema::null is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::not.json::forbid everything with empty schema::number is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::not.json::forbid everything with empty schema::object is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::not.json::forbid everything with empty schema::string is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::not.json::forbidden property::property present": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::oneOf.json::oneOf with empty schema::both valid - invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::oneOf.json::oneOf with empty schema::one valid - valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::required.json::required default validation::not required by default": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::required.json::required validation::ignores arrays": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::required.json::required validation::ignores boolean": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::required.json::required validation::ignores null": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::required.json::required validation::ignores other non-objects": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::required.json::required validation::ignores strings": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::required.json::required validation::non-present required property is invalid": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::required.json::required validation::present required property is valid": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
+        },
+        "draft7::required.json::required with empty array::property not required": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\InvalidKeywordException",
+            "reason": "empty-schema-object"
         }
     }
 }

--- a/tests/fixtures/compatibility/v1-json-schema-conversion-delta.json
+++ b/tests/fixtures/compatibility/v1-json-schema-conversion-delta.json
@@ -1,0 +1,103 @@
+{
+    "format_version": 1,
+    "description": "Cases from the official JSON Schema Test Suite whose validation verdict changes when the schema is rewritten by Studio\\Gesso\\Spec\\OpenApiSchemaConverter. Everything not listed here validates identically before and after conversion. See docs/conformance.md and issue #283.",
+    "corpus": {
+        "name": "json-schema-org/json-schema-test-suite",
+        "source": "https://github.com/json-schema-org/JSON-Schema-Test-Suite",
+        "commit": "cf2e5e0ff2e3d90239c3b59e68ac4c080bd4ac92",
+        "license": "MIT",
+        "pinned_in": "composer.json (repositories[].package.dist.reference)"
+    },
+    "suites": {
+        "draft7": {
+            "cases": 1657,
+            "boolean_root_schemas": 18,
+            "excluded_cases": 0,
+            "deltas": 0
+        },
+        "draft2020-12": {
+            "cases": 2163,
+            "boolean_root_schemas": 18,
+            "excluded_cases": 4,
+            "deltas": 11
+        }
+    },
+    "excluded_groups": {
+        "draft2020-12::unevaluatedItems.json::unevaluatedItems with $dynamicRef": {
+            "group": "unevaluatedItems with $dynamicRef",
+            "reason": "Bare opis/json-schema recurses without bound on $dynamicRef inside unevaluatedItems and exhausts the stack. The conversion layer is not involved — the same input crashes opis directly — and the resulting fatal error is not catchable, so the group is excluded statically rather than recorded as a delta."
+        },
+        "draft2020-12::unevaluatedProperties.json::unevaluatedProperties with $dynamicRef": {
+            "group": "unevaluatedProperties with $dynamicRef",
+            "reason": "Same unbounded $dynamicRef recursion in bare opis/json-schema, in the unevaluatedProperties applicator."
+        }
+    },
+    "deltas": {
+        "draft2020-12::format-assertion.json::schema that uses custom metaschema with format-assertion: false::format-assertion: false: invalid string": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "convert-error:Studio\\Gesso\\Exception\\InvalidOpenApiSpecException",
+            "reason": "Deliberate. The schema declares a custom metaschema URI in $schema. OpenApiSchemaDialect::assertSupported() rejects dialects it cannot evaluate instead of silently falling back to a dialect with different semantics, which for a contract-testing tool is the safer failure. See docs/supported-features.md."
+        },
+        "draft2020-12::format-assertion.json::schema that uses custom metaschema with format-assertion: false::format-assertion: false: valid string": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "convert-error:Studio\\Gesso\\Exception\\InvalidOpenApiSpecException",
+            "reason": "Deliberate. Custom metaschema URI in $schema; unsupported dialects fail loudly rather than falling back."
+        },
+        "draft2020-12::format-assertion.json::schema that uses custom metaschema with format-assertion: true::format-assertion: true: invalid string": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "convert-error:Studio\\Gesso\\Exception\\InvalidOpenApiSpecException",
+            "reason": "Deliberate. Custom metaschema URI in $schema; unsupported dialects fail loudly rather than falling back."
+        },
+        "draft2020-12::format-assertion.json::schema that uses custom metaschema with format-assertion: true::format-assertion: true: valid string": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "convert-error:Studio\\Gesso\\Exception\\InvalidOpenApiSpecException",
+            "reason": "Deliberate. Custom metaschema URI in $schema; unsupported dialects fail loudly rather than falling back."
+        },
+        "draft2020-12::refOfUnknownKeyword.json::reference internals of known non-applicator::match": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\UnresolvedReferenceException",
+            "reason": "Known limitation. The schema points $ref at \"#/examples/0\". The converter strips OAS annotation keywords including examples, so the reference target no longer exists and opis reports an unresolved reference. A spec that references into an examples array is unsupported; the outcome is a loud error, never a silent pass. Referencing annotation internals is not something OpenAPI sanctions, so this is documented rather than fixed."
+        },
+        "draft2020-12::refOfUnknownKeyword.json::reference internals of known non-applicator::mismatch": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "error:Opis\\JsonSchema\\Exceptions\\UnresolvedReferenceException",
+            "reason": "Known limitation. Same stripped-examples reference target as the match case above."
+        },
+        "draft2020-12::vocabulary.json::ignore unrecognized optional vocabulary::number value": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "convert-error:Studio\\Gesso\\Exception\\InvalidOpenApiSpecException",
+            "reason": "Deliberate. Custom metaschema URI in $schema; unsupported dialects fail loudly rather than falling back."
+        },
+        "draft2020-12::vocabulary.json::ignore unrecognized optional vocabulary::string value": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "convert-error:Studio\\Gesso\\Exception\\InvalidOpenApiSpecException",
+            "reason": "Deliberate. Custom metaschema URI in $schema; unsupported dialects fail loudly rather than falling back."
+        },
+        "draft2020-12::vocabulary.json::schema that uses custom metaschema with with no validation vocabulary::applicator vocabulary still works": {
+            "expected": "invalid",
+            "bare": "invalid",
+            "converted": "convert-error:Studio\\Gesso\\Exception\\InvalidOpenApiSpecException",
+            "reason": "Deliberate. Custom metaschema URI in $schema; unsupported dialects fail loudly rather than falling back."
+        },
+        "draft2020-12::vocabulary.json::schema that uses custom metaschema with with no validation vocabulary::no validation: invalid number, but it still validates": {
+            "expected": "valid",
+            "bare": "invalid",
+            "converted": "convert-error:Studio\\Gesso\\Exception\\InvalidOpenApiSpecException",
+            "reason": "Deliberate. Custom metaschema URI in $schema; unsupported dialects fail loudly rather than falling back. Note that bare opis also disagrees with the suite here (expected valid, opis says invalid): opis does not honour a metaschema that drops the validation vocabulary. That gap belongs to opis and is visible on https://bowtie.report; conversion only turns it into a loud error."
+        },
+        "draft2020-12::vocabulary.json::schema that uses custom metaschema with with no validation vocabulary::no validation: valid number": {
+            "expected": "valid",
+            "bare": "valid",
+            "converted": "convert-error:Studio\\Gesso\\Exception\\InvalidOpenApiSpecException",
+            "reason": "Deliberate. Custom metaschema URI in $schema; unsupported dialects fail loudly rather than falling back."
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Runs the official JSON Schema Test Suite twice — once through bare opis, once after `OpenApiSchemaConverter::convert()` — and pins the set of cases whose verdict differs. That set is committed as a baseline and asserted in CI, so a conversion regression surfaces as a new entry.

It found a real defect on its first run. See "What it found" below.

This is PR1 of the reduced scope agreed in #283 ([comment](https://github.com/studio-design/gesso/issues/283#issuecomment-5174474644)). PR2 (official OAS example documents through the loader and doctor) follows separately.

## Why

The package rewrites Schema Objects substantially before validating: 3.0 lowering to Draft 07, `discriminator` to `if`/`then`, `nullable` to type arrays, annotation stripping, `readOnly` / `writeOnly` to boolean subschemas. That rewriting is the part most likely to quietly change what a spec means, and nothing in the repository proved it does not.

It deliberately does **not** re-measure opis's own JSON Schema conformance — that is published independently at [bowtie.report](https://bowtie.report) via the `bowtie-json-schema/php-opis-json-schema` harness. Measuring the delta this package adds on top of opis is the part no external report covers, and it keeps the recorded set small enough to review entry by entry.

## What it found

| Suite | Pipeline | In corpus | Excluded | Boolean root | Compared | Verdict changed |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| `draft7` | 3.0 → Draft 07 | 1,657 | 0 | 18 | 1,639 | 56 |
| `draft2020-12` | 3.1 / 3.2 → 2020-12 | 2,167 | 4 | 18 | 2,145 | 70 |
| **Total** | | **3,824** | **4** | **36** | **3,784** | **126** |

Not every corpus case can go through both pipelines: 36 use a boolean `true` / `false` root schema, which a Schema Object cannot express and `convert()` never sees. They are counted and published rather than dropped, but validated once, not twice.

Each recorded case cites one of three shared reason keys:

**`empty-schema-object` — 115 cases. A real defect, filed as #478.** An empty Schema Object `{}` is indistinguishable from an empty array once a spec is decoded with `json_decode(..., true)`, so it reaches opis as a JSON array and is rejected as not-a-schema. `additionalProperties: {}`, `properties: {x: {}}`, `items: {}`, `not: {}` are ordinary OpenAPI and all hit it. It reproduces through the public validator with no test harness involved:

```
[response-body] GET /things in 'empty-object' spec:
Opis\JsonSchema\Exceptions\InvalidKeywordException threw:
properties[anything] must be a json schema (object or boolean)
```

114 of the 115 fail loudly like that. One does not: `{"items": {}, "additionalItems": false}` becomes tuple-form `items: []`, `additionalItems: false` then forbids every element past position 0, and a compliant array is reported as a contract violation with no error at all. A false failure with a plausible message is the worst class of bug for a contract-testing tool, and no existing test caught it.

Recorded rather than fixed here: the fix belongs in the converter and has to distinguish schema positions from keyword-value positions (`enum: []`, `required: []`, `allOf: []` are genuine empty arrays a naive fix would break), which needs its own regression tests.

**`unsupported-dialect` — 9 cases** (`vocabulary.json`, `format-assertion.json`). Custom metaschema URIs in `$schema`, rejected as unsupported dialects rather than falling back to one with different semantics. Deliberate, already documented in `docs/supported-features.md`.

**`stripped-annotation-ref` — 2 cases** (`refOfUnknownKeyword.json`). `$ref` pointing at `#/examples/0`; the converter strips `examples`, so the target no longer resolves. Loud error, never a silent pass. Referencing annotation internals is not something OpenAPI sanctions, so it is documented rather than fixed.

The 4 exclusions are `$dynamicRef` inside `unevaluatedItems` / `unevaluatedProperties`, where **bare opis** recurses without bound and exhausts the stack. The conversion layer is not involved and the fatal error is not catchable from PHP, so the groups are excluded statically and published with that reason.

## Verification

- [x] `composer test` passes (2860 tests, 10584 assertions)
- [x] `composer stan` passes
- [x] `composer cs-check` passes
- [x] `composer validate --strict` and `composer audit --abandoned=fail` pass with the new repository entry
- [x] Docs site builds; `npm run docs:links` and the accessibility / base / version verifiers pass
- [x] Baseline drift is actually caught: perturbing one count in the fixture fails the assertion
- [x] `#478` reproduced through `OpenApiResponseValidator` on a hand-written legal spec, independent of this harness
- [x] Remote-`$ref` resolution verified end to end: draft7 `refRemote.json` agrees with the suite 23/23
- [x] Conformance test runtime: 0.27s

## Notes for reviewers

**Corpus pinning.** The suite is not on Packagist (`json-schema/json-schema-test-suite` there is an unrelated squat with 52 downloads), its npm package `@json-schema-org/tests` ships a 15 KB JS loader with no test data, and it has no usable upstream tags — the two GitHub releases are from 2023 and the `Test-JSON-Schema-Acceptance-*` tags belong to a downstream Perl consumer. A commit SHA is the only real pin available.

Since a library does not commit `composer.lock`, the pin has to live in `composer.json`, so the corpus is declared as an inline `type: package` repository with the SHA in both `dist` and `source`. `composer install` fetches it as a zip — no git clone, no submodule init, no workflow change. `jsonrainbow/json-schema` uses the same mechanism but with `reference: main`, i.e. unpinned; this pins it. Composer's caveat that it "will not update the commit references" is the desired behaviour here.

Rejected: git submodule (needs `submodules: true` everywhere and upstream recommends tracking `main` unpinned), and committing a snapshot the way `opis/json-schema` does — opis edits the corpus to add `"skip": true` to unsupported cases, which is the "unsupported turned green" pattern #283 rules out.

**Three harness defects were fixed in the second commit**, each of which let cases pass while asserting nothing. All three were found in review, and together they are why the recorded set went from 11 to 126:

1. Reading the corpus with `json_decode(..., true)` collapsed `{}` and `[]` on *both* sides, so `empty-schema-object` raised the same exception in the reference run and was scored "no difference". The bare side now uses the faithful object form; only the converted side takes the array shape `OpenApiSpecLoader` produces.
2. The suite's `remotes/` was not served at `http://localhost:1234/`, so all 54 `refRemote` cases raised an identical unresolved-reference error on both sides.
3. opis writes `default` values into the instance it validates, so a shared `$data` let the bare run's mutation reach the converted run.

**Two assertions, on purpose.** The verdict triple is compared for equality; reasons are validated separately (every delta cites a known key, every published key is still cited). Rewording an explanation cannot become a false regression, and regenerating the fixture to hide an unexplained new entry does not work either.

**One non-obvious trap.** opis registers every `$id`-bearing schema in a process-wide loader cache. Without clearing between the bare and converted runs, the second validation collides on the same `$id` and reports 7 deltas that do not exist. `verdict()` clears it, as opis's own suite runner does.

Updating the pinned corpus is documented in `docs/conformance.md`.

Refs #283
