### PR TITLE
docs(quickstarts): add the missing spec-loader and coverage steps

### DIFF
--- a/docs/pest-plugin.md
+++ b/docs/pest-plugin.md
@@ -14,7 +14,7 @@ Pest tests can use the same validator pipeline as PHPUnit through a custom-expec
 composer require --dev pestphp/pest:^4.0
 ```
 
-The plugin is auto-loaded via Composer's `autoload.files`. No further wiring needed at install time. Pest 4 uses PHPUnit 12; PHPUnit 13 remains supported by Gesso's PHPUnit integration but is not compatible with the Pest runner.
+The plugin is auto-loaded via Composer's `autoload.files`, so the expectations need no registration. The spec loader still does: register `OpenApiCoverageExtension` in `phpunit.xml` with a `spec_base_path` parameter, as shown in the [Pest quickstart](quickstarts/pest.md). Pest 4 uses PHPUnit 12; PHPUnit 13 remains supported by Gesso's PHPUnit integration but is not compatible with the Pest runner.
 
 ## Wiring the trait into Pest tests
 

--- a/docs/quickstarts/core.md
+++ b/docs/quickstarts/core.md
@@ -17,7 +17,7 @@ the coverage report; without it the first validation call throws
 </extensions>
 ```
 
-Copy the minimal [`examples/core`](https://github.com/studio-design/gesso/tree/main/examples/core) project. Its test validates a JSON response without a framework adapter, then records the observation — the framework-independent validator never touches the coverage tracker, so a suite that only validates reports every endpoint as uncovered. The Laravel, Symfony, and Pest adapters record it for you:
+Copy the minimal [`examples/core`](https://github.com/studio-design/gesso/tree/main/examples/core) project. Its test validates a JSON response without a framework adapter, then records the observation — the framework-independent validator never touches the coverage tracker, so a suite that only validates prints no endpoint coverage table at all. The Laravel, Symfony, and Pest adapters record it for you:
 
 ```php
 $result = (new OpenApiResponseValidator(new StrictRequiredTracker()))->validate(

--- a/docs/quickstarts/core.md
+++ b/docs/quickstarts/core.md
@@ -4,7 +4,20 @@
 composer require --dev "studio-design/gesso:^2.0"
 ```
 
-Copy the minimal [`examples/core`](https://github.com/studio-design/gesso/tree/main/examples/core) project. Its test validates a JSON response without a framework adapter:
+Register the extension in `phpunit.xml`. It configures the spec loader and prints
+the coverage report; without it the first validation call throws
+`OpenApiSpecLoader base path not configured`:
+
+```xml
+<extensions>
+    <bootstrap class="Studio\Gesso\PHPUnit\OpenApiCoverageExtension">
+        <parameter name="spec_base_path" value="openapi"/>
+        <parameter name="specs" value="petstore"/>
+    </bootstrap>
+</extensions>
+```
+
+Copy the minimal [`examples/core`](https://github.com/studio-design/gesso/tree/main/examples/core) project. Its test validates a JSON response without a framework adapter, then records the observation — the framework-independent validator never touches the coverage tracker, so a suite that only validates reports every endpoint as uncovered. The Laravel, Symfony, and Pest adapters record it for you:
 
 ```php
 $result = (new OpenApiResponseValidator(new StrictRequiredTracker()))->validate(
@@ -14,6 +27,15 @@ $result = (new OpenApiResponseValidator(new StrictRequiredTracker()))->validate(
 );
 
 self::assertTrue($result->isValid(), $result->errorMessage());
+
+OpenApiCoverageTracker::recordResponse(
+    'petstore',
+    'GET',
+    $result->matchedPath() ?? '/pets',
+    $result->matchedStatusCode() ?? '200',
+    $result->matchedContentType(),
+    schemaValidated: true,
+);
 ```
 
 Run it:
@@ -22,4 +44,4 @@ Run it:
 composer test
 ```
 
-The PHPUnit extension prints the endpoint coverage report after the passing test. For applications using PSR-7 messages, continue with the [PSR-7 guide](../psr7.md).
+The PHPUnit extension prints the endpoint coverage report after the passing test. For applications using PSR-7 messages, continue with the [PSR-7 guide](../psr7.md) — `OpenApiPsr7Validator` records coverage itself.

--- a/docs/quickstarts/laravel.md
+++ b/docs/quickstarts/laravel.md
@@ -5,6 +5,20 @@ composer require --dev "studio-design/gesso:^2.0"
 php artisan vendor:publish --tag=gesso
 ```
 
+Register the extension in `phpunit.xml`. This is what configures the spec loader
+for the runtime validator; `gesso.spec_base_path` in the published
+`config/gesso.php` does not — it only feeds the `openapi:routes` and
+`openapi:stubs` Artisan commands:
+
+```xml
+<extensions>
+    <bootstrap class="Studio\Gesso\PHPUnit\OpenApiCoverageExtension">
+        <parameter name="spec_base_path" value="openapi"/>
+        <parameter name="specs" value="petstore"/>
+    </bootstrap>
+</extensions>
+```
+
 Set `default_spec` to `petstore`, add `ValidatesOpenApiSchema` to your base test case, then assert a normal Laravel response:
 
 ```php

--- a/docs/quickstarts/pest.md
+++ b/docs/quickstarts/pest.md
@@ -4,6 +4,19 @@
 composer require --dev "studio-design/gesso:^2.0" pestphp/pest
 ```
 
+Pest runs on PHPUnit, so the spec loader comes from the same extension. Register
+it in `phpunit.xml` — without it the first expectation throws
+`OpenApiSpecLoader base path not configured`:
+
+```xml
+<extensions>
+    <bootstrap class="Studio\Gesso\PHPUnit\OpenApiCoverageExtension">
+        <parameter name="spec_base_path" value="openapi"/>
+        <parameter name="specs" value="petstore"/>
+    </bootstrap>
+</extensions>
+```
+
 Use the automatically registered expectation with a Laravel response:
 
 ```php


### PR DESCRIPTION
Closes #510.

Three of the four quickstarts were not runnable as written. Verified by copying each page's snippets into a scratch project built from the corresponding `examples/` fixture and running it both ways.

## What was broken

**core / laravel / pest: no `<extensions>` block.** The PHPUnit extension is the only caller of `OpenApiSpecLoader::configure()` in the test path (`src/PHPUnit/OpenApiCoverageExtension.php:292`). Without it the first assertion throws:

```
InvalidOpenApiSpecException: OpenApiSpecLoader base path not configured.
  src/Spec/OpenApiSpecLoader.php:226
  ← src/Validation/Response/ResponseSchemaResolver.php:65
  ← src/OpenApiResponseValidator.php:112
```

Publishing `config/gesso.php` does not substitute for it. `gesso.spec_base_path` is read only at `src/Laravel/Commands/OpenApiStubsCommand.php:115` and `src/Laravel/Commands/OpenApiRoutesCommand.php:150` — it never reaches the validator. `laravel.md` now says so explicitly.

**core: no `recordResponse()`.** `OpenApiResponseValidator` has zero references to `OpenApiCoverageTracker`. With the extension registered but no recording, the suite is green and the report prints **no endpoint table at all** — only the SDK line. The page promised a coverage report two lines below.

## Verification

`examples/pest` with the `<extensions>` block deleted — 5/5 fail with `BasePathNotConfigured`. Restored, and with the example's own explicit `OpenApiSpecLoader::configure()` / `reset()` calls removed so only the quickstart's instruction remains — 5/5 pass, `endpoints: 1/3 fully covered`. Laravel reaches the loader through the same trait and the same static, so it is covered by the same evidence.

`examples/core` with `core.md`'s snippets pasted in verbatim:

| setup | result |
|---|---|
| no extension, no `recordResponse` (the old page) | `BasePathNotConfigured`, 0 assertions |
| extension only | green, report shows no endpoint table |
| both (this PR) | green, `endpoints: 1/1 fully covered (100%)` |

## Also

`docs/pest-plugin.md` said "No further wiring needed at install time" — true of the expectation autoloading, but it sent readers past the same gap. Rewritten to scope the claim and point at the quickstart.

## Compatibility

Documentation only. No change under `src/`, `bin/`, or `tests/`. The `spec_base_path` / `specs` parameters and `OpenApiCoverageTracker::recordResponse()` are existing compatibility surfaces (`docs/versioning.md:96`, `docs/api-reference.md:315-323`) and are unchanged.

`vendor/bin/phpunit --filter MarkdownCoverageRendererLintTest` and `vendor/bin/phpunit tests/Unit/Build/` pass.