### PR TITLE
fix(coverage): skip responses object extensions in the declared set

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -12,6 +12,8 @@ Coverage is tracked at **`(method, path, statusCode, contentType)` granularity**
 | `✗` / `:x:` | No pair validated for this endpoint |
 | `·` / `:information_source:` | Endpoint reached via request-validation but no response asserted |
 
+Specification extensions (`x-` keys) on a Responses Object are not responses and are excluded from the declared set.
+
 The report also breaks the coverage rate into two numbers — the strict endpoint rate (all declared responses validated) and the response-level rate (`responseCovered / responseTotal`).
 
 SDK response exploration is reported separately as **SDK exercise coverage**.

--- a/src/Cli/CoverageGateCommand.php
+++ b/src/Cli/CoverageGateCommand.php
@@ -353,6 +353,11 @@ final class CoverageGateCommand
                 $declaredResponses = is_array($operation['responses'] ?? null) ? $operation['responses'] : [];
                 foreach ($declaredResponses as $status => $response) {
                     $status = (string) $status;
+                    // Specification extensions are not responses; skipping them
+                    // keeps this index aligned with the coverage tracker.
+                    if (str_starts_with($status, 'x-')) {
+                        continue;
+                    }
                     if (!is_array($response)) {
                         continue;
                     }

--- a/src/Cli/DoctorCommand.php
+++ b/src/Cli/DoctorCommand.php
@@ -516,6 +516,12 @@ final class DoctorCommand
                 }
 
                 foreach ($responses as $status => $response) {
+                    // Specification extensions are legal on a Responses Object
+                    // and are skipped at runtime; inspecting them would report
+                    // a structure error against a valid document.
+                    if (str_starts_with((string) $status, 'x-')) {
+                        continue;
+                    }
                     if ($this->inspectResponseDefinition($response, $declared['method'], (string) $path, (string) $status, $label, $issues)) {
                         $responseCount++;
                     }

--- a/src/Coverage/OpenApiCoverageTracker.php
+++ b/src/Coverage/OpenApiCoverageTracker.php
@@ -866,6 +866,13 @@ final class OpenApiCoverageTracker
                 $responsePairs = [];
                 foreach ($responses as $statusKey => $responseSpec) {
                     $statusKeyStr = (string) $statusKey;
+                    // Specification extensions are legal on a Responses Object in
+                    // 3.0/3.1/3.2 and are not responses. SpecResponseKeyResolver
+                    // skips them at runtime, so counting them here would declare
+                    // a tuple nothing can ever cover.
+                    if (str_starts_with($statusKeyStr, 'x-')) {
+                        continue;
+                    }
                     if (!is_array($responseSpec)) {
                         self::warnMalformed($specName, sprintf('response %s %s %s is not an object (got %s); omitted from coverage', $upper, (string) $path, $statusKeyStr, get_debug_type($responseSpec)));
 

--- a/tests/Unit/Cli/CoverageGateCommandTest.php
+++ b/tests/Unit/Cli/CoverageGateCommandTest.php
@@ -96,6 +96,23 @@ class CoverageGateCommandTest extends TestCase
     }
 
     #[Test]
+    public function adding_a_responses_object_extension_is_not_a_changed_response(): void
+    {
+        // Issue #493: `x-` keys on a Responses Object are specification
+        // extensions, not declared responses, so they can never be covered.
+        $spec = $this->baseSpec();
+        $spec['paths']['/pets/{id}']['put']['responses']['x-doc'] = ['owner' => 'platform-team'];
+        $spec['paths']['/pets/{id}']['put']['responses']['x-owner'] = 'platform-team';
+
+        $this->writeSpec('base.json', $this->baseSpec());
+        $this->writeSpec('openapi.json', $spec);
+        $this->writeCoverage([]);
+
+        $this->assertSame(CoverageGateCommand::EXIT_OK, $this->gate());
+        $this->assertSame("[Gesso] No operation changed against the base spec.\n", $this->stdout);
+    }
+
+    #[Test]
     public function an_uncovered_added_response_fails_the_gate(): void
     {
         $this->writeSpec('base.json', $this->baseSpec());

--- a/tests/Unit/Cli/DoctorCommandTest.php
+++ b/tests/Unit/Cli/DoctorCommandTest.php
@@ -659,6 +659,26 @@ class DoctorCommandTest extends TestCase
     }
 
     #[Test]
+    public function ignores_specification_extensions_on_a_responses_object(): void
+    {
+        // Issue #493: `x-` keys are legal on a Responses Object and are skipped
+        // at runtime; doctor must neither count nor structurally reject them.
+        $spec = $this->writeSpec('response-extensions.json', (string) json_encode([
+            'openapi' => '3.1.0',
+            'info' => ['title' => 'Test', 'version' => '1'],
+            'paths' => ['/pets' => ['get' => ['responses' => [
+                '200' => ['description' => 'ok'],
+                'x-doc' => ['owner' => 'platform-team'],
+                'x-owner' => 'platform-team',
+            ]]]],
+        ], JSON_THROW_ON_ERROR));
+        $report = $this->runJsonDoctor($spec, $exit);
+
+        $this->assertSame(DoctorCommand::EXIT_OK, $exit);
+        $this->assertSame(1, $report['summary']['responses']);
+    }
+
+    #[Test]
     public function rejects_nested_response_nodes_using_runtime_malformed_node_rules(): void
     {
         $cases = [

--- a/tests/Unit/Coverage/OpenApiCoverageTrackerTest.php
+++ b/tests/Unit/Coverage/OpenApiCoverageTrackerTest.php
@@ -737,6 +737,41 @@ class OpenApiCoverageTrackerTest extends TestCase
     }
 
     #[Test]
+    public function response_object_extensions_are_not_declared_responses(): void
+    {
+        // Issue #493: `x-` keys on a Responses Object are specification
+        // extensions, not responses. Counting them left a tuple no recording
+        // could ever cover (SpecResponseKeyResolver skips them), and a
+        // scalar-valued one tripped the malformed-response warning.
+        $captured = [];
+        set_error_handler(static function (int $errno, string $message) use (&$captured): bool {
+            $captured[] = $message;
+
+            return true;
+        });
+
+        try {
+            $this->tracker->recordResponseOn(
+                'response-extensions',
+                'GET',
+                '/widgets',
+                '200',
+                'application/json',
+                schemaValidated: true,
+            );
+            $endpoint = $this->endpointSummary('response-extensions', 'GET /widgets');
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $captured);
+        $this->assertSame(1, $endpoint['totalResponseCount']);
+        $this->assertSame(1, $endpoint['coveredResponseCount']);
+        $this->assertSame(EndpointCoverageState::AllCovered, $endpoint['state']);
+        $this->assertSame(['200'], array_column($endpoint['responses'], 'statusKey'));
+    }
+
+    #[Test]
     public function openapi_32_query_and_additional_operations_appear_in_coverage(): void
     {
         $this->tracker->recordResponseOn(

--- a/tests/fixtures/specs/response-extensions.json
+++ b/tests/fixtures/specs/response-extensions.json
@@ -1,0 +1,30 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Response Extensions Fixture",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/widgets": {
+      "get": {
+        "operationId": "listWidgets",
+        "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "x-doc": {
+            "owner": "platform-team"
+          },
+          "x-owner": "platform-team"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

`x-` keys are legal specification extensions on a Responses Object in OpenAPI 3.0/3.1/3.2, but three spec walkers treated them as declared responses. They are now skipped, matching `SpecResponseKeyResolver` / `ResponseStatusTargetEnumerator` / `StubGenerator`.

## Why

Fixes #493.

- `OpenApiCoverageTracker::collectDeclaredEndpoints()` counted an object-valued extension as a declared `(status, content-type)` tuple that no recording can ever cover — coverage was understated and the threshold gate and coverage baseline inherited the error. A scalar-valued extension additionally emitted a spurious `response ... is not an object` warning against a valid document.
- `CoverageGateCommand`'s spec index explicitly mirrors that walk, so adding an extension surfaced as an uncovered changed response.
- `DoctorCommand` counted extensions toward `summary.responses` and reported a `structure` error for a scalar-valued one — a false failure on a valid spec.

The last two are not named in the issue but are the same defect in sibling callers; fixing only the tracker would leave the gate and doctor disagreeing with it again.

## Verification

- Regression tests added for the tracker, `coverage:gate`, and `doctor`, each covering an object-valued and a scalar-valued extension; all three confirmed failing before the fix (verified by stashing `src/`).
- [x] `composer test` passes (3099 tests)
- [x] `composer stan` passes — run as `vendor/bin/phpstan analyse --memory-limit=1G`; the default 128M limit crashes a parallel worker locally, unrelated to this change
- [x] `composer cs-check` passes

## Notes for reviewers

Behaviour change on a documented output surface: coverage totals move for any spec using response extensions, and the previously emitted malformed warnings disappear. The coverage JSON **format** is unchanged — only the values it reports are corrected — so `docs/versioning.md` needs no update; the correction is stated in the commit body so it reaches the release notes. `docs/coverage.md` gains one line documenting the exclusion.