### PR TITLE
fix(cli): accept OpenAPI 3.1+ documents that omit paths or responses

### DIFF
--- a/src/Cli/DoctorCommand.php
+++ b/src/Cli/DoctorCommand.php
@@ -424,7 +424,7 @@ final class DoctorCommand
             $spec = OpenApiSpecLoader::load($name);
             $version = OpenApiVersion::fromSpec($spec);
             $dialect = OpenApiSchemaDialect::fromSpec($spec, $version);
-            [$operations, $responses] = $this->inspectStructure($spec, $label, $issues);
+            [$operations, $responses] = $this->inspectStructure($spec, $version, $label, $issues);
             $this->inspectSchemas($spec, $version, $dialect, new DiscriminatorContext($spec, true));
             $this->inspectSkippedFeatures($spec, $label, $acknowledgedSchemes, $issues);
 
@@ -461,8 +461,20 @@ final class DoctorCommand
      *
      * @return array{0: int, 1: int}
      */
-    private function inspectStructure(array $spec, string $label, array &$issues): array
+    private function inspectStructure(array $spec, OpenApiVersion $version, string $label, array &$issues): array
     {
+        // `paths` and an operation's `responses` are REQUIRED in OAS 3.0 but
+        // optional from 3.1 on: a document may describe only `webhooks`, and an
+        // operation may describe only its request. The runtime validators
+        // already read both through `array_key_exists()` and treat an absent
+        // key as "nothing to match", so only a node that is present with the
+        // wrong type is a structure error.
+        $optional = $version !== OpenApiVersion::V3_0;
+
+        if ($optional && !array_key_exists('paths', $spec)) {
+            return [0, 0];
+        }
+
         $paths = $spec['paths'] ?? null;
         if (MalformedSpecNode::isMalformed($paths)) {
             $issues[] = $this->issue('error', 'structure', $label, sprintf('`paths` must be an object, got %s.', MalformedSpecNode::describe($paths)), null);
@@ -486,6 +498,10 @@ final class DoctorCommand
                     continue;
                 }
                 $operationCount++;
+                if ($optional && !array_key_exists('responses', $operation)) {
+                    continue;
+                }
+
                 $responses = $operation['responses'] ?? null;
                 if (MalformedSpecNode::isMalformed($responses)) {
                     $issues[] = $this->issue(

--- a/tests/Unit/Cli/DoctorCommandTest.php
+++ b/tests/Unit/Cli/DoctorCommandTest.php
@@ -721,6 +721,59 @@ class DoctorCommandTest extends TestCase
         $this->assertStringContainsString('discriminator.mapping', $report['issues'][0]['message']);
     }
 
+    #[Test]
+    public function omitted_paths_and_responses_are_legal_from_openapi_31_on(): void
+    {
+        // `paths` and an operation's `responses` lost their REQUIRED marker in
+        // OAS 3.1 (https://spec.openapis.org/oas/v3.1.1#openapi-object,
+        // #operation-object). Both official example documents below come from
+        // OAI/learn.openapis.org and previously failed the doctor outright.
+        $cases = [
+            // webhook-example: describes only `webhooks`, no `paths` at all.
+            ['3.1.0', ['webhooks' => ['newPet' => ['post' => ['responses' => ['200' => ['description' => 'ok']]]]]], 0],
+            // non-oauth-scopes: an operation carrying only `security`.
+            ['3.1.0', ['paths' => ['/users' => ['get' => ['security' => [['bearerAuth' => ['read:users']]]]]]], 1],
+            // 3.2-tags-example: operations carrying only `tags` / `summary`.
+            ['3.2.0', ['paths' => ['/flights' => ['get' => ['tags' => ['flights']]]]], 1],
+        ];
+
+        foreach ($cases as $index => [$openapi, $document, $expectedOperations]) {
+            $spec = $this->writeSpec("optional-{$index}.json", (string) json_encode(
+                ['openapi' => $openapi, 'info' => ['title' => 'Test', 'version' => '1']] + $document,
+                JSON_THROW_ON_ERROR,
+            ));
+            $report = $this->runJsonDoctor($spec, $exit);
+
+            $this->assertSame(DoctorCommand::EXIT_OK, $exit, "case {$index}");
+            $this->assertSame([], $report['issues'], "case {$index}");
+            $this->assertSame($expectedOperations, $report['summary']['operations'], "case {$index}");
+            $this->assertSame(0, $report['summary']['responses'], "case {$index}");
+        }
+    }
+
+    #[Test]
+    public function omitted_paths_and_responses_stay_errors_in_openapi_30_as_does_an_explicit_null(): void
+    {
+        $cases = [
+            ['3.0.3', [], '`paths` must be an object, got null.'],
+            ['3.0.3', ['paths' => ['/pets' => ['get' => []]]], 'Operation `GET /pets` has an invalid `responses` object: got null.'],
+            ['3.1.0', ['paths' => null], '`paths` must be an object, got null.'],
+            ['3.1.0', ['paths' => ['/pets' => ['get' => ['responses' => null]]]], 'Operation `GET /pets` has an invalid `responses` object: got null.'],
+        ];
+
+        foreach ($cases as $index => [$openapi, $document, $expectedMessage]) {
+            $spec = $this->writeSpec("required-{$index}.json", (string) json_encode(
+                ['openapi' => $openapi, 'info' => ['title' => 'Test', 'version' => '1']] + $document,
+                JSON_THROW_ON_ERROR,
+            ));
+            $report = $this->runJsonDoctor($spec, $exit);
+
+            $this->assertSame(DoctorCommand::EXIT_DIAGNOSTIC_FAILURE, $exit, "case {$index}");
+            $this->assertSame('structure', $report['issues'][0]['category'], "case {$index}");
+            $this->assertSame($expectedMessage, $report['issues'][0]['message'], "case {$index}");
+        }
+    }
+
     private function writeSpec(string $name, string $contents): string
     {
         $path = $this->workDir . '/' . $name;


### PR DESCRIPTION
## Summary

`gesso doctor` reported an absent `paths` object, and an absent `responses`
object on an operation, as structure errors on every OpenAPI version. Both lost
their `REQUIRED` marker in OAS 3.1, so the checks are now version-aware.

## Why

Found while preparing the OAS example-document conformance suite (#283): three
of the official example documents published by `OAI/learn.openapis.org` failed
`gesso doctor` even though they are valid.

| Document | Shape | Reported |
| --- | --- | --- |
| `v3.1/webhook-example` | only `webhooks`, no `paths` | `` `paths` must be an object, got null.`` |
| `v3.1/non-oauth-scopes` | `GET /users` carries only `security` | `` Operation `GET /users` has an invalid `responses` object: got null.`` |
| `v3.2/3.2-tags-example` | four operations carry only `tags` / `summary` | the same, ×4 |

Both fields are marked **REQUIRED** in [3.0.4](https://spec.openapis.org/oas/v3.0.4#openapi-object)
and lose that marker in [3.1.1](https://spec.openapis.org/oas/v3.1.1#openapi-object)
and [3.2.0](https://spec.openapis.org/oas/v3.2.0#openapi-object) — a document may
describe only `webhooks`, and an operation may describe only its request.

This also closed a doctor/runtime split that `AGENTS.md` names as an invariant:
`OpenApiRequestValidator`, `ResponseSchemaResolver`, and `SpecPathsPreflight`
already read both keys through `array_key_exists()` and treat an absent key as
"nothing to match". Doctor used `?? null`, which conflates absent with
`null`-valued.

## Verification

- New: `omitted_paths_and_responses_are_legal_from_openapi_31_on` — the three
  shapes above on 3.1 / 3.2, expecting exit 0, no issues, and the right
  operation count.
- New: `omitted_paths_and_responses_stay_errors_in_openapi_30_as_does_an_explicit_null`
  — absent still errors on 3.0, and an explicit `"paths": null` / `"responses": null`
  still errors on 3.1, which is what the `array_key_exists()` distinction buys.
- All 12 official 3.0/3.1/3.2 example documents now run clean through
  `bin/gesso doctor` in both their JSON and YAML forms.

- [x] `composer test` passes (2862 tests, 10608 assertions)
- [x] `composer stan` passes
- [x] `composer cs-check` passes

## Notes for reviewers

Deliberately unchanged: doctor stays silent about a document that yields zero
operations, matching its existing behaviour for `"paths": {}`. Validating
`webhooks` entries is a separate feature gap, not part of this fix.

The conformance suite that surfaced this follows in its own PR; it is green
against this branch.