### PR TITLE
feat(cli): add `gesso --version` and a `tool` identity block to doctor JSON

### DIFF
--- a/bin/gesso
+++ b/bin/gesso
@@ -7,6 +7,7 @@ use Studio\Gesso\Cli\CoverageGateCommand;
 use Studio\Gesso\Cli\DoctorCommand;
 use Studio\Gesso\Cli\StubsCommand;
 use Studio\Gesso\Coverage\CoverageMergeCommand;
+use Studio\Gesso\Internal\ToolVersion;
 
 $autoloadCandidates = [
     __DIR__ . '/../vendor/autoload.php',
@@ -41,6 +42,10 @@ $usage = <<<'USAGE'
       coverage:gate    Fail when a spec change touches an uncovered operation.
       stubs            Write test stubs for the responses no test covers.
 
+    Global options:
+      --version        Print the installed Gesso version and exit.
+      --help, -h       Print this message and exit.
+
     Run `gesso <command> --help` for command-specific options.
 
     USAGE;
@@ -51,6 +56,15 @@ $commandName = array_shift($argv);
 
 if ($commandName === null || $commandName === 'list' || $commandName === '--help' || $commandName === '-h') {
     fwrite(STDOUT, $usage);
+    exit(0);
+}
+
+// Matched before subcommand dispatch so `gesso --version` can never fall
+// through to the unknown-command branch below. `unknown` is the same sentinel
+// the JSON documents emit when Composer metadata is unreadable, and it still
+// exits 0 — a probe asking "which version" got an answer either way.
+if ($commandName === '--version') {
+    fwrite(STDOUT, 'gesso ' . ToolVersion::resolve() . "\n");
     exit(0);
 }
 

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -75,6 +75,17 @@ vendor/bin/gesso doctor \
 
 The command automatically uses an installed Guzzle (`guzzlehttp/guzzle` plus `guzzlehttp/psr7`) or Symfony HttpClient PSR-18 implementation. Every permitted host must be listed with `--remote-ref-host`; repeat the option when a trusted contract intentionally spans hosts. A nested `$ref` that switches to an unlisted host is rejected before any request is sent. Each remote document is limited to 10 MiB by default; use `--remote-ref-max-bytes=<positive integer>` only when a trusted contract requires a larger bound. Without `--allow-remote-refs`, an HTTP(S) `$ref` is reported as a reference error with an actionable hint. Network failures, oversized or malformed remote documents, content-type mismatches, and reference cycles also exit non-zero.
 
+## Installed version
+
+`gesso --version` is a global flag on the binary, matched before any subcommand:
+
+```bash
+$ vendor/bin/gesso --version
+gesso 2.4.0
+```
+
+It writes to STDOUT, writes nothing to STDERR, and exits `0`. When Composer's `InstalledVersions` metadata cannot be read it prints `gesso unknown` — the same sentinel the JSON documents emit — and still exits `0`, so a CI script or an agent probing for the version always gets an answer rather than a usage error. `gesso --help` lists it under `Global options:`.
+
 ## Machine-readable output
 
 Use `--format=json` for CI and tooling. The top-level `schemaVersion` is currently `1` and will change if the machine-readable contract requires an incompatible revision.
@@ -82,6 +93,10 @@ Use `--format=json` for CI and tooling. The top-level `schemaVersion` is current
 ```json
 {
     "schemaVersion": 1,
+    "tool": {
+        "name": "studio-design/gesso",
+        "version": "2.4.0"
+    },
     "status": "ok",
     "summary": {
         "specs": 1,
@@ -96,6 +111,10 @@ Use `--format=json` for CI and tooling. The top-level `schemaVersion` is current
     "phpunit": null
 }
 ```
+
+`tool` is `{ "name": "studio-design/gesso", "version": "<composer version or 'unknown'>" }`, the same block the [coverage JSON](coverage-json-schema.md) and [validation JSON](validation-json-schema.md) documents carry. `"unknown"` is emitted when Composer's `InstalledVersions` metadata is unavailable; the field is always a string.
+
+Additive changes — a new field such as `tool`, or a new `category` slug — keep `schemaVersion` at `1`. Removals, renames, and type changes bump it.
 
 Every issue has a stable `severity`, `category`, `spec`, `message`, and nullable `suggestion` field. Severities are:
 

--- a/src/Cli/DoctorCommand.php
+++ b/src/Cli/DoctorCommand.php
@@ -26,6 +26,7 @@ use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\Exception\MalformedDiscriminatorException;
 use Studio\Gesso\Exception\SpecFileNotFoundException;
 use Studio\Gesso\Internal\HttpRefLoader;
+use Studio\Gesso\Internal\ToolVersion;
 use Studio\Gesso\OpenApiVersion;
 use Studio\Gesso\Spec\OpenApiOperationResolver;
 use Studio\Gesso\Spec\OpenApiSchemaConverter;
@@ -841,6 +842,13 @@ final class DoctorCommand
 
         return [
             'schemaVersion' => self::JSON_SCHEMA_VERSION,
+            // Same shape and same `unknown` semantics as the `tool` block in
+            // coverage JSON and validation JSON, so a consumer reading two
+            // Gesso documents does not have to special-case this one.
+            'tool' => [
+                'name' => ToolVersion::PACKAGE,
+                'version' => ToolVersion::resolve(),
+            ],
             'status' => $counts['errors'] > 0 ? 'error' : ($counts['warnings'] > 0 || $counts['skipped'] > 0 ? 'warning' : 'ok'),
             'summary' => [
                 'specs' => count($specs),

--- a/src/Coverage/JsonCoverageRenderer.php
+++ b/src/Coverage/JsonCoverageRenderer.php
@@ -8,10 +8,9 @@ use const JSON_PRETTY_PRINT;
 use const JSON_UNESCAPED_SLASHES;
 use const JSON_UNESCAPED_UNICODE;
 
-use Composer\InstalledVersions;
 use DateTimeImmutable;
 use RuntimeException;
-use Throwable;
+use Studio\Gesso\Internal\ToolVersion;
 
 use function array_keys;
 use function array_unique;
@@ -91,8 +90,6 @@ use function sprintf;
 final class JsonCoverageRenderer
 {
     public const SCHEMA_VERSION = 3;
-    private const COMPOSER_PACKAGE_NAME = 'studio-design/gesso';
-    private const TOOL_NAME = 'studio-design/gesso';
 
     /**
      * @param array<string, CoverageResult> $results
@@ -117,8 +114,8 @@ final class JsonCoverageRenderer
             'schema_version' => self::SCHEMA_VERSION,
             'generated_at' => ($generatedAt ?? new DateTimeImmutable())->format(DateTimeImmutable::ATOM),
             'tool' => [
-                'name' => self::TOOL_NAME,
-                'version' => self::resolveToolVersion(),
+                'name' => ToolVersion::PACKAGE,
+                'version' => ToolVersion::resolve(),
             ],
             'aggregate' => [
                 ...self::aggregate($results),
@@ -331,25 +328,5 @@ final class JsonCoverageRenderer
         }
 
         return $rows;
-    }
-
-    /**
-     * Resolve the running tool version. The field is cosmetic — any failure
-     * here must never abort the report, so the catch is intentionally broad:
-     * `OutOfBoundsException` is the documented Composer 2.x "package not
-     * installed" path, but corrupted `installed.php`, Composer 1.x/2.x metadata
-     * mismatches, or stripped vendor directories can surface as other throwables.
-     * Silent by design — `'unknown'` is the documented sentinel and the schema
-     * forbids null, so emitting a string is enough.
-     */
-    private static function resolveToolVersion(): string
-    {
-        try {
-            $version = InstalledVersions::getVersion(self::COMPOSER_PACKAGE_NAME);
-        } catch (Throwable) {
-            return 'unknown';
-        }
-
-        return $version ?? 'unknown';
     }
 }

--- a/src/Internal/ToolVersion.php
+++ b/src/Internal/ToolVersion.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Internal;
+
+use Composer\InstalledVersions;
+use Throwable;
+
+/**
+ * Single source for the identity Gesso reports about itself: the Composer
+ * package name and the installed version.
+ *
+ * Every machine-readable document that carries a `tool` block, and the
+ * `gesso --version` branch in `bin/gesso`, read the version from here so the
+ * three cannot drift apart (issue #509).
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ *           `bin/gesso` reads it by design; `docs/versioning.md` names the
+ *           binary as the one place in the repository that crosses the
+ *           `@internal` boundary deliberately.
+ */
+final class ToolVersion
+{
+    public const PACKAGE = 'studio-design/gesso';
+
+    private function __construct() {}
+
+    /**
+     * Resolve the running tool version, or the string `'unknown'`.
+     *
+     * The value is cosmetic — any failure here must never abort the report, so
+     * the catch is intentionally broad: `OutOfBoundsException` is the documented
+     * Composer 2.x "package not installed" path
+     * (`vendor/composer/InstalledVersions.php`), but corrupted `installed.php`,
+     * Composer 1.x/2.x metadata mismatches, or stripped vendor directories can
+     * surface as other throwables. Silent by design — `'unknown'` is the
+     * documented sentinel and every schema that carries the value forbids null,
+     * so returning a string is enough.
+     *
+     * @param string $package Overridable so tests can exercise the
+     *                        missing-metadata path; callers pass nothing.
+     */
+    public static function resolve(string $package = self::PACKAGE): string
+    {
+        try {
+            $version = InstalledVersions::getVersion($package);
+        } catch (Throwable) {
+            return 'unknown';
+        }
+
+        return $version ?? 'unknown';
+    }
+}

--- a/src/JsonValidationResultRenderer.php
+++ b/src/JsonValidationResultRenderer.php
@@ -9,10 +9,8 @@ use const JSON_PRETTY_PRINT;
 use const JSON_UNESCAPED_SLASHES;
 use const JSON_UNESCAPED_UNICODE;
 
-use Composer\InstalledVersions;
 use RuntimeException;
-use Studio\Gesso\Coverage\JsonCoverageRenderer;
-use Throwable;
+use Studio\Gesso\Internal\ToolVersion;
 
 use function json_encode;
 use function json_last_error_msg;
@@ -41,8 +39,6 @@ use function sprintf;
 final class JsonValidationResultRenderer
 {
     public const SCHEMA_VERSION = 1;
-    private const COMPOSER_PACKAGE_NAME = 'studio-design/gesso';
-    private const TOOL_NAME = 'studio-design/gesso';
 
     /**
      * @return string A pretty-printed JSON document terminated by a single
@@ -74,8 +70,8 @@ final class JsonValidationResultRenderer
         $payload = [
             'schema_version' => self::SCHEMA_VERSION,
             'tool' => [
-                'name' => self::TOOL_NAME,
-                'version' => self::resolveToolVersion(),
+                'name' => ToolVersion::PACKAGE,
+                'version' => ToolVersion::resolve(),
             ],
             'outcome' => $result->outcome()->value,
             'matched' => [
@@ -103,23 +99,5 @@ final class JsonValidationResultRenderer
         }
 
         return $encoded . "\n";
-    }
-
-    /**
-     * Resolve the running tool version. The field is cosmetic — any failure
-     * here must never abort the document, so the catch is intentionally broad
-     * (mirrors {@see JsonCoverageRenderer}): corrupted
-     * Composer metadata or stripped vendor directories surface as `'unknown'`
-     * rather than an exception.
-     */
-    private static function resolveToolVersion(): string
-    {
-        try {
-            $version = InstalledVersions::getVersion(self::COMPOSER_PACKAGE_NAME);
-        } catch (Throwable) {
-            return 'unknown';
-        }
-
-        return $version ?? 'unknown';
     }
 }

--- a/tests/Integration/DoctorCliIntegrationTest.php
+++ b/tests/Integration/DoctorCliIntegrationTest.php
@@ -9,6 +9,7 @@ use const JSON_THROW_ON_ERROR;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+use function array_keys;
 use function dirname;
 use function escapeshellarg;
 use function fclose;
@@ -46,6 +47,25 @@ class DoctorCliIntegrationTest extends TestCase
         $this->assertSame(1, $report['schemaVersion']);
         $this->assertSame(2, $report['summary']['specs']);
         $this->assertGreaterThan(0, $report['summary']['operations']);
+    }
+
+    #[Test]
+    public function json_report_identifies_the_producing_tool(): void
+    {
+        [, $stdout] = $this->runCli([
+            'doctor',
+            '--spec=tests/fixtures/specs/petstore-3.0.json',
+            '--format=json',
+        ]);
+
+        $report = json_decode($stdout, true, flags: JSON_THROW_ON_ERROR);
+
+        // Byte-shape-identical to the `tool` block in coverage JSON and
+        // validation JSON: exactly `name` then `version`, both strings.
+        $this->assertSame(['name', 'version'], array_keys($report['tool']));
+        $this->assertSame('studio-design/gesso', $report['tool']['name']);
+        $this->assertIsString($report['tool']['version']);
+        $this->assertNotSame('', $report['tool']['version']);
     }
 
     #[Test]
@@ -119,7 +139,9 @@ class DoctorCliIntegrationTest extends TestCase
      */
     private function runCli(array $args): array
     {
-        $command = sprintf('php %s doctor', escapeshellarg($this->repoRoot . '/bin/gesso'));
+        // Every caller passes `doctor` as the first argument; the binary takes
+        // it as the subcommand and `DoctorCommand::parseArgv()` skips it.
+        $command = sprintf('php %s', escapeshellarg($this->repoRoot . '/bin/gesso'));
         foreach ($args as $arg) {
             $command .= ' ' . escapeshellarg($arg);
         }

--- a/tests/Integration/GessoCliIntegrationTest.php
+++ b/tests/Integration/GessoCliIntegrationTest.php
@@ -54,9 +54,36 @@ final class GessoCliIntegrationTest extends TestCase
         $this->assertSame(0, $exit);
         $this->assertSame('', $stderr);
         $this->assertSame(
-            file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v1.10-gesso-help.txt'),
+            file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v2-gesso-help.txt'),
             $stdout,
         );
+        // The global-options section is additive, so every v1.10 help line must
+        // survive it — containment against the frozen capture, not equality.
+        foreach (explode("\n", (string) file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v1.10-gesso-help.txt')) as $line) {
+            if (trim($line) === '') {
+                continue;
+            }
+            $this->assertStringContainsString($line, $stdout, 'v1.10 help line must be retained');
+        }
+    }
+
+    #[Test]
+    public function version_prints_the_installed_version_and_exits_zero(): void
+    {
+        [$exit, $stdout, $stderr] = $this->runCli(['--version']);
+
+        $this->assertSame(0, $exit);
+        $this->assertSame('', $stderr);
+        $this->assertMatchesRegularExpression('/^gesso \S+\n$/', $stdout);
+    }
+
+    #[Test]
+    public function help_documents_the_version_flag(): void
+    {
+        [, $stdout] = $this->runCli(['--help']);
+
+        $this->assertStringContainsString('Global options:', $stdout);
+        $this->assertStringContainsString('--version', $stdout);
     }
 
     #[Test]
@@ -156,7 +183,7 @@ final class GessoCliIntegrationTest extends TestCase
         $this->assertSame('', $stdout);
         $this->assertSame(
             '[Gesso] Unknown command: unknown' . "\n\n"
-                . file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v1.10-gesso-help.txt'),
+                . file_get_contents($this->repoRoot . '/tests/fixtures/compatibility/v2-gesso-help.txt'),
             $stderr,
         );
     }

--- a/tests/Unit/Internal/ToolVersionTest.php
+++ b/tests/Unit/Internal/ToolVersionTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Internal;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Internal\ToolVersion;
+
+final class ToolVersionTest extends TestCase
+{
+    #[Test]
+    public function resolves_the_installed_version_of_this_package(): void
+    {
+        $version = ToolVersion::resolve();
+
+        $this->assertNotSame('', $version);
+        // The suite runs from the repository, so Composer metadata is readable
+        // and the sentinel would mean the resolver stopped working.
+        $this->assertNotSame('unknown', $version);
+    }
+
+    /**
+     * `InstalledVersions::getVersion()` throws `OutOfBoundsException` for a
+     * package it does not know (`vendor/composer/InstalledVersions.php`). The
+     * documents that carry the value forbid null, so the sentinel has to be a
+     * string.
+     */
+    #[Test]
+    public function returns_the_unknown_sentinel_when_composer_metadata_is_unreadable(): void
+    {
+        $this->assertSame('unknown', ToolVersion::resolve('studio-design/not-installed'));
+    }
+
+    #[Test]
+    public function package_name_matches_the_composer_manifest(): void
+    {
+        $this->assertSame('studio-design/gesso', ToolVersion::PACKAGE);
+    }
+}

--- a/tests/fixtures/compatibility/v2-gesso-help.txt
+++ b/tests/fixtures/compatibility/v2-gesso-help.txt
@@ -1,0 +1,16 @@
+Gesso — OpenAPI contract testing for PHP.
+
+Usage:
+  gesso <command> [options]
+
+Commands:
+  doctor           Check whether Gesso can load and enforce a contract.
+  coverage:merge   Combine parallel-worker coverage sidecars.
+  coverage:gate    Fail when a spec change touches an uncovered operation.
+  stubs            Write test stubs for the responses no test covers.
+
+Global options:
+  --version        Print the installed Gesso version and exit.
+  --help, -h       Print this message and exit.
+
+Run `gesso <command> --help` for command-specific options.


### PR DESCRIPTION
Closes #509.

## What

Two related gaps, one shared cause.

`gesso --version` did not exist. The most conventional probe a CI script or an agent will try fell through to the unknown-command branch:

```
$ php bin/gesso --version
[Gesso] Unknown command: --version
<usage block>
$ echo $?
2
```

And doctor's JSON was the only report document without a `tool` block, so a consumer reading two Gesso documents had to special-case it.

The version data was already in the process — resolved twice, in two verbatim copies of the same `private static` helper (`JsonValidationResultRenderer`, `JsonCoverageRenderer`), neither reachable from `bin/gesso`.

## Changes

**`src/Internal/ToolVersion.php`** — `final`, `@internal`, holds `PACKAGE` and `resolve()`. Now the only place in `src/` that calls `InstalledVersions::getVersion()`. The `'unknown'` sentinel and the deliberately broad `catch (Throwable)` are carried over verbatim, along with the comment explaining why the catch is broad. Both renderers lost their private copy and their duplicated `COMPOSER_PACKAGE_NAME` / `TOOL_NAME` constants.

**`bin/gesso`** — a `--version` branch matched before subcommand dispatch, so it can never reach the unknown-command branch, plus a `Global options:` section in the usage block:

```
$ php bin/gesso --version
gesso 2.4.0
$ echo $?
0
```

`gesso unknown` with exit `0` when Composer metadata is unreadable — a probe asking "which version" gets an answer either way.

**`src/Cli/DoctorCommand.php`** — `'tool' => ['name' => …, 'version' => …]` directly after `schemaVersion`. Same key order, same shape, same `unknown` semantics as coverage JSON and validation JSON.

**Docs** — `docs/doctor.md` gains an "Installed version" section, the sample document gains `tool`, and the JSON section gains the evolution rule it did not have: additive changes keep `schemaVersion` at `1`.

## What is not in this PR

`schemaVersion` keeps its camelCase spelling and its value of `1`. Renaming it to `schema_version` to match the three other report documents is the change v3's consistency theme wants, but it breaks every current consumer and needs its own deprecation window. #509 excludes it explicitly and so does this diff — a reviewer can confirm there is no rename.

## Verification

Emitted values are unchanged: the coverage and validation JSON golden fixtures pass untouched, which is the proof that the extracted resolver behaves identically.

New tests:

- `tests/Unit/Internal/ToolVersionTest.php` — resolves a real version; returns the string `'unknown'` (never null, never empty) for a package Composer does not know; `PACKAGE` matches the manifest.
- `GessoCliIntegrationTest::version_prints_the_installed_version_and_exits_zero` — exit `0`, empty STDERR, `gesso <version>\n` on STDOUT.
- `GessoCliIntegrationTest::help_documents_the_version_flag`.
- `DoctorCliIntegrationTest::json_report_identifies_the_producing_tool` — asserts `array_keys($report['tool']) === ['name', 'version']`, so the block stays byte-shape-identical to the one in coverage JSON.

`tests/fixtures/compatibility/v1.10-gesso-help.txt` is a frozen capture, so the new output goes in `v2-gesso-help.txt` and the root-help test now does both: equality against the v2 capture, and containment of every non-blank v1.10 line — the same pattern `coverage_merge_uses_the_gesso_invocation_in_help_and_usage_errors` already uses for its v1.9 capture. That proves the global-options section is additive rather than just asserting the new text.

One incidental fix: `DoctorCliIntegrationTest::runCli()` injected `doctor` into the command line while every caller also passed `doctor` as the first argument. `DoctorCommand::parseArgv()` skips a literal `doctor` (`src/Cli/DoctorCommand.php:112-114`), so the duplicate was inert; the helper now just forwards its arguments.

Checks: `composer cs-check` clean (0 of 464, 0 of 4), `composer test` OK (3111 tests, 19577 assertions), PHPStan `[OK] No errors`, `markdownlint-cli2 docs/doctor.md` clean.

PHPStan needs `--memory-limit=1G` on this machine — `composer stan` hits a local 128M `php.ini` ceiling. Pre-existing and unrelated to this change; CI is unaffected.

## Unrelated flake found on the way

`composer test` failed twice on a working tree carrying a `.phpunit.cache` from an earlier session, in `SchemaDataGeneratorTest::same_seed_produces_same_output`. It disappears after `rm -rf .phpunit.cache` and does not reproduce under randomized order. `main` behaves the same way, and nothing here touches RNG. Filed as #517 with the evidence — the second `generate()` call is reproducible across runs while the first is not, which points at something consuming the global Mt19937 engine on first use.