### PR TITLE
feat(coverage): gate the set of uncovered responses with a committed baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ To validate every response automatically, set `'auto_assert' => true` and drop t
 | Schema under-description detection (`strict_required`) | [`docs/strict-required.md`](docs/strict-required.md) |
 | Undocumented response-property detection (`strict_additional_properties`) | [`docs/strict-additional-properties.md`](docs/strict-additional-properties.md) |
 | Violation baseline: adopt on a legacy API, fail only on new violations | [`docs/baseline.md`](docs/baseline.md) |
+| Coverage baseline: gate the set of uncovered responses instead of a percentage | [`docs/coverage-baseline.md`](docs/coverage-baseline.md) |
 | Coverage report modes & threshold gate | [`docs/coverage.md`](docs/coverage.md) |
 | HTML coverage output | [`docs/coverage-html-output.md`](docs/coverage-html-output.md) |
 | JSON coverage output schema | [`docs/coverage-json-schema.md`](docs/coverage-json-schema.md) |

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -269,6 +269,7 @@ export default defineConfig({
         items: [
           { text: 'Doctor command', link: '/doctor' },
           { text: 'Violation baseline', link: '/baseline' },
+          { text: 'Coverage baseline', link: '/coverage-baseline' },
           { text: 'PSR-7 validation', link: '/psr7' },
           { text: 'Laravel route parity', link: '/laravel-route-parity' },
           { text: 'Schema-driven fuzzing', link: '/fuzzing' },

--- a/docs/baseline.md
+++ b/docs/baseline.md
@@ -7,6 +7,10 @@ and Psalm baselines work: record today's violations in a committed file, keep
 CI green, and fail only on **new** violations. The debt stays enumerated in
 one reviewable file and can be ratcheted down entry by entry.
 
+Its counterpart for *untested* responses is the
+[coverage baseline](coverage-baseline.md), which shares the same generation
+command.
+
 ## Quick start
 
 1. Point the PHPUnit extension at a baseline file:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -126,6 +126,10 @@ selection signal, mirroring the `strict_required` skip:
 Run the full suite to evaluate the gate.
 ```
 
+The [coverage baseline](coverage-baseline.md) gate is skipped on the same
+signals, for the same reason, and additionally on any run that did not
+complete cleanly.
+
 This means a CI matrix that shards by `--testsuite` can keep the gate
 configured in the shared `phpunit.xml`: shard jobs skip it, and only a
 full-suite run (or the `coverage:merge` step for parallel runs) evaluates

--- a/docs/coverage-baseline.md
+++ b/docs/coverage-baseline.md
@@ -1,0 +1,175 @@
+# Coverage baseline
+
+The [coverage threshold gate](coverage.md#coverage-threshold-gate) answers
+"is coverage above N%". That is a poor fit for "coverage must not get worse",
+because a percentage has to be maintained by hand:
+
+- setting the threshold below the current rate leaves headroom, so several
+  responses can go uncovered without failing;
+- setting it exactly at the current rate couples the gate to the
+  **denominator** — documenting one new response in the spec fails an
+  otherwise unrelated PR, and the message only reports a percentage, not
+  which row caused it;
+- improving coverage without also raising the threshold silently restores
+  the headroom, and CI stays green while the ratchet loosens.
+
+The coverage baseline gates the **set** of uncovered responses instead. It is
+the [violation baseline](baseline.md) idea applied to coverage: commit
+today's gaps, fail on new ones by name, and let the ratchet show up as a diff.
+
+## Quick start
+
+1. Point the PHPUnit extension at a coverage baseline file:
+
+   ```xml
+   <extensions>
+       <bootstrap class="Studio\Gesso\PHPUnit\OpenApiCoverageExtension">
+           <parameter name="spec_base_path" value="openapi/bundled"/>
+           <parameter name="coverage_baseline_file" value="gesso-coverage-baseline.json"/>
+       </bootstrap>
+   </extensions>
+   ```
+
+2. Generate it from a full run (no `--filter`):
+
+   ```bash
+   OPENAPI_BASELINE_GENERATE=1 vendor/bin/phpunit
+   ```
+
+   ```text
+   [Gesso] Coverage baseline written: 105 uncovered response(s) → /path/to/gesso-coverage-baseline.json
+   ```
+
+3. Commit the file. Every later run compares its uncovered set against it.
+
+`OPENAPI_BASELINE_GENERATE` drives both baselines: if `baseline_file` is
+configured too, one command regenerates both. Configuring only
+`coverage_baseline_file` is fine — the violation baseline stays uninvolved.
+
+The file is deterministic — fully sorted, no timestamps — so regenerating an
+unchanged suite produces a byte-identical file. Its format is a versioned
+compatibility surface; see
+[versioning.md](versioning.md#whats-covered-by-semver).
+
+## What an entry is
+
+One entry per response the run did not validate, at the same granularity
+coverage is measured at:
+
+```json
+{
+    "spec": "front",
+    "method": "GET",
+    "path": "/v1/pets",
+    "status": "500",
+    "content_type": "application/json"
+}
+```
+
+`status` is the spec's response key (`200`, `5XX`, `default`), not an observed
+HTTP status. `content_type` is `*` for responses declared without a `content`
+block (204-style). Fixed HTTP methods normalize to uppercase; OpenAPI 3.2
+custom `additionalOperations` methods stay case-sensitive.
+
+**Skipped responses are baselined too.** A response matched by
+`skip_response_codes`, or one whose content type has no schema engine, counts
+as not covered — exactly as it does in the `min_response_coverage` numerator.
+Including it means switching from the percentage gate to the baseline never
+weakens the gate.
+
+## Enforcement semantics
+
+Every full run prints one summary line to stderr:
+
+```text
+[Gesso] coverage baseline: 105 entries, 105 uncovered response(s) in this run, 0 covered now.
+```
+
+An uncovered response that is **not** in the file fails the run and is named:
+
+```text
+[Gesso] FATAL: 2 response(s) are not covered and are not listed in the coverage baseline:
+  - [front] DELETE /v1/pets/{id} status=204 content-type=*
+  - [front] GET /v1/pets status=500 content-type=application/json
+  Action: cover them with a test, or accept them by regenerating the baseline with `OPENAPI_BASELINE_GENERATE=1 vendor/bin/phpunit`.
+```
+
+Because the gate compares sets, documenting a new response in the spec does
+not fail an unrelated PR — as long as that response is covered. If it is not,
+the failure names it and says so, which is the intended behavior arriving for
+the intended reason.
+
+The gate is skipped, with a one-line NOTE, when it cannot be evaluated
+honestly:
+
+- **Partial runs** (`--filter` / `--testsuite` / path arguments): a subset
+  leaves responses uncovered that the full suite covers.
+- **Runs that did not complete cleanly** (any failed, errored, skipped, or
+  incomplete test, or a truncated `--stop-on-*` run): a test that never
+  reached its contract assertion leaves its responses uncovered, and
+  reporting those as regressions would bury the real failure.
+
+A run that recorded no contract coverage at all is FATAL rather than a
+vacuous pass — an empty uncovered set there means "no data", not "no gaps".
+
+## Ratcheting down
+
+Baseline entries that are covered now — the ratchet-down signal — are
+reported per `coverage_baseline_stale`:
+
+| Value | Behavior |
+|---|---|
+| `note` (default) | Entries are listed on stderr as removable |
+| `fail` | Same listing, and the run exits non-zero — CI enforces that the baseline only shrinks |
+| `off` | Entries that are covered now are not reported |
+
+```text
+[Gesso] NOTE: 1 coverage baseline entry(ies) are covered now and can be removed from the baseline file:
+  - [front] GET /v1/pets status=500 content-type=application/json
+```
+
+Delete the listed entries, or re-run the generation command — it rewrites the
+file to exactly the current gaps. Either way the improvement appears in the
+diff, so it cannot be forgotten the way a threshold bump can. Entries for
+responses the spec no longer declares are reported the same way, since they
+can never be covered again.
+
+## Parallel runners
+
+A paratest worker sees only its slice of the suite, so no worker can decide
+whether a response is covered. Workers therefore neither generate nor enforce;
+the merge step owns both halves, reading the same merged coverage state it
+already renders reports from:
+
+```bash
+# Generate
+OPENAPI_BASELINE_GENERATE=1 vendor/bin/paratest --processes=4
+OPENAPI_BASELINE_GENERATE=1 vendor/bin/gesso coverage:merge \
+    --spec-base-path=openapi/bundled \
+    --coverage-baseline-file=gesso-coverage-baseline.json
+
+# Enforce
+vendor/bin/paratest --processes=4
+vendor/bin/gesso coverage:merge \
+    --spec-base-path=openapi/bundled \
+    --coverage-baseline-file=gesso-coverage-baseline.json \
+    --coverage-baseline-stale=fail
+```
+
+The merge exits 1 when a response is newly uncovered, when no sidecars were
+found, when no coverage was recorded, or when the baseline file cannot be
+read; it exits 2 for usage errors (an unknown `--coverage-baseline-stale`
+value, or that flag without `--coverage-baseline-file`).
+
+Unlike the sequential path, the merge has no view of whether the suite passed,
+so a red parallel run can report responses of failed tests as newly uncovered.
+Check the test run's own exit code first — the same caveat the threshold gate
+has here.
+
+## Using it alongside the threshold gate
+
+They are independent and can both be configured, but the baseline is the
+stronger of the two for regression protection. `min_endpoint_coverage` and
+`min_sdk_exercise_coverage` still measure things the coverage baseline does
+not, so keeping those while dropping `min_response_coverage` is a reasonable
+setup.

--- a/docs/coverage-baseline.md
+++ b/docs/coverage-baseline.md
@@ -161,6 +161,16 @@ found, when no coverage was recorded, or when the baseline file cannot be
 read; it exits 2 for usage errors (an unknown `--coverage-baseline-stale`
 value, or that flag without `--coverage-baseline-file`).
 
+On any of those failures the sidecars are **kept** instead of cleaned up, as
+the violation baseline does. Every recovery re-runs the merge, not the suite:
+fix a typo'd path, free disk space for the write, or accept the reported
+regressions by re-running with `OPENAPI_BASELINE_GENERATE=1`.
+
+A generation worker that cannot write its sidecar — and cannot drop a failure
+marker either — fails the parallel run rather than letting the merge build a
+baseline from the surviving workers, which would record the lost worker's
+covered responses as uncovered and loosen the ratchet for good.
+
 Unlike the sequential path, the merge has no view of whether the suite passed,
 so a red parallel run can report responses of failed tests as newly uncovered.
 Check the test run's own exit code first — the same caveat the threshold gate

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -130,6 +130,12 @@ configured SDK gate fails as unevaluable when that denominator is empty.
 
 Default is **warn-only**: a miss prints `[OpenAPI Coverage] WARN: …` to stderr but the run exits 0. Flip `min_coverage_strict=true` to make a miss fail-fast with exit 1.
 
+> To stop coverage from *regressing*, prefer the
+> [coverage baseline](coverage-baseline.md): it gates the set of uncovered
+> responses instead of a percentage, so there is no threshold to keep raising
+> by hand, documenting a new response cannot fail an unrelated PR, and a
+> failure names the offending rows.
+
 ```xml
 <extensions>
     <bootstrap class="Studio\Gesso\PHPUnit\OpenApiCoverageExtension">

--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -53,6 +53,8 @@ vendor/bin/gesso coverage:merge \
 | `--strict-required=<mode>` | `off` | `off` / `warn` / `fail`. Assert no schema under-description drift across worker observations. See [`strict-required.md`](strict-required.md#paratest) |
 | `--strict-additional-properties=<mode>` | `off` | `off` / `warn` / `fail`. Report returned response properties absent from schema declarations. See [`strict-additional-properties.md`](strict-additional-properties.md#parallel-test-runners) |
 | `--baseline-file=<path>` | — | Union the violation-baseline halves staged by an `OPENAPI_BASELINE_GENERATE=1` parallel run and write the merged baseline. See [`baseline.md`](baseline.md#generating-under-parallel-runners) |
+| `--coverage-baseline-file=<path>` | — | Gate the merged coverage against a committed set of known-uncovered responses; writes the file instead when `OPENAPI_BASELINE_GENERATE=1` is set. See [`coverage-baseline.md`](coverage-baseline.md#parallel-runners) |
+| `--coverage-baseline-stale=<mode>` | `note` | `off` / `note` / `fail`. How baseline entries that are covered now are reported |
 | `--no-cleanup` | (cleanup is on by default) | Keep sidecar files after merge |
 
 Sidecar dir defaults are deliberately stable — workers and the merge CLI

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -14,6 +14,7 @@
 
 - [Doctor command](https://studio-design.github.io/gesso/doctor): preflight a local spec for load and enforcement problems before tests run.
 - [Violation baseline](https://studio-design.github.io/gesso/baseline): adopt contract testing on a legacy API by baselining existing violations and failing only on new ones.
+- [Coverage baseline](https://studio-design.github.io/gesso/coverage-baseline): commit the set of uncovered responses and fail on new ones by name, instead of maintaining a coverage percentage.
 - [PSR-7 validation](https://studio-design.github.io/gesso/psr7): validate PSR-7 requests and responses from any HTTP client or middleware.
 - [Laravel route parity](https://studio-design.github.io/gesso/laravel-route-parity): compare registered Laravel routes with spec operations to catch undocumented drift.
 - [Schema-driven fuzzing](https://studio-design.github.io/gesso/fuzzing): generate deterministic valid and invalid request cases from schemas, with replay tokens.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -64,6 +64,22 @@ This library follows [Semantic Versioning 2.0](https://semver.org/). v1.0.0 is t
   baselined, and entries that no longer occur during a full run are reported
   as stale per `baseline_stale`. Unknown `baseline_version` values are
   rejected.
+- The coverage baseline file (`coverage_baseline_version` 1): the
+  `uncovered_responses` entry fields (`spec`, `method`, `path`, `status`,
+  `content_type`) and what they identify — one declared response the run did
+  not validate, at `(method, path, status, content-type)` granularity, where
+  `status` is the spec response key and `content_type` is `*` for responses
+  without a `content` block; fixed HTTP methods normalize to uppercase while
+  OpenAPI 3.2 custom `additionalOperations` methods stay case-sensitive. The
+  `coverage_baseline_file` / `coverage_baseline_stale` extension parameters
+  (same values as `baseline_stale`), the matching
+  `--coverage-baseline-file` / `--coverage-baseline-stale` merge flags, and
+  the shared `OPENAPI_BASELINE_GENERATE` generation switch are covered too.
+  The enforcement semantics are part of the contract: responses that were not
+  validated — including responses skipped by `skip_response_codes` — are
+  baselined, an uncovered response absent from the file fails the run, and
+  entries that are covered now are reported per the stale mode. Unknown
+  `coverage_baseline_version` values are rejected.
 - Named contract checks: `ContractCheck` names and default expected statuses
   and status classes, the `OpenApiContractChecks`/`ContractCheckPlan` fluent
   surface, and the
@@ -77,7 +93,7 @@ This library follows [Semantic Versioning 2.0](https://semver.org/). v1.0.0 is t
   - v2.x: the `doctor` and `coverage:merge` subcommands of `bin/gesso`; the
     legacy standalone binaries are not shipped
 - The Laravel `openapi:routes` command surface (flags, exit codes, and versioned JSON output)
-- The `OpenApiCoverageExtension` PHPUnit configuration parameters (`spec_base_path`, `strip_prefixes`, `specs`, `output_file`, `console_output`, `validation_output`, `baseline_file`, `strict_required`, `strict_additional_properties`, `strict_additional_properties_per_call`, …)
+- The `OpenApiCoverageExtension` PHPUnit configuration parameters (`spec_base_path`, `strip_prefixes`, `specs`, `output_file`, `console_output`, `validation_output`, `baseline_file`, `coverage_baseline_file`, `strict_required`, `strict_additional_properties`, `strict_additional_properties_per_call`, …)
 - The Laravel `ValidatesOpenApiSchema` trait's public methods
 - The category prefixes used in `E_USER_WARNING` messages (`[security]`, `[OpenAPI Schema]`, and the `[OpenAPI 3.2 ...]` categories)
 

--- a/src/Baseline/CoverageBaseline.php
+++ b/src/Baseline/CoverageBaseline.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Baseline;
+
+use const SORT_STRING;
+
+use function array_key_exists;
+use function array_values;
+use function count;
+use function ksort;
+
+/**
+ * Set of responses the suite is known not to cover (issue #481).
+ *
+ * Presence-only, like {@see ViolationBaseline}: an entry says "this response
+ * is not covered today", and nothing else about it is worth committing.
+ *
+ * @internal Implementation detail of the coverage baseline; the committed
+ *           baseline file format is the supported surface, not this class.
+ */
+final class CoverageBaseline
+{
+    /** @var array<string, CoverageBaselineEntry> keyed by entry key */
+    private array $entries = [];
+
+    public function add(CoverageBaselineEntry $entry): void
+    {
+        $this->entries[$entry->key()] ??= $entry;
+    }
+
+    public function contains(CoverageBaselineEntry $entry): bool
+    {
+        return array_key_exists($entry->key(), $this->entries);
+    }
+
+    public function count(): int
+    {
+        return count($this->entries);
+    }
+
+    /**
+     * Entries in deterministic order: field-by-field on the binary-safe
+     * entry key.
+     *
+     * @return list<CoverageBaselineEntry>
+     */
+    public function sorted(): array
+    {
+        $sorted = $this->entries;
+        ksort($sorted, SORT_STRING);
+
+        return array_values($sorted);
+    }
+}

--- a/src/Baseline/CoverageBaselineEntry.php
+++ b/src/Baseline/CoverageBaselineEntry.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Baseline;
+
+use Studio\Gesso\Coverage\OpenApiCoverageTracker;
+use Studio\Gesso\Spec\OpenApiOperationResolver;
+
+use function implode;
+use function sprintf;
+
+/**
+ * Stable identity of one response the suite does not cover, for the coverage
+ * baseline (issue #481).
+ *
+ * The tuple is exactly the granularity coverage is measured at —
+ * `(spec, method, path template, status key, content type)` — so an entry
+ * names a row of the coverage report rather than a percentage. `status` is
+ * the spec's response key (`200`, `5XX`, `default`), not an observed HTTP
+ * status, and `contentType` is `*` for responses declared without a
+ * `content` block, matching {@see OpenApiCoverageTracker::ANY_CONTENT_TYPE}.
+ *
+ * Fixed HTTP methods normalize to their canonical uppercase key; OpenAPI 3.2
+ * custom `additionalOperations` methods keep their exact spelling because
+ * they are case-sensitive, mirroring {@see ViolationFingerprint}.
+ *
+ * @internal Implementation detail of the coverage baseline; the committed
+ *           baseline file format is the supported surface, not this class.
+ *
+ * @phpstan-type CoverageBaselineEntryArray array{
+ *     spec: string,
+ *     method: string,
+ *     path: string,
+ *     status: string,
+ *     content_type: string,
+ * }
+ */
+final readonly class CoverageBaselineEntry
+{
+    public function __construct(
+        public string $spec,
+        public string $method,
+        public string $path,
+        public string $status,
+        public string $contentType,
+    ) {}
+
+    /**
+     * Build an entry from one coverage-report row, normalizing the method so
+     * a hand-edited `get` still matches the runtime `GET`.
+     */
+    public static function create(
+        string $spec,
+        string $method,
+        string $path,
+        string $status,
+        string $contentType,
+    ): self {
+        return new self(
+            spec: $spec,
+            method: OpenApiOperationResolver::normalizeMethodForKey($method),
+            path: $path,
+            status: $status,
+            contentType: $contentType,
+        );
+    }
+
+    /**
+     * Binary-safe identity/sort key. Every field is a non-empty string here
+     * (the tracker uses the `*` sentinel rather than null for "no content
+     * type"), so a plain separator join is unambiguous.
+     */
+    public function key(): string
+    {
+        return implode("\x1f", [$this->spec, $this->method, $this->path, $this->status, $this->contentType]);
+    }
+
+    /** One-line human-readable rendering for gate listings. */
+    public function describe(): string
+    {
+        return sprintf(
+            '[%s] %s %s status=%s content-type=%s',
+            $this->spec,
+            $this->method,
+            $this->path,
+            $this->status,
+            $this->contentType,
+        );
+    }
+
+    /** @return CoverageBaselineEntryArray */
+    public function toArray(): array
+    {
+        return [
+            'spec' => $this->spec,
+            'method' => $this->method,
+            'path' => $this->path,
+            'status' => $this->status,
+            'content_type' => $this->contentType,
+        ];
+    }
+}

--- a/src/Baseline/CoverageBaselineEvaluator.php
+++ b/src/Baseline/CoverageBaselineEvaluator.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Baseline;
+
+use Studio\Gesso\Coverage\CoverageThresholdEvaluator;
+use Studio\Gesso\Coverage\OpenApiCoverageTracker;
+use Studio\Gesso\Coverage\ResponseCoverageState;
+
+use function count;
+use function implode;
+use function sprintf;
+
+/**
+ * Pure evaluator for the coverage baseline gate (issue #481).
+ *
+ * Where {@see CoverageThresholdEvaluator} compares a rounded percentage
+ * against a hand-maintained float, this compares two **sets** of responses:
+ * the ones the run did not cover, and the ones the committed baseline says
+ * are known-uncovered. That makes the gate independent of the denominator —
+ * documenting a new response cannot fail an unrelated PR by moving a
+ * percentage — and lets a failure name the offending rows instead of
+ * reporting a number.
+ *
+ * A response counts as covered only when it is
+ * {@see ResponseCoverageState::Validated}; `Skipped` rows are baselined like
+ * uncovered ones, matching the numerator the percentage gate uses, so
+ * switching to the baseline never silently weakens the gate.
+ *
+ * Decoupled from I/O so the PHPUnit subscriber (in-process) and the merge
+ * CLI (paratest post-step) share one implementation.
+ *
+ * @internal Used by the PHPUnit extension and merge CLI. The
+ *           `coverage_baseline_file` configuration and the committed file
+ *           format are the supported surfaces.
+ *
+ * @phpstan-import-type CoverageResult from OpenApiCoverageTracker
+ *
+ * @phpstan-type CoverageBaselineVerdict array{
+ *     regressions: list<CoverageBaselineEntry>,
+ *     stale: list<CoverageBaselineEntry>,
+ *     uncovered: int,
+ * }
+ */
+final class CoverageBaselineEvaluator
+{
+    /** Static-only utility — no instances. */
+    private function __construct() {}
+
+    /**
+     * Every response the run did not validate, as a baseline.
+     *
+     * @param array<string, CoverageResult> $results
+     */
+    public static function collect(array $results): CoverageBaseline
+    {
+        $baseline = new CoverageBaseline();
+
+        foreach ($results as $specName => $result) {
+            foreach ($result['endpoints'] as $endpoint) {
+                foreach ($endpoint['responses'] as $response) {
+                    if ($response['state'] === ResponseCoverageState::Validated) {
+                        continue;
+                    }
+
+                    $baseline->add(CoverageBaselineEntry::create(
+                        $specName,
+                        $endpoint['method'],
+                        $endpoint['path'],
+                        $response['statusKey'],
+                        $response['contentTypeKey'],
+                    ));
+                }
+            }
+        }
+
+        return $baseline;
+    }
+
+    /**
+     * Compare the run against the committed baseline.
+     *
+     * `regressions` are uncovered responses the baseline does not list — the
+     * gate failure. `stale` are baseline entries that are covered now (or no
+     * longer declared at all): the ratchet-down signal, removable from the
+     * file.
+     *
+     * @param array<string, CoverageResult> $results
+     *
+     * @return CoverageBaselineVerdict
+     */
+    public static function evaluate(CoverageBaseline $baseline, array $results): array
+    {
+        $current = self::collect($results);
+
+        $regressions = [];
+        foreach ($current->sorted() as $entry) {
+            if (!$baseline->contains($entry)) {
+                $regressions[] = $entry;
+            }
+        }
+
+        $stale = [];
+        foreach ($baseline->sorted() as $entry) {
+            if (!$current->contains($entry)) {
+                $stale[] = $entry;
+            }
+        }
+
+        return [
+            'regressions' => $regressions,
+            'stale' => $stale,
+            'uncovered' => $current->count(),
+        ];
+    }
+
+    /**
+     * @param list<CoverageBaselineEntry> $regressions
+     */
+    public static function renderRegressionMessage(array $regressions, string $generateHint): string
+    {
+        return sprintf(
+            "[Gesso] FATAL: %d response(s) are not covered and are not listed in the coverage baseline:\n%s\n  Action: cover them with a test, or accept them by regenerating the baseline with `%s`.\n",
+            count($regressions),
+            self::renderListing($regressions),
+            $generateHint,
+        );
+    }
+
+    /**
+     * @param list<CoverageBaselineEntry> $stale
+     */
+    public static function renderStaleMessage(array $stale, bool $isFatal): string
+    {
+        return sprintf(
+            "[Gesso] %s: %d coverage baseline entry(ies) are covered now and can be removed from the baseline file:\n%s\n",
+            $isFatal ? 'FATAL' : 'NOTE',
+            count($stale),
+            self::renderListing($stale),
+        );
+    }
+
+    /**
+     * @param list<CoverageBaselineEntry> $entries
+     */
+    private static function renderListing(array $entries): string
+    {
+        $lines = [];
+        foreach ($entries as $entry) {
+            $lines[] = '  - ' . $entry->describe();
+        }
+
+        return implode("\n", $lines);
+    }
+}

--- a/src/Baseline/CoverageBaselineFile.php
+++ b/src/Baseline/CoverageBaselineFile.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Baseline;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+
+use InvalidArgumentException;
+use JsonException;
+use RuntimeException;
+
+use function array_diff;
+use function array_keys;
+use function array_map;
+use function file_get_contents;
+use function file_put_contents;
+use function implode;
+use function is_array;
+use function is_int;
+use function is_string;
+use function json_decode;
+use function json_encode;
+use function sprintf;
+
+/**
+ * Versioned wire format of the committed coverage baseline file (issue #481).
+ *
+ * Deterministic like the violation baseline — fully sorted entries, no
+ * timestamps — so regenerating an unchanged suite produces a byte-identical
+ * file and the ratchet shows up as a reviewable diff. Parsing validates the
+ * whole payload before returning, and re-normalizes hand-edited entries
+ * (fixed-HTTP-method casing) so a literal `get` still matches its canonical
+ * runtime form.
+ *
+ * @internal The committed baseline file format is the supported, versioned
+ *           compatibility surface (docs/versioning.md); this class is its
+ *           implementation.
+ */
+final class CoverageBaselineFile
+{
+    /**
+     * Coverage-baseline wire-format version. Parsers reject unknown values
+     * rather than guessing — a baseline written by a future library version
+     * must fail loudly instead of silently mis-matching entries.
+     */
+    public const BASELINE_VERSION = 1;
+
+    private const REQUIRED_STRING_FIELDS = ['spec', 'method', 'path', 'status'];
+
+    private function __construct() {}
+
+    /**
+     * @return array{coverage_baseline_version: int, uncovered_responses: list<array<string, string>>}
+     */
+    public static function toDocument(CoverageBaseline $baseline): array
+    {
+        return [
+            'coverage_baseline_version' => self::BASELINE_VERSION,
+            'uncovered_responses' => array_map(
+                static fn(CoverageBaselineEntry $entry): array => $entry->toArray(),
+                $baseline->sorted(),
+            ),
+        ];
+    }
+
+    public static function render(CoverageBaseline $baseline): string
+    {
+        return json_encode(
+            self::toDocument($baseline),
+            JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+        ) . "\n";
+    }
+
+    /**
+     * @throws InvalidArgumentException on malformed JSON, an unknown
+     *                                  coverage_baseline_version, or an
+     *                                  invalid entry
+     */
+    public static function parse(string $document): CoverageBaseline
+    {
+        try {
+            $decoded = json_decode($document, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new InvalidArgumentException(
+                'Coverage baseline file is not valid JSON: ' . $exception->getMessage(),
+                previous: $exception,
+            );
+        }
+
+        if (!is_array($decoded)) {
+            throw new InvalidArgumentException('Coverage baseline file must decode to a JSON object.');
+        }
+
+        return self::parseDocument($decoded);
+    }
+
+    /**
+     * @param array<mixed, mixed> $decoded
+     *
+     * @throws InvalidArgumentException on an unknown
+     *                                  coverage_baseline_version or an
+     *                                  invalid entry
+     */
+    public static function parseDocument(array $decoded): CoverageBaseline
+    {
+        $version = $decoded['coverage_baseline_version'] ?? null;
+        if (!is_int($version) || $version !== self::BASELINE_VERSION) {
+            throw new InvalidArgumentException(sprintf(
+                'Unsupported coverage_baseline_version: expected %d.',
+                self::BASELINE_VERSION,
+            ));
+        }
+
+        $responses = $decoded['uncovered_responses'] ?? null;
+        if (!is_array($responses)) {
+            throw new InvalidArgumentException('Coverage baseline "uncovered_responses" must be an array.');
+        }
+
+        $baseline = new CoverageBaseline();
+        foreach ($responses as $index => $entry) {
+            $baseline->add(self::parseEntry($index, $entry));
+        }
+
+        return $baseline;
+    }
+
+    /** @throws InvalidArgumentException when the file is unreadable or malformed */
+    public static function read(string $path): CoverageBaseline
+    {
+        $document = @file_get_contents($path);
+        if ($document === false) {
+            throw new InvalidArgumentException(sprintf('Could not read coverage baseline file: %s', $path));
+        }
+
+        return self::parse($document);
+    }
+
+    /** @throws RuntimeException when the file cannot be written */
+    public static function write(string $path, CoverageBaseline $baseline): void
+    {
+        if (@file_put_contents($path, self::render($baseline)) === false) {
+            throw new RuntimeException(sprintf('Could not write coverage baseline file: %s', $path));
+        }
+    }
+
+    private static function parseEntry(int|string $index, mixed $entry): CoverageBaselineEntry
+    {
+        if (!is_array($entry)) {
+            throw new InvalidArgumentException(sprintf('Coverage baseline entry #%s must be an object.', $index));
+        }
+
+        $unknown = array_diff(array_keys($entry), [...self::REQUIRED_STRING_FIELDS, 'content_type']);
+        if ($unknown !== []) {
+            throw new InvalidArgumentException(sprintf(
+                'Coverage baseline entry #%s has unknown field(s): %s.',
+                $index,
+                implode(', ', $unknown),
+            ));
+        }
+
+        $values = [];
+        foreach (self::REQUIRED_STRING_FIELDS as $field) {
+            $value = $entry[$field] ?? null;
+            if (!is_string($value) || $value === '') {
+                throw new InvalidArgumentException(sprintf(
+                    'Coverage baseline entry #%s field "%s" must be a non-empty string.',
+                    $index,
+                    $field,
+                ));
+            }
+            $values[$field] = $value;
+        }
+
+        // `content_type` is the only field copied verbatim from a spec
+        // `content` key, so an empty key round-trips instead of failing a
+        // regenerated baseline.
+        $contentType = $entry['content_type'] ?? null;
+        if (!is_string($contentType)) {
+            throw new InvalidArgumentException(sprintf(
+                'Coverage baseline entry #%s field "content_type" must be a string.',
+                $index,
+            ));
+        }
+
+        return CoverageBaselineEntry::create(
+            $values['spec'],
+            $values['method'],
+            $values['path'],
+            $values['status'],
+            $contentType,
+        );
+    }
+}

--- a/src/Coverage/CoverageMergeCommand.php
+++ b/src/Coverage/CoverageMergeCommand.php
@@ -8,6 +8,9 @@ use const FILE_APPEND;
 
 use InvalidArgumentException;
 use RuntimeException;
+use Studio\Gesso\Baseline\BaselineStaleMode;
+use Studio\Gesso\Baseline\CoverageBaselineEvaluator;
+use Studio\Gesso\Baseline\CoverageBaselineFile;
 use Studio\Gesso\Baseline\ViolationBaseline;
 use Studio\Gesso\Baseline\ViolationBaselineFile;
 use Studio\Gesso\Exception\InvalidOpenApiSpecException;
@@ -41,7 +44,9 @@ use function str_contains;
 use function str_replace;
 use function str_starts_with;
 use function strlen;
+use function strtolower;
 use function substr;
+use function trim;
 use function unlink;
 
 /**
@@ -81,6 +86,8 @@ use function unlink;
  *     strict_required?: string,
  *     strict_additional_properties?: string,
  *     baseline_file?: string,
+ *     coverage_baseline_file?: string,
+ *     coverage_baseline_stale?: string,
  *     help?: bool,
  * }
  *
@@ -212,6 +219,15 @@ final class CoverageMergeCommand
               --baseline-file=<path>        Union the violation-baseline halves staged by a
                                             parallel `OPENAPI_BASELINE_GENERATE=1` run and
                                             write the merged baseline here (Issue #417).
+              --coverage-baseline-file=<path>
+                                            Gate the merged coverage against a committed set of
+                                            known-uncovered responses: any uncovered response
+                                            missing from the file fails the merge by name
+                                            (Issue #481). With OPENAPI_BASELINE_GENERATE=1 set,
+                                            the file is (re)written instead of enforced.
+              --coverage-baseline-stale=<mode>
+                                            off | note | fail. How baseline entries that are
+                                            covered now are reported. Defaults to note.
               --no-cleanup                  Keep sidecar files after merge (default: cleanup).
               --help                        Show this message.
 
@@ -299,6 +315,33 @@ final class CoverageMergeCommand
             ? $this->absolutise($options['baseline_file'])
             : null;
 
+        // Issue #481: the coverage baseline gate for parallel runs. Unlike
+        // the violation baseline — whose entries are staged per worker — the
+        // merged coverage state already is the whole-suite view, so this
+        // command both generates and enforces from it.
+        $coverageBaselineFile = isset($options['coverage_baseline_file']) && $options['coverage_baseline_file'] !== ''
+            ? $this->absolutise($options['coverage_baseline_file'])
+            : null;
+        $coverageBaselineGenerate = $coverageBaselineFile !== null && self::baselineGenerationRequested();
+
+        try {
+            $coverageBaselineStaleMode = BaselineStaleMode::fromConfigValue($options['coverage_baseline_stale'] ?? null);
+        } catch (InvalidArgumentException $e) {
+            // Same severity as a malformed threshold (exit 2): a typo here
+            // silently changes the gate the user opted into.
+            $this->writeStderr(sprintf("[Gesso] FATAL: %s\n", $e->getMessage()));
+
+            return 2;
+        }
+
+        if ($coverageBaselineFile === null && isset($options['coverage_baseline_stale'])) {
+            $this->writeStderr(
+                "[Gesso] FATAL: --coverage-baseline-stale is set but --coverage-baseline-file was not given; there is no baseline to evaluate staleness against.\n",
+            );
+
+            return 2;
+        }
+
         if ($specBasePath === null) {
             $this->writeStderr("[OpenAPI Coverage] FATAL: --spec-base-path is required\n");
 
@@ -336,6 +379,16 @@ final class CoverageMergeCommand
                 $this->writeStderr(sprintf(
                     "[Gesso] FATAL: --baseline-file requested but no sidecars were found in %s; no baseline was written. Run the parallel suite with OPENAPI_BASELINE_GENERATE=1 first.\n",
                     $sidecarDir,
+                ));
+
+                return 1;
+            }
+
+            if ($coverageBaselineFile !== null) {
+                $this->writeStderr(sprintf(
+                    "[Gesso] FATAL: --coverage-baseline-file was given but no sidecars were found in %s; the coverage baseline cannot be %s.\n",
+                    $sidecarDir,
+                    $coverageBaselineGenerate ? 'generated' : 'evaluated',
                 ));
 
                 return 1;
@@ -479,11 +532,20 @@ final class CoverageMergeCommand
                     : 'no coverage recorded across sidecars',
             ));
 
+            if ($coverageBaselineFile !== null) {
+                // The uncovered set would be empty for lack of data, not for
+                // lack of gaps — enforcing it would pass a run that validated
+                // nothing, generating it would write an empty baseline.
+                $this->writeStderr(
+                    "[Gesso] FATAL: no contract test coverage was recorded; the coverage baseline cannot be evaluated.\n",
+                );
+            }
+
             if ($cleanup && !$this->cleanupSafely($sidecarDir)) {
                 return 1;
             }
 
-            return $strictGated || $strictAdditionalPropertiesFailure ? 1 : 0;
+            return $strictGated || $strictAdditionalPropertiesFailure || $coverageBaselineFile !== null ? 1 : 0;
         }
 
         $this->writeStdout(ConsoleCoverageRenderer::render($results, $consoleOutput, $sdkResults));
@@ -518,15 +580,39 @@ final class CoverageMergeCommand
             $sidecarsWithoutStrictAdditionalProperties,
         );
 
+        $coverageBaselineFailure = $coverageBaselineFile !== null && !$this->handleCoverageBaseline(
+            $coverageBaselineFile,
+            $coverageBaselineGenerate,
+            $coverageBaselineStaleMode,
+            $results,
+        );
+
         $cleanupFailure = $cleanup && !$this->cleanupSafely($sidecarDir);
 
         return $writeFailures > 0 ||
             $thresholdFailure ||
             $strictFailure ||
             $strictAdditionalPropertiesFailure ||
+            $coverageBaselineFailure ||
             $cleanupFailure
             ? 1
             : 0;
+    }
+
+    /**
+     * Issue #481: whether this merge should (re)write the coverage baseline
+     * instead of enforcing it. Truthy semantics mirror the PHPUnit
+     * extension's reading of the same variable, so one env var drives both
+     * halves of a parallel generation run.
+     */
+    private static function baselineGenerationRequested(): bool
+    {
+        $value = getenv('OPENAPI_BASELINE_GENERATE');
+        if ($value === false || trim($value) === '') {
+            return false;
+        }
+
+        return !in_array(strtolower(trim($value)), ['0', 'false', 'no'], true);
     }
 
     /**
@@ -590,6 +676,91 @@ final class CoverageMergeCommand
         ));
 
         return true;
+    }
+
+    /**
+     * Issue #481: generate or enforce the coverage baseline against the
+     * merged whole-suite coverage state. Returns `false` when the merge must
+     * exit non-zero.
+     *
+     * Unlike the sequential path this has no view of whether the suite
+     * passed, so a red parallel run can report responses of failed tests as
+     * newly uncovered. That is the same blind spot the threshold gate has
+     * here, and the merge already runs after a suite whose exit code CI
+     * checks separately.
+     *
+     * @param array<string, CoverageResult> $results
+     */
+    private function handleCoverageBaseline(
+        string $baselineFile,
+        bool $generate,
+        BaselineStaleMode $staleMode,
+        array $results,
+    ): bool {
+        if ($results === []) {
+            $this->writeStderr(
+                "[Gesso] FATAL: no contract test coverage was recorded; the coverage baseline cannot be evaluated.\n",
+            );
+
+            return false;
+        }
+
+        if ($generate) {
+            $collected = CoverageBaselineEvaluator::collect($results);
+
+            try {
+                CoverageBaselineFile::write($baselineFile, $collected);
+            } catch (RuntimeException $e) {
+                $this->writeStderr("[Gesso] FATAL: {$e->getMessage()}\n");
+
+                return false;
+            }
+
+            $this->writeStderr(sprintf(
+                "[Gesso] Coverage baseline written: %d uncovered response(s) → %s\n",
+                $collected->count(),
+                $baselineFile,
+            ));
+
+            return true;
+        }
+
+        try {
+            $baseline = CoverageBaselineFile::read($baselineFile);
+        } catch (InvalidArgumentException $e) {
+            $this->writeStderr(
+                "[Gesso] FATAL: --coverage-baseline-file could not be loaded: {$e->getMessage()}\n",
+            );
+
+            return false;
+        }
+
+        $verdict = CoverageBaselineEvaluator::evaluate($baseline, $results);
+
+        $this->writeStderr(sprintf(
+            "[Gesso] coverage baseline: %d entries, %d uncovered response(s) in this run, %d covered now.\n",
+            $baseline->count(),
+            $verdict['uncovered'],
+            count($verdict['stale']),
+        ));
+
+        if ($verdict['regressions'] !== []) {
+            $this->writeStderr(CoverageBaselineEvaluator::renderRegressionMessage(
+                $verdict['regressions'],
+                'OPENAPI_BASELINE_GENERATE=1 ' . $this->invocation,
+            ));
+
+            return false;
+        }
+
+        if ($verdict['stale'] === [] || $staleMode === BaselineStaleMode::Off) {
+            return true;
+        }
+
+        $isFatal = $staleMode === BaselineStaleMode::Fail;
+        $this->writeStderr(CoverageBaselineEvaluator::renderStaleMessage($verdict['stale'], $isFatal));
+
+        return !$isFatal;
     }
 
     /**

--- a/src/Coverage/CoverageMergeCommand.php
+++ b/src/Coverage/CoverageMergeCommand.php
@@ -587,7 +587,21 @@ final class CoverageMergeCommand
             $results,
         );
 
-        $cleanupFailure = $cleanup && !$this->cleanupSafely($sidecarDir);
+        // Issue #481, mirroring the violation baseline's fail-before-cleanup
+        // contract: keep the sidecars when the coverage baseline step failed.
+        // Every recovery re-runs *this command*, not the suite — fixing a
+        // typo'd path, freeing disk for the write, or accepting the reported
+        // regressions with `OPENAPI_BASELINE_GENERATE=1`. Deleting the
+        // sidecars would make each of those cost a full parallel run.
+        $cleanupFailure = $cleanup &&
+            !$coverageBaselineFailure &&
+            !$this->cleanupSafely($sidecarDir);
+        if ($coverageBaselineFailure && $cleanup) {
+            $this->writeStderr(sprintf(
+                "[Gesso] Sidecars kept in %s so the merge can be retried without re-running the suite.\n",
+                $sidecarDir,
+            ));
+        }
 
         return $writeFailures > 0 ||
             $thresholdFailure ||

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -11,6 +11,9 @@ use PHPUnit\Event\TestRunner\ExecutionFinished;
 use PHPUnit\Event\TestRunner\ExecutionFinishedSubscriber;
 use RuntimeException;
 use Studio\Gesso\Baseline\BaselineStaleMode;
+use Studio\Gesso\Baseline\CoverageBaseline;
+use Studio\Gesso\Baseline\CoverageBaselineEvaluator;
+use Studio\Gesso\Baseline\CoverageBaselineFile;
 use Studio\Gesso\Baseline\ViolationBaselineCollector;
 use Studio\Gesso\Baseline\ViolationBaselineEnforcer;
 use Studio\Gesso\Baseline\ViolationBaselineFile;
@@ -116,6 +119,16 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
      *                                            fail every suite-selecting CI shard. Console rendering is
      *                                            unaffected — it reads in-memory state and is transient. `null`
      *                                            (the backwards-compat default) means full-run behavior.
+     * @param null|CoverageBaseline $coverageBaseline Issue #481: the committed set of known-uncovered responses,
+     *                                                loaded and validated by the extension. Non-null puts the run in
+     *                                                coverage-baseline enforcement — an uncovered response missing
+     *                                                from the set fails the run by name, independent of any
+     *                                                percentage.
+     * @param null|string $coverageBaselineGeneratePath Issue #481: destination of a coverage-baseline generation run
+     *                                                  (`OPENAPI_BASELINE_GENERATE`, shared with the violation
+     *                                                  baseline). Mutually exclusive with $coverageBaseline.
+     * @param BaselineStaleMode $coverageBaselineStaleMode Issue #481: how entries that are covered now — the
+     *                                                     ratchet-down signal — are reported.
      */
     public function __construct(
         private array $specs,
@@ -142,6 +155,9 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         ?StrictAdditionalPropertiesTracker $strictAdditionalPropertiesTracker = null,
         private StrictAdditionalPropertiesMode $strictAdditionalPropertiesMode = StrictAdditionalPropertiesMode::Off,
         ?SdkExerciseCoverageTracker $sdkExerciseCoverageTracker = null,
+        private ?CoverageBaseline $coverageBaseline = null,
+        private ?string $coverageBaselineGeneratePath = null,
+        private BaselineStaleMode $coverageBaselineStaleMode = BaselineStaleMode::Note,
     ) {
         // Eager resolution at construction time keeps the readonly invariant
         // honest: by the time any other method runs, $coverageTracker and
@@ -202,6 +218,7 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
             $this->failOnEmptyResultsIfGated();
             $this->writeBaselineFile();
             $this->reportBaselineEnforcement();
+            $this->handleCoverageBaseline($results);
             $this->evaluateStrictRequiredGate();
             $this->evaluateStrictAdditionalPropertiesGate();
 
@@ -224,6 +241,8 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         } else {
             $this->evaluateThresholdGate($results, $sdkResults);
         }
+
+        $this->handleCoverageBaseline($results);
 
         // Issue #224: schema under-description detection runs after coverage
         // rendering so a strict-mode fail does not suppress the coverage
@@ -722,6 +741,145 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         if ($isFatal) {
             $this->exitNonZero();
         }
+    }
+
+    /**
+     * Issue #481: generate or enforce the coverage baseline — the set-based
+     * replacement for `min_response_coverage`. Generation writes today's
+     * uncovered responses; enforcement fails the run for any uncovered
+     * response the committed file does not list, and reports entries that
+     * are covered now as stale.
+     *
+     * Both halves need the full suite: a subset run leaves most responses
+     * uncovered, which would either bake a bogus baseline or report every
+     * filtered-out response as a regression. Partial runs are skipped with a
+     * NOTE, mirroring the threshold gate. Enforcement additionally requires
+     * the run to have completed cleanly — a failed or truncated test never
+     * reached its contract assertion, so its responses would be reported as
+     * newly uncovered on top of the failure the user is already looking at.
+     *
+     * @param array<string, CoverageResult> $results
+     */
+    private function handleCoverageBaseline(array $results): void
+    {
+        if ($this->coverageBaselineGeneratePath !== null) {
+            $this->writeCoverageBaselineFile($results);
+
+            return;
+        }
+
+        $baseline = $this->coverageBaseline;
+        if ($baseline === null) {
+            return;
+        }
+
+        if ($this->partialRun !== null) {
+            $this->writeStderr(sprintf(
+                '[Gesso] NOTE: the coverage baseline gate is skipped on partial runs (%s) '
+                . "because a subset run leaves responses uncovered that the full suite covers. Run the full suite to evaluate the gate.\n",
+                $this->partialRun->reason,
+            ));
+
+            return;
+        }
+
+        if ($this->baselineCompletionTracer !== null && !$this->baselineCompletionTracer->completedCleanly()) {
+            $this->writeStderr(sprintf(
+                "[Gesso] NOTE: the coverage baseline gate is skipped because the run did not complete cleanly (%s); responses of tests that never reached their contract assertion would be reported as newly uncovered. Re-run with all tests passing to evaluate the gate.\n",
+                $this->baselineCompletionTracer->describe(),
+            ));
+
+            return;
+        }
+
+        if ($results === []) {
+            // Same hazard as the threshold gate's empty-results branch: the
+            // uncovered set would be empty for lack of data, not for lack of
+            // gaps, and the gate would pass a run that validated nothing.
+            $this->writeStderr(
+                "[Gesso] FATAL: no contract test coverage was recorded; the coverage baseline gate cannot be evaluated.\n",
+            );
+            $this->exitNonZero();
+
+            return;
+        }
+
+        $verdict = CoverageBaselineEvaluator::evaluate($baseline, $results);
+
+        $this->writeStderr(sprintf(
+            "[Gesso] coverage baseline: %d entries, %d uncovered response(s) in this run, %d covered now.\n",
+            $baseline->count(),
+            $verdict['uncovered'],
+            count($verdict['stale']),
+        ));
+
+        if ($verdict['regressions'] !== []) {
+            $this->writeStderr(CoverageBaselineEvaluator::renderRegressionMessage(
+                $verdict['regressions'],
+                'OPENAPI_BASELINE_GENERATE=1 vendor/bin/phpunit',
+            ));
+            $this->exitNonZero();
+
+            return;
+        }
+
+        if ($verdict['stale'] === [] || $this->coverageBaselineStaleMode === BaselineStaleMode::Off) {
+            return;
+        }
+
+        $isFatal = $this->coverageBaselineStaleMode === BaselineStaleMode::Fail;
+        $this->writeStderr(CoverageBaselineEvaluator::renderStaleMessage($verdict['stale'], $isFatal));
+
+        if ($isFatal) {
+            $this->exitNonZero();
+        }
+    }
+
+    /**
+     * @param array<string, CoverageResult> $results
+     */
+    private function writeCoverageBaselineFile(array $results): void
+    {
+        $path = $this->coverageBaselineGeneratePath;
+        if ($path === null) {
+            return;
+        }
+
+        if ($this->partialRun !== null) {
+            $this->writeStderr(sprintf(
+                "[Gesso] WARNING: coverage baseline generation refused on a partial run (%s) — a subset run would record responses the full suite covers. No file was written.\n",
+                $this->partialRun->reason,
+            ));
+            $this->exitNonZero();
+
+            return;
+        }
+
+        if ($results === []) {
+            $this->writeStderr(
+                "[Gesso] WARNING: coverage baseline generation refused because no contract test coverage was recorded; the file would list every declared response. No file was written.\n",
+            );
+            $this->exitNonZero();
+
+            return;
+        }
+
+        $baseline = CoverageBaselineEvaluator::collect($results);
+
+        try {
+            CoverageBaselineFile::write($path, $baseline);
+        } catch (RuntimeException $e) {
+            $this->writeStderr("[Gesso] WARNING: {$e->getMessage()}\n");
+            $this->exitNonZero();
+
+            return;
+        }
+
+        $this->writeStderr(sprintf(
+            "[Gesso] Coverage baseline written: %d uncovered response(s) → %s\n",
+            $baseline->count(),
+            $path,
+        ));
     }
 
     /**

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -586,18 +586,29 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
             $this->writeStderr("[OpenAPI Coverage] WARNING: failed to write sidecar (token={$token}): {$e->getMessage()}\n");
             CoverageSidecarWriter::writeFailureMarker($dir, $token, $e->getMessage());
 
-            // Issue #417: a generation worker demoted its failures on the
-            // promise that the merge unions this sidecar; a lost sidecar
-            // cannot be recovered by the marker alone — the marker write is
-            // itself best-effort, and when it also fails (full disk,
-            // revoked permissions) the merge would see N-1 complete
-            // baseline halves and write an incomplete baseline. Fail the
-            // worker so the parallel run cannot end green with staged
-            // violations silently dropped.
-            if ($baselineDocument !== null) {
-                $this->writeStderr(
-                    "[Gesso] FATAL: baseline generation could not stage this worker's violations in the sidecar; failing the worker so the parallel run does not produce an incomplete baseline.\n",
-                );
+            // Issue #417 / #481: a lost sidecar cannot be recovered by the
+            // marker alone — the marker write is itself best-effort, and
+            // when it also fails (full disk, revoked permissions) the merge
+            // sees N-1 complete halves and writes an incomplete baseline.
+            // For the violation baseline that silently drops failures this
+            // worker already demoted; for the coverage baseline it records
+            // this worker's covered responses as uncovered, permanently
+            // loosening the ratchet. Either way, fail the worker so the
+            // parallel run cannot end green.
+            //
+            // Only generation runs need this: an enforcing worker stages
+            // nothing, and a merge missing one worker's coverage fails loudly
+            // with the "newly uncovered" listing instead of writing a file.
+            $lostGeneration = match (true) {
+                $baselineDocument !== null => "this worker's violations",
+                $this->coverageBaselineGeneratePath !== null => "this worker's covered responses",
+                default => null,
+            };
+            if ($lostGeneration !== null) {
+                $this->writeStderr(sprintf(
+                    "[Gesso] FATAL: baseline generation could not stage %s in the sidecar; failing the worker so the parallel run does not produce an incomplete baseline.\n",
+                    $lostGeneration,
+                ));
                 $this->exitNonZero();
             }
         }

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -14,6 +14,8 @@ use PHPUnit\Runner\Extension\Facade;
 use PHPUnit\Runner\Extension\ParameterCollection;
 use PHPUnit\TextUI\Configuration\Configuration;
 use Studio\Gesso\Baseline\BaselineStaleMode;
+use Studio\Gesso\Baseline\CoverageBaseline;
+use Studio\Gesso\Baseline\CoverageBaselineFile;
 use Studio\Gesso\Baseline\InvalidBaselineConfigurationException;
 use Studio\Gesso\Baseline\ViolationBaselineCollector;
 use Studio\Gesso\Baseline\ViolationBaselineEnforcer;
@@ -379,44 +381,69 @@ final class OpenApiCoverageExtension implements Extension
         // the committed baseline; the run only demotes failures when the
         // user explicitly asked for a generation run via the environment
         // variable, so a plain `vendor/bin/phpunit` never masks violations.
-        $baselineFile = null;
-        if ($parameters->has('baseline_file') && trim($parameters->get('baseline_file')) !== '') {
-            $baselineFile = trim($parameters->get('baseline_file'));
-            if (!str_starts_with($baselineFile, '/')) {
-                $baselineFile = getcwd() . '/' . $baselineFile;
-            }
-        }
+        $baselineFile = self::resolveBaselineFileParameter($parameters, 'baseline_file');
+
+        // Issue #481: the coverage baseline is the set-based counterpart —
+        // same generation entry point, its own committed file.
+        $coverageBaselineFile = self::resolveBaselineFileParameter($parameters, 'coverage_baseline_file');
 
         // Resolve baseline_stale before any baseline wiring so a typo'd or
         // orphaned parameter aborts bootstrap first (fail-loud policy).
-        $baselineStaleMode = self::resolveBaselineStaleMode($parameters, $baselineFile !== null);
+        $baselineStaleMode = self::resolveBaselineStaleMode(
+            $parameters,
+            'baseline_stale',
+            'baseline_file',
+            $baselineFile !== null,
+        );
+        $coverageBaselineStaleMode = self::resolveBaselineStaleMode(
+            $parameters,
+            'coverage_baseline_stale',
+            'coverage_baseline_file',
+            $coverageBaselineFile !== null,
+        );
+
+        $generationRequested = self::baselineGenerationRequested();
+        if ($generationRequested && $baselineFile === null && $coverageBaselineFile === null) {
+            // A generation run with nowhere to write would complete "green"
+            // (all failures demoted) and then drop every recorded violation
+            // on the floor — abort bootstrap instead.
+            self::writeStderr(
+                "[Gesso] FATAL: OPENAPI_BASELINE_GENERATE is set but neither `baseline_file` nor `coverage_baseline_file` is configured.\n"
+                . "  Action: add <parameter name=\"baseline_file\" value=\"gesso-baseline.json\"/> (violations) or\n"
+                . "          <parameter name=\"coverage_baseline_file\" value=\"gesso-coverage-baseline.json\"/> (coverage)\n"
+                . "          to the extension bootstrap.\n",
+            );
+
+            throw new InvalidBaselineConfigurationException(
+                'OPENAPI_BASELINE_GENERATE requires the baseline_file or coverage_baseline_file extension parameter.',
+            );
+        }
+
+        // Issue #481: enforcement loads and validates the committed file at
+        // bootstrap for the same fail-loud reason as the violation baseline.
+        // Worker processes load it too and then never evaluate it (the
+        // subscriber's worker branch returns early) — `gesso coverage:merge`
+        // is the gate for parallel runs.
+        $coverageBaseline = null;
+        $coverageBaselineGeneratePath = null;
+        if ($generationRequested) {
+            $coverageBaselineGeneratePath = $coverageBaselineFile;
+        } elseif ($coverageBaselineFile !== null) {
+            $coverageBaseline = self::readCoverageBaseline($coverageBaselineFile);
+        }
 
         ViolationBaselineCollector::resetCurrent();
         ViolationBaselineEnforcer::resetCurrent();
         $baselineGeneratePath = null;
-        if (self::baselineGenerationRequested()) {
+        if ($generationRequested && $baselineFile !== null) {
             // Issue #417: paratest workers (TEST_TOKEN set) run generation
             // like a sequential run — the collector demotes failures and the
             // subscriber's worker branch stages the fingerprints in the
             // sidecar envelope for `gesso coverage:merge --baseline-file`
             // to union into the committed file.
-            if ($baselineFile === null) {
-                // A generation run with nowhere to write would complete
-                // "green" (all failures demoted) and then drop every
-                // recorded violation on the floor — abort bootstrap instead.
-                self::writeStderr(
-                    "[Gesso] FATAL: OPENAPI_BASELINE_GENERATE is set but no `baseline_file` extension parameter is configured.\n"
-                    . "  Action: add <parameter name=\"baseline_file\" value=\"gesso-baseline.json\"/> to the extension bootstrap.\n",
-                );
-
-                throw new InvalidBaselineConfigurationException(
-                    'OPENAPI_BASELINE_GENERATE requires the baseline_file extension parameter.',
-                );
-            }
-
             ViolationBaselineCollector::setCurrent(new ViolationBaselineCollector());
             $baselineGeneratePath = $baselineFile;
-        } elseif ($baselineFile !== null) {
+        } elseif (!$generationRequested && $baselineFile !== null) {
             // Issue #402: enforcement. A configured baseline_file that cannot
             // be loaded is FATAL — swallowing a typo'd path or a corrupted
             // file would silently disable suppression (all-red run) or, worse,
@@ -525,8 +552,13 @@ final class OpenApiCoverageExtension implements Extension
         // finished with no defects — the stale gate must not report unhit
         // entries as removable when later assertions never ran (truncated
         // --stop-on-* runs, hook failures, failed/skipped tests).
+        //
+        // Issue #481: the coverage baseline needs the same proof for the
+        // opposite reason — a test that never reached its contract assertion
+        // leaves its responses uncovered, which would be reported as a
+        // regression on top of the failure the user is already looking at.
         $baselineCompletionTracer = null;
-        if (ViolationBaselineEnforcer::current() !== null) {
+        if (ViolationBaselineEnforcer::current() !== null || $coverageBaseline !== null) {
             $baselineCompletionTracer = new TestRunCompletionTracer();
             $facade->registerTracer($baselineCompletionTracer);
         }
@@ -554,33 +586,84 @@ final class OpenApiCoverageExtension implements Extension
             baselineGeneratePath: $baselineGeneratePath,
             baselineStaleMode: $baselineStaleMode,
             baselineCompletionTracer: $baselineCompletionTracer,
+            coverageBaseline: $coverageBaseline,
+            coverageBaselineGeneratePath: $coverageBaselineGeneratePath,
+            coverageBaselineStaleMode: $coverageBaselineStaleMode,
         ));
     }
 
     /**
-     * Issue #402: read the `baseline_stale` parameter. Missing and empty
-     * values resolve to {@see BaselineStaleMode::Note}; unrecognised values
-     * and a `baseline_stale` without a `baseline_file` (nothing to evaluate
-     * staleness against) are FATAL — silently dropping the parameter would
-     * defeat the opt-in fail-loud policy this extension enforces.
+     * Read a baseline path parameter, resolving a relative value against the
+     * working directory. Empty values are treated as "not configured" so a
+     * blank `value=""` does not point the baseline at the cwd itself.
+     */
+    private static function resolveBaselineFileParameter(
+        ParameterCollection $parameters,
+        string $name,
+    ): ?string {
+        if (!$parameters->has($name) || trim($parameters->get($name)) === '') {
+            return null;
+        }
+
+        $path = trim($parameters->get($name));
+
+        return str_starts_with($path, '/') ? $path : getcwd() . '/' . $path;
+    }
+
+    /**
+     * Issue #481: enforcement counterpart of the violation baseline's
+     * bootstrap read. A typo'd path or a corrupted file must not silently
+     * disable the gate.
+     */
+    private static function readCoverageBaseline(string $path): CoverageBaseline
+    {
+        try {
+            return CoverageBaselineFile::read($path);
+        } catch (InvalidArgumentException $e) {
+            self::writeStderr(
+                "[Gesso] FATAL: coverage_baseline_file could not be loaded: {$e->getMessage()}\n"
+                . "  Action: generate it with `OPENAPI_BASELINE_GENERATE=1 vendor/bin/phpunit`, fix the path, or remove the `coverage_baseline_file` parameter.\n",
+            );
+
+            throw new InvalidBaselineConfigurationException(
+                'coverage_baseline_file could not be loaded: ' . $e->getMessage(),
+                previous: $e,
+            );
+        }
+    }
+
+    /**
+     * Issue #402 / #481: read a `*_stale` parameter. Missing and empty values
+     * resolve to {@see BaselineStaleMode::Note}; unrecognised values and a
+     * stale mode without its baseline file (nothing to evaluate staleness
+     * against) are FATAL — silently dropping the parameter would defeat the
+     * opt-in fail-loud policy this extension enforces.
      */
     private static function resolveBaselineStaleMode(
         ParameterCollection $parameters,
+        string $name,
+        string $fileName,
         bool $hasBaselineFile,
     ): BaselineStaleMode {
-        if (!$parameters->has('baseline_stale')) {
+        if (!$parameters->has($name)) {
             return BaselineStaleMode::Note;
         }
 
         if (!$hasBaselineFile) {
-            $reason = 'baseline_stale is set but no `baseline_file` extension parameter is configured. '
-                . 'Stale evaluation needs a baseline to compare against; set `baseline_file` or remove `baseline_stale`.';
+            $reason = sprintf(
+                '%s is set but no `%s` extension parameter is configured. '
+                . 'Stale evaluation needs a baseline to compare against; set `%s` or remove `%s`.',
+                $name,
+                $fileName,
+                $fileName,
+                $name,
+            );
             self::writeStderr("[Gesso] FATAL: {$reason}\n");
 
             throw new InvalidBaselineConfigurationException($reason);
         }
 
-        $raw = $parameters->get('baseline_stale');
+        $raw = $parameters->get($name);
 
         try {
             return BaselineStaleMode::fromConfigValue($raw);

--- a/tests/Unit/Baseline/CoverageBaselineEvaluatorTest.php
+++ b/tests/Unit/Baseline/CoverageBaselineEvaluatorTest.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Baseline;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Baseline\CoverageBaseline;
+use Studio\Gesso\Baseline\CoverageBaselineEntry;
+use Studio\Gesso\Baseline\CoverageBaselineEvaluator;
+use Studio\Gesso\Coverage\EndpointCoverageState;
+use Studio\Gesso\Coverage\OpenApiCoverageTracker;
+use Studio\Gesso\Coverage\ResponseCoverageState;
+
+use function array_map;
+use function count;
+
+/**
+ * @phpstan-import-type CoverageResult from OpenApiCoverageTracker
+ * @phpstan-import-type ResponseRow from OpenApiCoverageTracker
+ */
+class CoverageBaselineEvaluatorTest extends TestCase
+{
+    #[Test]
+    public function collect_returns_every_response_that_was_not_validated(): void
+    {
+        $baseline = CoverageBaselineEvaluator::collect([
+            'front' => self::specResult([
+                self::endpoint('GET', '/pets', [
+                    ['200', 'application/json', ResponseCoverageState::Validated],
+                    ['500', 'application/json', ResponseCoverageState::Uncovered],
+                    ['503', '*', ResponseCoverageState::Skipped],
+                ]),
+            ]),
+        ]);
+
+        $this->assertSame(2, $baseline->count());
+        $this->assertSame([
+            '[front] GET /pets status=500 content-type=application/json',
+            '[front] GET /pets status=503 content-type=*',
+        ], array_map(static fn(CoverageBaselineEntry $e): string => $e->describe(), $baseline->sorted()));
+    }
+
+    #[Test]
+    public function collect_keys_entries_by_spec_name(): void
+    {
+        $rows = [self::endpoint('GET', '/pets', [['200', '*', ResponseCoverageState::Uncovered]])];
+
+        $baseline = CoverageBaselineEvaluator::collect([
+            'front' => self::specResult($rows),
+            'admin' => self::specResult($rows),
+        ]);
+
+        $this->assertSame(2, $baseline->count());
+        $this->assertTrue($baseline->contains(new CoverageBaselineEntry('admin', 'GET', '/pets', '200', '*')));
+        $this->assertTrue($baseline->contains(new CoverageBaselineEntry('front', 'GET', '/pets', '200', '*')));
+    }
+
+    #[Test]
+    public function evaluate_passes_when_the_uncovered_set_matches_the_baseline(): void
+    {
+        $results = [
+            'front' => self::specResult([
+                self::endpoint('GET', '/pets', [
+                    ['200', 'application/json', ResponseCoverageState::Validated],
+                    ['500', 'application/json', ResponseCoverageState::Uncovered],
+                ]),
+            ]),
+        ];
+
+        $verdict = CoverageBaselineEvaluator::evaluate(
+            self::baselineOf([['front', 'GET', '/pets', '500', 'application/json']]),
+            $results,
+        );
+
+        $this->assertSame([], $verdict['regressions']);
+        $this->assertSame([], $verdict['stale']);
+        $this->assertSame(1, $verdict['uncovered']);
+    }
+
+    #[Test]
+    public function evaluate_reports_a_newly_uncovered_response_as_a_regression(): void
+    {
+        $verdict = CoverageBaselineEvaluator::evaluate(
+            self::baselineOf([['front', 'GET', '/pets', '500', 'application/json']]),
+            [
+                'front' => self::specResult([
+                    self::endpoint('GET', '/pets', [
+                        ['200', 'application/json', ResponseCoverageState::Uncovered],
+                        ['500', 'application/json', ResponseCoverageState::Uncovered],
+                    ]),
+                ]),
+            ],
+        );
+
+        $this->assertCount(1, $verdict['regressions']);
+        $this->assertSame(
+            '[front] GET /pets status=200 content-type=application/json',
+            $verdict['regressions'][0]->describe(),
+        );
+        $this->assertSame([], $verdict['stale']);
+    }
+
+    #[Test]
+    public function evaluate_ignores_a_newly_documented_response_that_is_covered(): void
+    {
+        // Issue #481 problem 2: documenting a response grows the denominator.
+        // A percentage gate at the current value fails; a set gate does not,
+        // as long as the new response is actually covered.
+        $verdict = CoverageBaselineEvaluator::evaluate(
+            self::baselineOf([['front', 'GET', '/pets', '500', 'application/json']]),
+            [
+                'front' => self::specResult([
+                    self::endpoint('GET', '/pets', [
+                        ['200', 'application/json', ResponseCoverageState::Validated],
+                        ['503', 'application/json', ResponseCoverageState::Validated],
+                        ['500', 'application/json', ResponseCoverageState::Uncovered],
+                    ]),
+                ]),
+            ],
+        );
+
+        $this->assertSame([], $verdict['regressions']);
+        $this->assertSame([], $verdict['stale']);
+    }
+
+    #[Test]
+    public function evaluate_reports_a_now_covered_baseline_entry_as_stale(): void
+    {
+        $verdict = CoverageBaselineEvaluator::evaluate(
+            self::baselineOf([
+                ['front', 'GET', '/pets', '200', 'application/json'],
+                ['front', 'GET', '/pets', '500', 'application/json'],
+            ]),
+            [
+                'front' => self::specResult([
+                    self::endpoint('GET', '/pets', [
+                        ['200', 'application/json', ResponseCoverageState::Validated],
+                        ['500', 'application/json', ResponseCoverageState::Uncovered],
+                    ]),
+                ]),
+            ],
+        );
+
+        $this->assertSame([], $verdict['regressions']);
+        $this->assertCount(1, $verdict['stale']);
+        $this->assertSame(
+            '[front] GET /pets status=200 content-type=application/json',
+            $verdict['stale'][0]->describe(),
+        );
+    }
+
+    #[Test]
+    public function evaluate_reports_a_no_longer_declared_baseline_entry_as_stale(): void
+    {
+        $verdict = CoverageBaselineEvaluator::evaluate(
+            self::baselineOf([['front', 'DELETE', '/pets/{id}', '204', '*']]),
+            ['front' => self::specResult([])],
+        );
+
+        $this->assertSame([], $verdict['regressions']);
+        $this->assertCount(1, $verdict['stale']);
+    }
+
+    #[Test]
+    public function regression_message_names_every_offending_row(): void
+    {
+        $message = CoverageBaselineEvaluator::renderRegressionMessage(
+            self::baselineOf([
+                ['front', 'DELETE', '/pets/{id}', '204', '*'],
+                ['front', 'GET', '/pets', '500', 'application/json'],
+            ])->sorted(),
+            'OPENAPI_BASELINE_GENERATE=1 vendor/bin/phpunit',
+        );
+
+        $this->assertStringContainsString('[Gesso] FATAL: 2 response(s) are not covered', $message);
+        $this->assertStringContainsString("  - [front] DELETE /pets/{id} status=204 content-type=*\n", $message);
+        $this->assertStringContainsString('  - [front] GET /pets status=500 content-type=application/json', $message);
+        $this->assertStringContainsString('OPENAPI_BASELINE_GENERATE=1 vendor/bin/phpunit', $message);
+        $this->assertStringEndsWith("\n", $message);
+    }
+
+    #[Test]
+    public function stale_message_switches_severity(): void
+    {
+        $stale = self::baselineOf([['front', 'GET', '/pets', '200', '*']])->sorted();
+
+        $this->assertStringContainsString(
+            '[Gesso] NOTE: 1 coverage baseline entry(ies) are covered now',
+            CoverageBaselineEvaluator::renderStaleMessage($stale, false),
+        );
+        $this->assertStringContainsString(
+            '[Gesso] FATAL: 1 coverage baseline entry(ies) are covered now',
+            CoverageBaselineEvaluator::renderStaleMessage($stale, true),
+        );
+    }
+
+    /**
+     * @param list<array{0: string, 1: string, 2: string, 3: string, 4: string}> $entries
+     */
+    private static function baselineOf(array $entries): CoverageBaseline
+    {
+        $baseline = new CoverageBaseline();
+        foreach ($entries as [$spec, $method, $path, $status, $contentType]) {
+            $baseline->add(new CoverageBaselineEntry($spec, $method, $path, $status, $contentType));
+        }
+
+        return $baseline;
+    }
+
+    /**
+     * @param list<array{0: string, 1: string, 2: ResponseCoverageState}> $responses
+     *
+     * @return array{
+     *     endpoint: string,
+     *     method: string,
+     *     path: string,
+     *     operationId: ?string,
+     *     state: EndpointCoverageState,
+     *     requestReached: bool,
+     *     responses: list<ResponseRow>,
+     *     coveredResponseCount: int,
+     *     skippedResponseCount: int,
+     *     totalResponseCount: int,
+     *     unexpectedObservations: list<array{statusKey: string, contentTypeKey: string}>,
+     * }
+     */
+    private static function endpoint(string $method, string $path, array $responses): array
+    {
+        $rows = [];
+        $covered = 0;
+        $skipped = 0;
+        foreach ($responses as [$statusKey, $contentTypeKey, $state]) {
+            $rows[] = [
+                'statusKey' => $statusKey,
+                'contentTypeKey' => $contentTypeKey,
+                'state' => $state,
+                'hits' => $state === ResponseCoverageState::Uncovered ? 0 : 1,
+                'skipReason' => null,
+            ];
+            if ($state === ResponseCoverageState::Validated) {
+                $covered++;
+            } elseif ($state === ResponseCoverageState::Skipped) {
+                $skipped++;
+            }
+        }
+
+        return [
+            'endpoint' => $method . ' ' . $path,
+            'method' => $method,
+            'path' => $path,
+            'operationId' => null,
+            'state' => $covered === count($rows) ? EndpointCoverageState::AllCovered : EndpointCoverageState::Partial,
+            'requestReached' => true,
+            'responses' => $rows,
+            'coveredResponseCount' => $covered,
+            'skippedResponseCount' => $skipped,
+            'totalResponseCount' => count($rows),
+            'unexpectedObservations' => [],
+        ];
+    }
+
+    /**
+     * @param list<array<string, mixed>> $endpoints
+     *
+     * @return CoverageResult
+     */
+    private static function specResult(array $endpoints): array
+    {
+        $responseTotal = 0;
+        $responseCovered = 0;
+        $responseSkipped = 0;
+        foreach ($endpoints as $endpoint) {
+            $responseTotal += $endpoint['totalResponseCount'];
+            $responseCovered += $endpoint['coveredResponseCount'];
+            $responseSkipped += $endpoint['skippedResponseCount'];
+        }
+
+        /** @phpstan-ignore return.type */
+        return [
+            'endpoints' => $endpoints,
+            'endpointTotal' => count($endpoints),
+            'endpointFullyCovered' => 0,
+            'endpointPartial' => count($endpoints),
+            'endpointUncovered' => 0,
+            'endpointRequestOnly' => 0,
+            'responseTotal' => $responseTotal,
+            'responseCovered' => $responseCovered,
+            'responseSkipped' => $responseSkipped,
+            'responseUncovered' => $responseTotal - $responseCovered - $responseSkipped,
+        ];
+    }
+}

--- a/tests/Unit/Baseline/CoverageBaselineFileTest.php
+++ b/tests/Unit/Baseline/CoverageBaselineFileTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Baseline;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Baseline\CoverageBaseline;
+use Studio\Gesso\Baseline\CoverageBaselineEntry;
+use Studio\Gesso\Baseline\CoverageBaselineFile;
+
+use function json_decode;
+use function json_encode;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+class CoverageBaselineFileTest extends TestCase
+{
+    #[Test]
+    public function render_produces_a_sorted_versioned_document_with_a_trailing_newline(): void
+    {
+        $baseline = new CoverageBaseline();
+        $baseline->add(new CoverageBaselineEntry('front', 'POST', '/v1/pets', '201', 'application/json'));
+        $baseline->add(new CoverageBaselineEntry('front', 'GET', '/v1/pets', '500', '*'));
+
+        $rendered = CoverageBaselineFile::render($baseline);
+
+        $this->assertStringEndsWith("\n", $rendered);
+        $decoded = json_decode($rendered, true);
+        $this->assertSame(1, $decoded['coverage_baseline_version']);
+        $this->assertSame([
+            ['spec' => 'front', 'method' => 'GET', 'path' => '/v1/pets', 'status' => '500', 'content_type' => '*'],
+            ['spec' => 'front', 'method' => 'POST', 'path' => '/v1/pets', 'status' => '201', 'content_type' => 'application/json'],
+        ], $decoded['uncovered_responses']);
+    }
+
+    #[Test]
+    public function render_is_byte_identical_regardless_of_insertion_order(): void
+    {
+        $a = new CoverageBaseline();
+        $a->add(new CoverageBaselineEntry('front', 'GET', '/a', '200', '*'));
+        $a->add(new CoverageBaselineEntry('front', 'GET', '/b', '200', '*'));
+
+        $b = new CoverageBaseline();
+        $b->add(new CoverageBaselineEntry('front', 'GET', '/b', '200', '*'));
+        $b->add(new CoverageBaselineEntry('front', 'GET', '/a', '200', '*'));
+
+        $this->assertSame(CoverageBaselineFile::render($a), CoverageBaselineFile::render($b));
+    }
+
+    #[Test]
+    public function parse_round_trips_a_rendered_document(): void
+    {
+        $baseline = new CoverageBaseline();
+        $baseline->add(new CoverageBaselineEntry('front', 'DELETE', '/v1/pets/{id}', '204', '*'));
+
+        $parsed = CoverageBaselineFile::parse(CoverageBaselineFile::render($baseline));
+
+        $this->assertSame(1, $parsed->count());
+        $this->assertTrue($parsed->contains(new CoverageBaselineEntry('front', 'DELETE', '/v1/pets/{id}', '204', '*')));
+    }
+
+    #[Test]
+    public function parse_normalizes_hand_edited_fixed_method_casing(): void
+    {
+        $parsed = CoverageBaselineFile::parse((string) json_encode([
+            'coverage_baseline_version' => 1,
+            'uncovered_responses' => [
+                ['spec' => 'front', 'method' => 'get', 'path' => '/v1/pets', 'status' => '200', 'content_type' => '*'],
+            ],
+        ]));
+
+        $this->assertTrue($parsed->contains(new CoverageBaselineEntry('front', 'GET', '/v1/pets', '200', '*')));
+    }
+
+    #[Test]
+    public function parse_keeps_custom_additional_operation_method_casing_distinct(): void
+    {
+        $parsed = CoverageBaselineFile::parse((string) json_encode([
+            'coverage_baseline_version' => 1,
+            'uncovered_responses' => [
+                ['spec' => 'front', 'method' => 'COPY', 'path' => '/v1/pets', 'status' => '200', 'content_type' => '*'],
+            ],
+        ]));
+
+        $this->assertTrue($parsed->contains(new CoverageBaselineEntry('front', 'COPY', '/v1/pets', '200', '*')));
+        $this->assertFalse($parsed->contains(new CoverageBaselineEntry('front', 'copy', '/v1/pets', '200', '*')));
+    }
+
+    #[Test]
+    public function parse_accepts_an_empty_content_type(): void
+    {
+        $parsed = CoverageBaselineFile::parse((string) json_encode([
+            'coverage_baseline_version' => 1,
+            'uncovered_responses' => [
+                ['spec' => 'front', 'method' => 'GET', 'path' => '/v1/pets', 'status' => '200', 'content_type' => ''],
+            ],
+        ]));
+
+        $this->assertSame(1, $parsed->count());
+    }
+
+    #[Test]
+    public function parse_rejects_invalid_json(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Coverage baseline file is not valid JSON');
+
+        CoverageBaselineFile::parse('{');
+    }
+
+    #[Test]
+    public function parse_rejects_an_unknown_version(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported coverage_baseline_version');
+
+        CoverageBaselineFile::parse((string) json_encode([
+            'coverage_baseline_version' => 99,
+            'uncovered_responses' => [],
+        ]));
+    }
+
+    #[Test]
+    public function parse_rejects_a_missing_responses_array(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('"uncovered_responses" must be an array');
+
+        CoverageBaselineFile::parse((string) json_encode(['coverage_baseline_version' => 1]));
+    }
+
+    #[Test]
+    public function parse_rejects_an_unknown_entry_field(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('unknown field(s): note');
+
+        CoverageBaselineFile::parse((string) json_encode([
+            'coverage_baseline_version' => 1,
+            'uncovered_responses' => [
+                ['spec' => 'front', 'method' => 'GET', 'path' => '/a', 'status' => '200', 'content_type' => '*', 'note' => 'x'],
+            ],
+        ]));
+    }
+
+    #[Test]
+    public function parse_rejects_a_missing_required_field(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('field "status" must be a non-empty string');
+
+        CoverageBaselineFile::parse((string) json_encode([
+            'coverage_baseline_version' => 1,
+            'uncovered_responses' => [
+                ['spec' => 'front', 'method' => 'GET', 'path' => '/a', 'content_type' => '*'],
+            ],
+        ]));
+    }
+
+    #[Test]
+    public function parse_rejects_a_non_string_content_type(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('field "content_type" must be a string');
+
+        CoverageBaselineFile::parse((string) json_encode([
+            'coverage_baseline_version' => 1,
+            'uncovered_responses' => [
+                ['spec' => 'front', 'method' => 'GET', 'path' => '/a', 'status' => '200', 'content_type' => 42],
+            ],
+        ]));
+    }
+
+    #[Test]
+    public function read_rejects_a_missing_file(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Could not read coverage baseline file');
+
+        CoverageBaselineFile::read(sys_get_temp_dir() . '/gesso-coverage-baseline-does-not-exist.json');
+    }
+
+    #[Test]
+    public function write_then_read_round_trips(): void
+    {
+        $path = (string) tempnam(sys_get_temp_dir(), 'gesso-coverage-baseline');
+
+        try {
+            $baseline = new CoverageBaseline();
+            $baseline->add(new CoverageBaselineEntry('front', 'GET', '/v1/pets', 'default', 'application/problem+json'));
+            CoverageBaselineFile::write($path, $baseline);
+
+            $this->assertSame(1, CoverageBaselineFile::read($path)->count());
+        } finally {
+            @unlink($path);
+        }
+    }
+}

--- a/tests/Unit/Coverage/CoverageMergeCommandCoverageBaselineTest.php
+++ b/tests/Unit/Coverage/CoverageMergeCommandCoverageBaselineTest.php
@@ -175,6 +175,38 @@ class CoverageMergeCommandCoverageBaselineTest extends TestCase
     }
 
     #[Test]
+    public function a_failed_gate_keeps_the_sidecars_for_a_retry(): void
+    {
+        // Recovery from any coverage-baseline failure re-runs *this command*
+        // — fix the path, free disk, or accept the regressions with
+        // OPENAPI_BASELINE_GENERATE=1. Cleaning up would make each of those
+        // cost a full parallel suite run.
+        $this->writeGeneratedBaseline([['GET', '/v1/pets', '200', 'application/json']]);
+        $this->writeWorkerSidecar('1', [['GET', '/v1/pets/search', '200', 'application/json']]);
+
+        $stderr = '';
+        $exit = $this->merge($stderr, $this->baselinePath, cleanup: true);
+
+        $this->assertSame(1, $exit);
+        $this->assertNotSame([], glob($this->sidecarDir . '/*') ?: []);
+        $this->assertStringContainsString('Sidecars kept in', $stderr);
+    }
+
+    #[Test]
+    public function a_passing_gate_still_cleans_up_the_sidecars(): void
+    {
+        $this->writeGeneratedBaseline([['GET', '/v1/pets', '200', 'application/json']]);
+        $this->writeWorkerSidecar('1', [['GET', '/v1/pets', '200', 'application/json']]);
+
+        $stderr = '';
+        $exit = $this->merge($stderr, $this->baselinePath, cleanup: true);
+
+        $this->assertSame(0, $exit);
+        $this->assertSame([], glob($this->sidecarDir . '/*') ?: []);
+        $this->assertStringNotContainsString('Sidecars kept in', $stderr);
+    }
+
+    #[Test]
     public function no_sidecars_fails_instead_of_passing_the_gate_vacuously(): void
     {
         $stderr = '';
@@ -218,8 +250,12 @@ class CoverageMergeCommandCoverageBaselineTest extends TestCase
         $this->assertStringContainsString('--coverage-baseline-stale is set but --coverage-baseline-file', $stderr);
     }
 
-    private function merge(string &$stderr, ?string $baselineFile = null, ?string $staleMode = null): int
-    {
+    private function merge(
+        string &$stderr,
+        ?string $baselineFile = null,
+        ?string $staleMode = null,
+        bool $cleanup = false,
+    ): int {
         $command = new CoverageMergeCommand(
             stdoutWriter: static fn(string $msg): null => null,
             stderrWriter: static function (string $msg) use (&$stderr): void {
@@ -231,7 +267,7 @@ class CoverageMergeCommandCoverageBaselineTest extends TestCase
             'sidecar_dir' => $this->sidecarDir,
             'spec_base_path' => __DIR__ . '/../../fixtures/specs',
             'specs' => ['petstore-3.0'],
-            'cleanup' => false,
+            'cleanup' => $cleanup,
         ];
         if ($baselineFile !== null) {
             $options['coverage_baseline_file'] = $baselineFile;

--- a/tests/Unit/Coverage/CoverageMergeCommandCoverageBaselineTest.php
+++ b/tests/Unit/Coverage/CoverageMergeCommandCoverageBaselineTest.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Coverage;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Baseline\CoverageBaselineEntry;
+use Studio\Gesso\Baseline\CoverageBaselineFile;
+use Studio\Gesso\Coverage\CoverageMergeCommand;
+use Studio\Gesso\Coverage\CoverageSidecarEnvelope;
+use Studio\Gesso\Coverage\CoverageSidecarWriter;
+use Studio\Gesso\Coverage\OpenApiCoverageTracker;
+use Studio\Gesso\Spec\OpenApiSpecLoader;
+use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
+
+use function dirname;
+use function file_exists;
+use function file_put_contents;
+use function glob;
+use function is_dir;
+use function mkdir;
+use function putenv;
+use function rmdir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+/**
+ * Issue #481: the coverage baseline gate on the parallel-run path. The merge
+ * command owns both halves here — a worker's slice cannot answer "is this
+ * response covered by the suite".
+ */
+class CoverageMergeCommandCoverageBaselineTest extends TestCase
+{
+    private string $sidecarDir = '';
+    private string $baselinePath = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiCoverageTracker::reset();
+        StrictRequiredTracker::reset();
+        OpenApiSpecLoader::reset();
+        putenv('OPENAPI_BASELINE_GENERATE');
+
+        $base = sys_get_temp_dir() . '/gesso-merge-coverage-baseline-' . uniqid('', true);
+        $this->sidecarDir = $base . '/sidecars';
+        $this->baselinePath = $base . '/gesso-coverage-baseline.json';
+        mkdir($this->sidecarDir, 0o755, recursive: true);
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('OPENAPI_BASELINE_GENERATE');
+        foreach (glob($this->sidecarDir . '/*') ?: [] as $path) {
+            @unlink($path);
+        }
+        if (file_exists($this->baselinePath)) {
+            @unlink($this->baselinePath);
+        }
+        if (is_dir($this->sidecarDir)) {
+            @rmdir($this->sidecarDir);
+            @rmdir(dirname($this->sidecarDir));
+        }
+
+        OpenApiCoverageTracker::resetCurrent();
+        OpenApiCoverageTracker::reset();
+        StrictRequiredTracker::resetCurrent();
+        StrictRequiredTracker::reset();
+        OpenApiSpecLoader::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function parse_argv_accepts_the_coverage_baseline_flags(): void
+    {
+        $opts = CoverageMergeCommand::parseArgv([
+            '--coverage-baseline-file=gesso-coverage-baseline.json',
+            '--coverage-baseline-stale=fail',
+        ]);
+
+        $this->assertSame('gesso-coverage-baseline.json', $opts['coverage_baseline_file'] ?? null);
+        $this->assertSame('fail', $opts['coverage_baseline_stale'] ?? null);
+    }
+
+    #[Test]
+    public function generation_writes_the_merged_uncovered_set(): void
+    {
+        // Two workers cover one response each; the baseline must reflect the
+        // union, not either slice.
+        $this->writeWorkerSidecar('1', [['GET', '/v1/pets', '200', 'application/json']]);
+        $this->writeWorkerSidecar('2', [['GET', '/v1/pets/search', '200', 'application/json']]);
+        putenv('OPENAPI_BASELINE_GENERATE=1');
+
+        $stderr = '';
+        $exit = $this->merge($stderr, $this->baselinePath);
+
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('[Gesso] Coverage baseline written:', $stderr);
+        $written = CoverageBaselineFile::read($this->baselinePath);
+        $this->assertFalse($written->contains($this->entry('GET', '/v1/pets', '200', 'application/json')));
+        $this->assertFalse($written->contains($this->entry('GET', '/v1/pets/search', '200', 'application/json')));
+        $this->assertTrue($written->contains($this->entry('GET', '/v1/pets', '500', 'application/json')));
+    }
+
+    #[Test]
+    public function enforcement_passes_when_the_uncovered_set_matches(): void
+    {
+        $this->writeGeneratedBaseline([['GET', '/v1/pets', '200', 'application/json']]);
+        $this->writeWorkerSidecar('1', [['GET', '/v1/pets', '200', 'application/json']]);
+
+        $stderr = '';
+        $exit = $this->merge($stderr, $this->baselinePath);
+
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('[Gesso] coverage baseline:', $stderr);
+        $this->assertStringNotContainsString('[Gesso] FATAL', $stderr);
+    }
+
+    #[Test]
+    public function enforcement_fails_and_names_a_newly_uncovered_response(): void
+    {
+        $this->writeGeneratedBaseline([['GET', '/v1/pets', '200', 'application/json']]);
+        // This run lost the test that covered `GET /v1/pets 200`.
+        $this->writeWorkerSidecar('1', [['GET', '/v1/pets/search', '200', 'application/json']]);
+
+        $stderr = '';
+        $exit = $this->merge($stderr, $this->baselinePath);
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('[Gesso] FATAL: 1 response(s) are not covered', $stderr);
+        $this->assertStringContainsString(
+            '  - [petstore-3.0] GET /v1/pets status=200 content-type=application/json',
+            $stderr,
+        );
+        $this->assertStringContainsString('OPENAPI_BASELINE_GENERATE=1 gesso coverage:merge', $stderr);
+    }
+
+    #[Test]
+    public function a_covered_baseline_entry_is_reported_as_stale_without_failing(): void
+    {
+        // Generated while only the logout endpoint was covered; this run
+        // additionally covers `GET /v1/pets 200`, so that entry is removable.
+        $this->writeGeneratedBaseline([['GET', '/v1/logout', '200', 'text/html']]);
+        $this->writeWorkerSidecar('1', [
+            ['GET', '/v1/logout', '200', 'text/html'],
+            ['GET', '/v1/pets', '200', 'application/json'],
+        ]);
+
+        $stderr = '';
+        $exit = $this->merge($stderr, $this->baselinePath);
+
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('[Gesso] NOTE: 1 coverage baseline entry(ies) are covered now', $stderr);
+    }
+
+    #[Test]
+    public function stale_fail_mode_exits_one(): void
+    {
+        // Generated while only the logout endpoint was covered; this run
+        // additionally covers `GET /v1/pets 200`, so that entry is removable.
+        $this->writeGeneratedBaseline([['GET', '/v1/logout', '200', 'text/html']]);
+        $this->writeWorkerSidecar('1', [
+            ['GET', '/v1/logout', '200', 'text/html'],
+            ['GET', '/v1/pets', '200', 'application/json'],
+        ]);
+
+        $stderr = '';
+        $exit = $this->merge($stderr, $this->baselinePath, 'fail');
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('[Gesso] FATAL: 1 coverage baseline entry(ies) are covered now', $stderr);
+    }
+
+    #[Test]
+    public function no_sidecars_fails_instead_of_passing_the_gate_vacuously(): void
+    {
+        $stderr = '';
+        $exit = $this->merge($stderr, $this->baselinePath);
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('no sidecars were found', $stderr);
+        $this->assertStringContainsString('cannot be evaluated', $stderr);
+    }
+
+    #[Test]
+    public function an_unreadable_coverage_baseline_file_fails_the_merge(): void
+    {
+        $this->writeWorkerSidecar('1', [['GET', '/v1/pets', '200', 'application/json']]);
+        file_put_contents($this->baselinePath, '{"coverage_baseline_version": 99}');
+
+        $stderr = '';
+        $exit = $this->merge($stderr, $this->baselinePath);
+
+        $this->assertSame(1, $exit);
+        $this->assertStringContainsString('--coverage-baseline-file could not be loaded', $stderr);
+    }
+
+    #[Test]
+    public function an_unknown_stale_mode_is_a_usage_error(): void
+    {
+        $stderr = '';
+        $exit = $this->merge($stderr, $this->baselinePath, 'warn');
+
+        $this->assertSame(2, $exit);
+        $this->assertStringContainsString('Unknown baseline_stale value', $stderr);
+    }
+
+    #[Test]
+    public function a_stale_mode_without_the_file_is_a_usage_error(): void
+    {
+        $stderr = '';
+        $exit = $this->merge($stderr, staleMode: 'fail');
+
+        $this->assertSame(2, $exit);
+        $this->assertStringContainsString('--coverage-baseline-stale is set but --coverage-baseline-file', $stderr);
+    }
+
+    private function merge(string &$stderr, ?string $baselineFile = null, ?string $staleMode = null): int
+    {
+        $command = new CoverageMergeCommand(
+            stdoutWriter: static fn(string $msg): null => null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+        );
+
+        $options = [
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'cleanup' => false,
+        ];
+        if ($baselineFile !== null) {
+            $options['coverage_baseline_file'] = $baselineFile;
+        }
+        if ($staleMode !== null) {
+            $options['coverage_baseline_stale'] = $staleMode;
+        }
+
+        return $command->run($options);
+    }
+
+    /**
+     * Write the baseline a suite covering exactly `$covered` would generate.
+     *
+     * @param list<array{0: string, 1: string, 2: string, 3: string}> $covered
+     */
+    private function writeGeneratedBaseline(array $covered): void
+    {
+        $this->writeWorkerSidecar('9', $covered);
+        putenv('OPENAPI_BASELINE_GENERATE=1');
+        $stderr = '';
+        $this->merge($stderr, $this->baselinePath);
+        putenv('OPENAPI_BASELINE_GENERATE');
+
+        foreach (glob($this->sidecarDir . '/*') ?: [] as $path) {
+            @unlink($path);
+        }
+        OpenApiCoverageTracker::reset();
+    }
+
+    /**
+     * @param list<array{0: string, 1: string, 2: string, 3: string}> $covered
+     */
+    private function writeWorkerSidecar(string $token, array $covered): void
+    {
+        OpenApiCoverageTracker::reset();
+        StrictRequiredTracker::reset();
+        foreach ($covered as [$method, $path, $status, $contentType]) {
+            OpenApiCoverageTracker::recordResponse(
+                'petstore-3.0',
+                $method,
+                $path,
+                $status,
+                $contentType,
+                schemaValidated: true,
+            );
+        }
+
+        CoverageSidecarWriter::write($this->sidecarDir, $token, CoverageSidecarEnvelope::build(
+            OpenApiCoverageTracker::exportState(),
+            StrictRequiredTracker::exportState(),
+        ));
+        OpenApiCoverageTracker::reset();
+        StrictRequiredTracker::reset();
+    }
+
+    private function entry(string $method, string $path, string $status, string $contentType): CoverageBaselineEntry
+    {
+        return new CoverageBaselineEntry('petstore-3.0', $method, $path, $status, $contentType);
+    }
+}

--- a/tests/Unit/PHPUnit/CoverageReportSubscriberCoverageBaselineTest.php
+++ b/tests/Unit/PHPUnit/CoverageReportSubscriberCoverageBaselineTest.php
@@ -1,0 +1,439 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\PHPUnit;
+
+use PHPUnit\Event\Test\Finished;
+use PHPUnit\Event\TestRunner\ExecutionFinished;
+use PHPUnit\Event\TestRunner\ExecutionStarted;
+use PHPUnit\Event\TestSuite\TestSuite;
+use PHPUnit\Event\TestSuite\TestSuiteWithName;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionProperty;
+use Studio\Gesso\Baseline\BaselineStaleMode;
+use Studio\Gesso\Baseline\CoverageBaseline;
+use Studio\Gesso\Baseline\CoverageBaselineEntry;
+use Studio\Gesso\Baseline\CoverageBaselineFile;
+use Studio\Gesso\Coverage\OpenApiCoverageTracker;
+use Studio\Gesso\Internal\PartialRunDecision;
+use Studio\Gesso\PHPUnit\ConsoleOutput;
+use Studio\Gesso\PHPUnit\CoverageReportSubscriber;
+use Studio\Gesso\PHPUnit\TestRunCompletionTracer;
+use Studio\Gesso\Spec\OpenApiSpecLoader;
+
+use function getenv;
+use function glob;
+use function is_dir;
+use function mkdir;
+use function ob_get_clean;
+use function ob_start;
+use function putenv;
+use function rmdir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+class CoverageReportSubscriberCoverageBaselineTest extends TestCase
+{
+    private string $tmpDir = '';
+    private ?string $previousTestToken = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiCoverageTracker::reset();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../../fixtures/specs');
+
+        $this->tmpDir = sys_get_temp_dir() . '/gesso-coverage-baseline-' . uniqid('', true);
+        mkdir($this->tmpDir, 0o755, recursive: true);
+
+        $current = getenv('TEST_TOKEN');
+        $this->previousTestToken = $current === false ? null : $current;
+        putenv('TEST_TOKEN');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->previousTestToken === null) {
+            putenv('TEST_TOKEN');
+        } else {
+            putenv('TEST_TOKEN=' . $this->previousTestToken);
+        }
+
+        if (is_dir($this->tmpDir)) {
+            foreach (glob($this->tmpDir . '/*') ?: [] as $entry) {
+                @unlink($entry);
+            }
+            @rmdir($this->tmpDir);
+        }
+
+        OpenApiCoverageTracker::reset();
+        OpenApiSpecLoader::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function a_full_generation_run_writes_every_uncovered_response(): void
+    {
+        $this->recordCoveredPetsList();
+        $path = $this->tmpDir . '/gesso-coverage-baseline.json';
+
+        $stderr = '';
+        $this->notify($this->subscriber($stderr, generatePath: $path));
+
+        $this->assertFileExists($path);
+        $written = CoverageBaselineFile::read($path);
+        $this->assertFalse(
+            $written->contains(new CoverageBaselineEntry('petstore-3.0', 'GET', '/v1/pets', '200', 'application/json')),
+            'a validated response must not be baselined',
+        );
+        $this->assertTrue(
+            $written->contains(new CoverageBaselineEntry('petstore-3.0', 'GET', '/v1/pets', '500', 'application/json')),
+        );
+        $this->assertStringContainsString('[Gesso] Coverage baseline written:', $stderr);
+        $this->assertStringContainsString('uncovered response(s)', $stderr);
+    }
+
+    #[Test]
+    public function a_partial_generation_run_refuses_to_write_and_exits_non_zero(): void
+    {
+        $this->recordCoveredPetsList();
+        $path = $this->tmpDir . '/gesso-coverage-baseline.json';
+
+        $stderr = '';
+        $exitCode = null;
+        $this->notify($this->subscriber(
+            $stderr,
+            generatePath: $path,
+            partialRun: PartialRunDecision::partial('--filter'),
+            exitCode: $exitCode,
+        ));
+
+        $this->assertFileDoesNotExist($path);
+        $this->assertStringContainsString('[Gesso] WARNING: coverage baseline generation refused on a partial run', $stderr);
+        $this->assertSame(1, $exitCode);
+    }
+
+    #[Test]
+    public function a_generation_run_with_no_recorded_coverage_refuses_to_write(): void
+    {
+        // Without this guard the file would list every declared response and
+        // permanently baseline the whole contract.
+        $path = $this->tmpDir . '/gesso-coverage-baseline.json';
+
+        $stderr = '';
+        $exitCode = null;
+        $this->notify($this->subscriber($stderr, generatePath: $path, exitCode: $exitCode));
+
+        $this->assertFileDoesNotExist($path);
+        $this->assertStringContainsString('no contract test coverage was recorded', $stderr);
+        $this->assertSame(1, $exitCode);
+    }
+
+    #[Test]
+    public function enforcement_passes_when_the_uncovered_set_matches_the_baseline(): void
+    {
+        $this->recordCoveredPetsList();
+
+        $stderr = '';
+        $exitCode = null;
+        $this->notify($this->subscriber(
+            $stderr,
+            baseline: $this->generatedBaseline(),
+            exitCode: $exitCode,
+        ));
+
+        $this->assertNull($exitCode);
+        $this->assertStringContainsString('[Gesso] coverage baseline:', $stderr);
+        $this->assertStringContainsString('0 covered now', $stderr);
+        $this->assertStringNotContainsString('[Gesso] FATAL', $stderr);
+    }
+
+    #[Test]
+    public function enforcement_fails_and_names_a_newly_uncovered_response(): void
+    {
+        // The baseline was generated while `GET /v1/pets 200` was covered;
+        // this run does not cover it, so the row itself is reported.
+        $baseline = $this->generatedBaseline();
+        OpenApiCoverageTracker::reset();
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets/search',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+
+        $stderr = '';
+        $exitCode = null;
+        $this->notify($this->subscriber($stderr, baseline: $baseline, exitCode: $exitCode));
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('[Gesso] FATAL: 1 response(s) are not covered', $stderr);
+        $this->assertStringContainsString(
+            '  - [petstore-3.0] GET /v1/pets status=200 content-type=application/json',
+            $stderr,
+        );
+        $this->assertStringContainsString('OPENAPI_BASELINE_GENERATE=1 vendor/bin/phpunit', $stderr);
+    }
+
+    #[Test]
+    public function enforcement_is_independent_of_the_denominator(): void
+    {
+        // Issue #481 problem 2: a response documented after the baseline was
+        // generated moves the percentage but must not fail the gate as long
+        // as it is covered.
+        $baseline = new CoverageBaseline();
+        $baseline->add(new CoverageBaselineEntry('petstore-3.0', 'GET', '/v1/pets', '500', 'application/json'));
+        $this->recordCoveredPetsList();
+
+        $stderr = '';
+        $exitCode = null;
+        $this->notify($this->subscriber($stderr, baseline: $baseline, exitCode: $exitCode));
+
+        // Every other declared response is uncovered here, so this run *does*
+        // fail — but only for rows the baseline omits, never for the newly
+        // covered one.
+        $this->assertSame(1, $exitCode);
+        $this->assertStringNotContainsString(
+            '[petstore-3.0] GET /v1/pets status=200 content-type=application/json',
+            $stderr,
+        );
+    }
+
+    #[Test]
+    public function a_covered_baseline_entry_is_reported_as_stale(): void
+    {
+        $baseline = $this->generatedBaseline();
+        $baseline->add(new CoverageBaselineEntry('petstore-3.0', 'GET', '/v1/pets', '200', 'application/json'));
+
+        $stderr = '';
+        $exitCode = null;
+        $this->notify($this->subscriber($stderr, baseline: $baseline, exitCode: $exitCode));
+
+        $this->assertNull($exitCode, 'note mode must not fail the run');
+        $this->assertStringContainsString('1 covered now', $stderr);
+        $this->assertStringContainsString('[Gesso] NOTE: 1 coverage baseline entry(ies) are covered now', $stderr);
+        $this->assertStringContainsString(
+            '  - [petstore-3.0] GET /v1/pets status=200 content-type=application/json',
+            $stderr,
+        );
+    }
+
+    #[Test]
+    public function stale_fail_mode_exits_non_zero(): void
+    {
+        $baseline = $this->generatedBaseline();
+        $baseline->add(new CoverageBaselineEntry('petstore-3.0', 'GET', '/v1/pets', '200', 'application/json'));
+
+        $stderr = '';
+        $exitCode = null;
+        $this->notify($this->subscriber(
+            $stderr,
+            baseline: $baseline,
+            staleMode: BaselineStaleMode::Fail,
+            exitCode: $exitCode,
+        ));
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('[Gesso] FATAL: 1 coverage baseline entry(ies) are covered now', $stderr);
+    }
+
+    #[Test]
+    public function stale_off_mode_stays_silent(): void
+    {
+        $baseline = $this->generatedBaseline();
+        $baseline->add(new CoverageBaselineEntry('petstore-3.0', 'GET', '/v1/pets', '200', 'application/json'));
+
+        $stderr = '';
+        $exitCode = null;
+        $this->notify($this->subscriber(
+            $stderr,
+            baseline: $baseline,
+            staleMode: BaselineStaleMode::Off,
+            exitCode: $exitCode,
+        ));
+
+        $this->assertNull($exitCode);
+        $this->assertStringContainsString('1 covered now', $stderr);
+        $this->assertStringNotContainsString('can be removed from the baseline file', $stderr);
+    }
+
+    #[Test]
+    public function a_partial_run_skips_the_gate_with_a_note(): void
+    {
+        $baseline = $this->generatedBaseline();
+        OpenApiCoverageTracker::reset();
+
+        $stderr = '';
+        $exitCode = null;
+        $this->notify($this->subscriber(
+            $stderr,
+            baseline: $baseline,
+            partialRun: PartialRunDecision::partial('--filter'),
+            exitCode: $exitCode,
+        ));
+
+        $this->assertNull($exitCode);
+        $this->assertStringContainsString('[Gesso] NOTE: the coverage baseline gate is skipped on partial runs', $stderr);
+    }
+
+    #[Test]
+    public function a_run_that_did_not_complete_cleanly_skips_the_gate(): void
+    {
+        // A test that failed before its contract assertion leaves responses
+        // uncovered; reporting those as regressions would bury the real
+        // failure under a wall of coverage noise.
+        $baseline = $this->generatedBaseline();
+        OpenApiCoverageTracker::reset();
+        $this->recordCoveredPetsList();
+
+        $stderr = '';
+        $exitCode = null;
+        $this->notify($this->subscriber(
+            $stderr,
+            baseline: $baseline,
+            completionTracer: $this->completionTracer(plannedTests: 3, finishedTests: 2),
+            exitCode: $exitCode,
+        ));
+
+        $this->assertNull($exitCode);
+        $this->assertStringContainsString('the coverage baseline gate is skipped because the run did not complete cleanly', $stderr);
+    }
+
+    #[Test]
+    public function enforcement_fails_when_no_coverage_was_recorded_at_all(): void
+    {
+        $stderr = '';
+        $exitCode = null;
+        $this->notify($this->subscriber(
+            $stderr,
+            baseline: new CoverageBaseline(),
+            exitCode: $exitCode,
+        ));
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString(
+            '[Gesso] FATAL: no contract test coverage was recorded; the coverage baseline gate cannot be evaluated.',
+            $stderr,
+        );
+    }
+
+    #[Test]
+    public function a_paratest_worker_neither_generates_nor_enforces(): void
+    {
+        // The merge CLI owns both halves for parallel runs — a worker sees
+        // only its slice, so its uncovered set is meaningless.
+        $baseline = $this->generatedBaseline();
+        putenv('TEST_TOKEN=2');
+        $path = $this->tmpDir . '/gesso-coverage-baseline.json';
+
+        $stderr = '';
+        $exitCode = null;
+        $this->notify($this->subscriber(
+            $stderr,
+            baseline: $baseline,
+            generatePath: $path,
+            exitCode: $exitCode,
+        ));
+
+        $this->assertFileDoesNotExist($path);
+        $this->assertNull($exitCode);
+        $this->assertStringNotContainsString('coverage baseline', $stderr);
+    }
+
+    #[Test]
+    public function no_coverage_baseline_configuration_stays_silent(): void
+    {
+        $this->recordCoveredPetsList();
+
+        $stderr = '';
+        $this->notify($this->subscriber($stderr));
+
+        $this->assertStringNotContainsString('coverage baseline', $stderr);
+    }
+
+    private function recordCoveredPetsList(): void
+    {
+        OpenApiCoverageTracker::recordResponse(
+            'petstore-3.0',
+            'GET',
+            '/v1/pets',
+            '200',
+            'application/json',
+            schemaValidated: true,
+        );
+    }
+
+    /**
+     * The baseline a generation run writes for a suite that covers
+     * `GET /v1/pets 200` and nothing else — the starting point every
+     * enforcement test varies from.
+     */
+    private function generatedBaseline(): CoverageBaseline
+    {
+        $this->recordCoveredPetsList();
+        $path = $this->tmpDir . '/generated.json';
+        $stderr = '';
+        $this->notify($this->subscriber($stderr, generatePath: $path));
+
+        return CoverageBaselineFile::read($path);
+    }
+
+    private function completionTracer(int $plannedTests, int $finishedTests): TestRunCompletionTracer
+    {
+        $suite = (new ReflectionClass(TestSuiteWithName::class))->newInstanceWithoutConstructor();
+        (new ReflectionProperty(TestSuite::class, 'count'))->setValue($suite, $plannedTests);
+        $started = (new ReflectionClass(ExecutionStarted::class))->newInstanceWithoutConstructor();
+        (new ReflectionProperty(ExecutionStarted::class, 'testSuite'))->setValue($started, $suite);
+
+        $tracer = new TestRunCompletionTracer();
+        $tracer->trace($started);
+        for ($i = 0; $i < $finishedTests; $i++) {
+            $tracer->trace((new ReflectionClass(Finished::class))->newInstanceWithoutConstructor());
+        }
+
+        return $tracer;
+    }
+
+    private function subscriber(
+        string &$stderr,
+        ?CoverageBaseline $baseline = null,
+        ?string $generatePath = null,
+        BaselineStaleMode $staleMode = BaselineStaleMode::Note,
+        ?PartialRunDecision $partialRun = null,
+        ?TestRunCompletionTracer $completionTracer = null,
+        ?int &$exitCode = null,
+    ): CoverageReportSubscriber {
+        return new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            sidecarDir: $this->tmpDir,
+            exitHandler: static function (int $code) use (&$exitCode): void {
+                $exitCode = $code;
+            },
+            partialRun: $partialRun,
+            baselineCompletionTracer: $completionTracer,
+            coverageBaseline: $baseline,
+            coverageBaselineGeneratePath: $generatePath,
+            coverageBaselineStaleMode: $staleMode,
+        );
+    }
+
+    private function notify(CoverageReportSubscriber $subscriber): void
+    {
+        ob_start();
+        $subscriber->notify((new ReflectionClass(ExecutionFinished::class))->newInstanceWithoutConstructor());
+        ob_get_clean();
+    }
+}

--- a/tests/Unit/PHPUnit/CoverageReportSubscriberCoverageBaselineTest.php
+++ b/tests/Unit/PHPUnit/CoverageReportSubscriberCoverageBaselineTest.php
@@ -24,6 +24,7 @@ use Studio\Gesso\PHPUnit\CoverageReportSubscriber;
 use Studio\Gesso\PHPUnit\TestRunCompletionTracer;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 
+use function file_put_contents;
 use function getenv;
 use function glob;
 use function is_dir;
@@ -345,6 +346,78 @@ class CoverageReportSubscriberCoverageBaselineTest extends TestCase
         $this->assertFileDoesNotExist($path);
         $this->assertNull($exitCode);
         $this->assertStringNotContainsString('coverage baseline', $stderr);
+    }
+
+    #[Test]
+    public function a_generation_worker_exits_non_zero_when_the_sidecar_write_fails(): void
+    {
+        // Worst case: the sidecar write fails AND the failure marker cannot
+        // be dropped either (the sidecar dir path is an existing file, so
+        // ensureDir fails for both). The merge would then generate a
+        // baseline from N-1 workers, recording this worker's covered
+        // responses as uncovered and permanently loosening the ratchet.
+        $this->recordCoveredPetsList();
+        putenv('TEST_TOKEN=5');
+        $blocker = $this->tmpDir . '/not-a-dir';
+        file_put_contents($blocker, 'blocks the sidecar dir');
+
+        $stderr = '';
+        $exitCode = null;
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            sidecarDir: $blocker,
+            exitHandler: static function (int $code) use (&$exitCode): void {
+                $exitCode = $code;
+            },
+            coverageBaselineGeneratePath: $this->tmpDir . '/gesso-coverage-baseline.json',
+        );
+        $this->notify($subscriber);
+
+        $this->assertStringContainsString('[Gesso] FATAL', $stderr);
+        $this->assertStringContainsString("this worker's covered responses", $stderr);
+        $this->assertStringContainsString('incomplete baseline', $stderr);
+        $this->assertSame(1, $exitCode, 'a generation worker that lost its sidecar must fail the run');
+    }
+
+    #[Test]
+    public function an_enforcing_worker_stays_green_when_the_sidecar_write_fails(): void
+    {
+        // Nothing is staged for enforcement, and a merge missing one
+        // worker's coverage fails loudly with its "newly uncovered" listing
+        // rather than writing a file — so this worker must keep the
+        // coverage-only sidecar contract of staying green on I/O errors.
+        $this->recordCoveredPetsList();
+        $baseline = $this->generatedBaseline();
+        putenv('TEST_TOKEN=6');
+        $blocker = $this->tmpDir . '/not-a-dir-enforcing';
+        file_put_contents($blocker, 'blocks the sidecar dir');
+
+        $stderr = '';
+        $exitCode = null;
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            sidecarDir: $blocker,
+            exitHandler: static function (int $code) use (&$exitCode): void {
+                $exitCode = $code;
+            },
+            coverageBaseline: $baseline,
+        );
+        $this->notify($subscriber);
+
+        $this->assertNull($exitCode);
+        $this->assertStringNotContainsString('[Gesso] FATAL', $stderr);
     }
 
     #[Test]

--- a/tests/Unit/PHPUnit/OpenApiCoverageExtensionCoverageBaselineTest.php
+++ b/tests/Unit/PHPUnit/OpenApiCoverageExtensionCoverageBaselineTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\PHPUnit;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Runner\Extension\ParameterCollection;
+use Studio\Gesso\Baseline\CoverageBaseline;
+use Studio\Gesso\Baseline\CoverageBaselineEntry;
+use Studio\Gesso\Baseline\CoverageBaselineFile;
+use Studio\Gesso\Baseline\InvalidBaselineConfigurationException;
+use Studio\Gesso\PHPUnit\OpenApiCoverageExtension;
+use Studio\Gesso\Spec\OpenApiSpecLoader;
+
+use function fclose;
+use function file_put_contents;
+use function fopen;
+use function putenv;
+use function rewind;
+use function stream_get_contents;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+/**
+ * Issue #481: bootstrap-level handling of `coverage_baseline_file` /
+ * `coverage_baseline_stale`.
+ */
+class OpenApiCoverageExtensionCoverageBaselineTest extends TestCase
+{
+    /** @var null|resource */
+    private $stderrBuffer;
+
+    /** @var list<string> */
+    private array $tempFiles = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiSpecLoader::reset();
+        putenv('OPENAPI_BASELINE_GENERATE');
+
+        $buffer = fopen('php://memory', 'w+');
+        if ($buffer === false) {
+            $this->fail('Could not open in-memory buffer for STDERR capture');
+        }
+        $this->stderrBuffer = $buffer;
+        OpenApiCoverageExtension::overrideStderrForTesting($buffer);
+    }
+
+    protected function tearDown(): void
+    {
+        OpenApiCoverageExtension::overrideStderrForTesting(null);
+        if ($this->stderrBuffer !== null) {
+            fclose($this->stderrBuffer);
+            $this->stderrBuffer = null;
+        }
+        foreach ($this->tempFiles as $path) {
+            @unlink($path);
+        }
+        $this->tempFiles = [];
+        OpenApiSpecLoader::reset();
+        putenv('OPENAPI_BASELINE_GENERATE');
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function a_readable_coverage_baseline_file_bootstraps_cleanly(): void
+    {
+        $this->setupExtension(['coverage_baseline_file' => $this->writeFixture()]);
+
+        $this->assertSame('', $this->capturedStderr());
+    }
+
+    #[Test]
+    public function a_missing_coverage_baseline_file_is_fatal(): void
+    {
+        try {
+            $this->setupExtension(['coverage_baseline_file' => sys_get_temp_dir() . '/gesso-missing-' . uniqid() . '.json']);
+            $this->fail('Expected an InvalidBaselineConfigurationException.');
+        } catch (InvalidBaselineConfigurationException) {
+            $this->assertStringContainsString('[Gesso] FATAL', $this->capturedStderr());
+            $this->assertStringContainsString('coverage_baseline_file could not be loaded', $this->capturedStderr());
+        }
+    }
+
+    #[Test]
+    public function a_malformed_coverage_baseline_file_is_fatal(): void
+    {
+        $path = sys_get_temp_dir() . '/gesso-coverage-baseline-' . uniqid() . '.json';
+        file_put_contents($path, '{"coverage_baseline_version": 99}');
+        $this->tempFiles[] = $path;
+
+        try {
+            $this->setupExtension(['coverage_baseline_file' => $path]);
+            $this->fail('Expected an InvalidBaselineConfigurationException.');
+        } catch (InvalidBaselineConfigurationException) {
+            $this->assertStringContainsString('Unsupported coverage_baseline_version', $this->capturedStderr());
+        }
+    }
+
+    #[Test]
+    public function a_generation_run_never_reads_the_coverage_baseline_file(): void
+    {
+        // The file is about to be overwritten; a missing or stale one must
+        // not abort the very run that would fix it.
+        putenv('OPENAPI_BASELINE_GENERATE=1');
+
+        $this->setupExtension([
+            'coverage_baseline_file' => sys_get_temp_dir() . '/gesso-missing-' . uniqid() . '.json',
+        ]);
+
+        $this->assertSame('', $this->capturedStderr());
+    }
+
+    #[Test]
+    public function generation_with_only_a_coverage_baseline_file_is_allowed(): void
+    {
+        // Issue #481: `OPENAPI_BASELINE_GENERATE` drives both baselines, so
+        // configuring only the coverage half must not trip the violation
+        // baseline's "nowhere to write" guard.
+        putenv('OPENAPI_BASELINE_GENERATE=1');
+
+        $this->setupExtension(['coverage_baseline_file' => 'gesso-coverage-baseline.json']);
+
+        $this->assertSame('', $this->capturedStderr());
+    }
+
+    #[Test]
+    public function generation_without_either_baseline_file_is_fatal(): void
+    {
+        putenv('OPENAPI_BASELINE_GENERATE=1');
+
+        try {
+            $this->setupExtension([]);
+            $this->fail('Expected an InvalidBaselineConfigurationException.');
+        } catch (InvalidBaselineConfigurationException) {
+            $this->assertStringContainsString('coverage_baseline_file', $this->capturedStderr());
+        }
+    }
+
+    #[Test]
+    public function an_unknown_coverage_baseline_stale_value_is_fatal(): void
+    {
+        try {
+            $this->setupExtension([
+                'coverage_baseline_file' => $this->writeFixture(),
+                'coverage_baseline_stale' => 'warn',
+            ]);
+            $this->fail('Expected an InvalidBaselineConfigurationException.');
+        } catch (InvalidBaselineConfigurationException) {
+            $this->assertStringContainsString('Unknown baseline_stale value', $this->capturedStderr());
+        }
+    }
+
+    #[Test]
+    public function coverage_baseline_stale_without_its_file_is_fatal(): void
+    {
+        try {
+            $this->setupExtension(['coverage_baseline_stale' => 'note']);
+            $this->fail('Expected an InvalidBaselineConfigurationException.');
+        } catch (InvalidBaselineConfigurationException) {
+            $stderr = $this->capturedStderr();
+            $this->assertStringContainsString('coverage_baseline_stale is set', $stderr);
+            $this->assertStringContainsString('`coverage_baseline_file`', $stderr);
+        }
+    }
+
+    #[Test]
+    public function baseline_stale_still_points_at_the_violation_baseline_file(): void
+    {
+        // The two stale parameters are resolved by one helper; the error
+        // message must keep naming the right partner parameter.
+        try {
+            $this->setupExtension(['baseline_stale' => 'note']);
+            $this->fail('Expected an InvalidBaselineConfigurationException.');
+        } catch (InvalidBaselineConfigurationException) {
+            $stderr = $this->capturedStderr();
+            $this->assertStringContainsString('baseline_stale is set', $stderr);
+            $this->assertStringContainsString('`baseline_file`', $stderr);
+            $this->assertStringNotContainsString('coverage_baseline_file', $stderr);
+        }
+    }
+
+    private function writeFixture(): string
+    {
+        $baseline = new CoverageBaseline();
+        $baseline->add(new CoverageBaselineEntry('petstore-3.0', 'GET', '/v1/pets', '500', 'application/json'));
+        $path = sys_get_temp_dir() . '/gesso-coverage-baseline-' . uniqid() . '.json';
+        CoverageBaselineFile::write($path, $baseline);
+        $this->tempFiles[] = $path;
+
+        return $path;
+    }
+
+    /** @param array<string, string> $parameters */
+    private function setupExtension(array $parameters): void
+    {
+        $extension = new OpenApiCoverageExtension();
+        $extension->setupExtension(null, ParameterCollection::fromArray([
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => 'petstore-3.0',
+            ...$parameters,
+        ]), null);
+    }
+
+    private function capturedStderr(): string
+    {
+        if ($this->stderrBuffer === null) {
+            return '';
+        }
+        rewind($this->stderrBuffer);
+
+        return (string) stream_get_contents($this->stderrBuffer);
+    }
+}

--- a/tests/fixtures/compatibility/v2-diagnostic-prefixes.json
+++ b/tests/fixtures/compatibility/v2-diagnostic-prefixes.json
@@ -1,7 +1,7 @@
 {
     "[Gesso]": {
         "src/Baseline/CoverageBaselineEvaluator.php": 2,
-        "src/Coverage/CoverageMergeCommand.php": 14,
+        "src/Coverage/CoverageMergeCommand.php": 15,
         "src/Fuzz/SchemaDataGenerator.php": 1,
         "src/Laravel/ValidatesOpenApiSchema.php": 1,
         "src/PHPUnit/CoverageReportSubscriber.php": 19,

--- a/tests/fixtures/compatibility/v2-diagnostic-prefixes.json
+++ b/tests/fixtures/compatibility/v2-diagnostic-prefixes.json
@@ -1,10 +1,11 @@
 {
     "[Gesso]": {
-        "src/Coverage/CoverageMergeCommand.php": 5,
+        "src/Baseline/CoverageBaselineEvaluator.php": 2,
+        "src/Coverage/CoverageMergeCommand.php": 14,
         "src/Fuzz/SchemaDataGenerator.php": 1,
         "src/Laravel/ValidatesOpenApiSchema.php": 1,
-        "src/PHPUnit/CoverageReportSubscriber.php": 11,
-        "src/PHPUnit/OpenApiCoverageExtension.php": 6,
+        "src/PHPUnit/CoverageReportSubscriber.php": 19,
+        "src/PHPUnit/OpenApiCoverageExtension.php": 7,
         "src/Validation/Request/SecurityValidator.php": 2,
         "src/ValidationOutput.php": 1
     },


### PR DESCRIPTION
## 概要

Closes #481

`min_response_coverage` の「比率しきい値」では「カバレッジを後退させない」を表現できない、という issue #481 の 3 つの問題（headroom / 分母への結合 / 上げ忘れで黙って緩む）を、**未カバー response の集合をゲートする**方式で解消する。violation baseline (#402) と同じ考え方をカバレッジに適用したもの。

## 変更内容

### 新しい設定

```xml
<parameter name="coverage_baseline_file" value="gesso-coverage-baseline.json"/>
<parameter name="coverage_baseline_stale" value="fail"/>  <!-- off | note | fail, default note -->
```

生成は既存の `OPENAPI_BASELINE_GENERATE=1 vendor/bin/phpunit` に相乗り。`baseline_file` と `coverage_baseline_file` のどちらか一方だけの設定でも通るよう、生成時の FATAL 条件を緩めた。

paratest 用に `gesso coverage:merge --coverage-baseline-file=<path>` / `--coverage-baseline-stale=<mode>` を追加。worker は生成も enforcement もせず（slice では「カバーされているか」を判定できない）、merge 済みカバレッジ状態を持つ merge 側が両方を担当する。

### ゲートの挙動

- baseline に無い未カバー response が現れたら **その行を名指しで** FAIL

  ```text
  [Gesso] FATAL: 2 response(s) are not covered and are not listed in the coverage baseline:
    - [front] DELETE /v1/pets/{id} status=204 content-type=*
    - [front] GET /v1/pets status=500 content-type=application/json
  ```

- baseline にあるがカバー済みになった行は stale として報告（`note` / `fail` / `off`）。削除すると ratchet が diff に現れる
- 分母非依存: spec に response を足しても、それがカバーされていれば落ちない（issue の問題 2）

### 意図的な設計判断

- **`Skipped` も baseline に入れる。** `skip_response_codes` で skip された行は `min_response_coverage` の分子でも「未カバー」なので、含めないと比率ゲートより弱くなる。
- **partial run / clean に終わらなかった run ではゲートをスキップ**（NOTE 付き）。assertion に到達しなかったテストの response が「新規未カバー」として大量に報告されると、本来の失敗が埋もれる。
- **カバレッジが 1 件も記録されなかった run は FATAL。** 空の未カバー集合は「gap が無い」ではなく「データが無い」なので、素通しさせない。
- 新規ファイル形式は `coverage_baseline_version: 1` の versioned surface として `docs/versioning.md` に記載。

## テスト

- `composer ci` green（PHP-CS-Fixer × 2 / PHPStan level 6 / PHPUnit 3009 tests）
- 追加: 評価器・wire format の unit（23）、subscriber 経路（14）、extension bootstrap（9）、merge CLI（10）

## 関連情報

- 実装順の議論どおり #481 → #475 → #406 の 1 本目。tuple の正規形（`CoverageBaselineEntry`）をここで確定させたので、#475 / #406 はこれを再利用できる
- `[Gesso]` 診断プレフィックスの inventory fixture (`v2-diagnostic-prefixes.json`) を更新。identity-neutral prefix の v1.9 parity は不変