### PR TITLE
test(conformance): pin the official OpenAPI example documents through the loader and doctor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,10 +35,12 @@ maintenance cost.
 - `bin/gesso`: Composer-installed CLI for `doctor` and `coverage:merge`.
 - `tests/Unit`, `tests/Integration`, `tests/fixtures`: tests and representative
   OpenAPI fixtures. Pest integration tests run through a separate command.
-- `tests/Integration/Conformance`: runs the official JSON Schema Test Suite
-  (pinned by commit SHA in `composer.json`) through the schema converter and
-  pins the resulting verdict delta. See `docs/conformance.md` before changing
-  `OpenApiSchemaConverter`.
+- `tests/Integration/Conformance`: runs two upstream corpora, both pinned by
+  commit SHA in `composer.json` — the official JSON Schema Test Suite through
+  the schema converter (pinning the verdict delta), and the OpenAPI
+  Initiative's example documents through the loader and `gesso doctor`. See
+  `docs/conformance.md` before changing `OpenApiSchemaConverter` or the
+  doctor's structural checks.
 - `docs/`: focused guides. Start with `docs/setup.md`,
   `docs/supported-features.md`, `docs/coverage.md`, and `docs/versioning.md`.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ when upgrading from `studio-design/openapi-contract-testing` v1.10.
 - **Multi-format reports** — Markdown / JUnit XML / JSON / HTML output with one-click GitHub Step Summary
 - **Zero runtime overhead** — Only used in test suites
 
-**Conformance evidence**: all 22 example documents the OpenAPI Initiative publishes for 3.0, 3.1, and 3.2 — JSON and YAML alike — load and diagnose clean, and the schema rewriting behind the claims above is pinned against the official [JSON Schema Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite): of 3,784 cases compared, conversion changes the verdict on 126 — 115 of them one tracked defect ([#478](https://github.com/studio-design/gesso/issues/478)), the other 11 deliberate. Both corpora are pinned by commit SHA and enforced in CI. See [`docs/conformance.md`](docs/conformance.md).
+**Conformance evidence**: every example document the OpenAPI Initiative publishes for 3.0, 3.1, and 3.2 loads without error — 11 documents in both their JSON and YAML forms, of which ten are issue-free and `tictactoe` reports three security schemes as recognized but not enforced. The schema rewriting behind the claims above is pinned against the official [JSON Schema Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite): of 3,784 cases compared, conversion changes the verdict on 126 — 115 of them one tracked defect ([#478](https://github.com/studio-design/gesso/issues/478)), the other 11 deliberate. Both corpora are pinned by commit SHA and enforced in CI. See [`docs/conformance.md`](docs/conformance.md).
 
 ## Why this library?
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ when upgrading from `studio-design/openapi-contract-testing` v1.10.
 - **Multi-format reports** — Markdown / JUnit XML / JSON / HTML output with one-click GitHub Step Summary
 - **Zero runtime overhead** — Only used in test suites
 
-**Conformance evidence**: the schema rewriting behind those claims is pinned against the official [JSON Schema Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite). Of 3,784 cases compared, conversion changes the verdict on 126 — 115 of them one tracked defect ([#478](https://github.com/studio-design/gesso/issues/478)), the other 11 deliberate. Each is recorded with a reason and enforced in CI. See [`docs/conformance.md`](docs/conformance.md).
+**Conformance evidence**: all 22 example documents the OpenAPI Initiative publishes for 3.0, 3.1, and 3.2 — JSON and YAML alike — load and diagnose clean, and the schema rewriting behind the claims above is pinned against the official [JSON Schema Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite): of 3,784 cases compared, conversion changes the verdict on 126 — 115 of them one tracked defect ([#478](https://github.com/studio-design/gesso/issues/478)), the other 11 deliberate. Both corpora are pinned by commit SHA and enforced in CI. See [`docs/conformance.md`](docs/conformance.md).
 
 ## Why this library?
 
@@ -244,7 +244,7 @@ To validate every response automatically, set `'auto_assert' => true` and drop t
 | CI integration (GitHub Actions, PR comments, output formats, partial-run handling) | [`docs/ci.md`](docs/ci.md) |
 | API reference (`OpenApiResponseValidator`, `OpenApiSpecLoader`, `OpenApiCoverageTracker`) | [`docs/api-reference.md`](docs/api-reference.md) |
 | Supported features, known limitations, warning channel | [`docs/supported-features.md`](docs/supported-features.md) |
-| JSON Schema conformance result (conversion delta vs the official test suite) | [`docs/conformance.md`](docs/conformance.md) |
+| Conformance results (official OAS example documents, JSON Schema conversion delta) | [`docs/conformance.md`](docs/conformance.md) |
 | Versioning policy & support matrix | [`docs/versioning.md`](docs/versioning.md) |
 
 ## Development

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,25 @@
                     "reference": "cf2e5e0ff2e3d90239c3b59e68ac4c080bd4ac92"
                 }
             }
+        },
+        {
+            "comment": "The official OpenAPI example documents, maintained by the OpenAPI Initiative and published under CC-BY-4.0. Not on Packagist and not tagged, so they are pinned by commit SHA here for the same reason as the suite above. See docs/conformance.md.",
+            "type": "package",
+            "package": {
+                "name": "oai/learn.openapis.org",
+                "version": "2026.05.07",
+                "license": "CC-BY-4.0",
+                "dist": {
+                    "type": "zip",
+                    "url": "https://codeload.github.com/OAI/learn.openapis.org/zip/43756549c27cbf84107b190b82c65e0336f2f09f",
+                    "reference": "43756549c27cbf84107b190b82c65e0336f2f09f"
+                },
+                "source": {
+                    "type": "git",
+                    "url": "https://github.com/OAI/learn.openapis.org.git",
+                    "reference": "43756549c27cbf84107b190b82c65e0336f2f09f"
+                }
+            }
         }
     ],
     "require-dev": {
@@ -43,6 +62,7 @@
         "guzzlehttp/psr7": "^2.12.1",
         "json-schema-org/json-schema-test-suite": "2026.08.04",
         "nyholm/psr7": "^1.8",
+        "oai/learn.openapis.org": "2026.05.07",
         "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
         "phpstan/phpstan": "^2.1.13",
         "symfony/browser-kit": "^6.4 || ^7.0 || ^8.0",

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -299,7 +299,7 @@ export default defineConfig({
           { text: 'Setup', link: '/setup' },
           { text: 'Coverage', link: '/coverage' },
           { text: 'Supported features', link: '/supported-features' },
-          { text: 'JSON Schema conformance', link: '/conformance' },
+          { text: 'Conformance', link: '/conformance' },
           { text: 'API reference', link: '/api-reference' }
         ]
       }

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -5,7 +5,7 @@ commit SHA in `composer.json` and asserted on every CI run:
 
 | Corpus | Question it answers | Result |
 | --- | --- | --- |
-| [OAI/learn.openapis.org][learn] | Does Gesso understand the documents the OpenAPI Initiative itself publishes? | 22 of 22 load and diagnose clean |
+| [OAI/learn.openapis.org][learn] | Does Gesso understand the documents the OpenAPI Initiative itself publishes? | 22 of 22 files load without error; one document reports three not-enforced security schemes |
 | [JSON Schema Test Suite][suite] | What does Gesso's schema rewriting change about a schema's meaning? | 126 of 3,784 verdicts move; each one listed with a reason |
 
 Both results are committed as machine-readable baselines, so a number can only
@@ -31,10 +31,17 @@ package does not accept by design, and is not measured.
 | `v3.0/petstore-expanded` | 3.0.0 | 4 | 8 | clean |
 | `v3.0/uspto` | 3.0.1 | 3 | 5 | clean |
 | `v3.1/non-oauth-scopes` | 3.1.0 | 1 | 0 | clean |
-| `v3.1/tictactoe` | 3.1.0 | 3 | 5 JSON / 6 YAML | 3 security schemes reported as not enforced |
+| `v3.1/tictactoe` | 3.1.0 | 3 | 5 JSON / 6 YAML | `warning` — 3 security schemes reported as not enforced |
 | `v3.1/webhook-example` | 3.1.0 | 0 | 0 | clean; `webhooks`-only, nothing to enforce |
 | `v3.2/3.2-query-example` | 3.2.0 | 1 | 1 | clean |
 | `v3.2/3.2-tags-example` | 3.2.0 | 4 | 0 | clean |
+
+Nothing here produces an error: `gesso doctor` exits `0` on all 22 files and
+reports `status: ok` for ten of the eleven documents. `tictactoe` is the
+exception at `status: warning`, from three `skipped` diagnostics — its HTTP
+Basic and OAuth2 schemes are recognized and resolved, then reported as not
+enforced rather than silently passed. "Clean" in the table above means no
+issue of any severity.
 
 Recorded in `tests/fixtures/compatibility/v1-oas-example-documents.json` and
 asserted by `tests/Integration/Conformance/OasExampleDocumentTest.php`. Issues

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -1,4 +1,70 @@
-# JSON Schema conformance
+# Conformance
+
+Gesso is measured against two corpora nobody here maintains, both pinned by
+commit SHA in `composer.json` and asserted on every CI run:
+
+| Corpus | Question it answers | Result |
+| --- | --- | --- |
+| [OAI/learn.openapis.org][learn] | Does Gesso understand the documents the OpenAPI Initiative itself publishes? | 22 of 22 load and diagnose clean |
+| [JSON Schema Test Suite][suite] | What does Gesso's schema rewriting change about a schema's meaning? | 126 of 3,784 verdicts move; each one listed with a reason |
+
+Both results are committed as machine-readable baselines, so a number can only
+move when someone updates the record.
+
+## OpenAPI example documents
+
+Corpus: [`OAI/learn.openapis.org`][learn] at
+`43756549c27cbf84107b190b82c65e0336f2f09f` (CC-BY-4.0) — the example API
+descriptions published by the OpenAPI Initiative alongside the specification.
+
+Every document for OAS 3.0, 3.1, and 3.2 is loaded through `OpenApiSpecLoader`
+and diagnosed by `gesso doctor`, in **both** its JSON and its YAML form: 11
+documents, 22 files. The `examples/v2.0` directory is Swagger 2.0, which this
+package does not accept by design, and is not measured.
+
+| Document | OAS | Operations | Responses | Diagnosis |
+| --- | --- | ---: | ---: | --- |
+| `v3.0/api-with-examples` | 3.0.0 | 2 | 4 | clean |
+| `v3.0/callback-example` | 3.0.0 | 1 | 1 | clean |
+| `v3.0/link-example` | 3.0.0 | 6 | 6 | clean |
+| `v3.0/petstore` | 3.0.0 | 3 | 6 | clean |
+| `v3.0/petstore-expanded` | 3.0.0 | 4 | 8 | clean |
+| `v3.0/uspto` | 3.0.1 | 3 | 5 | clean |
+| `v3.1/non-oauth-scopes` | 3.1.0 | 1 | 0 | clean |
+| `v3.1/tictactoe` | 3.1.0 | 3 | 5 JSON / 6 YAML | 3 security schemes reported as not enforced |
+| `v3.1/webhook-example` | 3.1.0 | 0 | 0 | clean; `webhooks`-only, nothing to enforce |
+| `v3.2/3.2-query-example` | 3.2.0 | 1 | 1 | clean |
+| `v3.2/3.2-tags-example` | 3.2.0 | 4 | 0 | clean |
+
+Recorded in `tests/fixtures/compatibility/v1-oas-example-documents.json` and
+asserted by `tests/Integration/Conformance/OasExampleDocumentTest.php`. Issues
+are pinned as `severity/category` pairs, not prose: message wording is not a
+compatibility surface (see [versioning](versioning.md)) and is pinned by the
+doctor's own unit tests.
+
+Four things the table is deliberately not hiding:
+
+- **`webhook-example` yields zero operations.** The document describes only
+  `webhooks`, which Gesso deliberately does not consult (see
+  [supported features](supported-features.md#spec-features-not-consulted)). It
+  loads without complaint, and the zero is the honest signal — not a pass.
+- **`tictactoe` counts 5 responses as JSON and 6 as YAML.** That difference is
+  upstream, not in the pipeline: the YAML form declares a `202` on
+  `POST /board/{row}/{column}` that the JSON form omits. Every other document
+  is diagnosed identically in both serializations, and the test asserts that.
+- **The YAML forms are copied out of the corpus before they are read.** The
+  corpus ships `petstore.json` and `petstore.yaml` side by side, and the loader
+  resolves a bare spec name to the JSON sibling first — the doctor reports that
+  shadowing as a configuration error rather than diagnosing a file the runtime
+  would not have loaded. Copying the YAML forms into a tree of their own
+  exercises the YAML pipeline for real instead of pinning that diagnostic.
+- **Three of these documents used to fail.** `webhook-example`,
+  `non-oauth-scopes`, and `3.2-tags-example` omit `paths` or an operation's
+  `responses`, which OAS 3.1 made optional; the doctor reported all three as
+  structure errors until [#479](https://github.com/studio-design/gesso/pull/479)
+  made the check version-aware. That is what this corpus is for.
+
+## JSON Schema conversion delta
 
 Gesso rewrites your OpenAPI Schema Objects before validating anything: OAS 3.0
 is lowered to Draft 07, `discriminator` becomes `if`/`then` conditionals,
@@ -6,12 +72,11 @@ is lowered to Draft 07, `discriminator` becomes `if`/`then` conditionals,
 `readOnly` / `writeOnly` become boolean subschemas. That rewriting is the part
 of a contract-testing tool most likely to quietly change what your spec means.
 
-This page measures exactly where it does. Of 3,784 official test-suite cases put
-through both pipelines, conversion changes the verdict on 126 — 115 of them one
-tracked defect, the other 11 deliberate. Every one is listed with a reason and
-pinned in CI, so the number can only move when someone updates the record.
+This section measures exactly where it does. Of 3,784 official test-suite cases
+put through both pipelines, conversion changes the verdict on 126 — 115 of them
+one tracked defect, the other 11 deliberate. Every one is listed with a reason.
 
-## What is measured
+### What is measured
 
 3,784 of the 3,824 cases in the [official JSON Schema Test Suite][suite] are
 validated twice:
@@ -34,13 +99,13 @@ committed as
 and asserted by `tests/Integration/Conformance/JsonSchemaConversionDeltaTest.php`
 on every CI run. A new entry fails the build; so does a disappeared one.
 
-**This page does not claim that Gesso is a conformant JSON Schema validator.**
+**This does not claim that Gesso is a conformant JSON Schema validator.**
 That claim belongs to opis, and it is measured independently by
 [Bowtie][bowtie] via the `php-opis-json-schema` harness — a report Gesso has no
 hand in producing. What is measured here is the delta Gesso adds on top of
 opis, because that is the part no external report covers.
 
-## Current result
+### Current result
 
 Corpus: [`json-schema-org/JSON-Schema-Test-Suite`][suite] at
 `cf2e5e0ff2e3d90239c3b59e68ac4c080bd4ac92` (MIT), pinned by commit SHA in
@@ -61,7 +126,7 @@ identically on both sides.
 OAS 3.2 shares the 3.1 conversion pipeline, so running it would reproduce the
 3.1 numbers exactly and it is not run twice.
 
-### The 126 differences
+#### The 126 differences
 
 Three causes. Each recorded case cites one of them by key in the baseline's
 `reasons` map.
@@ -93,7 +158,7 @@ array is unsupported; the outcome is a loud error, never a silent pass.
 Referencing annotation internals is not something OpenAPI sanctions, so this is
 documented rather than fixed.
 
-### The 4 exclusions
+#### The 4 exclusions
 
 `unevaluatedItems with $dynamicRef` and `unevaluatedProperties with $dynamicRef`
 (2020-12) are skipped before they run. Bare opis recurses without bound on them
@@ -105,32 +170,40 @@ exclusion stays visible instead of silently shrinking the corpus.
 ## Running it
 
 ```bash
-composer install   # fetches the pinned corpus into vendor/
-vendor/bin/phpunit tests/Integration/Conformance/JsonSchemaConversionDeltaTest.php
+composer install   # fetches both pinned corpora into vendor/
+vendor/bin/phpunit tests/Integration/Conformance
 ```
 
-The corpus is a normal dev dependency, declared as an inline
-`repositories` entry in `composer.json` because the suite is not published to
-Packagist and carries no usable upstream tags.
+Both corpora are normal dev dependencies, declared as inline `repositories`
+entries in `composer.json` because neither is published to Packagist and
+neither carries usable upstream tags. `composer.lock` is not committed for a
+library, so `composer.json` is the pin.
 
-## Updating the pinned corpus
+## Updating a pinned corpus
 
 1. Bump `dist.url`, `dist.reference`, and `source.reference` in the
    `composer.json` repository entry to the new commit SHA, and bump the
    package `version` (Composer will not refresh a package repository unless the
    version changes).
-2. `composer update json-schema-org/json-schema-test-suite`.
-3. Run the test. It will report the new case counts and any verdict that moved.
-4. Update `corpus.commit`, `suites`, and any `deltas` entries in the
-   baseline — **each citing a key in the `reasons` map** — and update the
-   table above. A delta citing an unknown reason, or a published reason no
-   longer cited by anything, fails a second assertion, so an unexplained
-   regression cannot be papered over by regenerating the file.
+2. `composer update json-schema-org/json-schema-test-suite` or
+   `composer update oai/learn.openapis.org`.
+3. Run the test. It will report the new counts and anything that moved.
+4. Update `corpus.commit` and the moved entries in the corresponding baseline,
+   and update the tables above.
 
-If a newly added corpus group triggers the same unbounded opis recursion, the
-test process will die with a fatal error rather than fail cleanly. Add the
+For the conversion delta, every entry must cite a key in the baseline's
+`reasons` map. A delta citing an unknown reason, or a published reason no
+longer cited by anything, fails a second assertion, so an unexplained
+regression cannot be papered over by regenerating the file.
+
+If a newly added JSON Schema group triggers the same unbounded opis recursion,
+the test process will die with a fatal error rather than fail cleanly. Add the
 group to `EXCLUDED_GROUPS` in the test and to `excluded_groups` in the baseline.
 
+A newly added OpenAPI example document simply appears as an extra entry, and a
+removed one as a missing entry; both fail until the baseline records the change.
+
 [suite]: https://github.com/json-schema-org/JSON-Schema-Test-Suite
+[learn]: https://github.com/OAI/learn.openapis.org
 [opis]: https://opis.io/json-schema
 [bowtie]: https://bowtie.report

--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -2,7 +2,7 @@
 
 This is a contract-testing tool: where we can't enforce a constraint precisely, we prefer a loud failure or an explicit "skipped" outcome over silently accepting non-compliant data. The list below pins down what does and does not get checked so you can decide whether the gaps matter for your spec.
 
-The schema-conversion behaviour described here is measured against the official JSON Schema Test Suite on every CI run — see [JSON Schema conformance](conformance.md) for the current result.
+The schema-conversion behaviour described here is measured against the official JSON Schema Test Suite on every CI run, and the loader against the OpenAPI Initiative's own example documents — see [conformance](conformance.md) for the current results.
 
 - [OpenAPI 3.0, 3.1, and 3.2](#openapi-30-31-and-32)
   - [`readOnly` / `writeOnly` enforcement](#readonly--writeonly-enforcement)

--- a/tests/Integration/Conformance/OasExampleDocumentTest.php
+++ b/tests/Integration/Conformance/OasExampleDocumentTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\Gesso\Cli\DoctorCommand;
 
+use function array_keys;
 use function basename;
 use function copy;
 use function file_get_contents;
@@ -18,6 +19,7 @@ use function json_decode;
 use function ksort;
 use function mkdir;
 use function rmdir;
+use function sort;
 use function sprintf;
 use function str_ends_with;
 use function substr;
@@ -120,18 +122,32 @@ final class OasExampleDocumentTest extends TestCase
     public function json_and_yaml_forms_agree_except_where_the_corpus_itself_differs(): void
     {
         $documents = $this->measure();
-        $differences = [];
 
-        foreach ($documents as $key => $entry) {
-            if (!str_ends_with($key, '.json')) {
-                continue;
+        // Compared in both directions: a document that upstream ships in only
+        // one serialization would otherwise slip through as "nothing to
+        // compare" the moment the baseline records it.
+        $jsonForms = [];
+        $yamlForms = [];
+        foreach (array_keys($documents) as $key) {
+            if (str_ends_with($key, '.json')) {
+                $jsonForms[] = substr($key, 0, -5);
+            } elseif (str_ends_with($key, '.yaml')) {
+                $yamlForms[] = substr($key, 0, -5);
             }
+        }
+        sort($jsonForms);
+        sort($yamlForms);
 
-            $document = substr($key, 0, -5);
-            $yaml = $documents[$document . '.yaml'] ?? null;
-            $this->assertNotNull($yaml, sprintf('Document "%s" has no YAML form to compare against.', $document));
+        $this->assertSame(
+            $jsonForms,
+            $yamlForms,
+            'Every example document must be measured in both serializations. A document present in only one '
+            . 'of them is either an upstream change or a glob that stopped matching.',
+        );
 
-            if ($entry !== $yaml) {
+        $differences = [];
+        foreach ($jsonForms as $document) {
+            if ($documents[$document . '.json'] !== $documents[$document . '.yaml']) {
                 $differences[] = $document;
             }
         }

--- a/tests/Integration/Conformance/OasExampleDocumentTest.php
+++ b/tests/Integration/Conformance/OasExampleDocumentTest.php
@@ -6,15 +6,20 @@ namespace Studio\Gesso\Tests\Integration\Conformance;
 
 use const JSON_THROW_ON_ERROR;
 
+use FilesystemIterator;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
 use Studio\Gesso\Cli\DoctorCommand;
 
 use function array_keys;
-use function basename;
 use function copy;
+use function dirname;
 use function file_get_contents;
-use function glob;
+use function in_array;
+use function is_dir;
 use function json_decode;
 use function ksort;
 use function mkdir;
@@ -22,6 +27,8 @@ use function rmdir;
 use function sort;
 use function sprintf;
 use function str_ends_with;
+use function strlen;
+use function strrpos;
 use function substr;
 use function sys_get_temp_dir;
 use function uniqid;
@@ -76,22 +83,33 @@ final class OasExampleDocumentTest extends TestCase
         $this->yamlRoot = sys_get_temp_dir() . '/gesso-oas-examples-' . uniqid('', true);
 
         foreach (self::VERSIONS as $version) {
-            mkdir($this->yamlRoot . '/' . $version, recursive: true);
-            foreach ($this->documentsIn($version, 'yaml') as $path) {
-                copy($path, $this->yamlRoot . '/' . $version . '/' . basename($path));
+            foreach ($this->documentsIn($version) as $relative) {
+                if (str_ends_with($relative, '.json')) {
+                    continue;
+                }
+
+                $destination = $this->yamlRoot . '/' . $version . '/' . $relative;
+                if (!is_dir(dirname($destination))) {
+                    mkdir(dirname($destination), recursive: true);
+                }
+                copy($this->corpusPath() . '/examples/' . $version . '/' . $relative, $destination);
             }
         }
     }
 
     protected function tearDown(): void
     {
-        foreach (self::VERSIONS as $version) {
-            foreach (glob($this->yamlRoot . '/' . $version . '/*') ?: [] as $path) {
-                @unlink($path);
+        if (is_dir($this->yamlRoot)) {
+            $entries = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($this->yamlRoot, FilesystemIterator::SKIP_DOTS),
+                RecursiveIteratorIterator::CHILD_FIRST,
+            );
+            /** @var SplFileInfo $entry */
+            foreach ($entries as $entry) {
+                $entry->isDir() ? @rmdir($entry->getPathname()) : @unlink($entry->getPathname());
             }
-            @rmdir($this->yamlRoot . '/' . $version);
+            @rmdir($this->yamlRoot);
         }
-        @rmdir($this->yamlRoot);
 
         parent::tearDown();
     }
@@ -128,12 +146,21 @@ final class OasExampleDocumentTest extends TestCase
         // compare" the moment the baseline records it.
         $jsonForms = [];
         $yamlForms = [];
+        $yamlKeys = [];
         foreach (array_keys($documents) as $key) {
+            $stem = substr($key, 0, (int) strrpos($key, '.'));
             if (str_ends_with($key, '.json')) {
-                $jsonForms[] = substr($key, 0, -5);
-            } elseif (str_ends_with($key, '.yaml')) {
-                $yamlForms[] = substr($key, 0, -5);
+                $jsonForms[] = $stem;
+
+                continue;
             }
+
+            // A document shipped as both `.yaml` and `.yml` lands here twice
+            // and fails the comparison below, which is the intent: which of
+            // the two the loader would pick is then a decision to make, not a
+            // detail to average over.
+            $yamlForms[] = $stem;
+            $yamlKeys[$stem] = $key;
         }
         sort($jsonForms);
         sort($yamlForms);
@@ -142,12 +169,12 @@ final class OasExampleDocumentTest extends TestCase
             $jsonForms,
             $yamlForms,
             'Every example document must be measured in both serializations. A document present in only one '
-            . 'of them is either an upstream change or a glob that stopped matching.',
+            . 'of them is either an upstream change or an enumeration that stopped matching.',
         );
 
         $differences = [];
         foreach ($jsonForms as $document) {
-            if ($documents[$document . '.json'] !== $documents[$document . '.yaml']) {
+            if ($documents[$document . '.json'] !== $documents[$yamlKeys[$document]]) {
                 $differences[] = $document;
             }
         }
@@ -176,14 +203,14 @@ final class OasExampleDocumentTest extends TestCase
         $documents = [];
 
         foreach (self::VERSIONS as $version) {
-            foreach (['json', 'yaml'] as $extension) {
-                $paths = $extension === 'json'
-                    ? $this->documentsIn($version, 'json')
-                    : $this->yamlCopies($version);
+            foreach ($this->documentsIn($version) as $relative) {
+                // JSON forms are read where they are published; the YAML forms
+                // are read from the sibling-free copy made in setUp().
+                $path = str_ends_with($relative, '.json')
+                    ? $this->corpusPath() . '/examples/' . $version . '/' . $relative
+                    : $this->yamlRoot . '/' . $version . '/' . $relative;
 
-                foreach ($paths as $path) {
-                    $documents[$version . '/' . basename($path)] = $this->diagnose($path);
-                }
+                $documents[$version . '/' . $relative] = $this->diagnose($path);
             }
         }
 
@@ -227,29 +254,37 @@ final class OasExampleDocumentTest extends TestCase
     }
 
     /**
+     * Every `.json` / `.yaml` / `.yml` file under the version directory, as
+     * paths relative to it, sorted.
+     *
+     * Recursive on purpose: upstream already ships multi-file documents in
+     * subdirectories (`examples/v2.0/json/petstore-separate/`), so a 3.x
+     * document that arrives nested must reach the baseline instead of being
+     * silently skipped by a flat glob. A fragment that is not a standalone
+     * document would then fail the doctor loudly, which is the outcome that
+     * needs a human decision — unlike a file nobody ever looked at.
+     *
      * @return list<string>
      */
-    private function documentsIn(string $version, string $extension): array
+    private function documentsIn(string $version): array
     {
-        $directory = $this->corpusPath() . '/examples/' . $version;
-        $this->assertDirectoryExists($directory, sprintf('Corpus directory "%s" is missing.', $version));
+        $root = $this->corpusPath() . '/examples/' . $version;
+        $this->assertDirectoryExists($root, sprintf('Corpus directory "%s" is missing.', $version));
 
-        $matches = glob($directory . '/*.' . $extension);
-        $this->assertIsArray($matches);
-        $this->assertNotEmpty($matches, sprintf('No .%s documents in corpus directory "%s".', $extension, $version));
+        $documents = [];
+        /** @var SplFileInfo $file */
+        foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS)) as $file) {
+            if (!$file->isFile() || !in_array($file->getExtension(), ['json', 'yaml', 'yml'], true)) {
+                continue;
+            }
 
-        return $matches;
-    }
+            $documents[] = substr($file->getPathname(), strlen($root) + 1);
+        }
 
-    /**
-     * @return list<string>
-     */
-    private function yamlCopies(string $version): array
-    {
-        $matches = glob($this->yamlRoot . '/' . $version . '/*.yaml');
-        $this->assertIsArray($matches);
+        sort($documents);
+        $this->assertNotEmpty($documents, sprintf('No documents in corpus directory "%s".', $version));
 
-        return $matches;
+        return $documents;
     }
 
     private function installedCorpusCommit(): string

--- a/tests/Integration/Conformance/OasExampleDocumentTest.php
+++ b/tests/Integration/Conformance/OasExampleDocumentTest.php
@@ -1,0 +1,279 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Integration\Conformance;
+
+use const JSON_THROW_ON_ERROR;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Cli\DoctorCommand;
+
+use function basename;
+use function copy;
+use function file_get_contents;
+use function glob;
+use function json_decode;
+use function ksort;
+use function mkdir;
+use function rmdir;
+use function sprintf;
+use function str_ends_with;
+use function substr;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+/**
+ * Conformance signal for the spec loader and `gesso doctor` against the
+ * official OpenAPI example documents (issue #283).
+ *
+ * Every example document the OpenAPI Initiative publishes for OAS 3.0, 3.1,
+ * and 3.2 is loaded and diagnosed in both its JSON and its YAML form, and the
+ * outcome — OpenAPI version, operation and response counts, and the
+ * severity/category of every issue raised — is pinned by a committed baseline.
+ * A document that stops loading, starts raising an issue, or silently loses
+ * operations fails the build.
+ *
+ * Issue prose is deliberately not compared. Message wording is not a
+ * compatibility surface (see `docs/versioning.md`) and is covered by the
+ * doctor's own unit tests; what is pinned here is that the document is
+ * understood at all.
+ *
+ * The corpus is pinned by commit SHA in `composer.json` (the lock file is not
+ * committed for a library, so `composer.json` is the pin). See
+ * `docs/conformance.md`.
+ */
+final class OasExampleDocumentTest extends TestCase
+{
+    /**
+     * `examples/v2.0` also ships in the corpus. It is Swagger 2.0, which this
+     * package does not accept by design, so it is not measured.
+     */
+    private const VERSIONS = ['v3.0', 'v3.1', 'v3.2'];
+
+    /**
+     * Documents whose JSON and YAML forms legitimately disagree, keyed by
+     * document with the reason. Everything else must produce an identical
+     * diagnosis in both serializations.
+     */
+    private const SERIALIZATION_DIFFERENCES = ['v3.1/tictactoe'];
+    private string $yamlRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The corpus ships `petstore.json` and `petstore.yaml` side by side,
+        // and the loader resolves a bare spec name to the JSON sibling first —
+        // the doctor reports that shadowing as a configuration error rather
+        // than diagnosing a file the runtime would not have loaded. Copying the
+        // YAML forms into a tree of their own removes the sibling, so the YAML
+        // pipeline is exercised for real instead of pinning that diagnostic.
+        $this->yamlRoot = sys_get_temp_dir() . '/gesso-oas-examples-' . uniqid('', true);
+
+        foreach (self::VERSIONS as $version) {
+            mkdir($this->yamlRoot . '/' . $version, recursive: true);
+            foreach ($this->documentsIn($version, 'yaml') as $path) {
+                copy($path, $this->yamlRoot . '/' . $version . '/' . basename($path));
+            }
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (self::VERSIONS as $version) {
+            foreach (glob($this->yamlRoot . '/' . $version . '/*') ?: [] as $path) {
+                @unlink($path);
+            }
+            @rmdir($this->yamlRoot . '/' . $version);
+        }
+        @rmdir($this->yamlRoot);
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function every_official_example_document_is_diagnosed_as_the_baseline_records(): void
+    {
+        $baseline = $this->baseline();
+
+        $this->assertSame(
+            $baseline['corpus']['commit'],
+            $this->installedCorpusCommit(),
+            'The installed corpus does not match the commit the baseline was recorded against. '
+            . 'Re-pin composer.json or regenerate the baseline.',
+        );
+
+        $this->assertSame(
+            $baseline['documents'],
+            $this->measure(),
+            'The diagnosis of the official OpenAPI example documents has moved. A new issue on a document '
+            . 'that used to be clean is a regression; a lost operation or response means the loader stopped '
+            . 'understanding part of a document the OpenAPI Initiative publishes as valid. Update '
+            . 'tests/fixtures/compatibility/v1-oas-example-documents.json and docs/conformance.md.',
+        );
+    }
+
+    #[Test]
+    public function json_and_yaml_forms_agree_except_where_the_corpus_itself_differs(): void
+    {
+        $documents = $this->measure();
+        $differences = [];
+
+        foreach ($documents as $key => $entry) {
+            if (!str_ends_with($key, '.json')) {
+                continue;
+            }
+
+            $document = substr($key, 0, -5);
+            $yaml = $documents[$document . '.yaml'] ?? null;
+            $this->assertNotNull($yaml, sprintf('Document "%s" has no YAML form to compare against.', $document));
+
+            if ($entry !== $yaml) {
+                $differences[] = $document;
+            }
+        }
+
+        $this->assertSame(
+            self::SERIALIZATION_DIFFERENCES,
+            $differences,
+            'The JSON and YAML forms of an example document are no longer diagnosed identically. Unless the '
+            . 'two upstream files genuinely differ, this is a YAML pipeline defect.',
+        );
+
+        foreach (self::SERIALIZATION_DIFFERENCES as $document) {
+            $this->assertArrayHasKey(
+                $document,
+                $this->baseline()['serialization_differences'],
+                sprintf('Document "%s" is exempted from JSON/YAML parity without a published reason.', $document),
+            );
+        }
+    }
+
+    /**
+     * @return array<string, array{openapi: string, exit: int, operations: int, responses: int, issues: list<string>}>
+     */
+    private function measure(): array
+    {
+        $documents = [];
+
+        foreach (self::VERSIONS as $version) {
+            foreach (['json', 'yaml'] as $extension) {
+                $paths = $extension === 'json'
+                    ? $this->documentsIn($version, 'json')
+                    : $this->yamlCopies($version);
+
+                foreach ($paths as $path) {
+                    $documents[$version . '/' . basename($path)] = $this->diagnose($path);
+                }
+            }
+        }
+
+        ksort($documents);
+
+        return $documents;
+    }
+
+    /**
+     * @return array{openapi: string, exit: int, operations: int, responses: int, issues: list<string>}
+     */
+    private function diagnose(string $path): array
+    {
+        $output = '';
+        $command = new DoctorCommand(stdoutWriter: static function (string $message) use (&$output): void {
+            $output .= $message;
+        });
+        $exit = $command->run(['specs' => [$path], 'format' => 'json']);
+
+        /**
+         * @var array{
+         *     specs: list<array{openapi: string}>,
+         *     summary: array{operations: int, responses: int},
+         *     issues: list<array{severity: string, category: string}>
+         * } $report
+         */
+        $report = json_decode($output, true, flags: JSON_THROW_ON_ERROR);
+
+        $issues = [];
+        foreach ($report['issues'] as $issue) {
+            $issues[] = $issue['severity'] . '/' . $issue['category'];
+        }
+
+        return [
+            'openapi' => $report['specs'][0]['openapi'] ?? '',
+            'exit' => $exit,
+            'operations' => $report['summary']['operations'],
+            'responses' => $report['summary']['responses'],
+            'issues' => $issues,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function documentsIn(string $version, string $extension): array
+    {
+        $directory = $this->corpusPath() . '/examples/' . $version;
+        $this->assertDirectoryExists($directory, sprintf('Corpus directory "%s" is missing.', $version));
+
+        $matches = glob($directory . '/*.' . $extension);
+        $this->assertIsArray($matches);
+        $this->assertNotEmpty($matches, sprintf('No .%s documents in corpus directory "%s".', $extension, $version));
+
+        return $matches;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function yamlCopies(string $version): array
+    {
+        $matches = glob($this->yamlRoot . '/' . $version . '/*.yaml');
+        $this->assertIsArray($matches);
+
+        return $matches;
+    }
+
+    private function installedCorpusCommit(): string
+    {
+        $installed = file_get_contents($this->corpusPath() . '/../../composer/installed.json');
+        $this->assertIsString($installed, 'Cannot read vendor/composer/installed.json.');
+
+        /** @var array{packages: list<array{name: string, dist?: array{reference?: string}}>} $decoded */
+        $decoded = json_decode($installed, true, flags: JSON_THROW_ON_ERROR);
+
+        foreach ($decoded['packages'] as $package) {
+            if ($package['name'] === 'oai/learn.openapis.org') {
+                return $package['dist']['reference'] ?? '';
+            }
+        }
+
+        $this->fail('The OpenAPI example-document corpus is not installed.');
+    }
+
+    private function corpusPath(): string
+    {
+        $path = __DIR__ . '/../../../vendor/oai/learn.openapis.org';
+        $this->assertDirectoryExists($path, 'Run `composer install` to fetch the pinned OpenAPI example documents.');
+
+        return $path;
+    }
+
+    /**
+     * @return array{
+     *     corpus: array{commit: string},
+     *     documents: array<string, array{openapi: string, exit: int, operations: int, responses: int, issues: list<string>}>,
+     *     serialization_differences: array<string, string>
+     * }
+     */
+    private function baseline(): array
+    {
+        $path = __DIR__ . '/../../fixtures/compatibility/v1-oas-example-documents.json';
+        $contents = file_get_contents($path);
+        $this->assertIsString($contents, 'Missing example-document baseline.');
+
+        return json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+    }
+}

--- a/tests/fixtures/compatibility/v1-oas-example-documents.json
+++ b/tests/fixtures/compatibility/v1-oas-example-documents.json
@@ -1,0 +1,184 @@
+{
+    "format_version": 1,
+    "description": "How the official OpenAPI example documents published by the OpenAPI Initiative are diagnosed by the spec loader and `gesso doctor`. Recorded by tests/Integration/Conformance/OasExampleDocumentTest.php; see docs/conformance.md.",
+    "corpus": {
+        "name": "OAI/learn.openapis.org",
+        "source": "https://github.com/OAI/learn.openapis.org",
+        "commit": "43756549c27cbf84107b190b82c65e0336f2f09f",
+        "license": "CC-BY-4.0",
+        "pinned_in": "composer.json",
+        "measured": "examples/v3.0, examples/v3.1, examples/v3.2 — every document in both its JSON and its YAML form. examples/v2.0 is Swagger 2.0 and is out of scope."
+    },
+    "documents": {
+        "v3.0/api-with-examples.json": {
+            "openapi": "3.0.0",
+            "exit": 0,
+            "operations": 2,
+            "responses": 4,
+            "issues": []
+        },
+        "v3.0/api-with-examples.yaml": {
+            "openapi": "3.0.0",
+            "exit": 0,
+            "operations": 2,
+            "responses": 4,
+            "issues": []
+        },
+        "v3.0/callback-example.json": {
+            "openapi": "3.0.0",
+            "exit": 0,
+            "operations": 1,
+            "responses": 1,
+            "issues": []
+        },
+        "v3.0/callback-example.yaml": {
+            "openapi": "3.0.0",
+            "exit": 0,
+            "operations": 1,
+            "responses": 1,
+            "issues": []
+        },
+        "v3.0/link-example.json": {
+            "openapi": "3.0.0",
+            "exit": 0,
+            "operations": 6,
+            "responses": 6,
+            "issues": []
+        },
+        "v3.0/link-example.yaml": {
+            "openapi": "3.0.0",
+            "exit": 0,
+            "operations": 6,
+            "responses": 6,
+            "issues": []
+        },
+        "v3.0/petstore-expanded.json": {
+            "openapi": "3.0.0",
+            "exit": 0,
+            "operations": 4,
+            "responses": 8,
+            "issues": []
+        },
+        "v3.0/petstore-expanded.yaml": {
+            "openapi": "3.0.0",
+            "exit": 0,
+            "operations": 4,
+            "responses": 8,
+            "issues": []
+        },
+        "v3.0/petstore.json": {
+            "openapi": "3.0.0",
+            "exit": 0,
+            "operations": 3,
+            "responses": 6,
+            "issues": []
+        },
+        "v3.0/petstore.yaml": {
+            "openapi": "3.0.0",
+            "exit": 0,
+            "operations": 3,
+            "responses": 6,
+            "issues": []
+        },
+        "v3.0/uspto.json": {
+            "openapi": "3.0.1",
+            "exit": 0,
+            "operations": 3,
+            "responses": 5,
+            "issues": []
+        },
+        "v3.0/uspto.yaml": {
+            "openapi": "3.0.1",
+            "exit": 0,
+            "operations": 3,
+            "responses": 5,
+            "issues": []
+        },
+        "v3.1/non-oauth-scopes.json": {
+            "openapi": "3.1.0",
+            "exit": 0,
+            "operations": 1,
+            "responses": 0,
+            "issues": []
+        },
+        "v3.1/non-oauth-scopes.yaml": {
+            "openapi": "3.1.0",
+            "exit": 0,
+            "operations": 1,
+            "responses": 0,
+            "issues": []
+        },
+        "v3.1/tictactoe.json": {
+            "openapi": "3.1.0",
+            "exit": 0,
+            "operations": 3,
+            "responses": 5,
+            "issues": [
+                "skipped/feature",
+                "skipped/feature",
+                "skipped/feature"
+            ]
+        },
+        "v3.1/tictactoe.yaml": {
+            "openapi": "3.1.0",
+            "exit": 0,
+            "operations": 3,
+            "responses": 6,
+            "issues": [
+                "skipped/feature",
+                "skipped/feature",
+                "skipped/feature"
+            ]
+        },
+        "v3.1/webhook-example.json": {
+            "openapi": "3.1.0",
+            "exit": 0,
+            "operations": 0,
+            "responses": 0,
+            "issues": []
+        },
+        "v3.1/webhook-example.yaml": {
+            "openapi": "3.1.0",
+            "exit": 0,
+            "operations": 0,
+            "responses": 0,
+            "issues": []
+        },
+        "v3.2/3.2-query-example.json": {
+            "openapi": "3.2.0",
+            "exit": 0,
+            "operations": 1,
+            "responses": 1,
+            "issues": []
+        },
+        "v3.2/3.2-query-example.yaml": {
+            "openapi": "3.2.0",
+            "exit": 0,
+            "operations": 1,
+            "responses": 1,
+            "issues": []
+        },
+        "v3.2/3.2-tags-example.json": {
+            "openapi": "3.2.0",
+            "exit": 0,
+            "operations": 4,
+            "responses": 0,
+            "issues": []
+        },
+        "v3.2/3.2-tags-example.yaml": {
+            "openapi": "3.2.0",
+            "exit": 0,
+            "operations": 4,
+            "responses": 0,
+            "issues": []
+        }
+    },
+    "serialization_differences": {
+        "v3.1/tictactoe": "Upstream, not a pipeline difference: the YAML form declares a 202 response on `POST /board/{row}/{column}` that the JSON form omits, so the YAML form counts 6 responses to the JSON forms 5."
+    },
+    "notes": {
+        "issue-codes": "Issues are recorded as `severity/category` only. Message wording is not a compatibility surface (docs/versioning.md) and is pinned by the doctor's own unit tests.",
+        "skipped-feature-on-tictactoe": "The three `skipped/feature` issues are its HTTP-basic and OAuth2 security schemes: recognized, resolved, and reported as not enforced rather than silently passed.",
+        "webhook-example": "`v3.1/webhook-example` describes only `webhooks`, which this package deliberately does not consult (docs/supported-features.md), so it loads clean with zero operations. The zero is the honest signal, not a pass."
+    }
+}


### PR DESCRIPTION
> **Stacked on #479.** The base branch is `fix/doctor-optional-paths-responses-3.1`;
> merge that one first and GitHub will retarget this to `main`. Three of these
> documents fail without it. Note that CI's full matrix only runs for PRs
> targeting `main`, so this PR needs a rebase onto `main` after #479 merges.

## Summary

Runs every example API description the OpenAPI Initiative publishes for OAS 3.0,
3.1, and 3.2 — 11 documents, in both their JSON and YAML forms — through
`OpenApiSpecLoader` and `gesso doctor`, and pins the outcome in a committed
baseline. Second and last half of the reduced scope agreed on #283.

## Why

Issue #283 asked for a conformance signal built from an *independently
recognizable* corpus. #477 covered the JSON Schema side; this covers the OpenAPI
side — the documents a prospective user would reach for first.

Corpus: [`OAI/learn.openapis.org`](https://github.com/OAI/learn.openapis.org) at
`43756549c27cbf84107b190b82c65e0336f2f09f` (CC-BY-4.0), pinned by commit SHA as
an inline `repositories` entry in `composer.json` — same mechanism as the JSON
Schema Test Suite, for the same reason (not on Packagist, no usable tags, and
`composer.lock` is not committed for a library). `examples/v2.0` is Swagger 2.0
and is not measured.

It earned its keep immediately: three documents failed the doctor outright,
which is #479.

## Result

All 22 files exit `0`. Ten of the eleven documents report `status: ok`;
`tictactoe` reports `status: warning` from three `skipped` diagnostics.

| Document | OAS | Operations | Responses | Diagnosis |
| --- | --- | ---: | ---: | --- |
| `v3.0/api-with-examples` | 3.0.0 | 2 | 4 | clean |
| `v3.0/callback-example` | 3.0.0 | 1 | 1 | clean |
| `v3.0/link-example` | 3.0.0 | 6 | 6 | clean |
| `v3.0/petstore` | 3.0.0 | 3 | 6 | clean |
| `v3.0/petstore-expanded` | 3.0.0 | 4 | 8 | clean |
| `v3.0/uspto` | 3.0.1 | 3 | 5 | clean |
| `v3.1/non-oauth-scopes` | 3.1.0 | 1 | 0 | clean |
| `v3.1/tictactoe` | 3.1.0 | 3 | 5 JSON / 6 YAML | `warning` — 3 security schemes reported as not enforced |
| `v3.1/webhook-example` | 3.1.0 | 0 | 0 | clean; `webhooks`-only, nothing to enforce |
| `v3.2/3.2-query-example` | 3.2.0 | 1 | 1 | clean |
| `v3.2/3.2-tags-example` | 3.2.0 | 4 | 0 | clean |

Four things the baseline deliberately does not hide, each written up in
`docs/conformance.md`:

- `webhook-example` yields **zero** operations. `webhooks` is a documented
  not-consulted feature; the zero is the honest signal, not a pass.
- `tictactoe` counts 5 responses as JSON and 6 as YAML. That is upstream — the
  YAML form declares a `202` the JSON form omits. Every other document is
  diagnosed identically in both serializations, and a test asserts that.
- The YAML forms are copied out of the corpus before being read. The corpus
  ships `petstore.json` and `petstore.yaml` side by side and the loader resolves
  the JSON sibling first, which the doctor reports as a shadowing configuration
  error. Copying removes the sibling so the YAML pipeline is exercised for real
  instead of pinning that diagnostic.
- Issues are pinned as `severity/category` pairs, never prose. Message wording
  is not a compatibility surface (`docs/versioning.md`) and is covered by the
  doctor's own unit tests.

## Verification

- Drift check: perturbing one recorded operation count fails the build with a
  diff naming the document.
- Coverage check: dropping one `.json` form fails the both-serializations
  assertion; adding a nested `v3.1/nested/deep.{json,yaml}` pair fails the
  baseline with the new keys, confirming enumeration is recursive.
- `docs/conformance.md` restructured to cover both corpora under one page;
  README, sidebar, `supported-features.md`, and `AGENTS.md` follow.

- [x] `composer test` passes (2864 tests, 10697 assertions)
- [x] `composer stan` passes
- [x] `composer cs-check` passes
- [x] `composer validate --strict` passes, `npm run docs:links` finds no dead links

## Notes for reviewers

`composer install` now fetches a second corpus (~240 KB zip) into `vendor/`.