### PR TITLE
fix(cli): reject a spec shadowed by a sibling entry document in coverage:gate

### DIFF
--- a/src/Cli/CoverageGateCommand.php
+++ b/src/Cli/CoverageGateCommand.php
@@ -245,6 +245,29 @@ final class CoverageGateCommand
             throw new RuntimeException("Unsupported spec extension: .{$extension} ({$inputPath})");
         }
 
+        // The loader resolves a *name*, searching .json before .yaml before
+        // .yml, so `--spec=openapi.yaml` next to an openapi.json would silently
+        // gate the JSON document instead. Fail the way `gesso doctor` does
+        // rather than report a verdict on a spec the user did not name.
+        $directory = pathinfo($path, PATHINFO_DIRNAME);
+        $name = pathinfo($path, PATHINFO_FILENAME);
+        foreach (['json', 'yaml', 'yml'] as $candidateExtension) {
+            $candidate = $directory . '/' . $name . '.' . $candidateExtension;
+            if (!is_file($candidate)) {
+                continue;
+            }
+            if (realpath($candidate) !== realpath($path)) {
+                throw new RuntimeException(sprintf(
+                    'The runtime loader selects %s before the requested %s. '
+                    . 'Remove or rename the shadowing entry document.',
+                    $candidate,
+                    $inputPath,
+                ));
+            }
+
+            break;
+        }
+
         try {
             // The loader caches by spec name, so a base and a head document
             // sharing a filename (the common `openapi.json` case) would

--- a/tests/Unit/Cli/CoverageGateCommandTest.php
+++ b/tests/Unit/Cli/CoverageGateCommandTest.php
@@ -390,14 +390,50 @@ class CoverageGateCommandTest extends TestCase
         $this->assertStringContainsString('Spec is not a readable file', $this->stderr);
     }
 
-    private function gate(string $format = 'text', ?string $specName = null): int
+    #[Test]
+    public function a_spec_shadowed_by_a_json_sibling_is_a_usage_error(): void
     {
+        // The loader resolves a *name* and searches .json before .yaml, so
+        // gating --spec=openapi.yaml would silently diff the JSON document.
+        $this->writeSpec('base.json', $this->baseSpec());
+        $this->writeSpec('openapi.json', $this->headSpec());
+        file_put_contents($this->workDir . '/openapi.yaml', "openapi: 3.0.3\n");
+        $this->writeCoverage([]);
+
+        $this->assertSame(CoverageGateCommand::EXIT_USAGE, $this->gate(spec: $this->workDir . '/openapi.yaml'));
+        $this->assertStringContainsString(
+            'selects ' . $this->workDir . '/openapi.json before the requested ' . $this->workDir . '/openapi.yaml',
+            $this->stderr,
+        );
+    }
+
+    #[Test]
+    public function a_base_spec_shadowed_by_a_json_sibling_is_a_usage_error(): void
+    {
+        $this->writeSpec('base.json', $this->baseSpec());
+        $this->writeSpec('openapi.json', $this->headSpec());
+        file_put_contents($this->workDir . '/base.yaml', "openapi: 3.0.3\n");
+        $this->writeCoverage([]);
+
+        $this->assertSame(CoverageGateCommand::EXIT_USAGE, $this->gate(baseSpec: $this->workDir . '/base.yaml'));
+        $this->assertStringContainsString(
+            'selects ' . $this->workDir . '/base.json before the requested ' . $this->workDir . '/base.yaml',
+            $this->stderr,
+        );
+    }
+
+    private function gate(
+        string $format = 'text',
+        ?string $specName = null,
+        ?string $spec = null,
+        ?string $baseSpec = null,
+    ): int {
         $this->stdout = '';
         $this->stderr = '';
 
         $options = [
-            'base_spec' => $this->workDir . '/base.json',
-            'spec' => $this->workDir . '/openapi.json',
+            'base_spec' => $baseSpec ?? $this->workDir . '/base.json',
+            'spec' => $spec ?? $this->workDir . '/openapi.json',
             'coverage' => $this->workDir . '/coverage.json',
             'format' => $format,
             'invalid_options' => [],


### PR DESCRIPTION
## Summary

`coverage:gate` checked the extension of `--spec` / `--base-spec` and then passed only the basename to `OpenApiSpecLoader`, which resolves a *name* by searching `.json` before `.yaml` before `.yml`. Ported the shadowing check `StubsCommand` gained in #491, so both flags now fail with exit 2 naming the shadowing file.

## Why

With `openapi.json` and `openapi.yaml` side by side, `--spec=openapi.yaml` silently gated the JSON document and reported a verdict on a spec the user never named — the worst failure mode for a gate whose job is to fail a PR on uncovered change. `gesso doctor` already treats the same layout as an `error` diagnostic, so the two commands disagreed about the same directory.

Fixes #492

## Verification

- Failing-test-then-fix: both new tests exited 1 (gating the JSON) before the change, exit 2 after.
- `composer ci` (cs-fixer ×2 / stan / phpunit 3096 tests) passes.

- [x] `composer test` passes
- [x] `composer stan` passes
- [x] `composer cs-check` passes

## Notes for reviewers

The issue floated extracting the now-three copies of load-a-spec-by-path into a shared `@internal` helper. Skipped: the doctor's variant differs materially (returns diagnostics rather than throwing, and carries `--local-ref-root` relative-name resolution), so a common helper would only cover the loop itself. Worth revisiting if a fourth command appears.