### PR TITLE
docs(adr): record the v3 consistency policy and protected core

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -303,7 +303,8 @@ export default defineConfig({
           { text: 'Coverage', link: '/coverage' },
           { text: 'Supported features', link: '/supported-features' },
           { text: 'Conformance', link: '/conformance' },
-          { text: 'API reference', link: '/api-reference' }
+          { text: 'API reference', link: '/api-reference' },
+          { text: 'Decision records', link: '/adr/' }
         ]
       }
     ],

--- a/docs/adr/0004-v3-consistency-policy-and-protected-core.md
+++ b/docs/adr/0004-v3-consistency-policy-and-protected-core.md
@@ -61,44 +61,84 @@ an ADR that supersedes this one.
 | OpenAPI 3.0 / 3.1 / 3.2 are each validated under their own JSON Schema dialect: 3.0 through the Draft 07 compatibility pipeline, 3.1/3.2 under 2020-12, and an unknown dialect is rejected rather than guessed | `src/OpenApiVersion.php:19-21`; `src/Spec/OpenApiSchemaDialect.php:34` (3.0 → Draft 07), `:38` (default OAS 3.1 base), `:57` (`assertSupported()`) | No — the class is `@internal` |
 | Validation is tri-state. `Skipped` is a distinct outcome, never folded into success or failure | `src/OpenApiValidationOutcome.php:15-17` | Yes — `docs/versioning.md:18-19` |
 | Discriminator enforcement is on by default | `src/Validation/Support/DiscriminatorEnforcement.php:36` (`private static bool $enabled = true`) | No — the class is `@internal` |
-| The named contract checks and their default expected statuses | `src/Fuzz/ContractCheck.php:13-15` (`ignored_auth`, `missing_required_header`, `unsupported_method`) | Yes — `docs/versioning.md:83-88` |
+| The named contract checks, their default expected statuses, and their default status classes | `src/Fuzz/ContractCheck.php:13-15` (`ignored_auth`, `missing_required_header`, `unsupported_method`), `:23-30` (`defaultExpectedStatuses()`), `:46-52` (`defaultExpectedStatusClasses()` — `missing_required_header` passes on any 4xx, deliberately, so framework choice does not read as contract drift) | Yes — `docs/versioning.md:83-88` |
 | Coverage and gating are measured at `(method, path, status, content-type)` granularity | `src/Validation/Response/ResponseSchemaResolver.php:27`, `src/Coverage/OpenApiCoverageTracker.php:232`, `src/Cli/CoverageGateCommand.php:64` | Partly — only through the coverage baseline entry, `docs/versioning.md:67-82` |
 | Doctor diagnostics and runtime validation agree: a malformed spec node must not pass one path and fail the other | `AGENTS.md:66-68`; mirrored in code at `src/Cli/DoctorCommand.php:537` (response guards) and `:747` (security-scheme classification) | No |
 | Both upstream corpora stay pinned by commit SHA and stay measured | `composer.json` `repositories[].package.dist.reference`; asserted by `tests/Integration/Conformance/` | No — test fixtures |
 
-The three uncovered rows are the reason this ADR exists. `@internal` means the
-symbol may be renamed, moved, or merged without a major bump; it does not mean
-the behaviour behind it is negotiable.
+Six rows are behaviours; the seventh is how we find out whether the other six
+still hold. Unpinning a corpus, or dropping either conformance test, is a
+protected-core change even though no runtime behaviour moves — it removes the
+measurement, which is what makes the rest of this document enforceable. That row
+is therefore protected core *and* the mechanism the acceptance rule below relies
+on, not one or the other.
+
+Four rows are not SemVer-covered: dialect selection, the
+discriminator-enforcement default, doctor ⇄ runtime consistency, and the pinned
+corpora. Those four are why this ADR exists. `@internal` means the symbol may be
+renamed, moved, or merged without a major bump; it does not mean the behaviour
+behind it is negotiable. The `Partly` row is covered only through the coverage
+baseline entry, so the granularity is contractual where a baseline file names it
+and policy-protected everywhere else.
 
 ## Inclusion criterion
 
-> Anything that must keep running after the PHPUnit or Pest process exits does
-> not belong in Gesso.
+> Anything that must stay resident after the command that started it exits, or
+> that is not part of checking an implementation against its spec, does not
+> belong in Gesso.
 
-Gesso is a test-time library. Its unit of work is one assertion inside one test,
-and its lifetime is the test process. Everything in the package today satisfies
-that; the criterion exists to keep it that way.
+Two halves, and both are needed. The first excludes anything that has to be
+started, waited for, and torn down — a service. The second excludes work that
+terminates but is not a contract check.
+
+The first half is deliberately about *residency*, not about the test process.
+Gesso already does work outside a test run and must keep being allowed to:
+`gesso doctor` is a preflight that runs before the suite, and `coverage:merge`,
+`coverage:gate`, and `stubs` are batch steps that run after it —
+`CoverageMergeCommand` says so in its own docblock
+(`src/Coverage/CoverageMergeCommand.php:56-58`: *"Designed to be invoked as a
+separate step after the parallel test run finishes"*). Each is a short-lived
+process that reads files, writes files, and exits. That is in scope. A component
+that stays up between invocations, holds state across them, or has to be
+health-checked is not.
 
 ## Non-goals
 
-Each entry names the half of the criterion it fails.
+Most of these fail one half of the criterion. Three do not, and are recorded here
+anyway so they are not relitigated — with their real reason rather than a forced
+one, because a criterion that stretches to cover everything stops deciding
+anything.
+
+**Fails the first half — stays resident.**
 
 | Non-goal | Why it is out |
 | --- | --- |
-| An MCP server | Long-running process. It would outlive the test run by definition. |
-| A mock server | Long-running process, and it inverts the direction: Gesso checks a real implementation against the spec, it does not stand in for one. |
-| An Overlay merge engine | Not a test-time contract check. Applying an Overlay produces a spec; that is a spec-authoring or build step, and its output is what Gesso should be handed. |
-| oasdiff-style spec diffing | Not a test-time contract check. `CoverageGateCommand` already draws this line explicitly — its diff is structural ("did the resolved node change?"), never semantic ("is the change backwards-incompatible?"), and the semantic classification needs a rule catalogue that belongs to a dedicated tool (`src/Cli/CoverageGateCommand.php:67-70`). |
-| An official GitHub Action | Not a test-time contract check. It is a distribution wrapper around one, and `bin/gesso` already runs unmodified in any CI job. |
-| A general-purpose spec linter | Not a test-time contract check. `docs/doctor.md` states this for `gesso doctor` already: it is not a replacement for Spectral or Redocly. |
-| Spec generation | Not a test-time contract check. Generating the spec from code makes the spec a mirror of the implementation, which removes the thing Gesso is testing against. |
-| Gesso calling an LLM | Not a test-time contract check. A nondeterministic network call inside a test run cannot produce a verdict a test can rely on. Gesso's output is consumed by agents; nothing inside it consults one. |
-| OpenAPI 4.0 / Moonwalk support | This one does not fail the criterion. It is out because there is no stable specification to validate against yet. Revisit when there is; it needs its own ADR, not an extension of this one. |
+| An MCP server | A process that has to be started and kept up so a client can call it. |
+| A mock server | Same, and it inverts the direction: Gesso checks a real implementation against the spec, it does not stand in for one. |
 
-## Reduction-PR acceptance gate
+**Fails the second half — not part of checking an implementation against its
+spec.**
+
+| Non-goal | Why it is out |
+| --- | --- |
+| An Overlay merge engine | Applying an Overlay produces a spec. That is a spec-authoring or build step, and its output is what Gesso should be handed. |
+| oasdiff-style spec diffing | Spec versus spec, with no implementation in the comparison. `CoverageGateCommand` already draws this line — its diff is structural ("did the resolved node change?"), never semantic ("is the change backwards-incompatible?"), and the semantic classification needs a rule catalogue that belongs to a dedicated tool (`src/Cli/CoverageGateCommand.php:67-70`). |
+| A general-purpose spec linter | Spec style, no implementation. `docs/doctor.md:5` states this for `gesso doctor` already: it is not a replacement for Spectral or Redocly. |
+| Spec generation | Derives the spec from the implementation, which removes the independent thing Gesso tests against. |
+
+**Out for other reasons.** These pass both halves; they are excluded on their own
+terms.
+
+| Non-goal | Why it is out |
+| --- | --- |
+| An official GitHub Action | A second distribution surface — its own versioning, marketplace listing, and update cadence — for something `bin/gesso` already does in one `run:` line. Duplicated maintenance, no new capability. |
+| Gesso calling an LLM | A nondeterministic remote call cannot produce a verdict a test can rely on. Gesso's output is consumed by agents; nothing inside it consults one. |
+| OpenAPI 4.0 / Moonwalk support | There is no stable specification to validate against yet. Revisit when there is; it needs its own ADR, not an extension of this one. |
+
+## Reduction-PR acceptance rule
 
 A PR whose stated purpose is reducing surface area must leave both conformance
-baselines byte-identical:
+baselines unchanged:
 
 - `tests/fixtures/compatibility/v1-json-schema-conversion-delta.json` —
   `format_version: 1`, **11 deltas** (9 `unsupported-dialect`, 2
@@ -117,8 +157,39 @@ Either baseline moving means the PR changed meaning, not shape. That is not
 forbidden — it needs its own decision record and its own review, and it stops
 being a reduction PR.
 
-Both gates run in the `Integration` suite, which every CI matrix job executes
-(`.github/workflows/ci.yml:59-60`), so no extra step is required to enforce this.
+**This is a review rule, not an automated gate.** Be precise about what the
+conformance tests do and do not catch, because the difference is where a
+regression would slip through:
+
+- They catch *unintentional* drift. Both tests compare the current observation
+  against the committed fixture, and both first assert that the installed corpus
+  SHA matches the one the baseline was recorded against
+  (`JsonSchemaConversionDeltaTest.php:112-117`,
+  `OasExampleDocumentTest.php:122-127`), so an implementation change that moves a
+  verdict fails CI, and so does a corpus bump without a regenerated baseline.
+- They do **not** catch a deliberate co-update. A PR that changes the converter
+  and regenerates the fixture in the same commit is green. Nothing compares the
+  fixture against the base branch.
+- The JSON Schema comparison is narrower than the file. Only the verdict triple
+  (`expected` / `bare` / `converted`) per case key is asserted;
+  `JsonSchemaConversionDeltaTest.php:119-129` deliberately excludes the `reason`
+  prose so rewording an explanation cannot read as a conformance regression.
+  "Unchanged" in this rule means the verdict set, not the bytes.
+
+So the mechanical step belongs to the reviewer, and it is one command:
+
+```bash
+git diff origin/main -- \
+  tests/fixtures/compatibility/v1-json-schema-conversion-delta.json \
+  tests/fixtures/compatibility/v1-oas-example-documents.json
+```
+
+Empty output on a PR that claims to be reducing surface area. Non-empty means
+the PR is something else and needs its own decision record. A CI job that failed
+on any diff to these files was considered and rejected: it cannot tell a
+reduction PR from a deliberate conformance change or a corpus re-pin, so it
+would need a label protocol, which is its own decision rather than a detail of
+this one.
 
 ## What v3 does not delete
 
@@ -152,9 +223,11 @@ on their own terms; this ADR extends the device rather than replacing it.
 
 ## Consequences
 
-Three behaviours that SemVer does not cover become policy-protected: dialect
-selection, the discriminator-enforcement default, and doctor ⇄ runtime
-consistency. Their carriers stay `@internal` and freely renameable.
+Four things that SemVer does not cover become policy-protected: dialect
+selection, the discriminator-enforcement default, doctor ⇄ runtime consistency,
+and the pinned conformance corpora. The first three keep `@internal` carriers
+that stay freely renameable; the fourth is a commitment to keep measuring, so
+unpinning a corpus or deleting a conformance test now needs a superseding ADR.
 
 Three surfaces that SemVer *does* cover become protected beyond it — the
 `OpenApiValidationOutcome` cases (`docs/versioning.md:18-19`), the `ContractCheck`
@@ -162,9 +235,9 @@ names and default statuses (`:83-88`), and the coverage baseline granularity
 (`:67-82`). They may not be dropped even at a major boundary without a
 superseding ADR.
 
-The reduction gate makes "did this change meaning?" a mechanical question rather
-than a review judgement, which is what lets the v3 renames be reviewed as
-renames.
+The reduction rule gives "did this change meaning?" a fixed place to look — two
+fixture paths and one `git diff` — instead of leaving it to be re-derived per
+review. It does not make the question automatic, and the section above says so.
 
 ADR 0002's phases and ADR 0003's phase list stay open. In particular this ADR
 does not retract ADR 0003 phase 6, the SDK exercise coverage that already

--- a/docs/adr/0004-v3-consistency-policy-and-protected-core.md
+++ b/docs/adr/0004-v3-consistency-policy-and-protected-core.md
@@ -66,12 +66,29 @@ an ADR that supersedes this one.
 | Doctor diagnostics and runtime validation agree: a malformed spec node must not pass one path and fail the other | `AGENTS.md:66-68`; mirrored in code at `src/Cli/DoctorCommand.php:537` (response guards) and `:747` (security-scheme classification) | No |
 | Both upstream corpora stay pinned by commit SHA and stay measured | `composer.json` `repositories[].package.dist.reference`; asserted by `tests/Integration/Conformance/` | No — test fixtures |
 
-Six rows are behaviours; the seventh is how we find out whether the other six
-still hold. Unpinning a corpus, or dropping either conformance test, is a
-protected-core change even though no runtime behaviour moves — it removes the
-measurement, which is what makes the rest of this document enforceable. That row
-is therefore protected core *and* the mechanism the acceptance rule below relies
-on, not one or the other.
+Six rows are behaviours; the seventh is a measurement commitment. The two
+corpora do not cover the other six — they exercise schema conversion and the
+loader/doctor path, and nothing else. Unpinning a corpus or dropping either
+conformance test is still a protected-core change, because it removes the only
+independent evidence Gesso has about those two areas, but it must not be read as
+"the corpora prove the protected core".
+
+Each invariant has its own verification source, and a reduction PR has to keep
+all of them green — not just the two conformance baselines:
+
+| Invariant | Verified by |
+| --- | --- |
+| Dialect selection | `tests/Integration/Conformance/JsonSchemaConversionDeltaTest.php` (the delta set *is* the conversion pipeline's observable output), `tests/Unit/Spec/OpenApiSchemaDialectTest.php`, `tests/Unit/Spec/OpenApiSchemaConverterTest.php` |
+| Tri-state outcome | `tests/Unit/Compatibility/PublicApiBaselineTest.php` against `tests/fixtures/compatibility/v2-public-api.json`, which records the enum's `cases` map; plus `tests/Unit/OpenApiValidationResultTest.php` |
+| Discriminator enforcement default | `tests/Unit/Validation/Response/ResponseSchemaResolverTest.php`, `tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php`, `tests/Unit/ValidatesOpenApiSchemaEnforceDiscriminatorTest.php` |
+| Contract-check names and defaults | The public-API baseline records the `cases` map and the two method signatures, but **not** their return values; the values are pinned by `tests/Unit/Fuzz/ContractCheckSummaryTest.php:22` (`[405]`) and `tests/Unit/Fuzz/OpenApiContractChecksTest.php:464` (`[401, 403]`), `:683` (the 4xx family) |
+| Coverage granularity | `tests/Unit/Compatibility/MachineReadableFormatsBaselineTest.php` against `tests/fixtures/compatibility/v3-coverage-report.json`, plus the coverage tracker unit tests |
+| Doctor ⇄ runtime consistency | `tests/Integration/Conformance/OasExampleDocumentTest.php` for the corpus half, `tests/Unit/Cli/DoctorCommandTest.php` for the mirrored guards |
+| Pinned corpora | The two conformance tests themselves |
+
+Three invariants — tri-state outcome, contract-check defaults, coverage
+granularity — can be broken without either corpus baseline moving. That is the
+reason the rule below is stated as necessary, not sufficient.
 
 Four rows are not SemVer-covered: dialect selection, the
 discriminator-enforcement default, doctor ⇄ runtime consistency, and the pinned
@@ -138,7 +155,14 @@ terms.
 ## Reduction-PR acceptance rule
 
 A PR whose stated purpose is reducing surface area must leave both conformance
-baselines unchanged:
+baselines unchanged. **This is necessary, not sufficient** — the two corpora
+cover schema conversion and the loader/doctor path only, so an unchanged
+baseline is evidence about those two areas and about nothing else. The full
+condition is that every row of the verification table above stays green; the
+baselines are singled out here because they are the only ones a reviewer cannot
+read off a failing test.
+
+The two baselines:
 
 - `tests/fixtures/compatibility/v1-json-schema-conversion-delta.json` —
   `format_version: 1`, **11 deltas** (9 `unsupported-dialect`, 2
@@ -179,10 +203,14 @@ regression would slip through:
 So the mechanical step belongs to the reviewer, and it is one command:
 
 ```bash
-git diff origin/main -- \
+git diff origin/main...HEAD -- \
   tests/fixtures/compatibility/v1-json-schema-conversion-delta.json \
   tests/fixtures/compatibility/v1-oas-example-documents.json
 ```
+
+Three dots, not two: `origin/main...HEAD` diffs against the merge base, so a
+branch that has not been rebased does not report main's own commits as if the PR
+had made them.
 
 Empty output on a PR that claims to be reducing surface area. Non-empty means
 the PR is something else and needs its own decision record. A CI job that failed
@@ -235,9 +263,18 @@ names and default statuses (`:83-88`), and the coverage baseline granularity
 (`:67-82`). They may not be dropped even at a major boundary without a
 superseding ADR.
 
-The reduction rule gives "did this change meaning?" a fixed place to look — two
-fixture paths and one `git diff` — instead of leaving it to be re-derived per
-review. It does not make the question automatic, and the section above says so.
+The reduction rule gives "did this change meaning?" a fixed place to look — the
+verification table, plus one `git diff` for the two baselines no failing test
+would surface — instead of leaving it to be re-derived per review. It does not
+make the question automatic, and the section above says so.
+
+Writing the verification table also exposed a gap worth recording: three
+invariants (tri-state outcome, contract-check defaults, coverage granularity)
+rest on ordinary unit tests rather than on a compatibility fixture. That is
+adequate — they are asserted, and the public-API baseline pins the enum cases —
+but it means a reviewer checking a reduction PR has to trust the suite rather
+than read a single artifact, which is why the rule is explicit about being
+necessary rather than sufficient.
 
 ADR 0002's phases and ADR 0003's phase list stay open. In particular this ADR
 does not retract ADR 0003 phase 6, the SDK exercise coverage that already

--- a/docs/adr/0004-v3-consistency-policy-and-protected-core.md
+++ b/docs/adr/0004-v3-consistency-policy-and-protected-core.md
@@ -1,0 +1,171 @@
+# ADR 0004: v3 consistency policy and protected core
+
+- Status: Accepted
+- Date: 2026-08-06
+- Issue: [#500](https://github.com/studio-design/gesso/issues/500)
+- Related: [#499](https://github.com/studio-design/gesso/issues/499),
+  [#501](https://github.com/studio-design/gesso/issues/501),
+  [#502](https://github.com/studio-design/gesso/issues/502),
+  [#503](https://github.com/studio-design/gesso/issues/503),
+  [#504](https://github.com/studio-design/gesso/issues/504),
+  [#505](https://github.com/studio-design/gesso/issues/505),
+  [#506](https://github.com/studio-design/gesso/issues/506),
+  [#507](https://github.com/studio-design/gesso/issues/507),
+  [#508](https://github.com/studio-design/gesso/issues/508)
+- Supersedes: none
+
+## Context
+
+The v3 milestone reduces surface area rather than capability: one configuration
+location, names that match meaning, one output envelope. That direction is only
+safe if two things are written down before the first reduction PR, because both
+are currently implicit.
+
+**What must never regress while we shrink.** The behaviours that make Gesso a
+contract-testing tool rather than a JSON validator are enforced today by
+scattered code and fixtures, not by a stated policy. Three of them are not
+SemVer-covered at all: `Spec\OpenApiSchemaDialect` is `@internal`
+(`src/Spec/OpenApiSchemaDialect.php:20`), `Validation\Support\DiscriminatorEnforcement`
+is `@internal` (`src/Validation/Support/DiscriminatorEnforcement.php:32`), and the
+doctor ⇄ runtime consistency rule exists only as one sentence of agent guidance
+(`AGENTS.md:66-68`). A refactor could satisfy every letter of
+[the versioning policy](../versioning.md) and still gut them.
+
+**What a reduction PR must prove.** Two mechanical conformance gates already
+exist under `tests/Integration/Conformance/`, but nothing states that they are
+the acceptance criterion for reduction work.
+
+ADR 0001 solved the equivalent problem for v2 with its
+[scope boundaries](0001-gesso-v2-identity.md#scope-boundaries) — a list of what
+the rename did *not* authorize. That device stopped scope creep then, and v3
+planning invites the same pressure now.
+
+## Decision
+
+v3 changes shape, not capability. Nothing is added and nothing is removed.
+
+Every v3 change must be expressible as one of: moving a configuration key to the
+single entry point, renaming a symbol/flag/key to match its meaning, or
+collapsing two output shapes into one. A change that alters what Gesso decides
+about a request, a response, or a schema is not a v3 change, regardless of how
+much surface area it would save.
+
+## Protected core
+
+Seven invariants. Renaming or relocating their carriers is allowed — that is
+what v3 is for. Weakening the behaviour is not, at any version boundary, without
+an ADR that supersedes this one.
+
+| Invariant | Anchor today | SemVer-covered? |
+| --- | --- | --- |
+| OpenAPI 3.0 / 3.1 / 3.2 are each validated under their own JSON Schema dialect: 3.0 through the Draft 07 compatibility pipeline, 3.1/3.2 under 2020-12, and an unknown dialect is rejected rather than guessed | `src/OpenApiVersion.php:19-21`; `src/Spec/OpenApiSchemaDialect.php:34` (3.0 → Draft 07), `:38` (default OAS 3.1 base), `:57` (`assertSupported()`) | No — the class is `@internal` |
+| Validation is tri-state. `Skipped` is a distinct outcome, never folded into success or failure | `src/OpenApiValidationOutcome.php:15-17` | Yes — `docs/versioning.md:18-19` |
+| Discriminator enforcement is on by default | `src/Validation/Support/DiscriminatorEnforcement.php:36` (`private static bool $enabled = true`) | No — the class is `@internal` |
+| The named contract checks and their default expected statuses | `src/Fuzz/ContractCheck.php:13-15` (`ignored_auth`, `missing_required_header`, `unsupported_method`) | Yes — `docs/versioning.md:83-88` |
+| Coverage and gating are measured at `(method, path, status, content-type)` granularity | `src/Validation/Response/ResponseSchemaResolver.php:27`, `src/Coverage/OpenApiCoverageTracker.php:232`, `src/Cli/CoverageGateCommand.php:64` | Partly — only through the coverage baseline entry, `docs/versioning.md:67-82` |
+| Doctor diagnostics and runtime validation agree: a malformed spec node must not pass one path and fail the other | `AGENTS.md:66-68`; mirrored in code at `src/Cli/DoctorCommand.php:537` (response guards) and `:747` (security-scheme classification) | No |
+| Both upstream corpora stay pinned by commit SHA and stay measured | `composer.json` `repositories[].package.dist.reference`; asserted by `tests/Integration/Conformance/` | No — test fixtures |
+
+The three uncovered rows are the reason this ADR exists. `@internal` means the
+symbol may be renamed, moved, or merged without a major bump; it does not mean
+the behaviour behind it is negotiable.
+
+## Inclusion criterion
+
+> Anything that must keep running after the PHPUnit or Pest process exits does
+> not belong in Gesso.
+
+Gesso is a test-time library. Its unit of work is one assertion inside one test,
+and its lifetime is the test process. Everything in the package today satisfies
+that; the criterion exists to keep it that way.
+
+## Non-goals
+
+Each entry names the half of the criterion it fails.
+
+| Non-goal | Why it is out |
+| --- | --- |
+| An MCP server | Long-running process. It would outlive the test run by definition. |
+| A mock server | Long-running process, and it inverts the direction: Gesso checks a real implementation against the spec, it does not stand in for one. |
+| An Overlay merge engine | Not a test-time contract check. Applying an Overlay produces a spec; that is a spec-authoring or build step, and its output is what Gesso should be handed. |
+| oasdiff-style spec diffing | Not a test-time contract check. `CoverageGateCommand` already draws this line explicitly — its diff is structural ("did the resolved node change?"), never semantic ("is the change backwards-incompatible?"), and the semantic classification needs a rule catalogue that belongs to a dedicated tool (`src/Cli/CoverageGateCommand.php:67-70`). |
+| An official GitHub Action | Not a test-time contract check. It is a distribution wrapper around one, and `bin/gesso` already runs unmodified in any CI job. |
+| A general-purpose spec linter | Not a test-time contract check. `docs/doctor.md` states this for `gesso doctor` already: it is not a replacement for Spectral or Redocly. |
+| Spec generation | Not a test-time contract check. Generating the spec from code makes the spec a mirror of the implementation, which removes the thing Gesso is testing against. |
+| Gesso calling an LLM | Not a test-time contract check. A nondeterministic network call inside a test run cannot produce a verdict a test can rely on. Gesso's output is consumed by agents; nothing inside it consults one. |
+| OpenAPI 4.0 / Moonwalk support | This one does not fail the criterion. It is out because there is no stable specification to validate against yet. Revisit when there is; it needs its own ADR, not an extension of this one. |
+
+## Reduction-PR acceptance gate
+
+A PR whose stated purpose is reducing surface area must leave both conformance
+baselines byte-identical:
+
+- `tests/fixtures/compatibility/v1-json-schema-conversion-delta.json` —
+  `format_version: 1`, **11 deltas** (9 `unsupported-dialect`, 2
+  `stripped-annotation-ref`) and **2 statically excluded groups** (both
+  `$dynamicRef` under an `unevaluated*` applicator, where bare opis exhausts the
+  stack). 3,784 of the corpus's 3,824 cases are actually compared; the corpus is
+  pinned at `cf2e5e0ff2e3d90239c3b59e68ac4c080bd4ac92` and the test fails if the
+  installed SHA differs from the baseline.
+- `tests/fixtures/compatibility/v1-oas-example-documents.json` — **22 documents**,
+  `gesso doctor` exit `0` on all 22. Two entries, the JSON and YAML forms of
+  `v3.1/tictactoe`, each carry 3 `skipped/feature` security-scheme diagnostics;
+  every other document is clean. The corpus is pinned at
+  `43756549c27cbf84107b190b82c65e0336f2f09f`.
+
+Either baseline moving means the PR changed meaning, not shape. That is not
+forbidden — it needs its own decision record and its own review, and it stops
+being a reduction PR.
+
+Both gates run in the `Integration` suite, which every CI matrix job executes
+(`.github/workflows/ci.yml:59-60`), so no extra step is required to enforce this.
+
+## What v3 does not delete
+
+Enum drift (`src/Schema/`), SDK exercise coverage
+(`src/Coverage/SdkExerciseCoverageTracker.php`,
+`src/Coverage/SdkExerciseCoverageReportBuilder.php`), and `src/Fuzz/` all stay.
+
+They are recent, and downstream measurement supports keeping them: one consumer
+runs enum drift with fail-on-drift enabled over 52 backed enums, and another uses
+the named contract checks across 2 files and 246 lines. v3 records the boundary
+in the naming — `src/Fuzz/` holding the named contract checks is a misfiling that
+[#503](https://github.com/studio-design/gesso/issues/503) corrects — and defers
+the carve-out question to v4.
+
+This is a deliberate constraint on v3, not an endorsement of the current split.
+A v4 that removes any of them needs its own ADR and its own evidence.
+
+## Scope boundaries
+
+Inherited from ADR 0001 and restated for v3. The consistency milestone does not
+authorize:
+
+- splitting the repository into multiple Composer packages;
+- a major upgrade of `opis/json-schema` or another production dependency;
+- rewriting the validator, coverage engine, or framework adapters wholesale;
+- changing OpenAPI validation semantics solely because a major version is
+  available.
+
+ADR 0001's boundaries were written for the v2 identity migration and still hold
+on their own terms; this ADR extends the device rather than replacing it.
+
+## Consequences
+
+Three behaviours that SemVer does not cover become policy-protected: dialect
+selection, the discriminator-enforcement default, and doctor ⇄ runtime
+consistency. Their carriers stay `@internal` and freely renameable.
+
+Three surfaces that SemVer *does* cover become protected beyond it — the
+`OpenApiValidationOutcome` cases (`docs/versioning.md:18-19`), the `ContractCheck`
+names and default statuses (`:83-88`), and the coverage baseline granularity
+(`:67-82`). They may not be dropped even at a major boundary without a
+superseding ADR.
+
+The reduction gate makes "did this change meaning?" a mechanical question rather
+than a review judgement, which is what lets the v3 renames be reviewed as
+renames.
+
+ADR 0002's phases and ADR 0003's phase list stay open. In particular this ADR
+does not retract ADR 0003 phase 6, the SDK exercise coverage that already
+shipped.

--- a/docs/adr/0004-v3-consistency-policy-and-protected-core.md
+++ b/docs/adr/0004-v3-consistency-policy-and-protected-core.md
@@ -83,7 +83,7 @@ all of them green — not just the two conformance baselines:
 | Discriminator enforcement default | `tests/Unit/Validation/Response/ResponseSchemaResolverTest.php`, `tests/Unit/PHPUnit/OpenApiCoverageExtensionTest.php`, `tests/Unit/ValidatesOpenApiSchemaEnforceDiscriminatorTest.php` |
 | Contract-check names and defaults | The public-API baseline records the `cases` map and the two method signatures, but **not** their return values; the values are pinned by `tests/Unit/Fuzz/ContractCheckSummaryTest.php:22` (`[405]`) and `tests/Unit/Fuzz/OpenApiContractChecksTest.php:464` (`[401, 403]`), `:683` (the 4xx family) |
 | Coverage granularity | `tests/Unit/Compatibility/MachineReadableFormatsBaselineTest.php` against `tests/fixtures/compatibility/v3-coverage-report.json`, plus the coverage tracker unit tests |
-| Doctor ⇄ runtime consistency | `tests/Integration/Conformance/OasExampleDocumentTest.php` for the corpus half, `tests/Unit/Cli/DoctorCommandTest.php` for the mirrored guards |
+| Doctor ⇄ runtime consistency | Both sides, since agreement is the invariant. Doctor: `tests/Integration/Conformance/OasExampleDocumentTest.php` (corpus) and `tests/Unit/Cli/DoctorCommandTest.php`. Runtime: `tests/Unit/OpenApiRequestValidatorTest.php:3101` (`security_scheme_missing_type_is_hard_spec_error`, the counterpart to `DoctorCommand.php:747`) and `tests/Unit/OpenApiResponseValidatorTest.php:2404` (`malformed_response_status_entry_returns_failure`, the counterpart to `:537`) |
 | Pinned corpora | The two conformance tests themselves |
 
 Three invariants — tri-state outcome, contract-check defaults, coverage
@@ -159,8 +159,8 @@ baselines unchanged. **This is necessary, not sufficient** — the two corpora
 cover schema conversion and the loader/doctor path only, so an unchanged
 baseline is evidence about those two areas and about nothing else. The full
 condition is that every row of the verification table above stays green; the
-baselines are singled out here because they are the only ones a reviewer cannot
-read off a failing test.
+baselines are singled out because their expected values live in a data file the
+same PR can regenerate, so a green suite stays compatible with a moved verdict.
 
 The two baselines:
 
@@ -264,17 +264,20 @@ names and default statuses (`:83-88`), and the coverage baseline granularity
 superseding ADR.
 
 The reduction rule gives "did this change meaning?" a fixed place to look — the
-verification table, plus one `git diff` for the two baselines no failing test
-would surface — instead of leaving it to be re-derived per review. It does not
-make the question automatic, and the section above says so.
+verification table, plus one `git diff` — instead of leaving it to be re-derived
+per review. The `git diff` is not there because the tests are weak: an
+implementation change alone fails them. It is there for the one case they cannot
+see, an implementation change and a regenerated baseline in the same commit.
 
-Writing the verification table also exposed a gap worth recording: three
-invariants (tri-state outcome, contract-check defaults, coverage granularity)
-rest on ordinary unit tests rather than on a compatibility fixture. That is
-adequate — they are asserted, and the public-API baseline pins the enum cases —
-but it means a reviewer checking a reduction PR has to trust the suite rather
-than read a single artifact, which is why the rule is explicit about being
-necessary rather than sufficient.
+Writing the verification table also exposed a gap worth recording. Most
+invariants have a committed artifact a reviewer can read directly — the enum
+cases in `v2-public-api.json`, the coverage document shape in
+`v3-coverage-report.json`, the two conformance baselines. The contract-check
+*default return values* do not: the public-API baseline records the `cases` map
+and both method signatures, so a change from `[401, 403]` to something else
+would move no fixture and would be caught only by the unit assertions in
+`tests/Unit/Fuzz/`. That is adequate coverage, but it is the one row of the
+table where "read the diff" does not work and the suite has to be trusted.
 
 ADR 0002's phases and ADR 0003's phase list stay open. In particular this ADR
 does not retract ADR 0003 phase 6, the SDK exercise coverage that already

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,19 @@
+# Architecture decision records
+
+Decisions that shape what Gesso is, rather than how one part of it works. A
+change that contradicts an accepted ADR needs a new ADR that supersedes it, not
+just a pull request.
+
+| ADR | Status | Date | Decision |
+| --- | --- | --- | --- |
+| [0001 — Align the v2 technical identity with Gesso](0001-gesso-v2-identity.md) | Accepted | 2026-07-13 | Namespace, package, and CLI rename to the Gesso identity, with the scope boundaries the rename did not authorize. |
+| [0002 — Phase Arazzo workflow execution behind shared runtime expressions](0002-arazzo-workflow-execution.md) | Accepted | 2026-07-30 | Arazzo support lands in phases, starting from a runtime-expression evaluator shared with the existing validators. |
+| [0003 — Branch-complete response payloads and an SDK round-trip harness](0003-sdk-roundtrip-harness.md) | Accepted | 2026-07-31 | Close the SDK ⇄ spec gap by feeding spec-derived payloads through a generated decoder. |
+| [0004 — v3 consistency policy and protected core](0004-v3-consistency-policy-and-protected-core.md) | Accepted | 2026-08-06 | v3 changes shape, not capability: the invariants that may not regress, the inclusion criterion and its non-goals, and the rule a reduction PR is held to. |
+
+## Writing one
+
+Follow the most recent file. The header carries `Status`, `Date`, `Issue`, and
+`Related`; 0004 adds `Supersedes`, which every later ADR should carry even when
+the value is `none`. Number files sequentially and add the row above in the same
+change, so this page never lags the directory.


### PR DESCRIPTION
Closes #500.

Adds `docs/adr/0004-v3-consistency-policy-and-protected-core.md` and `docs/adr/index.md`, and lists the index in the docs sidebar. Docs-only — no public symbol, CLI flag, exit code, extension parameter, env name, Artisan command, or wire format is touched.

## Why now

This has to merge before the first v3 consistency PR, because it is what that PR gets measured against.

Four of the seven invariants that make Gesso a contract-testing tool rather than a JSON validator are not SemVer-covered: `OpenApiSchemaDialect` is `@internal`, `DiscriminatorEnforcement` is `@internal`, the doctor ⇄ runtime consistency rule exists only as one sentence in `AGENTS.md`, and the pinned conformance corpora are test fixtures. A refactor could satisfy every letter of `docs/versioning.md` and still gut them.

## What it records

**Protected core** — seven invariants, each with a verified `file:line` anchor and a note on whether SemVer covers it. The framing that matters: `@internal` means the *symbol* is renameable, not that the *behaviour* is negotiable.

Six rows are behaviours; the seventh, the pinned corpora, is a measurement commitment. The ADR is explicit that the corpora do **not** prove the other six — they exercise schema conversion and the loader/doctor path and nothing else — and carries a per-invariant table naming the test that actually pins each one.

**Inclusion criterion**, one sentence, built on residency rather than on the test process:

> Anything that must stay resident after the command that started it exits, or that is not part of checking an implementation against its spec, does not belong in Gesso.

The residency framing is deliberate. Gesso already does work outside a test run — `doctor` before the suite, `coverage:merge` / `coverage:gate` / `stubs` after it — and a criterion phrased around the test process would have excluded four of its own commands.

**Non-goals**, in three groups: fails the first half (MCP server, mock server), fails the second half (Overlay merge, spec diffing, general linter, spec generation), and out for reasons of their own (an official GitHub Action, Gesso calling an LLM, OpenAPI 4.0/Moonwalk). Those last three pass both halves of the criterion and are recorded with their real reason instead — a criterion stretched to cover everything stops deciding anything.

**Reduction-PR acceptance rule** — a review rule, explicitly not an automated gate, and explicitly necessary rather than sufficient. Both conformance baselines must be unchanged, and the section states precisely what the tests do and do not catch.

**What v3 does not delete** — enum drift, SDK exercise coverage, and `src/Fuzz/` all stay; the carve-out question moves to v4.

## Verified rather than copied

Every anchor in the issue was re-checked against the tree, and several had drifted:

| Issue said | Actually |
| --- | --- |
| `OpenApiSchemaDialect.php:21` (`@internal`) | `:20` |
| `:31-34` (3.0 → Draft 07) | `:34` |
| `:36` (default OAS 3.1) | `:38` |
| `OpenApiValidationOutcome.php:13-17` | cases at `:15-17` |
| `DoctorCommand.php:536`, `:746-750` | `:537`, `:747` |

One substantive correction to the issue. It says *"one document (`v3.1/tictactoe`) is `warning` from 3 `skipped/feature` diagnostics"*. The baseline records no `status` field at all — it records `exit` and `issues`, and **two** entries carry those 3 diagnostics: `v3.1/tictactoe.json` and `v3.1/tictactoe.yaml`, since the corpus is measured in both JSON and YAML form.

Baseline values quoted in the rule, read from the committed fixtures rather than from the issue:

- `v1-json-schema-conversion-delta.json` — `format_version: 1`, 11 deltas (9 `unsupported-dialect`, 2 `stripped-annotation-ref`), 2 excluded groups, 3,784 of 3,824 cases compared, corpus pinned at `cf2e5e0f…`.
- `v1-oas-example-documents.json` — 22 documents, exit `0` on all 22, corpus pinned at `4375654…`.

## Review rounds

Eight findings across two rounds, all confirmed against the tree before fixing.

**Round 1.**

- The inclusion criterion's elaboration said Gesso's lifetime is the test process, which contradicted `CoverageMergeCommand`'s own docblock (`src/Coverage/CoverageMergeCommand.php:56-58`: *"Designed to be invoked as a separate step after the parallel test run finishes"*). Rephrased around residency.
- The reduction section claimed CI enforced it with no extra step. It does not — see below.
- The protected core said three rows are uncovered; four are.
- The `ContractCheck` anchor covered only the case names; `:23-30` and `:46-52` added.
- No ADR index existed. Added one covering all four records, listed under Reference in the sidebar — until now no ADR was reachable from the docs site at all.

**Round 2.**

- The claim that the corpora measure the other six invariants was wrong. Tri-state outcome, contract-check defaults, and coverage granularity can all be broken with both baselines untouched. Replaced with a per-invariant verification table and a rule stated as necessary rather than sufficient. Building the table surfaced something worth knowing: `v2-public-api.json` records the `ContractCheck` `cases` map and both method *signatures*, but not their return values — the `[401, 403]` / `[405]` / 4xx-family defaults are pinned only by `tests/Unit/Fuzz/ContractCheckSummaryTest.php:22` and `tests/Unit/Fuzz/OpenApiContractChecksTest.php:464,683`.
- The reviewer command used a two-dot range, which reports main's own commits on an unrebased branch. Now `origin/main...HEAD`, with a note on why.

**Round 3.**

- The doctor ⇄ runtime row cited only doctor-side tests. Agreement is the invariant, so the runtime counterparts are now named too: `OpenApiRequestValidatorTest.php:3101` against `DoctorCommand.php:747`, and `OpenApiResponseValidatorTest.php:2404` against `:537`.
- Two sentences contradicted the document's own explanation. "The two baselines no failing test would surface" is wrong — an implementation change alone *does* fail the conformance tests; the `git diff` exists for the deliberate co-update they cannot see. And the recorded gap was overstated: tri-state is in `v2-public-api.json` and coverage granularity is in `v3-coverage-report.json`, so the only invariant with no readable artifact is the contract-check default return values.

### Why the reduction rule is not automated

Both conformance tests compare the current observation against the **committed** fixture, after asserting the installed corpus SHA matches the one the baseline was recorded against (`JsonSchemaConversionDeltaTest.php:112-117`, `OasExampleDocumentTest.php:122-127`). So they catch unintentional drift and a corpus bump without a regenerated baseline — but a PR that changes the converter and regenerates the fixture in one commit is green, because nothing compares the fixture against the base branch.

"Byte-identical" was wrong on a second count too: `JsonSchemaConversionDeltaTest.php:119-129` compares only the verdict triple per case key and deliberately excludes the `reason` prose, so rewording an explanation cannot read as a conformance regression. The ADR now says "unchanged" means the verdict set, not the bytes.

A CI job failing on any diff to these two files was considered and rejected: it cannot distinguish a reduction PR from a deliberate conformance change or a corpus re-pin, so it would need a label protocol — its own decision, not a detail of this one. That reasoning is recorded in the ADR rather than left in the PR thread.

## Checks

`vendor/bin/phpunit --testsuite Integration` OK (169 tests) — the acceptance criterion asking the quoted baselines to be current at merge time. `composer test` OK (3111 tests, 19801 assertions). `markdownlint-cli2` clean on both new files, `markdown-link-check` resolves 12/12 and 4/4, `npm run docs:build` succeeds with the new sidebar entry.

Paths that `.gitattributes` excludes from the distributed archive (`AGENTS.md`, `phpunit.xml.dist`, `tests/…`, `.github/…`) appear as inline code only, never as links, so `PackageArchivePolicyTest::shipped_documentation_never_links_into_excluded_paths()` stays green.