### PR TITLE
docs: unblank the CI guide page and document the v2.4.0 upgrade

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -10,15 +10,29 @@ read each intermediate section in order — behavioural changes compose.
 ## Within v2.x
 
 The v2.x line is covered end-to-end by SemVer (see `docs/versioning.md` for the
-surface contract). Minor releases are additive by default; only the releases
-listed below change existing behaviour.
+surface contract). Minor releases are additive by default, but "additive" does
+not mean "no behaviour changes" — a fix that closes a silent-pass gap changes
+what your suite reports.
+
+Only v2.4.0 has a section below. Earlier v2 minors carry behavioural fixes that
+were never written up here: v2.2.0 stopped applying the coverage threshold gate
+to partial runs (#453) and v2.3.0 began rejecting `null` response content
+(#466), among others. If you are jumping from v2.0.x, v2.1.x, or v2.2.x, read
+the `### Bug Fixes` entries for each intermediate release in `CHANGELOG.md`;
+this file cannot be relied on to list them.
 
 ### From v2.3.0 → v2.4.0
 
-No public method signatures, CLI flags, exit codes, or wire formats change. The
-new `coverage:gate` / `stubs` commands, the coverage baseline, and the
-`ignored_auth` / `missing_required_header` contract checks are all opt-in. Four
-existing behaviours change:
+There are no backward-incompatible changes to the public API. The additions —
+new `coverage:gate` / `stubs` CLI commands, new `coverage_baseline_*` extension
+parameters and `coverage:merge` flags, the new `Studio\Gesso\UploadedPart`
+class, new methods such as `ContractCheckPlan::dispatchIsolatedUsing()` and
+`ExploredCase::withCookies()`, and a new optional trailing `$cookies` parameter
+on `ExploredCase::__construct()` — leave every existing
+signature, flag, exit code, and wire format meaning what it meant in v2.3.0. The
+new commands, the coverage baseline, and the `ignored_auth` /
+`missing_required_header` contract checks are all opt-in. Four existing
+behaviours change:
 
 - **Form request bodies are now validated against their schema** (#486). A
   `multipart/form-data` or `application/x-www-form-urlencoded` request body that

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,6 +7,69 @@ full record.
 Sections are ordered newest-first. If you are jumping multiple minors,
 read each intermediate section in order — behavioural changes compose.
 
+## Within v2.x
+
+The v2.x line is covered end-to-end by SemVer (see `docs/versioning.md` for the
+surface contract). Minor releases are additive by default; only the releases
+listed below change existing behaviour.
+
+### From v2.3.0 → v2.4.0
+
+No public method signatures, CLI flags, exit codes, or wire formats change. The
+new `coverage:gate` / `stubs` commands, the coverage baseline, and the
+`ignored_auth` / `missing_required_header` contract checks are all opt-in. Four
+existing behaviours change:
+
+- **Form request bodies are now validated against their schema** (#486). A
+  `multipart/form-data` or `application/x-www-form-urlencoded` request body that
+  matched a spec media type declaring a `schema` previously came back `Skipped`
+  — and `OpenApiValidationResult::isValid()` reports `Skipped` as valid, so it
+  passed silently. It is now checked.
+  - **Behaviour change**: contract tests posting form bodies may begin failing.
+    Values arrive as strings and are coerced to the declared property types
+    exactly as query parameters are, so `age=3` satisfies `type: integer` while
+    `age=three` fails at `/age`. Fix the payload or the schema; these failures
+    expose drift the skip only hid.
+  - Applies to the Laravel trait, the Symfony trait, and the PSR-7 validator.
+    Response-side form bodies remain presence-only.
+  - There is no opt-out flag. A part whose media type the wire did not preserve
+    is still reported as unchecked rather than failed, and a raw
+    `multipart/form-data` payload with no parsed parts stays `Skipped` with a
+    reason. See
+    [`docs/supported-features.md`](docs/supported-features.md#body-validation).
+- **An empty Schema Object `{}` is read as "any value"** (#483). It previously
+  reached opis as a JSON array and was rejected with
+  `InvalidKeywordException: … must be a json schema`, and
+  `{items: {}, additionalItems: false}` was silently read as the empty tuple
+  form, failing compliant arrays. Specs that could not load, or that failed
+  valid payloads for this reason, now work. Nothing that previously passed
+  starts failing.
+- **Specification extensions on a Responses Object are no longer counted**
+  (#495). An `x-`-prefixed key under `responses` was previously declared as a
+  coverage tuple nothing could ever cover, and reported by `doctor` as a
+  structure error.
+  - **Behaviour change**: the coverage denominator drops for specs using them,
+    so reported percentages rise and a `min_response_coverage` gate becomes
+    easier to satisfy. Regenerate any committed coverage baseline. `doctor`
+    stops emitting the false structure error, which can flip its exit code from
+    1 to 0.
+- **`doctor` accepts OpenAPI 3.1+ documents that omit `paths` or `responses`**
+  (#479). Both are required in 3.0 but optional from 3.1 on — a document may
+  describe only `webhooks`, and an operation may describe only its request. The
+  runtime validators already treated an absent key as "nothing to match"; only
+  `doctor` disagreed.
+  - **Behaviour change**: a CI job gating on `gesso doctor`'s exit code may go
+    from 1 to 0 for such documents. A node that is *present* with the wrong type
+    is still an error.
+
+Users of the fuzz `ContractCheckPlan` with a custom dispatcher should also note
+that `ExploredCase` now carries a `cookies` map. Forward it to your client's
+cookie bag — Laravel and Symfony test clients take cookies as a separate
+`SymfonyRequest::create()` argument, so a `Cookie:` request header alone never
+reaches `$request->cookie(...)`. A dispatcher that drops them makes a
+cookie-credential `ignored_auth` probe pass for the wrong reason. Existing
+checks are unaffected.
+
 ## From v1.10.x to v2.0.0
 
 Gesso v2 uses `Studio\Gesso\` as its only PHP namespace and is installed from

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -152,7 +152,7 @@ parameter (or `coverage:merge --json-output` for parallel runs) as shown in
 > gate's failure would be swallowed.
 
 A single-file spec with no local `$ref` needs no worktree —
-`git show "origin/${{ github.base_ref }}:openapi.json" > "${RUNNER_TEMP}/base.json"`
+<code v-pre>git show "origin/${{ github.base_ref }}:openapi.json" > "${RUNNER_TEMP}/base.json"</code>
 is enough. If you already publish a bundled artifact, point `--base-spec` at
 the base branch's bundle instead.
 


### PR DESCRIPTION
## Summary

Two documentation fixes found while checking the v2.4.0 release diff for
regressions. `docs/ci.md` currently renders as an empty page on the docs site,
and `UPGRADING.md` has no entry for a release that changes four existing
behaviours.

## Why

**The CI guide ships blank.** #490 added a `coverage:gate` GitHub Actions
recipe, including an inline-code example containing `${{ github.base_ref }}`.
VitePress applies `v-pre` to fenced code blocks but not to inline code spans, so
Vue evaluated it as a mustache and SSR threw
`TypeError: Cannot read properties of undefined (reading 'base_ref')`. The
built `ci.html` contains none of the page's content. `npm run docs:build`
exits 0 anyway, so neither `ci.yml` nor `docs.yml` catches it. Wrapping the
example in `<code v-pre>` restores the page.

**v2.4.0 has no upgrade notes.** `UPGRADING.md` documents non-trivial upgrades
between releases and has no `Within v2.x` section at all, while this release
changes four existing behaviours — most consequentially #486, which turns form
request bodies from `Skipped` (and `Skipped` is `isValid() === true`) into
actually validated, so green suites posting form bodies can go red on upgrade.
The other three are #483, #495, and #479. All are documented in the feature
docs, but nothing points an upgrading user at them.

Docs only — no `src/` change.

## Verification

- [x] `composer test` passes
- [x] `composer stan` passes
- [x] `composer cs-check` passes

- Docs build: `npm run docs:build` no longer emits the TypeError, and `ci.html`
  regains its content (`Partial test runs`, `pipefail`, `coverage:gate` all
  present; all were absent before).
- Links: `markdown-link-check` passes on both files, including the new
  `docs/supported-features.md#body-validation` anchor.
- `composer ci` re-run on this tree: 3099 tests, 11320 assertions, green.

## Notes for reviewers

- `<code v-pre>` rather than escaping the braces: it keeps the snippet
  copy-pasteable and renders as ordinary inline code on GitHub, which strips the
  unknown attribute.
- The `Within v2.x` section is written in the style of the existing
  `Within v1.x` one and placed first, per the file's newest-first ordering. It
  covers v2.4.0 only — v2.1–v2.3 were not back-filled, which is a pre-existing
  gap and out of scope here.
- The upgrade notes also flag that a custom `ContractCheckPlan` dispatcher
  should forward the new `ExploredCase::$cookies` map, since a dispatcher that
  drops it makes a cookie-credential `ignored_auth` probe pass for the wrong
  reason.
- Not verified: the rendered page on the deployed docs site (checked the local
  build output only).
