### PR TITLE
feat(cli): add coverage:gate for spec patch coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ To validate every response automatically, set `'auto_assert' => true` and drop t
 | Violation baseline: adopt on a legacy API, fail only on new violations | [`docs/baseline.md`](docs/baseline.md) |
 | Coverage baseline: gate the set of uncovered responses instead of a percentage | [`docs/coverage-baseline.md`](docs/coverage-baseline.md) |
 | Coverage report modes & threshold gate | [`docs/coverage.md`](docs/coverage.md) |
+| Spec patch coverage: fail a PR that changes an operation no test covers | [`docs/coverage-gate.md`](docs/coverage-gate.md) |
 | HTML coverage output | [`docs/coverage-html-output.md`](docs/coverage-html-output.md) |
 | JSON coverage output schema | [`docs/coverage-json-schema.md`](docs/coverage-json-schema.md) |
 | JSON validation result output schema | [`docs/validation-json-schema.md`](docs/validation-json-schema.md) |

--- a/bin/gesso
+++ b/bin/gesso
@@ -3,6 +3,7 @@
 
 declare(strict_types=1);
 
+use Studio\Gesso\Cli\CoverageGateCommand;
 use Studio\Gesso\Cli\DoctorCommand;
 use Studio\Gesso\Coverage\CoverageMergeCommand;
 
@@ -36,6 +37,7 @@ $usage = <<<'USAGE'
     Commands:
       doctor           Check whether Gesso can load and enforce a contract.
       coverage:merge   Combine parallel-worker coverage sidecars.
+      coverage:gate    Fail when a spec change touches an uncovered operation.
 
     Run `gesso <command> --help` for command-specific options.
 
@@ -58,6 +60,11 @@ if ($commandName === 'doctor') {
 if ($commandName === 'coverage:merge') {
     $command = new CoverageMergeCommand(invocation: 'gesso coverage:merge');
     exit($command->run(CoverageMergeCommand::parseArgv($argv)));
+}
+
+if ($commandName === 'coverage:gate') {
+    $command = new CoverageGateCommand(invocation: 'gesso coverage:gate');
+    exit($command->run(CoverageGateCommand::parseArgv($argv)));
 }
 
 fwrite(STDERR, "[Gesso] Unknown command: {$commandName}\n\n{$usage}");

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -270,6 +270,7 @@ export default defineConfig({
           { text: 'Doctor command', link: '/doctor' },
           { text: 'Violation baseline', link: '/baseline' },
           { text: 'Coverage baseline', link: '/coverage-baseline' },
+          { text: 'Spec patch coverage gate', link: '/coverage-gate' },
           { text: 'PSR-7 validation', link: '/psr7' },
           { text: 'Laravel route parity', link: '/laravel-route-parity' },
           { text: 'Schema-driven fuzzing', link: '/fuzzing' },

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -3,6 +3,7 @@
 - [GitHub Actions Step Summary](#github-actions-step-summary)
 - [Markdown output file](#markdown-output-file)
 - [Coverage output formats](#coverage-output-formats)
+- [Spec patch coverage gate](#spec-patch-coverage-gate)
 
 ## GitHub Actions Step Summary
 
@@ -92,6 +93,58 @@ vendor/bin/gesso coverage:merge \
 > the file as Markdown, so an HTML/JUnit/JSON payload would be escaped. Use
 > the per-format flags above for artifact uploads and `output_file` /
 > `github_step_summary` for the in-PR summary.
+
+## Spec patch coverage gate
+
+`gesso coverage:gate` fails the build when a pull request changes an operation
+that no test exercises — see [Spec patch coverage gate](coverage-gate.md) for
+the full behaviour and exit codes. It needs the base branch's copy of the spec,
+so check out with enough history for `git show` to reach it:
+
+```yaml
+name: Spec patch coverage
+
+on: pull_request
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+
+      - run: composer install --prefer-dist --no-progress
+
+      - name: Run tests with JSON coverage
+        run: vendor/bin/phpunit
+
+      - name: Fetch the base spec
+        run: |
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          git show "origin/${{ github.base_ref }}:openapi.json" > "${RUNNER_TEMP}/base.json"
+
+      - name: Gate the changed operations
+        run: |
+          set -o pipefail
+          vendor/bin/gesso coverage:gate \
+            --base-spec="${RUNNER_TEMP}/base.json" \
+            --spec=openapi.json \
+            --coverage=build/coverage.json \
+            --format=markdown | tee -a "${GITHUB_STEP_SUMMARY}"
+```
+
+The PHPUnit run must emit `build/coverage.json`; add the `json_output`
+parameter (or `coverage:merge --json-output` for parallel runs) as shown in
+[Coverage output formats](#coverage-output-formats).
+
+> **Note:** `set -o pipefail` is required. GitHub Actions runs `run:` blocks
+> under `bash -e` without it, so the step would take `tee`'s exit code and the
+> gate's failure would be swallowed.
 
 ## Partial test runs (`--filter`, `--testsuite`, path args, …)
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -98,8 +98,13 @@ vendor/bin/gesso coverage:merge \
 
 `gesso coverage:gate` fails the build when a pull request changes an operation
 that no test exercises — see [Spec patch coverage gate](coverage-gate.md) for
-the full behaviour and exit codes. It needs the base branch's copy of the spec,
-so check out with enough history for `git show` to reach it:
+the full behaviour and exit codes.
+
+It needs the base branch's copy of the spec **including whatever that copy
+`$ref`s**: the gate resolves local references relative to the base document's
+own directory, exactly like the runtime loader. Materialise the base revision
+as a `git worktree` rather than redirecting a single `git show`, so a split
+spec (`root.yaml` → `./schemas/*.yaml`) resolves there too:
 
 ```yaml
 name: Spec patch coverage
@@ -123,16 +128,16 @@ jobs:
       - name: Run tests with JSON coverage
         run: vendor/bin/phpunit
 
-      - name: Fetch the base spec
+      - name: Check out the base spec tree
         run: |
-          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
-          git show "origin/${{ github.base_ref }}:openapi.json" > "${RUNNER_TEMP}/base.json"
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          git worktree add "${RUNNER_TEMP}/base" FETCH_HEAD
 
       - name: Gate the changed operations
         run: |
           set -o pipefail
           vendor/bin/gesso coverage:gate \
-            --base-spec="${RUNNER_TEMP}/base.json" \
+            --base-spec="${RUNNER_TEMP}/base/openapi.json" \
             --spec=openapi.json \
             --coverage=build/coverage.json \
             --format=markdown | tee -a "${GITHUB_STEP_SUMMARY}"
@@ -145,6 +150,11 @@ parameter (or `coverage:merge --json-output` for parallel runs) as shown in
 > **Note:** `set -o pipefail` is required. GitHub Actions runs `run:` blocks
 > under `bash -e` without it, so the step would take `tee`'s exit code and the
 > gate's failure would be swallowed.
+
+A single-file spec with no local `$ref` needs no worktree —
+`git show "origin/${{ github.base_ref }}:openapi.json" > "${RUNNER_TEMP}/base.json"`
+is enough. If you already publish a bundled artifact, point `--base-spec` at
+the base branch's bundle instead.
 
 ## Partial test runs (`--filter`, `--testsuite`, path args, …)
 

--- a/docs/coverage-gate.md
+++ b/docs/coverage-gate.md
@@ -1,0 +1,97 @@
+# Spec patch coverage gate
+
+`gesso coverage:gate` fails a pull request when it changes an operation that no
+test exercises. It is the OpenAPI counterpart of `diff-cover` / Codecov's patch
+status: instead of "the whole spec must be 80% covered", it enforces "whatever
+*this* change touched must be covered".
+
+It needs three inputs:
+
+| Input | Where it comes from |
+|---|---|
+| the base spec | `git show origin/main:openapi.json > base.json` |
+| the current spec | your working tree |
+| a coverage document | [`json_output`](coverage-json-schema.md) from the test run |
+
+```bash
+git show origin/main:openapi.json > /tmp/base.json
+
+vendor/bin/gesso coverage:gate \
+  --base-spec=/tmp/base.json \
+  --spec=openapi.json \
+  --coverage=build/coverage.json
+```
+
+```text
+[Gesso] 2 operations changed against the base spec:
+
+  DELETE /pets/{id}
+    204 (no content)        UNCOVERED
+  PUT /pets/{id}
+    200 application/json    covered
+
+1 changed response is not covered by any test.
+```
+
+## What counts as a change
+
+Both documents are resolved through the same loader the validators use, then
+each operation is fingerprinted:
+
+- **added** — the `(method, path)` is not in the base spec. Every declared
+  response is in scope.
+- **changed** — the operation exists in both, but its resolved tree differs.
+  When only some responses changed, only those are in scope. When the
+  operation's request contract changed (parameters, request body, security,
+  …), every response of that operation is in scope, because a changed request
+  is worth re-exercising end to end.
+- **removed** — listed for information only. A response that no longer exists
+  cannot be tested, so it never fails the gate.
+
+The comparison is **structural, not semantic**. The gate does not classify a
+change as breaking or non-breaking — that is the job of a dedicated diff tool
+such as [oasdiff](https://github.com/oasdiff/oasdiff) or
+[pb33f/openapi-changes](https://github.com/pb33f/openapi-changes). Because the
+comparison happens after reference resolution, moving a schema into
+`components` and pointing a `$ref` at it is *not* a change.
+
+## What counts as covered
+
+The gate joins each in-scope `(method, path, status, content-type)` tuple
+against the coverage document at the same granularity coverage is measured at.
+A tuple passes only when its `response_state` is `validated`. A `skipped`
+response is rendered as `SKIPPED` and fails the gate — a skip is a deliberate
+hole, and a change is exactly the moment to revisit it. A tuple missing from
+the coverage document entirely counts as `UNCOVERED`.
+
+## Options
+
+| Flag | Description |
+|---|---|
+| `--base-spec=<path>` | Spec as it looks on the base branch. Required. |
+| `--spec=<path>` | Spec as it looks on this branch. Required. |
+| `--coverage=<path>` | Coverage JSON, `schema_version` 3. Required. |
+| `--spec-name=<name>` | Key under `specs` in the coverage document. Defaults to the `--spec` filename without its extension. |
+| `--format=text\|markdown` | `markdown` renders a table for `$GITHUB_STEP_SUMMARY`. Default `text`. |
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Every changed operation is covered, including "nothing changed". |
+| `1` | A changed operation has a response no test validated. |
+| `2` | Command-line usage is invalid, or a spec / coverage file cannot be read. |
+
+## In CI
+
+See [CI integration](ci.md#spec-patch-coverage-gate) for a complete
+`on: pull_request` workflow.
+
+## Related
+
+- [Coverage](coverage.md) — how coverage is measured and reported.
+- [Coverage baseline](coverage-baseline.md) — ratchet the *existing* uncovered
+  set instead of gating on the diff. The two compose: the baseline stops
+  regressions from growing, the gate stops new work from arriving uncovered.
+- [Coverage JSON schema](coverage-json-schema.md) — the document this command
+  reads.

--- a/docs/coverage-gate.md
+++ b/docs/coverage-gate.md
@@ -42,11 +42,21 @@ each operation is fingerprinted:
   response is in scope.
 - **changed** — the operation exists in both, but its resolved tree differs.
   When only some responses changed, only those are in scope. When the
-  operation's request contract changed (parameters, request body, security,
-  …), every response of that operation is in scope, because a changed request
-  is worth re-exercising end to end.
-- **removed** — listed for information only. A response that no longer exists
-  cannot be tested, so it never fails the gate.
+  operation's request contract changed, every response of that operation is in
+  scope, because a changed request is worth re-exercising end to end.
+- **removed** — listed for information only. An operation or a response that
+  no longer exists cannot be tested, so a removal never fails the gate. A
+  change that only deletes a response still reports the operation, rendering
+  the deleted row as `removed (not testable)`.
+
+The request contract means the **effective** one, not just the operation
+object: the Path Item fields the operation inherits (shared `parameters`,
+`servers`, …) and the security requirement that actually applies —
+operation-level if declared, otherwise the root default — together with the
+`components.securitySchemes` definitions it names. Tightening a path-level
+parameter to `required`, or swapping an API key from a header to a query
+parameter, therefore puts every affected operation in scope even though no
+operation object changed.
 
 The comparison is **structural, not semantic**. The gate does not classify a
 change as breaking or non-breaking — that is the job of a dedicated diff tool
@@ -54,6 +64,14 @@ such as [oasdiff](https://github.com/oasdiff/oasdiff) or
 [pb33f/openapi-changes](https://github.com/pb33f/openapi-changes). Because the
 comparison happens after reference resolution, moving a schema into
 `components` and pointing a `$ref` at it is *not* a change.
+
+## Which operations are gated
+
+The gate covers the methods a coverage document can actually contain: `GET`,
+`POST`, `PUT`, `PATCH`, `DELETE`, `QUERY`, and OpenAPI 3.2
+`additionalOperations`. `OPTIONS`, `HEAD`, and `TRACE` are skipped, because
+the [coverage tracker](coverage.md) never records them — gating them would
+demand coverage no report can ever show.
 
 ## What counts as covered
 

--- a/docs/coverage-gate.md
+++ b/docs/coverage-gate.md
@@ -66,13 +66,18 @@ each operation is fingerprinted:
 The request contract means the **effective** one, not just the operation
 object:
 
-- the Path Item fields the operation inherits (`servers`, …);
 - the parameters after the Path Item / operation merge — an operation-level
   entry replaces the Path Item entry with the same `in` + `name`, so changing
   an *already-overridden* Path Item parameter is not a change;
+- the `servers` that actually apply. `servers` overrides rather than merges,
+  so exactly one level is ever in force: operation, else Path Item, else root.
+  A root `servers` change reaches every operation that inherits it, and never
+  reaches one that declares its own;
 - the security requirement that actually applies — operation-level if
   declared, otherwise the root default — together with the
-  `components.securitySchemes` definitions it names.
+  `components.securitySchemes` definitions it names;
+- any remaining Path Item fields the operation inherits (`summary`,
+  `description`, extensions).
 
 Tightening a path-level parameter to `required`, or swapping an API key from a
 header to a query parameter, therefore puts every affected operation in scope

--- a/docs/coverage-gate.md
+++ b/docs/coverage-gate.md
@@ -9,7 +9,7 @@ It needs three inputs:
 
 | Input | Where it comes from |
 |---|---|
-| the base spec | `git show origin/main:openapi.json > base.json` |
+| the base spec | `git show` for a single file, `git worktree` for a split spec (below) |
 | the current spec | your working tree |
 | a coverage document | [`json_output`](coverage-json-schema.md) from the test run |
 
@@ -19,6 +19,20 @@ git show origin/main:openapi.json > /tmp/base.json
 vendor/bin/gesso coverage:gate \
   --base-spec=/tmp/base.json \
   --spec=openapi.json \
+  --coverage=build/coverage.json
+```
+
+Both documents are loaded exactly like the runtime loader loads them, so local
+`$ref`s resolve **relative to their own entry document's directory**. The
+single-file `git show` redirect above only works for a spec that has no local
+`$ref`. For a split spec, materialise the whole base tree instead:
+
+```bash
+git worktree add /tmp/base origin/main
+
+vendor/bin/gesso coverage:gate \
+  --base-spec=/tmp/base/openapi/root.yaml \
+  --spec=openapi/root.yaml \
   --coverage=build/coverage.json
 ```
 
@@ -50,13 +64,19 @@ each operation is fingerprinted:
   the deleted row as `removed (not testable)`.
 
 The request contract means the **effective** one, not just the operation
-object: the Path Item fields the operation inherits (shared `parameters`,
-`servers`, …) and the security requirement that actually applies —
-operation-level if declared, otherwise the root default — together with the
-`components.securitySchemes` definitions it names. Tightening a path-level
-parameter to `required`, or swapping an API key from a header to a query
-parameter, therefore puts every affected operation in scope even though no
-operation object changed.
+object:
+
+- the Path Item fields the operation inherits (`servers`, …);
+- the parameters after the Path Item / operation merge — an operation-level
+  entry replaces the Path Item entry with the same `in` + `name`, so changing
+  an *already-overridden* Path Item parameter is not a change;
+- the security requirement that actually applies — operation-level if
+  declared, otherwise the root default — together with the
+  `components.securitySchemes` definitions it names.
+
+Tightening a path-level parameter to `required`, or swapping an API key from a
+header to a query parameter, therefore puts every affected operation in scope
+even though no operation object changed.
 
 The comparison is **structural, not semantic**. The gate does not classify a
 change as breaking or non-breaking — that is the job of a dedicated diff tool

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -134,7 +134,9 @@ Default is **warn-only**: a miss prints `[OpenAPI Coverage] WARN: …` to stderr
 > [coverage baseline](coverage-baseline.md): it gates the set of uncovered
 > responses instead of a percentage, so there is no threshold to keep raising
 > by hand, documenting a new response cannot fail an unrelated PR, and a
-> failure names the offending rows.
+> failure names the offending rows. To gate only what the pull request
+> actually touched, add the
+> [spec patch coverage gate](coverage-gate.md).
 
 ```xml
 <extensions>

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -90,8 +90,8 @@ This library follows [Semantic Versioning 2.0](https://semver.org/). v1.0.0 is t
   output where applicable):
   - v1.x: `bin/openapi-contract`, `bin/openapi-coverage-merge`, and the v1.10
     `bin/gesso` entry point
-  - v2.x: the `doctor` and `coverage:merge` subcommands of `bin/gesso`; the
-    legacy standalone binaries are not shipped
+  - v2.x: the `doctor`, `coverage:merge`, and `coverage:gate` subcommands of
+    `bin/gesso`; the legacy standalone binaries are not shipped
 - The Laravel `openapi:routes` command surface (flags, exit codes, and versioned JSON output)
 - The `OpenApiCoverageExtension` PHPUnit configuration parameters (`spec_base_path`, `strip_prefixes`, `specs`, `output_file`, `console_output`, `validation_output`, `baseline_file`, `coverage_baseline_file`, `strict_required`, `strict_additional_properties`, `strict_additional_properties_per_call`, …)
 - The Laravel `ValidatesOpenApiSchema` trait's public methods
@@ -162,7 +162,7 @@ written by `json_output` has its own `schema_version` contract documented in
 
 ## What's NOT covered by SemVer
 
-- Anything marked `@internal` — including the `Internal\` and `Validation\Support\` namespaces, the per-validator helpers under `Validation\Request\` / `Validation\Response\`, `Spec\OpenApiSchemaConverter` / `Spec\OpenApiPathMatcher` / `Spec\OpenApiRefResolver` / `Spec\OpenApiPathSuggester`, the PHPUnit `CoverageReportSubscriber`, `Cli\DoctorCommand`, `Coverage\CoverageMergeCommand` (the `gesso doctor` and `gesso coverage:merge` CLI surfaces remain covered — these classes are their implementation details), and test seams (`*::resetWarningStateForTesting()`, `OpenApiSpecLoader::reset()`, `OpenApiCoverageTracker::reset()` / `exportState()` / `importState()`).
+- Anything marked `@internal` — including the `Internal\` and `Validation\Support\` namespaces, the per-validator helpers under `Validation\Request\` / `Validation\Response\`, `Spec\OpenApiSchemaConverter` / `Spec\OpenApiPathMatcher` / `Spec\OpenApiRefResolver` / `Spec\OpenApiPathSuggester`, the PHPUnit `CoverageReportSubscriber`, `Cli\DoctorCommand`, `Cli\CoverageGateCommand`, `Coverage\CoverageMergeCommand` (the `gesso doctor`, `gesso coverage:gate`, and `gesso coverage:merge` CLI surfaces remain covered — these classes are their implementation details), and test seams (`*::resetWarningStateForTesting()`, `OpenApiSpecLoader::reset()`, `OpenApiCoverageTracker::reset()` / `exportState()` / `importState()`).
 - Validator error message wording (we may improve them; assert on presence/category, not on exact strings).
 - The text-mode assertion failure layout — the header line, the error list,
   and the trailing `Reproduce:` curl line (including its redaction details).

--- a/src/Cli/CoverageGateCommand.php
+++ b/src/Cli/CoverageGateCommand.php
@@ -18,6 +18,7 @@ use Studio\Gesso\Coverage\JsonCoverageRenderer;
 use Studio\Gesso\Coverage\OpenApiCoverageTracker;
 use Studio\Gesso\Spec\OpenApiOperationResolver;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
+use Studio\Gesso\Validation\Request\ParameterCollector;
 use Throwable;
 
 use function array_is_list;
@@ -140,8 +141,10 @@ final class CoverageGateCommand
               {$invocation} --base-spec=<path> --spec=<path> --coverage=<path> [options]
 
             Options:
-              --base-spec=<path>   Spec as it looks on the base branch, e.g. written by
-                                   `git show origin/main:openapi.json > base.json`.
+              --base-spec=<path>   Spec as it looks on the base branch. Local \$refs
+                                   resolve from its own directory, so materialise the
+                                   whole tree (`git worktree add /tmp/base origin/main`)
+                                   unless the spec is a single self-contained file.
               --spec=<path>        Spec as it looks on this branch.
               --coverage=<path>    Coverage JSON (schema_version 3) written by the
                                    `json_output` extension parameter or
@@ -290,9 +293,11 @@ final class CoverageGateCommand
 
             // Path Item fields the operations under it inherit. Everything
             // that is itself an operation is stripped so a sibling's change
-            // does not leak into this operation's fingerprint.
+            // does not leak into this operation's fingerprint. `parameters`
+            // is stripped too — it is fingerprinted per operation, after the
+            // override merge.
             $inherited = $pathItem;
-            unset($inherited['additionalOperations']);
+            unset($inherited['additionalOperations'], $inherited['parameters']);
             foreach (OpenApiOperationResolver::FIXED_OPERATION_FIELDS as $field) {
                 unset($inherited[$field]);
             }
@@ -310,10 +315,11 @@ final class CoverageGateCommand
 
                 $endpoint = $method . ' ' . (string) $path;
                 $ownShape = $operation;
-                unset($ownShape['responses']);
+                unset($ownShape['responses'], $ownShape['parameters']);
                 $shape = [
                     $ownShape,
                     $inherited,
+                    $this->effectiveParameters($pathItem, $operation),
                     $this->effectiveSecurity($operation, $rootSecurity, $securitySchemes),
                 ];
 
@@ -374,6 +380,46 @@ final class CoverageGateCommand
     {
         return in_array($method, ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'QUERY'], true) ||
             str_starts_with($location, 'additionalOperations[');
+    }
+
+    /**
+     * The parameters that actually apply, merged the way
+     * {@see ParameterCollector::collect()}
+     * merges them: an operation-level entry replaces the Path Item entry with
+     * the same `in` + `name`. Fingerprinting the two lists separately would
+     * flag a change to an already-overridden Path Item parameter, even though
+     * the request validator never sees it.
+     *
+     * @param array<string, mixed> $pathItem
+     * @param array<string, mixed> $operation
+     *
+     * @return array<string, mixed>
+     */
+    private function effectiveParameters(array $pathItem, array $operation): array
+    {
+        $merged = [];
+        $unkeyable = 0;
+
+        foreach ([$pathItem['parameters'] ?? [], $operation['parameters'] ?? []] as $index => $source) {
+            if (!is_array($source)) {
+                // Malformed node: keep it in the fingerprint rather than
+                // dropping it, so a change to it still reads as a change.
+                $merged['!' . $index] = $source;
+
+                continue;
+            }
+
+            foreach ($source as $parameter) {
+                $key = is_array($parameter) &&
+                    is_string($parameter['in'] ?? null) &&
+                    is_string($parameter['name'] ?? null)
+                        ? $parameter['in'] . ':' . $parameter['name']
+                        : '#' . $unkeyable++;
+                $merged[$key] = $parameter;
+            }
+        }
+
+        return $merged;
     }
 
     /**

--- a/src/Cli/CoverageGateCommand.php
+++ b/src/Cli/CoverageGateCommand.php
@@ -281,6 +281,7 @@ final class CoverageGateCommand
         /** @var array<string, mixed> $paths */
         $paths = is_array($spec['paths'] ?? null) ? $spec['paths'] : [];
         $rootSecurity = $spec['security'] ?? null;
+        $rootServers = $spec['servers'] ?? null;
         $components = is_array($spec['components'] ?? null) ? $spec['components'] : [];
         /** @var array<string, mixed> $securitySchemes */
         $securitySchemes = is_array($components['securitySchemes'] ?? null) ? $components['securitySchemes'] : [];
@@ -294,10 +295,10 @@ final class CoverageGateCommand
             // Path Item fields the operations under it inherit. Everything
             // that is itself an operation is stripped so a sibling's change
             // does not leak into this operation's fingerprint. `parameters`
-            // is stripped too — it is fingerprinted per operation, after the
-            // override merge.
+            // and `servers` are stripped too — both are fingerprinted per
+            // operation, after their inheritance rules are applied.
             $inherited = $pathItem;
-            unset($inherited['additionalOperations'], $inherited['parameters']);
+            unset($inherited['additionalOperations'], $inherited['parameters'], $inherited['servers']);
             foreach (OpenApiOperationResolver::FIXED_OPERATION_FIELDS as $field) {
                 unset($inherited[$field]);
             }
@@ -315,11 +316,12 @@ final class CoverageGateCommand
 
                 $endpoint = $method . ' ' . (string) $path;
                 $ownShape = $operation;
-                unset($ownShape['responses'], $ownShape['parameters']);
+                unset($ownShape['responses'], $ownShape['parameters'], $ownShape['servers']);
                 $shape = [
                     $ownShape,
                     $inherited,
                     $this->effectiveParameters($pathItem, $operation),
+                    $this->effectiveServers($operation, $pathItem, $rootServers),
                     $this->effectiveSecurity($operation, $rootSecurity, $securitySchemes),
                 ];
 
@@ -420,6 +422,28 @@ final class CoverageGateCommand
         }
 
         return $merged;
+    }
+
+    /**
+     * The servers that actually apply. `servers` is not inherited additively:
+     * an Operation Object's array overrides the Path Item's, which overrides
+     * the root's, so only one of the three is ever in force. Fingerprinting
+     * the levels separately would both miss a root-only change and flag a
+     * Path Item change an operation already overrides.
+     *
+     * @param array<string, mixed> $operation
+     * @param array<string, mixed> $pathItem
+     */
+    private function effectiveServers(array $operation, array $pathItem, mixed $rootServers): mixed
+    {
+        if (array_key_exists('servers', $operation)) {
+            return $operation['servers'];
+        }
+        if (array_key_exists('servers', $pathItem)) {
+            return $pathItem['servers'];
+        }
+
+        return $rootServers;
     }
 
     /**

--- a/src/Cli/CoverageGateCommand.php
+++ b/src/Cli/CoverageGateCommand.php
@@ -1,0 +1,642 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Cli;
+
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+use const PATHINFO_DIRNAME;
+use const PATHINFO_EXTENSION;
+use const PATHINFO_FILENAME;
+use const STDERR;
+
+use JsonException;
+use RuntimeException;
+use Studio\Gesso\Coverage\JsonCoverageRenderer;
+use Studio\Gesso\Coverage\OpenApiCoverageTracker;
+use Studio\Gesso\Spec\OpenApiOperationResolver;
+use Studio\Gesso\Spec\OpenApiSpecLoader;
+use Throwable;
+
+use function array_is_list;
+use function array_keys;
+use function array_map;
+use function explode;
+use function file_get_contents;
+use function fwrite;
+use function getcwd;
+use function hash;
+use function implode;
+use function in_array;
+use function is_array;
+use function is_callable;
+use function is_file;
+use function is_int;
+use function is_readable;
+use function is_string;
+use function json_decode;
+use function json_encode;
+use function ksort;
+use function max;
+use function pathinfo;
+use function realpath;
+use function rtrim;
+use function sprintf;
+use function str_contains;
+use function str_pad;
+use function str_replace;
+use function str_starts_with;
+use function strcmp;
+use function strlen;
+use function substr;
+use function usort;
+
+/**
+ * Patch-coverage gate for a spec change (issue #475): the OpenAPI counterpart
+ * of `diff-cover` / Codecov's patch status.
+ *
+ * It answers one question — "did this pull request change an operation that no
+ * test exercises?" — by structurally diffing the current spec against a base
+ * spec and joining the touched `(method, path, status, content-type)` tuples
+ * against a `schema_version: 3` coverage document.
+ *
+ * Deliberately *not* a breaking-change detector. The diff is structural
+ * ("did the resolved node change?"), never semantic ("is the change
+ * backwards-incompatible?"); that classification belongs to dedicated diff
+ * tools and would drag in a rule catalogue to maintain. Because both specs go
+ * through {@see OpenApiSpecLoader}, a pure `$ref` reshuffle that resolves to
+ * the same tree reads as unchanged.
+ *
+ * @phpstan-type GateOptions array{base_spec?: string, spec?: string, coverage?: string, spec_name?: string, format?: string, help?: bool, invalid_options?: list<string>}
+ * @phpstan-type GateResponse array{status: string, content_type: string, state: string, covered: bool}
+ * @phpstan-type GateOperation array{endpoint: string, change: 'added'|'changed'|'removed', responses: list<GateResponse>}
+ * @phpstan-type IndexedResponse array{status: string, content_type: string, hash: string}
+ * @phpstan-type IndexedOperation array{endpoint: string, shape: string, responses: array<string, IndexedResponse>}
+ *
+ * @internal The `gesso coverage:gate` CLI surface is the supported API.
+ */
+final class CoverageGateCommand
+{
+    public const EXIT_OK = 0;
+    public const EXIT_UNCOVERED_CHANGE = 1;
+    public const EXIT_USAGE = 2;
+
+    /** @param null|callable(string): void $stdoutWriter */
+    public function __construct(
+        private mixed $stdoutWriter = null,
+        private mixed $stderrWriter = null,
+        private readonly string $invocation = 'gesso coverage:gate',
+    ) {}
+
+    /**
+     * @param list<string> $argv excluding the script name
+     *
+     * @return GateOptions
+     */
+    public static function parseArgv(array $argv): array
+    {
+        $options = ['invalid_options' => []];
+
+        foreach ($argv as $arg) {
+            if ($arg === 'coverage:gate') {
+                continue;
+            }
+            if ($arg === '--help' || $arg === '-h') {
+                $options['help'] = true;
+
+                continue;
+            }
+            if (!str_starts_with($arg, '--')) {
+                $options['invalid_options'][] = $arg;
+
+                continue;
+            }
+
+            $option = substr($arg, 2);
+            [$name, $value] = str_contains($option, '=') ? explode('=', $option, 2) : [$option, 'true'];
+            $name = str_replace('-', '_', $name);
+
+            if (!in_array($name, ['base_spec', 'spec', 'coverage', 'spec_name', 'format'], true)) {
+                $options['invalid_options'][] = '--' . str_replace('_', '-', $name);
+
+                continue;
+            }
+
+            $options[$name] = $value;
+        }
+
+        return $options;
+    }
+
+    public static function usage(string $invocation = 'gesso coverage:gate'): string
+    {
+        return <<<USAGE
+            {$invocation} — fail when this change touches an operation no test covers.
+
+            Usage:
+              {$invocation} --base-spec=<path> --spec=<path> --coverage=<path> [options]
+
+            Options:
+              --base-spec=<path>   Spec as it looks on the base branch, e.g. written by
+                                   `git show origin/main:openapi.json > base.json`.
+              --spec=<path>        Spec as it looks on this branch.
+              --coverage=<path>    Coverage JSON (schema_version 3) written by the
+                                   `json_output` extension parameter or
+                                   `gesso coverage:merge --json-output`.
+              --spec-name=<name>   Key under `specs` in the coverage document.
+                                   Defaults to the --spec filename without extension.
+              --format=text|markdown
+                                   Output format (default: text). `markdown` is meant for
+                                   \$GITHUB_STEP_SUMMARY.
+              --help               Show this message.
+
+            Exit codes:
+              0  Every changed operation is covered (including "nothing changed").
+              1  A changed operation has a response no test validated.
+              2  Command-line usage is invalid, or a spec / coverage file cannot be read.
+
+            USAGE;
+    }
+
+    /** @param GateOptions $options */
+    public function run(array $options): int
+    {
+        if (($options['help'] ?? false) === true) {
+            $this->writeStdout(self::usage($this->invocation));
+
+            return self::EXIT_OK;
+        }
+
+        $format = $options['format'] ?? 'text';
+        $invalid = $options['invalid_options'] ?? [];
+        if ($invalid !== []) {
+            return $this->usageError('Unknown argument(s): ' . implode(', ', $invalid));
+        }
+        if (!in_array($format, ['text', 'markdown'], true)) {
+            return $this->usageError("Unsupported --format={$format}.");
+        }
+        foreach (['base_spec', 'spec', 'coverage'] as $required) {
+            if (($options[$required] ?? '') === '') {
+                return $this->usageError('--' . str_replace('_', '-', $required) . ' is required.');
+            }
+        }
+
+        /** @var string $basePath */
+        $basePath = $options['base_spec'];
+        /** @var string $headPath */
+        $headPath = $options['spec'];
+        /** @var string $coveragePath */
+        $coveragePath = $options['coverage'];
+
+        try {
+            $baseIndex = $this->index($this->loadSpec($basePath));
+            $headIndex = $this->index($this->loadSpec($headPath));
+        } catch (Throwable $e) {
+            return $this->usageError($e->getMessage());
+        }
+
+        $specName = $options['spec_name'] ?? pathinfo($this->absolutise($headPath), PATHINFO_FILENAME);
+
+        try {
+            $states = $this->loadCoverage($coveragePath, $specName);
+        } catch (Throwable $e) {
+            return $this->usageError($e->getMessage());
+        }
+
+        $operations = $this->diff($baseIndex, $headIndex, $states);
+
+        $uncovered = 0;
+        foreach ($operations as $operation) {
+            foreach ($operation['responses'] as $response) {
+                if (!$response['covered']) {
+                    $uncovered++;
+                }
+            }
+        }
+
+        $this->writeStdout($format === 'markdown'
+            ? $this->renderMarkdown($operations, $uncovered)
+            : $this->renderText($operations, $uncovered));
+
+        return $uncovered === 0 ? self::EXIT_OK : self::EXIT_UNCOVERED_CHANGE;
+    }
+
+    /**
+     * Resolve one entry document through the runtime loader so both sides of
+     * the diff see the same `$ref`-resolved tree the validators would.
+     *
+     * @return array<string, mixed>
+     */
+    private function loadSpec(string $inputPath): array
+    {
+        $path = $this->absolutise($inputPath);
+        if (!is_file($path) || !is_readable($path)) {
+            throw new RuntimeException("Spec is not a readable file: {$inputPath}");
+        }
+
+        $extension = pathinfo($path, PATHINFO_EXTENSION);
+        if (!in_array($extension, ['json', 'yaml', 'yml'], true)) {
+            throw new RuntimeException("Unsupported spec extension: .{$extension} ({$inputPath})");
+        }
+
+        try {
+            // The loader caches by spec name, so a base and a head document
+            // sharing a filename (the common `openapi.json` case) would
+            // otherwise collide on the second load().
+            OpenApiSpecLoader::reset();
+            OpenApiSpecLoader::configure(pathinfo($path, PATHINFO_DIRNAME));
+
+            return OpenApiSpecLoader::load(pathinfo($path, PATHINFO_FILENAME));
+        } catch (Throwable $e) {
+            throw new RuntimeException("Cannot load {$inputPath}: " . $e->getMessage(), previous: $e);
+        } finally {
+            OpenApiSpecLoader::reset();
+        }
+    }
+
+    /**
+     * Fingerprint every declared operation and response tuple.
+     *
+     * `shape` covers the operation minus its responses (parameters, request
+     * body, security, …) — a request-contract change makes every response of
+     * that operation worth re-testing, even when the response nodes are
+     * untouched.
+     *
+     * @param array<string, mixed> $spec
+     *
+     * @return array<string, IndexedOperation>
+     */
+    private function index(array $spec): array
+    {
+        /** @var array<string, mixed> $paths */
+        $paths = is_array($spec['paths'] ?? null) ? $spec['paths'] : [];
+        $index = [];
+
+        foreach ($paths as $path => $pathItem) {
+            if (!is_array($pathItem)) {
+                continue;
+            }
+
+            foreach (OpenApiOperationResolver::declaredOperations($pathItem) as $declared) {
+                $operation = $declared['operation'];
+                if (!is_array($operation)) {
+                    continue;
+                }
+
+                $method = $declared['method'];
+                $endpoint = $method . ' ' . (string) $path;
+                $shape = $operation;
+                unset($shape['responses']);
+
+                $responses = [];
+                /** @var array<string, mixed> $declaredResponses */
+                $declaredResponses = is_array($operation['responses'] ?? null) ? $operation['responses'] : [];
+                foreach ($declaredResponses as $status => $response) {
+                    $status = (string) $status;
+                    if (!is_array($response)) {
+                        continue;
+                    }
+
+                    // Mirrors OpenApiCoverageTracker's declared-response walk:
+                    // a response without `content` contributes a single
+                    // `(status, '*')` tuple so 204s stay visible.
+                    $content = is_array($response['content'] ?? null) ? $response['content'] : [];
+                    if ($content === []) {
+                        $key = $status . "\x1f" . OpenApiCoverageTracker::ANY_CONTENT_TYPE;
+                        $responses[$key] = [
+                            'status' => $status,
+                            'content_type' => OpenApiCoverageTracker::ANY_CONTENT_TYPE,
+                            'hash' => $this->fingerprint($response),
+                        ];
+
+                        continue;
+                    }
+
+                    $envelope = $response;
+                    unset($envelope['content']);
+                    foreach ($content as $contentType => $media) {
+                        $contentType = (string) $contentType;
+                        $responses[$status . "\x1f" . $contentType] = [
+                            'status' => $status,
+                            'content_type' => $contentType,
+                            'hash' => $this->fingerprint([$envelope, $media]),
+                        ];
+                    }
+                }
+
+                $index[$endpoint] = [
+                    'endpoint' => $endpoint,
+                    'shape' => $this->fingerprint($shape),
+                    'responses' => $responses,
+                ];
+            }
+        }
+
+        return $index;
+    }
+
+    /**
+     * @param array<string, IndexedOperation> $base
+     * @param array<string, IndexedOperation> $head
+     * @param array<string, string> $states
+     *
+     * @return list<GateOperation>
+     */
+    private function diff(array $base, array $head, array $states): array
+    {
+        $operations = [];
+
+        foreach ($head as $endpoint => $current) {
+            $previous = $base[$endpoint] ?? null;
+            $shapeChanged = $previous !== null && $previous['shape'] !== $current['shape'];
+
+            $touched = [];
+            foreach ($current['responses'] as $key => $response) {
+                $before = $previous['responses'][$key] ?? null;
+                if ($previous !== null && !$shapeChanged && $before !== null && $before['hash'] === $response['hash']) {
+                    continue;
+                }
+                $state = $states[$endpoint . "\x1f" . $key] ?? 'uncovered';
+                $touched[] = [
+                    'status' => $response['status'],
+                    'content_type' => $response['content_type'],
+                    'state' => $state,
+                    'covered' => $state === 'validated',
+                ];
+            }
+
+            if ($previous !== null && $touched === []) {
+                continue;
+            }
+
+            $operations[] = [
+                'endpoint' => $endpoint,
+                'change' => $previous === null ? 'added' : 'changed',
+                'responses' => $touched,
+            ];
+        }
+
+        foreach ($base as $endpoint => $previous) {
+            if (isset($head[$endpoint])) {
+                continue;
+            }
+            $operations[] = ['endpoint' => $endpoint, 'change' => 'removed', 'responses' => []];
+        }
+
+        usort($operations, static fn(array $a, array $b): int => strcmp($a['endpoint'], $b['endpoint']));
+
+        return $operations;
+    }
+
+    /**
+     * Read the `(method, path, status, content-type)` states out of a
+     * coverage document.
+     *
+     * @return array<string, string>
+     */
+    private function loadCoverage(string $inputPath, string $specName): array
+    {
+        $path = $this->absolutise($inputPath);
+        $raw = is_file($path) && is_readable($path) ? file_get_contents($path) : false;
+        if ($raw === false) {
+            throw new RuntimeException("Coverage file is not a readable file: {$inputPath}");
+        }
+
+        try {
+            $document = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new RuntimeException("Coverage file is not valid JSON: {$inputPath}", previous: $e);
+        }
+        if (!is_array($document)) {
+            throw new RuntimeException("Coverage file must decode to a JSON object: {$inputPath}");
+        }
+
+        $version = $document['schema_version'] ?? null;
+        if (!is_int($version) || $version !== JsonCoverageRenderer::SCHEMA_VERSION) {
+            throw new RuntimeException(sprintf(
+                'Unsupported coverage schema_version in %s: expected %d.',
+                $inputPath,
+                JsonCoverageRenderer::SCHEMA_VERSION,
+            ));
+        }
+
+        $specs = is_array($document['specs'] ?? null) ? $document['specs'] : [];
+        $spec = $specs[$specName] ?? null;
+        if (!is_array($spec)) {
+            $available = array_map(static fn(mixed $name): string => (string) $name, array_keys($specs));
+
+            throw new RuntimeException(sprintf(
+                'Coverage document has no spec named "%s". Available: %s. Use --spec-name to select one.',
+                $specName,
+                $available === [] ? '(none)' : implode(', ', $available),
+            ));
+        }
+
+        $states = [];
+        $endpoints = is_array($spec['endpoints'] ?? null) ? $spec['endpoints'] : [];
+        foreach ($endpoints as $endpoint) {
+            if (!is_array($endpoint) || !is_string($endpoint['method'] ?? null) || !is_string($endpoint['path'] ?? null)) {
+                continue;
+            }
+            $key = $endpoint['method'] . ' ' . $endpoint['path'];
+            $responses = is_array($endpoint['responses'] ?? null) ? $endpoint['responses'] : [];
+            foreach ($responses as $response) {
+                if (!is_array($response) ||
+                    !is_string($response['status_key'] ?? null) ||
+                    !is_string($response['content_type_key'] ?? null) ||
+                    !is_string($response['response_state'] ?? null)) {
+                    continue;
+                }
+                $states[$key . "\x1f" . $response['status_key'] . "\x1f" . $response['content_type_key']] = $response['response_state'];
+            }
+        }
+
+        return $states;
+    }
+
+    /**
+     * Order-insensitive fingerprint of a resolved node: object keys sort,
+     * array order is kept.
+     */
+    private function fingerprint(mixed $node): string
+    {
+        try {
+            $encoded = json_encode(
+                $this->canonicalize($node),
+                JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+            );
+        } catch (JsonException) {
+            // Unencodable node (e.g. an invalid UTF-8 byte sequence surviving
+            // the loader): treat it as always-changed rather than silently
+            // equal, so the gate errs toward asking for coverage.
+            return 'unencodable:' . hash('xxh128', (string) json_encode(null));
+        }
+
+        return hash('xxh128', $encoded);
+    }
+
+    private function canonicalize(mixed $node): mixed
+    {
+        if (!is_array($node)) {
+            return $node;
+        }
+
+        $canonical = array_map(fn(mixed $child): mixed => $this->canonicalize($child), $node);
+        if (!array_is_list($canonical)) {
+            ksort($canonical);
+        }
+
+        return $canonical;
+    }
+
+    /** @param list<GateOperation> $operations */
+    private function renderText(array $operations, int $uncovered): string
+    {
+        if ($operations === []) {
+            return "[Gesso] No operation changed against the base spec.\n";
+        }
+
+        $changed = 0;
+        $width = 0;
+        foreach ($operations as $operation) {
+            if ($operation['change'] !== 'removed') {
+                $changed++;
+            }
+            foreach ($operation['responses'] as $response) {
+                $width = max($width, strlen($this->describeResponse($response)));
+            }
+        }
+
+        $lines = [sprintf(
+            '[Gesso] %d operation%s changed against the base spec:',
+            $changed,
+            $changed === 1 ? '' : 's',
+        ), ''];
+
+        foreach ($operations as $operation) {
+            if ($operation['change'] === 'removed') {
+                $lines[] = sprintf('  %s    removed from the spec (not testable)', $operation['endpoint']);
+
+                continue;
+            }
+            $lines[] = '  ' . $operation['endpoint'];
+            foreach ($operation['responses'] as $response) {
+                $lines[] = sprintf(
+                    '    %s    %s',
+                    str_pad($this->describeResponse($response), $width),
+                    $this->describeState($response),
+                );
+            }
+        }
+
+        $lines[] = '';
+        $lines[] = $uncovered === 0
+            ? 'All changed responses are covered.'
+            : sprintf(
+                '%d changed response%s not covered by any test.',
+                $uncovered,
+                $uncovered === 1 ? ' is' : 's are',
+            );
+
+        return implode("\n", $lines) . "\n";
+    }
+
+    /** @param list<GateOperation> $operations */
+    private function renderMarkdown(array $operations, int $uncovered): string
+    {
+        $lines = ['### Gesso spec patch coverage', ''];
+        if ($operations === []) {
+            $lines[] = 'No operation changed against the base spec.';
+
+            return implode("\n", $lines) . "\n";
+        }
+
+        $lines[] = $uncovered === 0
+            ? 'All changed responses are covered.'
+            : sprintf(
+                '**%d changed response%s not covered by any test.**',
+                $uncovered,
+                $uncovered === 1 ? ' is' : 's are',
+            );
+        $lines[] = '';
+        $lines[] = '| Operation | Change | Response | Coverage |';
+        $lines[] = '| --- | --- | --- | --- |';
+
+        foreach ($operations as $operation) {
+            if ($operation['responses'] === []) {
+                $lines[] = sprintf('| `%s` | %s | — | — |', $operation['endpoint'], $operation['change']);
+
+                continue;
+            }
+            foreach ($operation['responses'] as $response) {
+                $lines[] = sprintf(
+                    '| `%s` | %s | `%s` | %s |',
+                    $operation['endpoint'],
+                    $operation['change'],
+                    $this->describeResponse($response),
+                    $this->describeState($response),
+                );
+            }
+        }
+
+        return implode("\n", $lines) . "\n";
+    }
+
+    /** @param GateResponse $response */
+    private function describeResponse(array $response): string
+    {
+        return $response['content_type'] === OpenApiCoverageTracker::ANY_CONTENT_TYPE
+            ? $response['status'] . ' (no content)'
+            : $response['status'] . ' ' . $response['content_type'];
+    }
+
+    /** @param GateResponse $response */
+    private function describeState(array $response): string
+    {
+        return match ($response['state']) {
+            'validated' => 'covered',
+            'skipped' => 'SKIPPED',
+            default => 'UNCOVERED',
+        };
+    }
+
+    private function absolutise(string $path): string
+    {
+        if (str_starts_with($path, '/')) {
+            return $path;
+        }
+        $cwd = getcwd();
+        $absolute = rtrim($cwd !== false ? $cwd : '.', '/') . '/' . $path;
+
+        return realpath($absolute) ?: $absolute;
+    }
+
+    private function usageError(string $message): int
+    {
+        $this->writeStderr("[Gesso] {$message}\n\n" . self::usage($this->invocation));
+
+        return self::EXIT_USAGE;
+    }
+
+    private function writeStdout(string $message): void
+    {
+        if (is_callable($this->stdoutWriter)) {
+            ($this->stdoutWriter)($message);
+
+            return;
+        }
+        echo $message;
+    }
+
+    private function writeStderr(string $message): void
+    {
+        if (is_callable($this->stderrWriter)) {
+            ($this->stderrWriter)($message);
+
+            return;
+        }
+        fwrite(STDERR, $message);
+    }
+}

--- a/src/Cli/CoverageGateCommand.php
+++ b/src/Cli/CoverageGateCommand.php
@@ -21,6 +21,7 @@ use Studio\Gesso\Spec\OpenApiSpecLoader;
 use Throwable;
 
 use function array_is_list;
+use function array_key_exists;
 use function array_keys;
 use function array_map;
 use function explode;
@@ -70,7 +71,7 @@ use function usort;
  * the same tree reads as unchanged.
  *
  * @phpstan-type GateOptions array{base_spec?: string, spec?: string, coverage?: string, spec_name?: string, format?: string, help?: bool, invalid_options?: list<string>}
- * @phpstan-type GateResponse array{status: string, content_type: string, state: string, covered: bool}
+ * @phpstan-type GateResponse array{status: string, content_type: string, change: 'added'|'changed'|'removed', state: string, covered: bool}
  * @phpstan-type GateOperation array{endpoint: string, change: 'added'|'changed'|'removed', responses: list<GateResponse>}
  * @phpstan-type IndexedResponse array{status: string, content_type: string, hash: string}
  * @phpstan-type IndexedOperation array{endpoint: string, shape: string, responses: array<string, IndexedResponse>}
@@ -259,10 +260,14 @@ final class CoverageGateCommand
     /**
      * Fingerprint every declared operation and response tuple.
      *
-     * `shape` covers the operation minus its responses (parameters, request
-     * body, security, …) — a request-contract change makes every response of
-     * that operation worth re-testing, even when the response nodes are
-     * untouched.
+     * `shape` covers the operation's *effective* request contract, not just
+     * its own node: the operation minus its responses, plus the Path Item
+     * fields it inherits (shared `parameters`, `servers`, …), plus the
+     * security requirement that actually applies (operation-level, else the
+     * root default) together with the `components.securitySchemes`
+     * definitions it names. Those live outside the operation object but are
+     * part of what the request validator enforces, so a change to any of them
+     * makes every response of that operation worth re-testing.
      *
      * @param array<string, mixed> $spec
      *
@@ -272,11 +277,24 @@ final class CoverageGateCommand
     {
         /** @var array<string, mixed> $paths */
         $paths = is_array($spec['paths'] ?? null) ? $spec['paths'] : [];
+        $rootSecurity = $spec['security'] ?? null;
+        $components = is_array($spec['components'] ?? null) ? $spec['components'] : [];
+        /** @var array<string, mixed> $securitySchemes */
+        $securitySchemes = is_array($components['securitySchemes'] ?? null) ? $components['securitySchemes'] : [];
         $index = [];
 
         foreach ($paths as $path => $pathItem) {
             if (!is_array($pathItem)) {
                 continue;
+            }
+
+            // Path Item fields the operations under it inherit. Everything
+            // that is itself an operation is stripped so a sibling's change
+            // does not leak into this operation's fingerprint.
+            $inherited = $pathItem;
+            unset($inherited['additionalOperations']);
+            foreach (OpenApiOperationResolver::FIXED_OPERATION_FIELDS as $field) {
+                unset($inherited[$field]);
             }
 
             foreach (OpenApiOperationResolver::declaredOperations($pathItem) as $declared) {
@@ -286,9 +304,18 @@ final class CoverageGateCommand
                 }
 
                 $method = $declared['method'];
+                if (!$this->isTrackedMethod($method, $declared['location'])) {
+                    continue;
+                }
+
                 $endpoint = $method . ' ' . (string) $path;
-                $shape = $operation;
-                unset($shape['responses']);
+                $ownShape = $operation;
+                unset($ownShape['responses']);
+                $shape = [
+                    $ownShape,
+                    $inherited,
+                    $this->effectiveSecurity($operation, $rootSecurity, $securitySchemes),
+                ];
 
                 $responses = [];
                 /** @var array<string, mixed> $declaredResponses */
@@ -338,6 +365,48 @@ final class CoverageGateCommand
     }
 
     /**
+     * Only operations {@see OpenApiCoverageTracker} puts in a coverage
+     * document can be gated. It records the baseline methods plus OpenAPI 3.2
+     * `additionalOperations`; `OPTIONS` / `HEAD` / `TRACE` never appear there,
+     * so gating them would mean demanding coverage no report can ever show.
+     */
+    private function isTrackedMethod(string $method, string $location): bool
+    {
+        return in_array($method, ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'QUERY'], true) ||
+            str_starts_with($location, 'additionalOperations[');
+    }
+
+    /**
+     * The security requirement that actually applies, resolved to the scheme
+     * definitions it names. An operation-level `security` — including an
+     * explicit `[]` opting out — overrides the root default, matching how
+     * the request validator selects it.
+     *
+     * @param array<string, mixed> $operation
+     * @param array<string, mixed> $securitySchemes
+     */
+    private function effectiveSecurity(array $operation, mixed $rootSecurity, array $securitySchemes): mixed
+    {
+        $security = array_key_exists('security', $operation) ? $operation['security'] : $rootSecurity;
+        if (!is_array($security)) {
+            return $security;
+        }
+
+        $schemes = [];
+        foreach ($security as $requirement) {
+            if (!is_array($requirement)) {
+                continue;
+            }
+            foreach (array_keys($requirement) as $name) {
+                $name = (string) $name;
+                $schemes[$name] = $securitySchemes[$name] ?? null;
+            }
+        }
+
+        return [$security, $schemes];
+    }
+
+    /**
      * @param array<string, IndexedOperation> $base
      * @param array<string, IndexedOperation> $head
      * @param array<string, string> $states
@@ -362,14 +431,36 @@ final class CoverageGateCommand
                 $touched[] = [
                     'status' => $response['status'],
                     'content_type' => $response['content_type'],
+                    'change' => $before === null ? 'added' : 'changed',
                     'state' => $state,
                     'covered' => $state === 'validated',
+                ];
+            }
+
+            // A tuple the change deletes is still a structural change worth
+            // showing, but it cannot be tested any more, so it never fails
+            // the gate.
+            foreach ($previous['responses'] ?? [] as $key => $response) {
+                if (isset($current['responses'][$key])) {
+                    continue;
+                }
+                $touched[] = [
+                    'status' => $response['status'],
+                    'content_type' => $response['content_type'],
+                    'change' => 'removed',
+                    'state' => 'removed',
+                    'covered' => true,
                 ];
             }
 
             if ($previous !== null && $touched === []) {
                 continue;
             }
+
+            usort($touched, static fn(array $a, array $b): int => strcmp(
+                $a['status'] . ' ' . $a['content_type'],
+                $b['status'] . ' ' . $b['content_type'],
+            ));
 
             $operations[] = [
                 'endpoint' => $endpoint,
@@ -574,7 +665,7 @@ final class CoverageGateCommand
                 $lines[] = sprintf(
                     '| `%s` | %s | `%s` | %s |',
                     $operation['endpoint'],
-                    $operation['change'],
+                    $response['change'],
                     $this->describeResponse($response),
                     $this->describeState($response),
                 );
@@ -598,6 +689,7 @@ final class CoverageGateCommand
         return match ($response['state']) {
             'validated' => 'covered',
             'skipped' => 'SKIPPED',
+            'removed' => 'removed (not testable)',
             default => 'UNCOVERED',
         };
     }

--- a/tests/Integration/GessoCliIntegrationTest.php
+++ b/tests/Integration/GessoCliIntegrationTest.php
@@ -7,6 +7,7 @@ namespace Studio\Gesso\Tests\Integration;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Cli\CoverageGateCommand;
 use Studio\Gesso\Coverage\CoverageMergeCommand;
 
 use function dirname;
@@ -115,6 +116,20 @@ final class GessoCliIntegrationTest extends TestCase
             ),
             $errorStderr,
         );
+    }
+
+    #[Test]
+    public function coverage_gate_uses_the_gesso_invocation_in_help_and_usage_errors(): void
+    {
+        [$helpExit, $helpStdout, $helpStderr] = $this->runCli(['coverage:gate', '--help']);
+        [$errorExit, $errorStdout, $errorStderr] = $this->runCli(['coverage:gate', '--spec=openapi.json']);
+
+        $this->assertSame(0, $helpExit);
+        $this->assertSame('', $helpStderr);
+        $this->assertSame(CoverageGateCommand::usage(), $helpStdout);
+        $this->assertSame(2, $errorExit);
+        $this->assertSame('', $errorStdout);
+        $this->assertStringContainsString('[Gesso] --base-spec is required.', $errorStderr);
     }
 
     #[Test]

--- a/tests/Unit/Cli/CoverageGateCommandTest.php
+++ b/tests/Unit/Cli/CoverageGateCommandTest.php
@@ -145,6 +145,100 @@ class CoverageGateCommandTest extends TestCase
     }
 
     #[Test]
+    public function a_path_level_parameter_change_puts_the_operation_in_scope(): void
+    {
+        $base = $this->baseSpec();
+        $base['paths']['/pets/{id}']['parameters'] = [
+            ['name' => 'trace', 'in' => 'query', 'required' => false, 'schema' => ['type' => 'string']],
+        ];
+        $head = $base;
+        $head['paths']['/pets/{id}']['parameters'][0]['required'] = true;
+
+        $this->writeSpec('base.json', $base);
+        $this->writeSpec('openapi.json', $head);
+        $this->writeCoverage([$this->endpoint('PUT', '/pets/{id}', [['200', 'application/json', 'uncovered']])]);
+
+        $this->assertSame(CoverageGateCommand::EXIT_UNCOVERED_CHANGE, $this->gate());
+        $this->assertStringContainsString('  PUT /pets/{id}', $this->stdout);
+        $this->assertStringContainsString('200 application/json    UNCOVERED', $this->stdout);
+    }
+
+    #[Test]
+    public function a_security_scheme_definition_change_puts_the_operation_in_scope(): void
+    {
+        $base = $this->baseSpec();
+        $base['security'] = [['ApiKey' => []]];
+        $base['components'] = ['securitySchemes' => ['ApiKey' => ['type' => 'apiKey', 'name' => 'X-Key', 'in' => 'header']]];
+        $head = $base;
+        $head['components']['securitySchemes']['ApiKey']['in'] = 'query';
+
+        $this->writeSpec('base.json', $base);
+        $this->writeSpec('openapi.json', $head);
+        $this->writeCoverage([$this->endpoint('PUT', '/pets/{id}', [['200', 'application/json', 'uncovered']])]);
+
+        $this->assertSame(CoverageGateCommand::EXIT_UNCOVERED_CHANGE, $this->gate());
+        $this->assertStringContainsString('  PUT /pets/{id}', $this->stdout);
+    }
+
+    #[Test]
+    public function an_operation_level_security_override_shields_it_from_a_root_change(): void
+    {
+        $base = $this->baseSpec();
+        $base['security'] = [['ApiKey' => []]];
+        $base['components'] = ['securitySchemes' => [
+            'ApiKey' => ['type' => 'apiKey', 'name' => 'X-Key', 'in' => 'header'],
+            'Basic' => ['type' => 'http', 'scheme' => 'basic'],
+        ]];
+        $base['paths']['/pets/{id}']['put']['security'] = [['Basic' => []]];
+        $head = $base;
+        $head['components']['securitySchemes']['ApiKey']['in'] = 'query';
+
+        $this->writeSpec('base.json', $base);
+        $this->writeSpec('openapi.json', $head);
+        $this->writeCoverage([]);
+
+        // Only GET /legacy inherits the root requirement, so PUT stays out.
+        $this->assertSame(CoverageGateCommand::EXIT_UNCOVERED_CHANGE, $this->gate());
+        $this->assertStringContainsString('  GET /legacy', $this->stdout);
+        $this->assertStringNotContainsString('  PUT /pets/{id}', $this->stdout);
+    }
+
+    #[Test]
+    public function methods_the_coverage_tracker_never_records_are_out_of_scope(): void
+    {
+        $head = $this->baseSpec();
+        // HEAD / OPTIONS / TRACE never reach a coverage document, so gating
+        // them would demand coverage no report can show.
+        $head['paths']['/pets/{id}']['head'] = ['responses' => ['200' => ['description' => 'ok']]];
+        $head['paths']['/pets/{id}']['options'] = ['responses' => ['204' => ['description' => 'no content']]];
+
+        $this->writeSpec('base.json', $this->baseSpec());
+        $this->writeSpec('openapi.json', $head);
+        $this->writeCoverage([]);
+
+        $this->assertSame(CoverageGateCommand::EXIT_OK, $this->gate());
+        $this->assertSame("[Gesso] No operation changed against the base spec.\n", $this->stdout);
+    }
+
+    #[Test]
+    public function a_deleted_response_is_reported_but_does_not_fail_the_gate(): void
+    {
+        $base = $this->baseSpec();
+        $base['paths']['/pets/{id}']['put']['responses']['404'] = [
+            'description' => 'missing',
+            'content' => ['application/json' => ['schema' => ['type' => 'object']]],
+        ];
+
+        $this->writeSpec('base.json', $base);
+        $this->writeSpec('openapi.json', $this->baseSpec());
+        $this->writeCoverage([]);
+
+        $this->assertSame(CoverageGateCommand::EXIT_OK, $this->gate());
+        $this->assertStringContainsString('[Gesso] 1 operation changed against the base spec:', $this->stdout);
+        $this->assertStringContainsString('404 application/json    removed (not testable)', $this->stdout);
+    }
+
+    #[Test]
     public function a_response_the_coverage_document_never_saw_counts_as_uncovered(): void
     {
         $this->writeSpec('base.json', $this->baseSpec());

--- a/tests/Unit/Cli/CoverageGateCommandTest.php
+++ b/tests/Unit/Cli/CoverageGateCommandTest.php
@@ -188,6 +188,42 @@ class CoverageGateCommandTest extends TestCase
     }
 
     #[Test]
+    public function a_root_server_change_puts_every_inheriting_operation_in_scope(): void
+    {
+        $base = $this->baseSpec();
+        $base['servers'] = [['url' => 'https://api.example.com/v1']];
+        $head = $base;
+        $head['servers'][0]['url'] = 'https://api.example.com/v2';
+
+        $this->writeSpec('base.json', $base);
+        $this->writeSpec('openapi.json', $head);
+        $this->writeCoverage([$this->endpoint('PUT', '/pets/{id}', [['200', 'application/json', 'uncovered']])]);
+
+        $this->assertSame(CoverageGateCommand::EXIT_UNCOVERED_CHANGE, $this->gate());
+        $this->assertStringContainsString('  PUT /pets/{id}', $this->stdout);
+        $this->assertStringContainsString('  GET /legacy', $this->stdout);
+    }
+
+    #[Test]
+    public function an_operation_level_servers_override_shields_it_from_a_path_item_change(): void
+    {
+        $base = $this->baseSpec();
+        $base['paths']['/pets/{id}']['servers'] = [['url' => 'https://pets.example.com']];
+        // servers is override-not-merge, so the Path Item entry never applies
+        // to this operation.
+        $base['paths']['/pets/{id}']['put']['servers'] = [['url' => 'https://writes.example.com']];
+        $head = $base;
+        $head['paths']['/pets/{id}']['servers'][0]['url'] = 'https://pets2.example.com';
+
+        $this->writeSpec('base.json', $base);
+        $this->writeSpec('openapi.json', $head);
+        $this->writeCoverage([]);
+
+        $this->assertSame(CoverageGateCommand::EXIT_OK, $this->gate());
+        $this->assertSame("[Gesso] No operation changed against the base spec.\n", $this->stdout);
+    }
+
+    #[Test]
     public function a_security_scheme_definition_change_puts_the_operation_in_scope(): void
     {
         $base = $this->baseSpec();

--- a/tests/Unit/Cli/CoverageGateCommandTest.php
+++ b/tests/Unit/Cli/CoverageGateCommandTest.php
@@ -1,0 +1,341 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Cli;
+
+use const JSON_THROW_ON_ERROR;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Cli\CoverageGateCommand;
+use Studio\Gesso\Spec\OpenApiSpecLoader;
+
+use function array_map;
+use function file_put_contents;
+use function glob;
+use function json_encode;
+use function mkdir;
+use function rmdir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+class CoverageGateCommandTest extends TestCase
+{
+    private string $workDir;
+    private string $stdout = '';
+    private string $stderr = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->workDir = sys_get_temp_dir() . '/gesso-coverage-gate-' . uniqid('', true);
+        mkdir($this->workDir);
+        OpenApiSpecLoader::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->workDir . '/*') ?: [] as $path) {
+            @unlink($path);
+        }
+        @rmdir($this->workDir);
+        OpenApiSpecLoader::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function parses_every_supported_flag(): void
+    {
+        $this->assertSame(
+            [
+                'invalid_options' => [],
+                'base_spec' => 'base.json',
+                'spec' => 'openapi.json',
+                'coverage' => 'build/coverage.json',
+                'spec_name' => 'front',
+                'format' => 'markdown',
+            ],
+            CoverageGateCommand::parseArgv([
+                'coverage:gate',
+                '--base-spec=base.json',
+                '--spec=openapi.json',
+                '--coverage=build/coverage.json',
+                '--spec-name=front',
+                '--format=markdown',
+            ]),
+        );
+    }
+
+    #[Test]
+    public function an_unchanged_spec_reports_no_change_and_exits_zero(): void
+    {
+        $this->writeSpec('base.json', $this->baseSpec());
+        $this->writeSpec('openapi.json', $this->baseSpec());
+        $this->writeCoverage([]);
+
+        $this->assertSame(CoverageGateCommand::EXIT_OK, $this->gate());
+        $this->assertSame("[Gesso] No operation changed against the base spec.\n", $this->stdout);
+    }
+
+    #[Test]
+    public function a_ref_rewrite_that_resolves_to_the_same_tree_is_unchanged(): void
+    {
+        $spec = $this->baseSpec();
+        $spec['components'] = ['schemas' => ['Pet' => ['type' => 'object', 'properties' => ['id' => ['type' => 'integer']]]]];
+        $spec['paths']['/pets/{id}']['put']['responses']['200']['content']['application/json']['schema']
+            = ['$ref' => '#/components/schemas/Pet'];
+
+        $this->writeSpec('base.json', $this->baseSpec());
+        $this->writeSpec('openapi.json', $spec);
+        $this->writeCoverage([]);
+
+        $this->assertSame(CoverageGateCommand::EXIT_OK, $this->gate());
+        $this->assertSame("[Gesso] No operation changed against the base spec.\n", $this->stdout);
+    }
+
+    #[Test]
+    public function an_uncovered_added_response_fails_the_gate(): void
+    {
+        $this->writeSpec('base.json', $this->baseSpec());
+        $this->writeSpec('openapi.json', $this->headSpec());
+        $this->writeCoverage([
+            $this->endpoint('PUT', '/pets/{id}', [['200', 'application/json', 'validated']]),
+            $this->endpoint('DELETE', '/pets/{id}', [['204', '*', 'uncovered']]),
+        ]);
+
+        $this->assertSame(CoverageGateCommand::EXIT_UNCOVERED_CHANGE, $this->gate());
+        $this->assertStringContainsString('[Gesso] 2 operations changed against the base spec:', $this->stdout);
+        $this->assertStringContainsString('  PUT /pets/{id}', $this->stdout);
+        $this->assertStringContainsString('200 application/json    covered', $this->stdout);
+        $this->assertStringContainsString('204 (no content)        UNCOVERED', $this->stdout);
+        $this->assertStringContainsString('GET /legacy    removed from the spec (not testable)', $this->stdout);
+        $this->assertStringContainsString('1 changed response is not covered by any test.', $this->stdout);
+    }
+
+    #[Test]
+    public function a_fully_covered_change_passes_the_gate(): void
+    {
+        $this->writeSpec('base.json', $this->baseSpec());
+        $this->writeSpec('openapi.json', $this->headSpec());
+        $this->writeCoverage([
+            $this->endpoint('PUT', '/pets/{id}', [['200', 'application/json', 'validated']]),
+            $this->endpoint('DELETE', '/pets/{id}', [['204', '*', 'validated']]),
+        ]);
+
+        $this->assertSame(CoverageGateCommand::EXIT_OK, $this->gate());
+        $this->assertStringContainsString('All changed responses are covered.', $this->stdout);
+    }
+
+    #[Test]
+    public function a_changed_request_body_puts_untouched_responses_in_scope(): void
+    {
+        $spec = $this->baseSpec();
+        $spec['paths']['/pets/{id}']['put']['requestBody'] = [
+            'content' => ['application/json' => ['schema' => ['type' => 'object']]],
+        ];
+
+        $this->writeSpec('base.json', $this->baseSpec());
+        $this->writeSpec('openapi.json', $spec);
+        $this->writeCoverage([$this->endpoint('PUT', '/pets/{id}', [['200', 'application/json', 'uncovered']])]);
+
+        $this->assertSame(CoverageGateCommand::EXIT_UNCOVERED_CHANGE, $this->gate());
+        $this->assertStringContainsString('200 application/json    UNCOVERED', $this->stdout);
+    }
+
+    #[Test]
+    public function a_response_the_coverage_document_never_saw_counts_as_uncovered(): void
+    {
+        $this->writeSpec('base.json', $this->baseSpec());
+        $this->writeSpec('openapi.json', $this->headSpec());
+        $this->writeCoverage([$this->endpoint('PUT', '/pets/{id}', [['200', 'application/json', 'validated']])]);
+
+        $this->assertSame(CoverageGateCommand::EXIT_UNCOVERED_CHANGE, $this->gate());
+        $this->assertStringContainsString('204 (no content)        UNCOVERED', $this->stdout);
+    }
+
+    #[Test]
+    public function a_skipped_response_does_not_satisfy_the_gate(): void
+    {
+        $this->writeSpec('base.json', $this->baseSpec());
+        $this->writeSpec('openapi.json', $this->headSpec());
+        $this->writeCoverage([
+            $this->endpoint('PUT', '/pets/{id}', [['200', 'application/json', 'validated']]),
+            $this->endpoint('DELETE', '/pets/{id}', [['204', '*', 'skipped']]),
+        ]);
+
+        $this->assertSame(CoverageGateCommand::EXIT_UNCOVERED_CHANGE, $this->gate());
+        $this->assertStringContainsString('204 (no content)        SKIPPED', $this->stdout);
+    }
+
+    #[Test]
+    public function markdown_format_renders_a_step_summary_table(): void
+    {
+        $this->writeSpec('base.json', $this->baseSpec());
+        $this->writeSpec('openapi.json', $this->headSpec());
+        $this->writeCoverage([
+            $this->endpoint('PUT', '/pets/{id}', [['200', 'application/json', 'validated']]),
+            $this->endpoint('DELETE', '/pets/{id}', [['204', '*', 'uncovered']]),
+        ]);
+
+        $this->assertSame(CoverageGateCommand::EXIT_UNCOVERED_CHANGE, $this->gate(format: 'markdown'));
+        $this->assertStringContainsString('### Gesso spec patch coverage', $this->stdout);
+        $this->assertStringContainsString('**1 changed response is not covered by any test.**', $this->stdout);
+        $this->assertStringContainsString('| Operation | Change | Response | Coverage |', $this->stdout);
+        $this->assertStringContainsString('| `DELETE /pets/{id}` | added | `204 (no content)` | UNCOVERED |', $this->stdout);
+        $this->assertStringContainsString('| `GET /legacy` | removed | — | — |', $this->stdout);
+    }
+
+    #[Test]
+    public function a_missing_required_flag_is_a_usage_error(): void
+    {
+        $this->assertSame(
+            CoverageGateCommand::EXIT_USAGE,
+            $this->command()->run(['base_spec' => 'base.json', 'invalid_options' => []]),
+        );
+        $this->assertStringContainsString('--spec is required.', $this->stderr);
+    }
+
+    #[Test]
+    public function an_unknown_spec_name_lists_the_available_ones(): void
+    {
+        $this->writeSpec('base.json', $this->baseSpec());
+        $this->writeSpec('openapi.json', $this->headSpec());
+        $this->writeCoverage([], specName: 'front');
+
+        $this->assertSame(CoverageGateCommand::EXIT_USAGE, $this->gate());
+        $this->assertStringContainsString('has no spec named "openapi". Available: front.', $this->stderr);
+        // --spec-name selects the coverage key; the gate then runs normally
+        // (and here fails, because that spec recorded nothing).
+        $this->assertSame(CoverageGateCommand::EXIT_UNCOVERED_CHANGE, $this->gate(specName: 'front'));
+        $this->assertSame('', $this->stderr);
+    }
+
+    #[Test]
+    public function an_unsupported_coverage_schema_version_is_a_usage_error(): void
+    {
+        $this->writeSpec('base.json', $this->baseSpec());
+        $this->writeSpec('openapi.json', $this->headSpec());
+        file_put_contents(
+            $this->workDir . '/coverage.json',
+            json_encode(['schema_version' => 2, 'specs' => []], JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertSame(CoverageGateCommand::EXIT_USAGE, $this->gate());
+        $this->assertStringContainsString('Unsupported coverage schema_version', $this->stderr);
+    }
+
+    #[Test]
+    public function an_unreadable_spec_is_a_usage_error(): void
+    {
+        $this->writeSpec('openapi.json', $this->headSpec());
+        $this->writeCoverage([]);
+
+        $this->assertSame(CoverageGateCommand::EXIT_USAGE, $this->gate());
+        $this->assertStringContainsString('Spec is not a readable file', $this->stderr);
+    }
+
+    private function gate(string $format = 'text', ?string $specName = null): int
+    {
+        $this->stdout = '';
+        $this->stderr = '';
+
+        $options = [
+            'base_spec' => $this->workDir . '/base.json',
+            'spec' => $this->workDir . '/openapi.json',
+            'coverage' => $this->workDir . '/coverage.json',
+            'format' => $format,
+            'invalid_options' => [],
+        ];
+        if ($specName !== null) {
+            $options['spec_name'] = $specName;
+        }
+
+        return $this->command()->run($options);
+    }
+
+    private function command(): CoverageGateCommand
+    {
+        return new CoverageGateCommand(
+            function (string $message): void {
+                $this->stdout .= $message;
+            },
+            function (string $message): void {
+                $this->stderr .= $message;
+            },
+        );
+    }
+
+    /** @param array<string, mixed> $spec */
+    private function writeSpec(string $file, array $spec): void
+    {
+        file_put_contents($this->workDir . '/' . $file, json_encode($spec, JSON_THROW_ON_ERROR));
+    }
+
+    /** @param list<array<string, mixed>> $endpoints */
+    private function writeCoverage(array $endpoints, string $specName = 'openapi'): void
+    {
+        file_put_contents($this->workDir . '/coverage.json', json_encode([
+            'schema_version' => 3,
+            'specs' => [$specName => ['endpoints' => $endpoints]],
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * @param list<array{0: string, 1: string, 2: string}> $responses
+     *
+     * @return array<string, mixed>
+     */
+    private function endpoint(string $method, string $path, array $responses): array
+    {
+        return [
+            'endpoint' => $method . ' ' . $path,
+            'method' => $method,
+            'path' => $path,
+            'responses' => array_map(static fn(array $row): array => [
+                'status_key' => $row[0],
+                'content_type_key' => $row[1],
+                'response_state' => $row[2],
+            ], $responses),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function baseSpec(): array
+    {
+        return [
+            'openapi' => '3.0.3',
+            'info' => ['title' => 'Pets', 'version' => '1.0.0'],
+            'paths' => [
+                '/pets/{id}' => [
+                    'put' => [
+                        'parameters' => [['name' => 'id', 'in' => 'path', 'required' => true, 'schema' => ['type' => 'integer']]],
+                        'responses' => [
+                            '200' => [
+                                'description' => 'ok',
+                                'content' => ['application/json' => ['schema' => ['type' => 'object', 'properties' => ['id' => ['type' => 'integer']]]]],
+                            ],
+                        ],
+                    ],
+                ],
+                '/legacy' => ['get' => ['responses' => ['200' => ['description' => 'ok']]]],
+            ],
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function headSpec(): array
+    {
+        $spec = $this->baseSpec();
+        unset($spec['paths']['/legacy']);
+        $spec['paths']['/pets/{id}']['put']['responses']['200']['content']['application/json']['schema']['properties']['name']
+            = ['type' => 'string'];
+        $spec['paths']['/pets/{id}']['delete'] = [
+            'parameters' => [['name' => 'id', 'in' => 'path', 'required' => true, 'schema' => ['type' => 'integer']]],
+            'responses' => ['204' => ['description' => 'deleted']],
+        ];
+
+        return $spec;
+    }
+}

--- a/tests/Unit/Cli/CoverageGateCommandTest.php
+++ b/tests/Unit/Cli/CoverageGateCommandTest.php
@@ -164,6 +164,30 @@ class CoverageGateCommandTest extends TestCase
     }
 
     #[Test]
+    public function an_overridden_path_level_parameter_change_is_not_a_change(): void
+    {
+        $base = $this->baseSpec();
+        $base['paths']['/pets/{id}']['parameters'] = [
+            ['name' => 'id', 'in' => 'path', 'required' => true, 'schema' => ['type' => 'string']],
+        ];
+        // The operation redeclares the same (in, name), so the Path Item entry
+        // never reaches the request validator.
+        $base['paths']['/pets/{id}']['put']['parameters'] = [
+            ['name' => 'id', 'in' => 'path', 'required' => true, 'schema' => ['type' => 'integer']],
+        ];
+        $head = $base;
+        $head['paths']['/pets/{id}']['parameters'][0]['schema'] = ['type' => 'number', 'format' => 'double'];
+
+        $this->writeSpec('base.json', $base);
+        $this->writeSpec('openapi.json', $head);
+        $this->writeCoverage([]);
+
+        // GET /legacy has no parameters at all, so nothing changes anywhere.
+        $this->assertSame(CoverageGateCommand::EXIT_OK, $this->gate());
+        $this->assertSame("[Gesso] No operation changed against the base spec.\n", $this->stdout);
+    }
+
+    #[Test]
     public function a_security_scheme_definition_change_puts_the_operation_in_scope(): void
     {
         $base = $this->baseSpec();

--- a/tests/fixtures/compatibility/v1.10-gesso-help.txt
+++ b/tests/fixtures/compatibility/v1.10-gesso-help.txt
@@ -6,5 +6,6 @@ Usage:
 Commands:
   doctor           Check whether Gesso can load and enforce a contract.
   coverage:merge   Combine parallel-worker coverage sidecars.
+  coverage:gate    Fail when a spec change touches an uncovered operation.
 
 Run `gesso <command> --help` for command-specific options.

--- a/tests/fixtures/compatibility/v2-diagnostic-prefixes.json
+++ b/tests/fixtures/compatibility/v2-diagnostic-prefixes.json
@@ -1,6 +1,7 @@
 {
     "[Gesso]": {
         "src/Baseline/CoverageBaselineEvaluator.php": 2,
+        "src/Cli/CoverageGateCommand.php": 3,
         "src/Coverage/CoverageMergeCommand.php": 15,
         "src/Fuzz/SchemaDataGenerator.php": 1,
         "src/Laravel/ValidatesOpenApiSchema.php": 1,


### PR DESCRIPTION
## Summary

Adds `gesso coverage:gate`: it fails a pull request when the change touches an
operation that no test exercises. This is the OpenAPI counterpart of
`diff-cover` / Codecov's patch status — instead of "the whole spec must be 80%
covered", it enforces "whatever *this* change touched must be covered".

```bash
git show origin/main:openapi.json > /tmp/base.json

vendor/bin/gesso coverage:gate \
  --base-spec=/tmp/base.json \
  --spec=openapi.json \
  --coverage=build/coverage.json
```

## Why

Fixes #475.

Coverage at `(method, path, status, content-type)` granularity is data only
Gesso has — a diff tool with no test-run data cannot build this gate. The
existing threshold gate and coverage baseline stop coverage from *regressing*;
neither stops new work from arriving uncovered.

Design decisions, all per the issue:

- **Structural diff only.** No breaking / non-breaking classification, so
  there is no rule catalogue to maintain against oasdiff or openapi-changes.
  Both documents go through `OpenApiSpecLoader`, so a `$ref` rewrite that
  resolves to the same tree reads as unchanged.
- **Two fingerprint levels.** The *effective* request contract and each
  `(status, content-type)` tuple. A changed request contract puts every
  response of that operation in scope; otherwise only the changed tuples are.
  "Effective" means the operation object, the Path Item fields it inherits,
  the parameters after `ParameterCollector`'s `in` + `name` override merge,
  the one `servers` array actually in force (operation → Path Item → root),
  and the applicable security requirement with its
  `components.securitySchemes` definitions — those live outside the operation
  but are part of the contract the operation exposes.
- **Scoped to the methods coverage records.** `GET` / `POST` / `PUT` /
  `PATCH` / `DELETE` / `QUERY` and 3.2 `additionalOperations`. `OPTIONS` /
  `HEAD` / `TRACE` never reach a coverage document, so gating them would
  demand coverage no report can show.
- **Exit codes follow `DoctorCommand`**: 0 covered / 1 uncovered change /
  2 usage. The issue's proposed "breaking = 2" is not adopted.
- **Only `validated` passes.** A `skipped` response renders as `SKIPPED` and
  fails, as specified in the issue. Flagging in case reviewers want a
  `--allow-skipped` escape hatch instead.

Out of scope, unchanged from the issue: semantic analysis, git integration
(the caller prepares the base spec), HTML output, and consuming other tools'
diff JSON.

## Verification

- [x] `composer test` passes
- [x] `composer stan` passes
- [x] `composer cs-check` passes

- Unit: 21 cases including the two regression tests the issue asks for
  (identical specs → exit 0 with an explicit "no change" line; `$ref`-only
  rewrite → unchanged), plus request-contract change widening scope, `skipped`,
  markdown output, and each usage error. Review round 2 added five more:
  path-level `parameters`, a `securitySchemes` definition change, an
  operation-level `security` override shielding it from a root change,
  `HEAD`/`OPTIONS` staying out of scope, and a delete-only response change.
  Round 3 added an already-overridden Path Item parameter staying out of scope,
  a root `servers` change reaching every inheriting operation, and an
  operation-level `servers` override shielding it from a Path Item change.
- Manual: a split spec (`root.json` → `./schemas/pet.json`) resolves through
  the gate when the whole base tree is present, and fails loudly with
  `Local $ref target not found` when only the entry document is copied — which
  is what the original CI example did. The example now uses `git worktree add`.
- Integration: the real `bin/gesso` binary for `coverage:gate --help` and the
  usage error; root help fixture updated for the new subcommand.
- Manual: run against the committed `docs/samples/coverage.json` in both
  formats — exit 1 with the uncovered `422 application/problem+json` named.

## Notes for reviewers

- `tests/fixtures/compatibility/v1.10-gesso-help.txt` and
  `v2-diagnostic-prefixes.json` are updated additively — one new command line
  and one new `[Gesso]` prefix entry. No existing line is removed.
- `docs/versioning.md` records `coverage:gate` as a v2.x CLI surface and
  `Cli\CoverageGateCommand` as its `@internal` implementation, matching how
  `doctor` and `coverage:merge` are documented.
- The response-tuple enumeration in `index()` mirrors
  `OpenApiCoverageTracker::collectDeclaredEndpoints()` (including the `*`
  sentinel for no-content responses) so the join keys line up. It does not
  re-emit that walker's malformed-node warnings — `gesso doctor` is the
  loud path for those.



