### PR TITLE
feat(deprecations): add the E_USER_DEPRECATED channel and the standing deprecation rule

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,6 +7,30 @@ full record.
 Sections are ordered newest-first. If you are jumping multiple minors,
 read each intermediate section in order — behavioural changes compose.
 
+## Deprecations
+
+Every surface v3 removes or renames is deprecated in a v2 minor first, per the
+[deprecation policy](docs/versioning.md#deprecation-policy). Using one emits a
+one-shot `E_USER_DEPRECATED` naming the replacement and the removal version,
+and the PHPUnit extension prints a single end-of-run STDERR line:
+
+```text
+[Gesso deprecation] 2 deprecated surface(s) still in use, 45 call(s): laravel.config.auto_inject_dummy_bearer (31), phpunit.enum_spec_base_path (14). All are removed in Gesso 3.0.
+```
+
+**If your suite prints no such line on the final v2 minor, upgrading to v3.0
+needs no changes to your code, configuration, or CLI invocations.** Work through
+the table below until it does.
+
+| Deprecated in | Surface | Replacement | Removed in |
+| --- | --- | --- | --- |
+| — | Nothing is deprecated yet. | — | — |
+
+The table mirrors `tests/fixtures/compatibility/v2-deprecations.json`, which a
+test keeps in sync with the emitters in `src/`. The `Deprecated in` column names
+the release that started warning, not the release that introduced the
+replacement.
+
 ## Within v2.x
 
 The v2.x line is covered end-to-end by SemVer (see `docs/versioning.md` for the

--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -77,20 +77,29 @@ itself; the default already does this.
 
 Sidecars are a versioned worker-to-merge protocol, separate from the coverage
 report produced by `json_output`. The current writer emits an
-`envelopeVersion: 6` envelope containing coverage state `version: 1`,
+`envelopeVersion: 8` envelope containing coverage state `version: 1`,
 strict-required state `version: 2`, and strict-additional-properties state
-`version: 1`, plus SDK exercise state `version: 1`. A baseline-generation run
-(`OPENAPI_BASELINE_GENERATE=1`) emits `envelopeVersion: 7` and adds the violation-baseline document
+`version: 1`, plus SDK exercise state `version: 1` and deprecation state
+`version: 1`. A baseline-generation run
+(`OPENAPI_BASELINE_GENERATE=1`) emits `envelopeVersion: 9` and adds the violation-baseline document
 (`baseline_version: 1`).
 
-The merge reader also accepts envelopes 2–5 and the older bare coverage state
+The merge reader also accepts envelopes 2–7 and the older bare coverage state
 `version: 1`, so HTTP coverage can still be combined while a worker fleet is
-being upgraded. Envelopes 2/3 have no strict-additional-properties state, and
-envelopes 2–5 have no SDK exercise state. A strict SDK exercise threshold
-therefore requires every worker on v6/v7; warn-only mode reports missing
+being upgraded. Envelopes 2/3 have no strict-additional-properties state,
+envelopes 2–5 have no SDK exercise state, and envelopes 2–7 have no deprecation
+state. A strict SDK exercise threshold
+therefore requires every worker on v6+; warn-only mode reports missing
 worker state and evaluates the available SDK observations. Likewise, plain
 envelopes carry no baseline data, so `--baseline-file` requires every worker
 to use a corresponding baseline envelope.
+
+Deprecation counts travel the same way. A worker never reaches the end-of-run
+report, so it stages its per-id counts in the envelope and `coverage:merge`
+writes the one summed `[Gesso deprecation]` line — silence there means no
+worker used a deprecated surface. When some sidecar predates the deprecation
+channel the merge says so instead, because a missing half and "this worker used
+none" are the same absence.
 
 Unknown envelope or tracker versions fail the merge rather than being guessed.
 Strict-required state `version: 1` is also rejected because merging it with the

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -642,7 +642,7 @@ Notes:
 
 ## Acknowledging an unvalidatable security scheme
 
-The validator cannot enforce `oauth2`, `openIdConnect`, `mutualTLS`, or `http` schemes other than `bearer` (basic, digest, …). Requests secured only by such a scheme silently pass the security check, and the first encounter per scheme emits a one-shot `E_USER_WARNING` so the silent pass does not stay invisible (see the [warning channel](supported-features.md#warning-channel-e_user_warning-contract)).
+The validator cannot enforce `oauth2`, `openIdConnect`, `mutualTLS`, or `http` schemes other than `bearer` (basic, digest, …). Requests secured only by such a scheme silently pass the security check, and the first encounter per scheme emits a one-shot `E_USER_WARNING` so the silent pass does not stay invisible (see the [warning channel](supported-features.md#diagnostic-channels-e_user_warning-and-e_user_deprecated)).
 
 Under Laravel that warning is converted into a test failure by the framework's error handler — and because it is one-shot, *which* test fails depends on execution order. When the scheme genuinely cannot be avoided (e.g. RFC 7009 / RFC 7662 mandate HTTP Basic client authentication for token revocation / introspection endpoints) and the authentication is covered by a dedicated test, acknowledge the scheme **by name** instead of filtering `E_USER_WARNING` globally:
 

--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -12,7 +12,7 @@ The schema-conversion behaviour described here is measured against the official 
 - [Schema features](#schema-features)
 - [HTTP methods](#http-methods)
 - [Spec features not consulted](#spec-features-not-consulted)
-- [Warning channel (`E_USER_WARNING` contract)](#warning-channel-e_user_warning-contract)
+- [Diagnostic channels (`E_USER_WARNING` and `E_USER_DEPRECATED`)](#diagnostic-channels-e_user_warning-and-e_user_deprecated)
 
 ## OpenAPI 3.0, 3.1, and 3.2
 
@@ -106,17 +106,22 @@ The PHPUnit coverage report counts `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, Open
 ## Spec features not consulted
 Webhooks (3.1+), Callbacks, Response `Links`, Server URL templating (`servers` with `variables`), Examples (`example` / `examples`, including 3.2 `dataValue` / `serializedValue` — not used for fuzzing or validation), 3.2 tag hierarchy (`summary` / `parent` / `kind`), `externalDocs`, and vendor extensions (`x-*` keys, ignored harmlessly). OAuth2 device authorization and other OAuth/OpenID schemes remain on the existing `[security]` warning path.
 
-## Warning channel (`E_USER_WARNING` contract)
+## Diagnostic channels (`E_USER_WARNING` and `E_USER_DEPRECATED`)
 
 The library uses PHP's native `trigger_error(..., E_USER_WARNING)` as the loud-signal channel for silent-pass conditions the validator cannot enforce. **This is the v1.0 official API**: warnings are dedup'd per-process and prefixed with a category tag so callers can route or filter them mechanically.
 
-| Category prefix | Source | Dedup key |
-|---|---|---|
-| `[security]` | `SecurityValidator` (`oauth2`, `openIdConnect`, `mutualTLS`, `http-basic`, `http-digest`) | scheme name |
-| `[OpenAPI Schema]` | `OpenApiSchemaConverter` (3.0-only `unevaluated*` / `dependent*`, unknown / malformed `format`) | per-keyword / per-format-value |
-| `[OpenAPI 3.2 querystring]` | `QueryParameterValidator` (serialized query media type cannot be reconstructed) | declared media-type set |
-| `[OpenAPI 3.2 discriminator]` | `OpenApiSchemaConverter` (`defaultMapping` with implicit mappings only) | process-wide limitation key |
-| `[OpenAPI 3.2 $self]` | `OpenApiSpecLoader` (`$self` base URI is not applied) | spec load/cache |
+A second channel, `trigger_error(..., E_USER_DEPRECATED)`, carries migration notices for surfaces that a future major removes. It follows the same dedup and category-prefix contract, but uses a distinct error level and a distinct prefix so an error handler can route migration work separately from operational signals. The `Level` column below says which channel each prefix arrives on.
+
+| Category prefix | Level | Source | Dedup key |
+|---|---|---|---|
+| `[security]` | `E_USER_WARNING` | `SecurityValidator` (`oauth2`, `openIdConnect`, `mutualTLS`, `http-basic`, `http-digest`) | scheme name |
+| `[OpenAPI Schema]` | `E_USER_WARNING` | `OpenApiSchemaConverter` (3.0-only `unevaluated*` / `dependent*`, unknown / malformed `format`) | per-keyword / per-format-value |
+| `[OpenAPI 3.2 querystring]` | `E_USER_WARNING` | `QueryParameterValidator` (serialized query media type cannot be reconstructed) | declared media-type set |
+| `[OpenAPI 3.2 discriminator]` | `E_USER_WARNING` | `OpenApiSchemaConverter` (`defaultMapping` with implicit mappings only) | process-wide limitation key |
+| `[OpenAPI 3.2 $self]` | `E_USER_WARNING` | `OpenApiSpecLoader` (`$self` base URI is not applied) | spec load/cache |
+| `[Gesso deprecation]` | `E_USER_DEPRECATED` | `Internal\Deprecations` (every deprecated configuration key, CLI flag, and PHP symbol) | deprecation id |
+
+**Deprecation notices:** each notice names what to use instead and the version that removes the surface, because the emitter cannot represent one that does not. Under the PHPUnit extension, one summary line is written to STDERR after the run listing every deprecated surface still in use with its call count; nothing is written when the run used none. See [Deprecations in `UPGRADING.md`](https://github.com/studio-design/gesso/blob/main/UPGRADING.md#deprecations) for the current list and [versioning](versioning.md) for the rule that ties a removal to a prior deprecation.
 
 **How to consume:**
 

--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -121,7 +121,7 @@ A second channel, `trigger_error(..., E_USER_DEPRECATED)`, carries migration not
 | `[OpenAPI 3.2 $self]` | `E_USER_WARNING` | `OpenApiSpecLoader` (`$self` base URI is not applied) | spec load/cache |
 | `[Gesso deprecation]` | `E_USER_DEPRECATED` | `Internal\Deprecations` (every deprecated configuration key, CLI flag, and PHP symbol) | deprecation id |
 
-**Deprecation notices:** each notice names what to use instead and the version that removes the surface, because the emitter cannot represent one that does not. Under the PHPUnit extension, one summary line is written to STDERR after the run listing every deprecated surface still in use with its call count; nothing is written when the run used none. See [Deprecations in `UPGRADING.md`](https://github.com/studio-design/gesso/blob/main/UPGRADING.md#deprecations) for the current list and [versioning](versioning.md) for the rule that ties a removal to a prior deprecation.
+**Deprecation notices:** each notice names what to use instead and the version that removes the surface, because the emitter cannot represent one that does not. Under the PHPUnit extension, one summary line is written to STDERR after the run listing every deprecated surface still in use with its call count; nothing is written when the run used none. Under paratest each worker stages its counts in the sidecar and `gesso coverage:merge` writes the one summed line, so the report survives a parallel run. See [Deprecations in `UPGRADING.md`](https://github.com/studio-design/gesso/blob/main/UPGRADING.md#deprecations) for the current list and [versioning](versioning.md) for the rule that ties a removal to a prior deprecation.
 
 **How to consume:**
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -4,6 +4,7 @@ This library follows [Semantic Versioning 2.0](https://semver.org/). v1.0.0 is t
 
 - [What's covered by SemVer](#whats-covered-by-semver)
 - [What's NOT covered by SemVer](#whats-not-covered-by-semver)
+- [Deprecation policy](#deprecation-policy)
 - [Support policy](#support-policy)
 - [v1 maintenance lifecycle](#v1-maintenance-lifecycle)
 - [Release checklist](#release-checklist)
@@ -95,7 +96,7 @@ This library follows [Semantic Versioning 2.0](https://semver.org/). v1.0.0 is t
 - The Laravel `openapi:routes` and `openapi:stubs` command surfaces (flags, exit codes, and versioned JSON output)
 - The `OpenApiCoverageExtension` PHPUnit configuration parameters (`spec_base_path`, `strip_prefixes`, `specs`, `output_file`, `console_output`, `validation_output`, `baseline_file`, `coverage_baseline_file`, `strict_required`, `strict_additional_properties`, `strict_additional_properties_per_call`, …)
 - The Laravel `ValidatesOpenApiSchema` trait's public methods
-- The category prefixes used in `E_USER_WARNING` messages (`[security]`, `[OpenAPI Schema]`, and the `[OpenAPI 3.2 ...]` categories)
+- The category prefixes used in `E_USER_WARNING` messages (`[security]`, `[OpenAPI Schema]`, and the `[OpenAPI 3.2 ...]` categories) and in `E_USER_DEPRECATED` messages (`[Gesso deprecation]`). Adding a category is a minor change; renaming or removing one is major.
 
 ### Versioned sidecar compatibility
 
@@ -175,6 +176,40 @@ written by `json_output` has its own `schema_version` contract documented in
 
 See [UPGRADING.md](https://github.com/studio-design/gesso/blob/main/UPGRADING.md) for migration notes between versions.
 
+## Deprecation policy
+
+SemVer requires a minor bump when public API is deprecated and a major bump for
+its incompatible removal. This project adds one standing rule on top:
+
+> A surface covered by this document is removed or renamed in a major release
+> only if a deprecation for it shipped in a minor release of the preceding
+> major. The last minor of a major is therefore the last chance to deprecate
+> anything for the next one.
+
+The rule covers every surface listed under "What's covered by SemVer" — not
+just PHP symbols, but configuration keys, CLI flags, environment variables, and
+Artisan command names. It does not apply to `@internal` symbols or to anything
+in the "NOT covered by SemVer" list.
+
+Deprecations are announced at runtime, not only in a docblock. Each one emits a
+one-shot `E_USER_DEPRECATED` carrying the `[Gesso deprecation]` prefix, the
+replacement, and the removal version; the PHPUnit extension writes a single
+end-of-run STDERR line counting how many deprecated surfaces the suite still
+uses. See [diagnostic
+channels](supported-features.md#diagnostic-channels-e_user_warning-and-e_user_deprecated).
+
+**If a run on the final minor of a major reports zero Gesso deprecations,
+upgrading to the next major requires no consumer code, configuration, or CLI
+changes.** That is what the rule buys: the deprecation report, not the upgrade
+guide, is the authoritative answer to "am I ready?".
+
+For the v2 → v3 transition, the deprecation-carrying release is the final v2
+minor. Its number is not chosen by hand — release-please derives it from
+Conventional Commit types — so the constraint is an ordering one: every v2
+release must ship before the first breaking commit reaches `main`, because that
+commit turns the pending release into `3.0.0` and no further v2 release can be
+cut from the branch.
+
 ## Support policy
 
 | Component | Supported |
@@ -193,11 +228,10 @@ receive fixes.
 
 v1.10.0 is the final planned feature minor of the original
 `studio-design/openapi-contract-testing` package. It may add backward-compatible
-migration aids and deprecations for Gesso 2.0. SemVer requires a minor bump when
-public API is deprecated and a major bump for its incompatible removal. This
-project additionally requires migration deprecations to ship in v1.10.0 before
-removal in v2. After v1.10.0, the v1 line receives patches from the `1.x`
-maintenance branch:
+migration aids and deprecations for Gesso 2.0. Under the [deprecation
+policy](#deprecation-policy), v1.10.0 is the last release that can carry a
+deprecation for a surface v2 removes. After v1.10.0, the v1 line receives
+patches from the `1.x` maintenance branch:
 
 V1.10.0 also provides lazy `Studio\Gesso\` aliases for all non-`@internal`
 public PHP types. Consumers should use these aliases to migrate imports before

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -115,16 +115,19 @@ The baseline-generation protocol introduced `envelopeVersion: 3` — the v2
 shape plus a `baseline` key holding the violation-baseline document
 (`baseline_version: 1`). It remains an accepted compatibility input.
 
-The current writer emits `envelopeVersion: 6` for plain worker runs. It carries
+The current writer emits `envelopeVersion: 8` for plain worker runs. It carries
 coverage state `version: 1`, strict-required state `version: 2`,
-strict-additional-properties state `version: 1`, and SDK exercise state
-`version: 1`. A baseline-generation worker emits `envelopeVersion: 7`, which
-adds the `baseline` document to the v6 tracker halves.
+strict-additional-properties state `version: 1`, SDK exercise state
+`version: 1`, and deprecation state `version: 1`. A baseline-generation worker
+emits `envelopeVersion: 9`, which adds the `baseline` document to the v8
+tracker halves.
 
-The reader accepts envelopes 2–7 and the legacy bare coverage state. Versions
+The reader accepts envelopes 2–9 and the legacy bare coverage state. Versions
 4/5 are the older strict-additional-properties shapes; versions 2/3 contribute
-no strict-additional-properties state, and versions 2–5 contribute no SDK
-exercise state. A plain envelope carrying a `baseline` key or a baseline
+no strict-additional-properties state, versions 2–5 contribute no SDK
+exercise state, and versions 2–7 contribute no deprecation state — for which
+the merge reports that its count is a lower bound rather than treating a
+missing half as "this worker used none". A plain envelope carrying a `baseline` key or a baseline
 envelope missing one is rejected as malformed; `coverage:merge
 --baseline-file` refuses to write a union when any sidecar lacks the baseline
 half. Likewise, a strict parallel SDK exercise threshold rejects any worker
@@ -195,7 +198,8 @@ Deprecations are announced at runtime, not only in a docblock. Each one emits a
 one-shot `E_USER_DEPRECATED` carrying the `[Gesso deprecation]` prefix, the
 replacement, and the removal version; the PHPUnit extension writes a single
 end-of-run STDERR line counting how many deprecated surfaces the suite still
-uses. See [diagnostic
+uses. Under paratest that line comes from `gesso coverage:merge`, summed over
+the worker sidecars. See [diagnostic
 channels](supported-features.md#diagnostic-channels-e_user_warning-and-e_user_deprecated).
 
 **If a run on the final minor of a major reports zero Gesso deprecations,

--- a/src/Coverage/CoverageMergeCommand.php
+++ b/src/Coverage/CoverageMergeCommand.php
@@ -15,6 +15,7 @@ use Studio\Gesso\Baseline\ViolationBaseline;
 use Studio\Gesso\Baseline\ViolationBaselineFile;
 use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\Exception\SpecFileNotFoundException;
+use Studio\Gesso\Internal\Deprecations;
 use Studio\Gesso\PHPUnit\ConsoleOutput;
 use Studio\Gesso\PHPUnit\CoverageReportSubscriber;
 use Studio\Gesso\PHPUnit\OpenApiCoverageExtension;
@@ -455,6 +456,8 @@ final class CoverageMergeCommand
         $sidecarsWithoutBaseline = 0;
         $sidecarsWithoutStrictAdditionalProperties = 0;
         $sidecarsWithoutSdkExercise = 0;
+        $sidecarsWithoutDeprecations = 0;
+        $deprecationStates = [];
         foreach ($payloads as $payload) {
             try {
                 $parsed = CoverageSidecarEnvelope::parse($payload);
@@ -472,6 +475,11 @@ final class CoverageMergeCommand
                 } else {
                     $sidecarsWithoutSdkExercise++;
                 }
+                if ($parsed['deprecations'] !== null) {
+                    $deprecationStates[] = $parsed['deprecations'];
+                } else {
+                    $sidecarsWithoutDeprecations++;
+                }
                 if ($parsed['baseline'] !== null) {
                     // parseDocument re-validates the embedded document
                     // (unknown baseline_version fails loudly — the
@@ -488,6 +496,12 @@ final class CoverageMergeCommand
                 return 1;
             }
         }
+
+        // Reported before the gates below, and before any of them can return
+        // non-zero: a parallel run's deprecation report is the only place the
+        // residual count surfaces at all, so it must not depend on the merge
+        // succeeding. Issue #499.
+        $this->reportDeprecations($deprecationStates, $sidecarsWithoutDeprecations, count($payloads));
 
         if (!$this->handleBaseline($baselineFile, $mergedBaseline, $sidecarsWithoutBaseline, count($payloads))) {
             return 1;
@@ -627,6 +641,58 @@ final class CoverageMergeCommand
         }
 
         return !in_array(strtolower(trim($value)), ['0', 'false', 'no'], true);
+    }
+
+    /**
+     * Issue #499: report the deprecation counts the workers staged, summed
+     * across the fleet. Silence means no worker used a deprecated surface —
+     * the documented "ready for the next major" signal — so a fleet that
+     * cannot prove that has to say so instead of printing nothing.
+     *
+     * A sidecar written by a pre-#499 worker carries no deprecation half,
+     * which is indistinguishable from "that worker used none". The note is
+     * therefore emitted whether or not the merged count is empty: an
+     * incomplete zero and an incomplete non-zero are both unsafe to read as
+     * the readiness verdict.
+     *
+     * @param list<array<string, mixed>> $states
+     */
+    private function reportDeprecations(array $states, int $sidecarsWithoutDeprecations, int $sidecarCount): void
+    {
+        try {
+            $merged = Deprecations::mergeStates($states);
+        } catch (InvalidArgumentException $e) {
+            // Never fatal: a malformed deprecation half must not fail a merge
+            // whose coverage and gate data parsed cleanly. Report it instead,
+            // because the alternative is silence that reads as "no
+            // deprecations".
+            $this->writeStderr(sprintf(
+                "%s WARNING: could not read the staged deprecation state: %s The residual count is not reported for this run.\n",
+                Deprecations::PREFIX,
+                $e->getMessage(),
+            ));
+
+            return;
+        }
+
+        $summary = Deprecations::renderSummary($merged);
+        if ($summary !== null) {
+            $this->writeStderr($summary);
+        }
+
+        if ($sidecarsWithoutDeprecations === 0) {
+            return;
+        }
+
+        $this->writeStderr(sprintf(
+            "%s NOTE: %d of %d worker sidecar(s) carry no deprecation state (written by a Gesso version older than the deprecation channel), so %s. Upgrade every worker to the same version before reading this as a v3-readiness verdict.\n",
+            Deprecations::PREFIX,
+            $sidecarsWithoutDeprecations,
+            $sidecarCount,
+            $summary === null
+                ? 'the absence of a deprecation report above does not prove the suite uses none'
+                : 'the counts above are a lower bound',
+        ));
     }
 
     /**

--- a/src/Coverage/CoverageSidecarEnvelope.php
+++ b/src/Coverage/CoverageSidecarEnvelope.php
@@ -6,11 +6,13 @@ namespace Studio\Gesso\Coverage;
 
 use InvalidArgumentException;
 use Studio\Gesso\Baseline\ViolationBaselineFile;
+use Studio\Gesso\Internal\Deprecations;
 use Studio\Gesso\Validation\Strict\StrictAdditionalPropertiesTracker;
 use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
 
 use function array_key_exists;
 use function get_debug_type;
+use function implode;
 use function in_array;
 use function is_array;
 use function is_int;
@@ -53,9 +55,16 @@ use function sprintf;
  * Older v2/v3 envelopes remain readable and contribute no strict
  * additional-properties observations.
  *
- * Wire shapes v6/v7 add `sdkExercise` state. v6 is the current plain-worker
- * format; v7 is v6 plus the baseline half. Versions v2-v5 remain readable
+ * Wire shapes v6/v7 add `sdkExercise` state. Versions v2-v5 remain readable
  * and contribute no SDK exercise observations.
+ *
+ * Wire shapes v8/v9 add the `deprecations` half (issue #499) — the per-id
+ * counts {@see Deprecations} accumulated in the worker.
+ * v8 is the current plain-worker format; v9 is v8 plus the baseline half. The
+ * half is written even when the worker used no deprecated surface, because
+ * "this worker saw none" is what the merged report has to be able to prove;
+ * v2-v7 remain readable but cannot distinguish that from "not recorded", so
+ * the merge CLI says so rather than reporting a zero it cannot stand behind.
  *
  * Backwards compatibility: workers running an older library version write
  * a bare v1 coverage payload (`{ "version": 1, "specs": { ... } }`) with no
@@ -84,6 +93,7 @@ use function sprintf;
  *     strictRequired: StrictRequiredStatePayload,
  *     strictAdditionalProperties?: StrictAdditionalPropertiesState,
  *     sdkExercise?: array<string, mixed>,
+ *     deprecations?: array<string, mixed>,
  *     baseline?: array<string, mixed>,
  * }
  * @phpstan-type ParsedEnvelope array{
@@ -91,6 +101,7 @@ use function sprintf;
  *     strictRequired: array<string, mixed>|null,
  *     strictAdditionalProperties: array<string, mixed>|null,
  *     sdkExercise: array<string, mixed>|null,
+ *     deprecations: array<string, mixed>|null,
  *     baseline: array<string, mixed>|null,
  * }
  */
@@ -114,6 +125,49 @@ final class CoverageSidecarEnvelope
     public const ENVELOPE_VERSION_WITH_STRICT_ADDITIONAL_PROPERTIES_AND_BASELINE = 5;
     public const ENVELOPE_VERSION_WITH_SDK_EXERCISE = 6;
     public const ENVELOPE_VERSION_WITH_SDK_EXERCISE_AND_BASELINE = 7;
+    public const ENVELOPE_VERSION_WITH_DEPRECATIONS = 8;
+    public const ENVELOPE_VERSION_WITH_DEPRECATIONS_AND_BASELINE = 9;
+
+    /**
+     * Every accepted envelope version, in the order they were introduced.
+     * The pairs alternate plain / with-baseline because the baseline half is
+     * present only during an `OPENAPI_BASELINE_GENERATE` run, so it is
+     * orthogonal to the tracker half that raised the version.
+     */
+    private const ACCEPTED_VERSIONS = [
+        self::ENVELOPE_VERSION,
+        self::ENVELOPE_VERSION_WITH_BASELINE,
+        self::ENVELOPE_VERSION_WITH_STRICT_ADDITIONAL_PROPERTIES,
+        self::ENVELOPE_VERSION_WITH_STRICT_ADDITIONAL_PROPERTIES_AND_BASELINE,
+        self::ENVELOPE_VERSION_WITH_SDK_EXERCISE,
+        self::ENVELOPE_VERSION_WITH_SDK_EXERCISE_AND_BASELINE,
+        self::ENVELOPE_VERSION_WITH_DEPRECATIONS,
+        self::ENVELOPE_VERSION_WITH_DEPRECATIONS_AND_BASELINE,
+    ];
+
+    /** Versions whose writer always emits the `strictAdditionalProperties` half. */
+    private const VERSIONS_WITH_STRICT_ADDITIONAL_PROPERTIES = [
+        self::ENVELOPE_VERSION_WITH_STRICT_ADDITIONAL_PROPERTIES,
+        self::ENVELOPE_VERSION_WITH_STRICT_ADDITIONAL_PROPERTIES_AND_BASELINE,
+        self::ENVELOPE_VERSION_WITH_SDK_EXERCISE,
+        self::ENVELOPE_VERSION_WITH_SDK_EXERCISE_AND_BASELINE,
+        self::ENVELOPE_VERSION_WITH_DEPRECATIONS,
+        self::ENVELOPE_VERSION_WITH_DEPRECATIONS_AND_BASELINE,
+    ];
+
+    /** Versions whose writer always emits the `sdkExercise` half. */
+    private const VERSIONS_WITH_SDK_EXERCISE = [
+        self::ENVELOPE_VERSION_WITH_SDK_EXERCISE,
+        self::ENVELOPE_VERSION_WITH_SDK_EXERCISE_AND_BASELINE,
+        self::ENVELOPE_VERSION_WITH_DEPRECATIONS,
+        self::ENVELOPE_VERSION_WITH_DEPRECATIONS_AND_BASELINE,
+    ];
+
+    /** Versions whose writer always emits the `deprecations` half. */
+    private const VERSIONS_WITH_DEPRECATIONS = [
+        self::ENVELOPE_VERSION_WITH_DEPRECATIONS,
+        self::ENVELOPE_VERSION_WITH_DEPRECATIONS_AND_BASELINE,
+    ];
 
     private function __construct() {}
 
@@ -131,6 +185,7 @@ final class CoverageSidecarEnvelope
      * @param null|array<string, mixed> $baselineDocument
      * @param null|array<string, mixed> $strictAdditionalPropertiesState
      * @param null|array<string, mixed> $sdkExerciseState
+     * @param null|array<string, mixed> $deprecationsState
      *
      * @phpstan-param CoverageStatePayload $coverageState
      * @phpstan-param StrictRequiredStatePayload $strictRequiredState
@@ -144,58 +199,56 @@ final class CoverageSidecarEnvelope
         ?array $baselineDocument = null,
         ?array $strictAdditionalPropertiesState = null,
         ?array $sdkExerciseState = null,
+        ?array $deprecationsState = null,
     ): array {
-        if ($sdkExerciseState !== null) {
-            if ($strictAdditionalPropertiesState === null) {
-                throw new InvalidArgumentException('SDK exercise sidecar envelopes require strict additional-properties state.');
-            }
-
-            $payload = [
-                'envelopeVersion' => $baselineDocument === null
-                    ? self::ENVELOPE_VERSION_WITH_SDK_EXERCISE
-                    : self::ENVELOPE_VERSION_WITH_SDK_EXERCISE_AND_BASELINE,
-                'coverage' => $coverageState,
-                'strictRequired' => $strictRequiredState,
-                'strictAdditionalProperties' => $strictAdditionalPropertiesState,
-                'sdkExercise' => $sdkExerciseState,
-            ];
-            if ($baselineDocument !== null) {
-                $payload['baseline'] = $baselineDocument;
-            }
-
-            return $payload;
+        // The halves were introduced in order, and each version implies every
+        // earlier one, so a caller that supplies a later half without an
+        // earlier one is describing an envelope no reader can represent.
+        if ($sdkExerciseState !== null && $strictAdditionalPropertiesState === null) {
+            throw new InvalidArgumentException('SDK exercise sidecar envelopes require strict additional-properties state.');
         }
 
-        if ($strictAdditionalPropertiesState !== null) {
-            $payload = [
-                'envelopeVersion' => $baselineDocument === null
-                    ? self::ENVELOPE_VERSION_WITH_STRICT_ADDITIONAL_PROPERTIES
-                    : self::ENVELOPE_VERSION_WITH_STRICT_ADDITIONAL_PROPERTIES_AND_BASELINE,
-                'coverage' => $coverageState,
-                'strictRequired' => $strictRequiredState,
-                'strictAdditionalProperties' => $strictAdditionalPropertiesState,
-            ];
-            if ($baselineDocument !== null) {
-                $payload['baseline'] = $baselineDocument;
-            }
-
-            return $payload;
+        if ($deprecationsState !== null && $sdkExerciseState === null) {
+            throw new InvalidArgumentException('Deprecation sidecar envelopes require SDK exercise state.');
         }
 
-        if ($baselineDocument === null) {
-            return [
-                'envelopeVersion' => self::ENVELOPE_VERSION,
-                'coverage' => $coverageState,
-                'strictRequired' => $strictRequiredState,
-            ];
-        }
-
-        return [
-            'envelopeVersion' => self::ENVELOPE_VERSION_WITH_BASELINE,
+        $withBaseline = $baselineDocument !== null;
+        $payload = [
+            'envelopeVersion' => match (true) {
+                $deprecationsState !== null => $withBaseline
+                    ? self::ENVELOPE_VERSION_WITH_DEPRECATIONS_AND_BASELINE
+                    : self::ENVELOPE_VERSION_WITH_DEPRECATIONS,
+                $sdkExerciseState !== null => $withBaseline
+                    ? self::ENVELOPE_VERSION_WITH_SDK_EXERCISE_AND_BASELINE
+                    : self::ENVELOPE_VERSION_WITH_SDK_EXERCISE,
+                $strictAdditionalPropertiesState !== null => $withBaseline
+                    ? self::ENVELOPE_VERSION_WITH_STRICT_ADDITIONAL_PROPERTIES_AND_BASELINE
+                    : self::ENVELOPE_VERSION_WITH_STRICT_ADDITIONAL_PROPERTIES,
+                default => $withBaseline
+                    ? self::ENVELOPE_VERSION_WITH_BASELINE
+                    : self::ENVELOPE_VERSION,
+            },
             'coverage' => $coverageState,
             'strictRequired' => $strictRequiredState,
-            'baseline' => $baselineDocument,
         ];
+
+        if ($strictAdditionalPropertiesState !== null) {
+            $payload['strictAdditionalProperties'] = $strictAdditionalPropertiesState;
+        }
+
+        if ($sdkExerciseState !== null) {
+            $payload['sdkExercise'] = $sdkExerciseState;
+        }
+
+        if ($deprecationsState !== null) {
+            $payload['deprecations'] = $deprecationsState;
+        }
+
+        if ($baselineDocument !== null) {
+            $payload['baseline'] = $baselineDocument;
+        }
+
+        return $payload;
     }
 
     /**
@@ -231,11 +284,12 @@ final class CoverageSidecarEnvelope
             if (
                 array_key_exists('strictRequired', $payload) ||
                 array_key_exists('strictAdditionalProperties', $payload) ||
-                array_key_exists('sdkExercise', $payload)
+                array_key_exists('sdkExercise', $payload) ||
+                array_key_exists('deprecations', $payload)
             ) {
                 throw new InvalidArgumentException(
                     'Legacy v1 sidecar payload must not contain top-level "strictRequired" '
-                    . ', "strictAdditionalProperties", or "sdkExercise" keys; '
+                    . ', "strictAdditionalProperties", "sdkExercise", or "deprecations" keys; '
                     . 'expected a versioned envelope when strict data is present.',
                 );
             }
@@ -248,6 +302,7 @@ final class CoverageSidecarEnvelope
                 'strictRequired' => null,
                 'strictAdditionalProperties' => null,
                 'sdkExercise' => null,
+                'deprecations' => null,
                 'baseline' => null,
             ];
         }
@@ -265,26 +320,11 @@ final class CoverageSidecarEnvelope
     private static function parseEnvelope(array $payload): array
     {
         $version = $payload['envelopeVersion'] ?? null;
-        if (
-            !is_int($version) ||
-            !in_array($version, [
-                self::ENVELOPE_VERSION,
-                self::ENVELOPE_VERSION_WITH_BASELINE,
-                self::ENVELOPE_VERSION_WITH_STRICT_ADDITIONAL_PROPERTIES,
-                self::ENVELOPE_VERSION_WITH_STRICT_ADDITIONAL_PROPERTIES_AND_BASELINE,
-                self::ENVELOPE_VERSION_WITH_SDK_EXERCISE,
-                self::ENVELOPE_VERSION_WITH_SDK_EXERCISE_AND_BASELINE,
-            ], true)
-        ) {
+        if (!is_int($version) || !in_array($version, self::ACCEPTED_VERSIONS, true)) {
             throw new InvalidArgumentException(sprintf(
-                'Unsupported sidecar envelope version: got %s, expected one of %d, %d, %d, %d, %d, or %d.',
+                'Unsupported sidecar envelope version: got %s, expected one of %s.',
                 is_int($version) ? (string) $version : get_debug_type($version),
-                self::ENVELOPE_VERSION,
-                self::ENVELOPE_VERSION_WITH_BASELINE,
-                self::ENVELOPE_VERSION_WITH_STRICT_ADDITIONAL_PROPERTIES,
-                self::ENVELOPE_VERSION_WITH_STRICT_ADDITIONAL_PROPERTIES_AND_BASELINE,
-                self::ENVELOPE_VERSION_WITH_SDK_EXERCISE,
-                self::ENVELOPE_VERSION_WITH_SDK_EXERCISE_AND_BASELINE,
+                implode(', ', self::ACCEPTED_VERSIONS),
             ));
         }
 
@@ -304,51 +344,34 @@ final class CoverageSidecarEnvelope
             ));
         }
 
-        $strictAdditionalProperties = $payload['strictAdditionalProperties'] ?? null;
-        $hasStrictAdditionalProperties = in_array($version, [
-            self::ENVELOPE_VERSION_WITH_STRICT_ADDITIONAL_PROPERTIES,
-            self::ENVELOPE_VERSION_WITH_STRICT_ADDITIONAL_PROPERTIES_AND_BASELINE,
-            self::ENVELOPE_VERSION_WITH_SDK_EXERCISE,
-            self::ENVELOPE_VERSION_WITH_SDK_EXERCISE_AND_BASELINE,
-        ], true);
-        if ($hasStrictAdditionalProperties && !is_array($strictAdditionalProperties)) {
-            throw new InvalidArgumentException(sprintf(
-                'Sidecar envelope v%d "strictAdditionalProperties" must be an array; got %s.',
-                $version,
-                get_debug_type($strictAdditionalProperties),
-            ));
-        }
-        if (!$hasStrictAdditionalProperties && array_key_exists('strictAdditionalProperties', $payload)) {
-            throw new InvalidArgumentException(sprintf(
-                'Sidecar envelope v%d must not contain "strictAdditionalProperties"; expected envelopeVersion=4, 5, 6, or 7.',
-                $version,
-            ));
-        }
-
-        $sdkExercise = $payload['sdkExercise'] ?? null;
-        $hasSdkExercise = in_array($version, [
-            self::ENVELOPE_VERSION_WITH_SDK_EXERCISE,
-            self::ENVELOPE_VERSION_WITH_SDK_EXERCISE_AND_BASELINE,
-        ], true);
-        if ($hasSdkExercise && !is_array($sdkExercise)) {
-            throw new InvalidArgumentException(sprintf(
-                'Sidecar envelope v%d "sdkExercise" must be an array; got %s.',
-                $version,
-                get_debug_type($sdkExercise),
-            ));
-        }
-        if (!$hasSdkExercise && array_key_exists('sdkExercise', $payload)) {
-            throw new InvalidArgumentException(sprintf(
-                'Sidecar envelope v%d must not contain "sdkExercise"; expected envelopeVersion=6 or 7.',
-                $version,
-            ));
-        }
+        $strictAdditionalProperties = self::readHalf(
+            $payload,
+            $version,
+            'strictAdditionalProperties',
+            self::VERSIONS_WITH_STRICT_ADDITIONAL_PROPERTIES,
+            '4, 5, 6, 7, 8, or 9',
+        );
+        $sdkExercise = self::readHalf(
+            $payload,
+            $version,
+            'sdkExercise',
+            self::VERSIONS_WITH_SDK_EXERCISE,
+            '6, 7, 8, or 9',
+        );
+        $deprecations = self::readHalf(
+            $payload,
+            $version,
+            'deprecations',
+            self::VERSIONS_WITH_DEPRECATIONS,
+            '8 or 9',
+        );
 
         $baseline = $payload['baseline'] ?? null;
         if (in_array($version, [
             self::ENVELOPE_VERSION,
             self::ENVELOPE_VERSION_WITH_STRICT_ADDITIONAL_PROPERTIES,
             self::ENVELOPE_VERSION_WITH_SDK_EXERCISE,
+            self::ENVELOPE_VERSION_WITH_DEPRECATIONS,
         ], true)) {
             // A plain envelope must not smuggle a baseline half: accepting it
             // would silently drop generation data whenever a future writer
@@ -359,6 +382,7 @@ final class CoverageSidecarEnvelope
                     self::ENVELOPE_VERSION => self::ENVELOPE_VERSION_WITH_BASELINE,
                     self::ENVELOPE_VERSION_WITH_STRICT_ADDITIONAL_PROPERTIES => self::ENVELOPE_VERSION_WITH_STRICT_ADDITIONAL_PROPERTIES_AND_BASELINE,
                     self::ENVELOPE_VERSION_WITH_SDK_EXERCISE => self::ENVELOPE_VERSION_WITH_SDK_EXERCISE_AND_BASELINE,
+                    self::ENVELOPE_VERSION_WITH_DEPRECATIONS => self::ENVELOPE_VERSION_WITH_DEPRECATIONS_AND_BASELINE,
                 };
 
                 throw new InvalidArgumentException(sprintf(
@@ -382,7 +406,55 @@ final class CoverageSidecarEnvelope
             'strictRequired' => $strictRequired,
             'strictAdditionalProperties' => $strictAdditionalProperties,
             'sdkExercise' => $sdkExercise,
+            'deprecations' => $deprecations,
             'baseline' => $baseline,
         ];
+    }
+
+    /**
+     * Read one optional half whose presence is determined by the envelope
+     * version: required where the version declares it, forbidden elsewhere.
+     *
+     * A half present under a version that does not declare it is rejected for
+     * the same reason as the `baseline` guard below — silently ignoring it
+     * would drop a worker's data whenever a writer forgets the version bump.
+     *
+     * @param array<string, mixed> $payload
+     * @param list<int> $versionsCarryingHalf
+     *
+     * @return null|array<string, mixed>
+     */
+    private static function readHalf(
+        array $payload,
+        int $version,
+        string $key,
+        array $versionsCarryingHalf,
+        string $expectedVersions,
+    ): ?array {
+        $value = $payload[$key] ?? null;
+
+        if (in_array($version, $versionsCarryingHalf, true)) {
+            if (!is_array($value)) {
+                throw new InvalidArgumentException(sprintf(
+                    'Sidecar envelope v%d "%s" must be an array; got %s.',
+                    $version,
+                    $key,
+                    get_debug_type($value),
+                ));
+            }
+
+            return $value;
+        }
+
+        if (array_key_exists($key, $payload)) {
+            throw new InvalidArgumentException(sprintf(
+                'Sidecar envelope v%d must not contain "%s"; expected envelopeVersion=%s.',
+                $version,
+                $key,
+                $expectedVersions,
+            ));
+        }
+
+        return null;
     }
 }

--- a/src/Internal/Deprecations.php
+++ b/src/Internal/Deprecations.php
@@ -9,13 +9,15 @@ use const E_USER_DEPRECATED;
 use InvalidArgumentException;
 
 use function array_key_exists;
-use function array_keys;
 use function array_map;
-use function array_sum;
 use function array_unique;
 use function array_values;
 use function count;
+use function get_debug_type;
 use function implode;
+use function is_array;
+use function is_int;
+use function is_string;
 use function ksort;
 use function sprintf;
 use function trigger_error;
@@ -38,10 +40,23 @@ use function trim;
  * still depends on the surface.
  *
  * @internal Not part of the package's public API. Do not use from user code.
+ *
+ * @phpstan-type DeprecationEntry array{count: int<1, max>, removed_in: string}
+ * @phpstan-type DeprecationStatePayload array{
+ *     version: int,
+ *     deprecations: array<string, DeprecationEntry>,
+ * }
  */
 final class Deprecations
 {
     public const PREFIX = '[Gesso deprecation]';
+
+    /**
+     * Wire version of {@see self::exportState()}, carried inside the sidecar
+     * envelope and owned by this class rather than by the envelope version —
+     * the same split the coverage and strict-required trackers use.
+     */
+    public const STATE_VERSION = 1;
 
     /** @var array<string, int<1, max>> */
     private static array $counts = [];
@@ -108,41 +123,109 @@ final class Deprecations
     }
 
     /**
+     * This process's notice state, in the shape the sidecar envelope carries.
+     *
+     * A paratest worker never reaches the end-of-run report — it hands its
+     * state to `gesso coverage:merge` instead, exactly as the coverage and
+     * strict-required trackers do. Exported unconditionally, including as an
+     * empty map: the envelope version determines whether the key is present,
+     * and "this worker saw none" is the load-bearing half of the report.
+     *
+     * @return DeprecationStatePayload
+     */
+    public static function exportState(): array
+    {
+        $entries = [];
+        foreach (self::counts() as $id => $count) {
+            $entries[$id] = ['count' => $count, 'removed_in' => self::$removedIn[$id]];
+        }
+
+        return ['version' => self::STATE_VERSION, 'deprecations' => $entries];
+    }
+
+    /**
+     * Sum several workers' exported states into one id → entry map.
+     *
+     * Counts add; the removal version is taken from the first sidecar that
+     * declares the id, since a mixed-version fleet that disagrees about when a
+     * surface disappears is reporting a library-version skew, not two facts.
+     *
+     * @param list<array<string, mixed>> $payloads
+     *
+     * @return array<string, DeprecationEntry>
+     *
+     * @throws InvalidArgumentException on an unknown state version or a
+     *                                  malformed entry
+     */
+    public static function mergeStates(array $payloads): array
+    {
+        $merged = [];
+        foreach ($payloads as $payload) {
+            foreach (self::parseState($payload) as $id => $entry) {
+                $merged[$id] = array_key_exists($id, $merged)
+                    ? ['count' => $merged[$id]['count'] + $entry['count'], 'removed_in' => $merged[$id]['removed_in']]
+                    : $entry;
+            }
+        }
+
+        ksort($merged);
+
+        return $merged;
+    }
+
+    /**
      * The one-line residual report written after a test run, or `null` when no
      * deprecated surface was used. Silence is the "ready for the next major"
      * signal, so an empty state must produce no line at all.
+     *
+     * Takes the state as an argument so the sequential PHPUnit run and the
+     * merge CLI — which reports a union it never emitted itself — render the
+     * same line from the same code.
+     *
+     * @param array<string, DeprecationEntry> $state
      */
-    public static function summaryLine(): ?string
+    public static function renderSummary(array $state): ?string
     {
-        $counts = self::counts();
-        if ($counts === []) {
+        if ($state === []) {
             return null;
         }
 
+        ksort($state);
         $versions = array_values(array_unique(array_map(
-            static fn(string $id): string => self::$removedIn[$id],
-            array_keys($counts),
+            static fn(array $entry): string => $entry['removed_in'],
+            $state,
         )));
 
         // One shared removal version is the normal case and reads better as a
         // trailing sentence; a mixed set has to carry the version per id or the
         // sentence would claim something false about some of them.
         $single = count($versions) === 1;
+        $calls = 0;
         $entries = [];
-        foreach ($counts as $id => $count) {
+        foreach ($state as $id => $entry) {
+            $calls += $entry['count'];
             $entries[] = $single
-                ? sprintf('%s (%d)', $id, $count)
-                : sprintf('%s (%d, removed in %s)', $id, $count, self::$removedIn[$id]);
+                ? sprintf('%s (%d)', $id, $entry['count'])
+                : sprintf('%s (%d, removed in %s)', $id, $entry['count'], $entry['removed_in']);
         }
 
         return sprintf(
             "%s %d deprecated surface(s) still in use, %d call(s): %s.%s\n",
             self::PREFIX,
-            count($counts),
-            array_sum($counts),
+            count($state),
+            $calls,
             implode(', ', $entries),
             $single ? sprintf(' All are removed in Gesso %s.', $versions[0]) : '',
         );
+    }
+
+    /**
+     * The one-line residual report for this process, or `null` when it used no
+     * deprecated surface.
+     */
+    public static function summaryLine(): ?string
+    {
+        return self::renderSummary(self::exportState()['deprecations']);
     }
 
     /**
@@ -156,6 +239,63 @@ final class Deprecations
     {
         self::$counts = [];
         self::$removedIn = [];
+    }
+
+    /**
+     * Validate one exported state payload and return its entry map.
+     *
+     * Unknown versions are rejected rather than guessed, matching every other
+     * sidecar half: a newer worker's state reaching an older merge CLI must
+     * fail loudly instead of silently reporting a partial deprecation count,
+     * which reads as "ready for the next major".
+     *
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, DeprecationEntry>
+     */
+    private static function parseState(array $payload): array
+    {
+        $version = $payload['version'] ?? null;
+        if ($version !== self::STATE_VERSION) {
+            throw new InvalidArgumentException(sprintf(
+                'Unsupported deprecation state version: got %s, expected %d.',
+                is_int($version) ? (string) $version : get_debug_type($version),
+                self::STATE_VERSION,
+            ));
+        }
+
+        $entries = $payload['deprecations'] ?? null;
+        if (!is_array($entries)) {
+            throw new InvalidArgumentException(sprintf(
+                'Deprecation state "deprecations" must be an array; got %s.',
+                get_debug_type($entries),
+            ));
+        }
+
+        $parsed = [];
+        foreach ($entries as $id => $entry) {
+            if (!is_string($id) || trim($id) === '') {
+                throw new InvalidArgumentException('Deprecation state keys must be non-empty id strings.');
+            }
+
+            if (!is_array($entry) || !is_int($entry['count'] ?? null) || !is_string($entry['removed_in'] ?? null)) {
+                throw new InvalidArgumentException(sprintf(
+                    'Deprecation state entry "%s" must declare an integer "count" and a string "removed_in".',
+                    $id,
+                ));
+            }
+
+            if ($entry['count'] < 1 || trim($entry['removed_in']) === '') {
+                throw new InvalidArgumentException(sprintf(
+                    'Deprecation state entry "%s" must declare a positive "count" and a non-empty "removed_in".',
+                    $id,
+                ));
+            }
+
+            $parsed[$id] = ['count' => $entry['count'], 'removed_in' => $entry['removed_in']];
+        }
+
+        return $parsed;
     }
 
     private static function rejectEmpty(string $parameter, string $value): void

--- a/src/Internal/Deprecations.php
+++ b/src/Internal/Deprecations.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Internal;
+
+use const E_USER_DEPRECATED;
+
+use InvalidArgumentException;
+
+use function array_key_exists;
+use function array_keys;
+use function array_map;
+use function array_sum;
+use function array_unique;
+use function array_values;
+use function count;
+use function implode;
+use function ksort;
+use function sprintf;
+use function trigger_error;
+use function trim;
+
+/**
+ * The single emitter for Gesso's `E_USER_DEPRECATED` channel (issue #499).
+ *
+ * A deprecation that does not name its successor and its removal version is
+ * unrepresentable here: `$replacement` and `$removedIn` are required and
+ * rejected when empty. That is the point of routing every deprecation through
+ * one method instead of scattering `trigger_error()` calls — the registry in
+ * `tests/fixtures/compatibility/v2-deprecations.json` can then be checked
+ * against the call sites, and a major that removes a surface has a list to
+ * delete from.
+ *
+ * Notices dedup per `$id` per process, matching the `E_USER_WARNING` channel's
+ * contract (`docs/supported-features.md`). Counts keep accumulating after the
+ * first emission so the end-of-run summary can report how much of a suite
+ * still depends on the surface.
+ *
+ * @internal Not part of the package's public API. Do not use from user code.
+ */
+final class Deprecations
+{
+    public const PREFIX = '[Gesso deprecation]';
+
+    /** @var array<string, int<1, max>> */
+    private static array $counts = [];
+
+    /** @var array<string, string> */
+    private static array $removedIn = [];
+
+    private function __construct() {}
+
+    /**
+     * Record one use of a deprecated surface, emitting the notice on the first
+     * use in this process.
+     *
+     * @param string $id Stable dedup key, also the registry key. Dotted
+     *                   and scoped by surface, e.g.
+     *                   `laravel.config.auto_inject_dummy_bearer`.
+     * @param string $subject Human-readable name of what is deprecated, as it
+     *                        reads in the middle of a sentence.
+     * @param string $replacement What to use instead.
+     * @param string $removedIn Gesso version that removes the surface, e.g. `3.0`.
+     */
+    public static function notice(
+        string $id,
+        string $subject,
+        string $replacement,
+        string $removedIn,
+    ): void {
+        self::rejectEmpty('id', $id);
+        self::rejectEmpty('subject', $subject);
+        self::rejectEmpty('replacement', $replacement);
+        self::rejectEmpty('removedIn', $removedIn);
+
+        $alreadyNotified = array_key_exists($id, self::$counts);
+        self::$counts[$id] = $alreadyNotified ? self::$counts[$id] + 1 : 1;
+        self::$removedIn[$id] = $removedIn;
+
+        if ($alreadyNotified) {
+            return;
+        }
+
+        trigger_error(
+            sprintf(
+                '%s %s is deprecated. Use %s instead. It is removed in Gesso %s. See UPGRADING.md#deprecations.',
+                self::PREFIX,
+                $subject,
+                $replacement,
+                $removedIn,
+            ),
+            E_USER_DEPRECATED,
+        );
+    }
+
+    /**
+     * Per-id call counts for this process, keyed by the `notice()` id.
+     *
+     * @return array<string, int<1, max>>
+     */
+    public static function counts(): array
+    {
+        $counts = self::$counts;
+        ksort($counts);
+
+        return $counts;
+    }
+
+    /**
+     * The one-line residual report written after a test run, or `null` when no
+     * deprecated surface was used. Silence is the "ready for the next major"
+     * signal, so an empty state must produce no line at all.
+     */
+    public static function summaryLine(): ?string
+    {
+        $counts = self::counts();
+        if ($counts === []) {
+            return null;
+        }
+
+        $versions = array_values(array_unique(array_map(
+            static fn(string $id): string => self::$removedIn[$id],
+            array_keys($counts),
+        )));
+
+        // One shared removal version is the normal case and reads better as a
+        // trailing sentence; a mixed set has to carry the version per id or the
+        // sentence would claim something false about some of them.
+        $single = count($versions) === 1;
+        $entries = [];
+        foreach ($counts as $id => $count) {
+            $entries[] = $single
+                ? sprintf('%s (%d)', $id, $count)
+                : sprintf('%s (%d, removed in %s)', $id, $count, self::$removedIn[$id]);
+        }
+
+        return sprintf(
+            "%s %d deprecated surface(s) still in use, %d call(s): %s.%s\n",
+            self::PREFIX,
+            count($counts),
+            array_sum($counts),
+            implode(', ', $entries),
+            $single ? sprintf(' All are removed in Gesso %s.', $versions[0]) : '',
+        );
+    }
+
+    /**
+     * Clear the per-process notice state. Test seam — production code never
+     * needs this. Named for the `*::resetWarningStateForTesting()` convention
+     * used by the warning channel's emitters.
+     *
+     * @internal
+     */
+    public static function resetForTesting(): void
+    {
+        self::$counts = [];
+        self::$removedIn = [];
+    }
+
+    private static function rejectEmpty(string $parameter, string $value): void
+    {
+        if (trim($value) !== '') {
+            return;
+        }
+
+        throw new InvalidArgumentException(sprintf(
+            'Deprecations::notice() requires a non-empty $%s.',
+            $parameter,
+        ));
+    }
+}

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -32,6 +32,7 @@ use Studio\Gesso\Coverage\SdkExerciseCoverageTracker;
 use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\Exception\InvalidOpenApiSpecReason;
 use Studio\Gesso\Exception\SpecFileNotFoundException;
+use Studio\Gesso\Internal\Deprecations;
 use Studio\Gesso\Internal\PartialRunDecision;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 use Studio\Gesso\Validation\Strict\StrictAdditionalPropertiesAsserter;
@@ -204,6 +205,11 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         }
 
         $this->restoreSpecLoaderConfigurationIfReset();
+
+        // Written before the gates below because `strict_*` in fail mode can
+        // terminate the process; the residual count is the migration signal for
+        // the next major and must not depend on the run passing.
+        $this->reportDeprecations();
 
         $results = $this->computeAllResults();
         $sdkResults = $this->computeAllSdkResults();
@@ -660,6 +666,22 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
             $collector->baseline()->count(),
             $this->baselineGeneratePath,
         ));
+    }
+
+    /**
+     * Write the one-line residual deprecation count, or nothing when no
+     * deprecated surface was used in this run. {@see Deprecations::summaryLine()}
+     * owns the wording; the subscriber only decides where it goes and that it
+     * is stderr, for the reason recorded on `writeStderr()`.
+     */
+    private function reportDeprecations(): void
+    {
+        $line = Deprecations::summaryLine();
+        if ($line === null) {
+            return;
+        }
+
+        $this->writeStderr($line);
     }
 
     /**

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -572,12 +572,18 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         // workers. The strict_required half is always exported, independent
         // of the worker's `strict_required` mode — the merge CLI decides
         // whether to assert (Issue #226).
+        //
+        // Issue #499: the deprecation half travels the same way. A worker
+        // returns before the end-of-run report, so without this the residual
+        // count would be empty for every parallel run — and an empty count is
+        // exactly the "ready for the next major" signal.
         $envelope = CoverageSidecarEnvelope::build(
             coverageState: $this->coverageTracker->exportStateOn(),
             strictRequiredState: $this->strictRequiredTracker->exportStateOn(),
             baselineDocument: $baselineDocument,
             strictAdditionalPropertiesState: $this->strictAdditionalPropertiesTracker->exportStateOn(),
             sdkExerciseState: $this->sdkExerciseCoverageTracker->exportStateOn(),
+            deprecationsState: Deprecations::exportState(),
         );
 
         try {

--- a/tests/Unit/Compatibility/DeprecationRegistryTest.php
+++ b/tests/Unit/Compatibility/DeprecationRegistryTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Compatibility;
+
+use const JSON_THROW_ON_ERROR;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+use function array_keys;
+use function dirname;
+use function file_get_contents;
+use function json_decode;
+use function preg_match_all;
+use function sort;
+
+/**
+ * The registry fixture is the ordering artifact between the deprecation
+ * release and the major that removes the surfaces (issue #499): a removal PR
+ * deletes the entry it removes, so a removal with nothing to delete never
+ * shipped a deprecation.
+ *
+ * This test keeps the fixture and the call sites in `src/` in sync in both
+ * directions, and rejects an entry that cannot answer "use what instead, and
+ * gone when?".
+ */
+final class DeprecationRegistryTest extends TestCase
+{
+    #[Test]
+    public function every_notice_id_in_src_has_a_registry_entry(): void
+    {
+        $registered = array_keys($this->registry());
+        sort($registered);
+
+        $this->assertSame($registered, $this->emittedIds());
+    }
+
+    #[Test]
+    public function every_registry_entry_names_its_replacement_and_removal(): void
+    {
+        foreach ($this->registry() as $id => $entry) {
+            $this->assertIsArray($entry, $id);
+
+            foreach (['surface', 'replacement', 'removed_in'] as $key) {
+                $this->assertArrayHasKey($key, $entry, $id);
+                $this->assertIsString($entry[$key], $id . '.' . $key);
+                $this->assertNotSame('', $entry[$key], $id . '.' . $key);
+            }
+        }
+    }
+
+    /**
+     * Every call site passes `id:` as a named argument with a single-quoted
+     * literal, so the registry can be checked statically. A call that computes
+     * its id is intentionally unsupported: an id that varies at runtime cannot
+     * be listed here, and therefore cannot be deleted from here either.
+     *
+     * @return list<string>
+     */
+    private function emittedIds(): array
+    {
+        $ids = [];
+
+        foreach ($this->sourceFiles() as $contents) {
+            preg_match_all("/Deprecations::notice\(\s*id:\s*'([^']+)'/", $contents, $matches);
+            foreach ($matches[1] as $id) {
+                $ids[$id] = true;
+            }
+        }
+
+        $ids = array_keys($ids);
+        sort($ids);
+
+        return $ids;
+    }
+
+    /** @return array<string, mixed> */
+    private function registry(): array
+    {
+        $contents = file_get_contents(
+            dirname(__DIR__, 2) . '/fixtures/compatibility/v2-deprecations.json',
+        );
+        $this->assertIsString($contents);
+
+        /** @var array{deprecations: array<string, mixed>} $fixture */
+        $fixture = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+
+        return $fixture['deprecations'];
+    }
+
+    /** @return list<string> */
+    private function sourceFiles(): array
+    {
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator(dirname(__DIR__, 3) . '/src'),
+        );
+        $sources = [];
+
+        /** @var SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $contents = file_get_contents($file->getPathname());
+            $this->assertIsString($contents);
+            $sources[] = $contents;
+        }
+
+        return $sources;
+    }
+}

--- a/tests/Unit/Compatibility/DeprecationRegistryTest.php
+++ b/tests/Unit/Compatibility/DeprecationRegistryTest.php
@@ -5,19 +5,46 @@ declare(strict_types=1);
 namespace Studio\Gesso\Tests\Unit\Compatibility;
 
 use const JSON_THROW_ON_ERROR;
+use const T_AS;
+use const T_ATTRIBUTE;
+use const T_CLASS;
+use const T_COMMENT;
+use const T_CONSTANT_ENCAPSED_STRING;
+use const T_CURLY_OPEN;
+use const T_DOC_COMMENT;
+use const T_DOLLAR_OPEN_CURLY_BRACES;
+use const T_DOUBLE_COLON;
+use const T_NAME_FULLY_QUALIFIED;
+use const T_NAME_QUALIFIED;
+use const T_NAMESPACE;
+use const T_STRING;
+use const T_USE;
+use const T_WHITESPACE;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
+use Studio\Gesso\Internal\Deprecations;
 
+use function array_key_exists;
 use function array_keys;
+use function count;
 use function dirname;
+use function explode;
 use function file_get_contents;
+use function implode;
+use function in_array;
+use function is_array;
 use function json_decode;
-use function preg_match_all;
+use function ltrim;
 use function sort;
+use function sprintf;
+use function stripslashes;
+use function strtolower;
+use function substr;
+use function token_get_all;
 
 /**
  * The registry fixture is the ordering artifact between the deprecation
@@ -25,12 +52,16 @@ use function sort;
  * deletes the entry it removes, so a removal with nothing to delete never
  * shipped a deprecation.
  *
- * This test keeps the fixture and the call sites in `src/` in sync in both
- * directions, and rejects an entry that cannot answer "use what instead, and
- * gone when?".
+ * The scan below is deliberately token-based rather than textual. A regex over
+ * one call spelling would leave every other spelling — positional arguments,
+ * an aliased import, a computed id — invisible to the registry check, which is
+ * the one failure mode that matters here: a deprecation nobody can find is a
+ * deprecation nobody deletes.
  */
 final class DeprecationRegistryTest extends TestCase
 {
+    private const EMITTER = Deprecations::class;
+
     #[Test]
     public function every_notice_id_in_src_has_a_registry_entry(): void
     {
@@ -54,29 +85,454 @@ final class DeprecationRegistryTest extends TestCase
         }
     }
 
+    #[Test]
+    public function the_scanner_finds_every_call_spelling(): void
+    {
+        // Guards the guard: if this scan silently stopped matching, the
+        // registry check above would pass vacuously forever. Each snippet is
+        // a spelling the scan must resolve to the same emitter.
+        $spellings = [
+            "<?php\nnamespace X;\nuse Studio\\Gesso\\Internal\\Deprecations;\nDeprecations::notice(id: 'a', subject: 's', replacement: 'r', removedIn: '3.0');",
+            "<?php\nnamespace X;\nuse Studio\\Gesso\\Internal\\Deprecations as D;\nD::notice('a', 's', 'r', '3.0');",
+            "<?php\nnamespace X;\n\\Studio\\Gesso\\Internal\\Deprecations::notice(subject: 's', id: 'a', replacement: 'r', removedIn: '3.0');",
+            "<?php\nnamespace Studio\\Gesso\\Internal;\nDeprecations::notice('a', 's', 'r', '3.0');",
+            "<?php\nnamespace X;\nuse Studio\\Gesso\\Internal;\nInternal\\Deprecations::notice('a', 's', 'r', '3.0');",
+        ];
+
+        foreach ($spellings as $index => $source) {
+            $this->assertSame(['a'], $this->scan('snippet-' . $index, $source), 'spelling ' . $index);
+        }
+    }
+
+    #[Test]
+    public function the_scanner_ignores_a_notice_call_on_another_class(): void
+    {
+        $source = "<?php\nnamespace X;\nuse X\\Logger;\nLogger::notice('not-a-deprecation');";
+
+        $this->assertSame([], $this->scan('other-class', $source));
+    }
+
+    #[Test]
+    public function a_computed_id_fails_instead_of_going_unnoticed(): void
+    {
+        $source = "<?php\nnamespace X;\nuse Studio\\Gesso\\Internal\\Deprecations;\n"
+            . "Deprecations::notice(id: \$key, subject: 's', replacement: 'r', removedIn: '3.0');";
+
+        $failures = [];
+        $this->scan('computed', $source, $failures);
+
+        $this->assertCount(1, $failures);
+        $this->assertStringContainsString('the id must be a literal string', $failures[0]);
+    }
+
+    #[Test]
+    public function a_mis_cased_call_is_still_resolved(): void
+    {
+        // PHP resolves class and method names case-insensitively, so these
+        // reach the real emitter. A scanner that matched the source spelling
+        // would let them ship without a registry entry.
+        $spellings = [
+            "<?php\nnamespace X;\nuse Studio\\Gesso\\Internal\\Deprecations;\nDeprecations::Notice('a', 's', 'r', '3.0');",
+            "<?php\nnamespace X;\nuse Studio\\Gesso\\Internal\\Deprecations;\nDeprecations::NOTICE('a', 's', 'r', '3.0');",
+            "<?php\nnamespace X;\n\\Studio\\Gesso\\INTERNAL\\Deprecations::notice('a', 's', 'r', '3.0');",
+        ];
+
+        foreach ($spellings as $index => $source) {
+            $this->assertSame(['a'], $this->scan('cased-' . $index, $source), 'spelling ' . $index);
+        }
+    }
+
+    #[Test]
+    public function an_interpolated_argument_does_not_hide_a_literal_id(): void
+    {
+        // `"{$x}"` opens its brace with an array token and closes it with a
+        // plain `}`. Counting only the plain openers ran the argument split
+        // off the end of the file, which surfaced as "the id is not a literal"
+        // on a call whose id is a literal — sending the author after the wrong
+        // problem, and hiding a real registry gap behind a wrong explanation.
+        $source = "<?php\nnamespace X;\nuse Studio\\Gesso\\Internal\\Deprecations;\n"
+            . "Deprecations::notice(subject: \"the {\$name} option\", id: 'laravel.config.legacy',"
+            . " replacement: 'r', removedIn: '3.0');\n"
+            . "Deprecations::notice(id: 'second.call', subject: 's', replacement: 'r', removedIn: '3.0');";
+
+        $failures = [];
+
+        $this->assertSame(['laravel.config.legacy', 'second.call'], $this->scan('interpolated', $source, $failures));
+        $this->assertSame([], $failures);
+    }
+
+    #[Test]
+    public function an_unterminated_call_says_so_rather_than_blaming_the_id(): void
+    {
+        $source = "<?php\nnamespace X;\nuse Studio\\Gesso\\Internal\\Deprecations;\n"
+            . "Deprecations::notice(id: 'a', subject: 's'";
+
+        $failures = [];
+        $this->scan('unterminated', $source, $failures);
+
+        $this->assertCount(1, $failures);
+        $this->assertStringContainsString('did not find the closing parenthesis', $failures[0]);
+    }
+
     /**
-     * Every call site passes `id:` as a named argument with a single-quoted
-     * literal, so the registry can be checked statically. A call that computes
-     * its id is intentionally unsupported: an id that varies at runtime cannot
-     * be listed here, and therefore cannot be deleted from here either.
+     * Every id emitted through {@see Deprecations::notice()} anywhere in
+     * `src/`, sorted. A call whose id cannot be read statically fails the test
+     * rather than being skipped — an id the registry cannot list is an id the
+     * removing major cannot delete.
      *
      * @return list<string>
      */
     private function emittedIds(): array
     {
         $ids = [];
+        $failures = [];
 
-        foreach ($this->sourceFiles() as $contents) {
-            preg_match_all("/Deprecations::notice\(\s*id:\s*'([^']+)'/", $contents, $matches);
-            foreach ($matches[1] as $id) {
+        foreach ($this->sourceFiles() as $file => $contents) {
+            foreach ($this->scan($file, $contents, $failures) as $id) {
                 $ids[$id] = true;
             }
         }
+
+        $this->assertSame([], $failures, 'every Deprecations::notice() id must be statically readable');
 
         $ids = array_keys($ids);
         sort($ids);
 
         return $ids;
+    }
+
+    /**
+     * Resolve every `Deprecations::notice()` call in one PHP source and return
+     * its ids. Unreadable ids are appended to `$failures` rather than thrown,
+     * so one scan reports every offending call site at once.
+     *
+     * @param list<string> $failures
+     *
+     * @return list<string>
+     */
+    private function scan(string $file, string $contents, array &$failures = []): array
+    {
+        $tokens = $this->significantTokens($contents);
+        $namespace = $this->namespaceOf($tokens);
+        $aliases = $this->importsOf($tokens);
+        $selfClass = $this->classOf($tokens, $namespace);
+        $ids = [];
+
+        foreach ($tokens as $index => $token) {
+            if (!is_array($token) || !$this->isStaticCallTo($tokens, $index, 'notice')) {
+                continue;
+            }
+
+            // Class names are case-insensitive to PHP too, so the comparison
+            // must be as well or a mis-cased reference reaches the emitter
+            // while the registry never sees it.
+            if (strtolower($this->resolve($token, $namespace, $aliases, $selfClass)) !== strtolower(self::EMITTER)) {
+                continue;
+            }
+
+            $id = $this->idArgument($tokens, $index + 3, $reason);
+            if ($id === null) {
+                $failures[] = sprintf(
+                    '%s: this Deprecations::notice() call cannot be checked against the deprecation '
+                    . 'registry because %s.',
+                    $file,
+                    $reason ?? 'the id could not be read',
+                );
+
+                continue;
+            }
+
+            $ids[] = $id;
+        }
+
+        return $ids;
+    }
+
+    /**
+     * Drop whitespace and comments so callers can index neighbours directly.
+     *
+     * @return list<array{int, string}|string>
+     */
+    private function significantTokens(string $contents): array
+    {
+        $tokens = [];
+        foreach (token_get_all($contents) as $token) {
+            if (is_array($token) && in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                continue;
+            }
+
+            $tokens[] = is_array($token) ? [$token[0], $token[1]] : $token;
+        }
+
+        return $tokens;
+    }
+
+    /**
+     * True when `$tokens[$index]` is the class part of a `Class::$method(`
+     * static call.
+     *
+     * @param list<array{int, string}|string> $tokens
+     */
+    private function isStaticCallTo(array $tokens, int $index, string $method): bool
+    {
+        $class = $tokens[$index] ?? null;
+        if (!is_array($class) || !in_array($class[0], [T_STRING, T_NAME_QUALIFIED, T_NAME_FULLY_QUALIFIED], true)) {
+            return false;
+        }
+
+        $operator = $tokens[$index + 1] ?? null;
+        $name = $tokens[$index + 2] ?? null;
+
+        return is_array($operator) &&
+            $operator[0] === T_DOUBLE_COLON &&
+            is_array($name) &&
+            $name[0] === T_STRING &&
+            // PHP resolves method names case-insensitively, so `::Notice(`
+            // reaches the same emitter. Matching the source spelling would let
+            // that call site skip the registry entirely.
+            strtolower($name[1]) === $method &&
+            ($tokens[$index + 3] ?? null) === '(';
+    }
+
+    /**
+     * The `id` argument of the call whose `(` sits at `$open`, or `null` when
+     * it cannot be read. Prefers the `id:` named argument and falls back to the
+     * first positional one, matching PHP's own resolution order. `$reason`
+     * receives the explanation, so a scan that cannot read an id says which
+     * kind of unreadable it hit rather than guessing.
+     *
+     * @param list<array{int, string}|string> $tokens
+     */
+    private function idArgument(array $tokens, int $open, ?string &$reason = null): ?string
+    {
+        $reason = null;
+        $arguments = $this->argumentSegments($tokens, $open);
+        if ($arguments === null) {
+            $reason = 'its argument list could not be split into arguments — the scanner did not '
+                . 'find the closing parenthesis, so it cannot see the id';
+
+            return null;
+        }
+
+        $notALiteral = 'the id must be a literal string so the deprecation registry can list it';
+
+        foreach ($arguments as $segment) {
+            $head = $segment[0] ?? null;
+            if (is_array($head) && $head[0] === T_STRING && $head[1] === 'id' && ($segment[1] ?? null) === ':') {
+                $id = $this->literal($segment, 2);
+                $reason = $id === null ? $notALiteral : null;
+
+                return $id;
+            }
+        }
+
+        $first = $arguments[0] ?? null;
+        $head = $first[0] ?? null;
+        // A named argument in first position that is not `id` means the call
+        // passes no positional id at all.
+        if ($first === null || (is_array($head) && $head[0] === T_STRING && ($first[1] ?? null) === ':')) {
+            $reason = 'the call passes no id argument';
+
+            return null;
+        }
+
+        $id = $this->literal($first, 0);
+        $reason = $id === null ? $notALiteral : null;
+
+        return $id;
+    }
+
+    /**
+     * Split the argument list opened at `$open` into per-argument token runs,
+     * ignoring commas nested inside brackets. `null` when the matching `)` was
+     * never reached — a scan that ran off the end has not read the arguments,
+     * and reporting its garbage as "the id is not a literal" would send the
+     * author after the wrong problem.
+     *
+     * @param list<array{int, string}|string> $tokens
+     *
+     * @return null|list<list<array{int, string}|string>>
+     */
+    private function argumentSegments(array $tokens, int $open): ?array
+    {
+        $segments = [];
+        $current = [];
+        $depth = 0;
+        $closed = false;
+
+        for ($i = $open + 1, $count = count($tokens); $i < $count; $i++) {
+            $token = $tokens[$i];
+
+            // Interpolation and attributes open a bracket with an array token
+            // (`T_CURLY_OPEN` for `"{$x}"`, `T_ATTRIBUTE` for `#[`) but close
+            // it with a plain `}` / `]`. Counting only the plain openers drives
+            // the depth negative and swallows the rest of the file.
+            if (is_array($token)) {
+                if (in_array($token[0], [T_CURLY_OPEN, T_DOLLAR_OPEN_CURLY_BRACES, T_ATTRIBUTE], true)) {
+                    $depth++;
+                }
+
+                $current[] = $token;
+
+                continue;
+            }
+
+            if (in_array($token, ['(', '[', '{'], true)) {
+                $depth++;
+            } elseif (in_array($token, [')', ']', '}'], true)) {
+                if ($token === ')' && $depth === 0) {
+                    $closed = true;
+
+                    break;
+                }
+
+                $depth--;
+            } elseif ($token === ',' && $depth === 0) {
+                $segments[] = $current;
+                $current = [];
+
+                continue;
+            }
+
+            $current[] = $token;
+        }
+
+        if (!$closed || $depth !== 0) {
+            return null;
+        }
+
+        if ($current !== []) {
+            $segments[] = $current;
+        }
+
+        return $segments;
+    }
+
+    /**
+     * The value of `$segment` from `$offset` on, when it is exactly one string
+     * literal. Anything else — a constant, a variable, a concatenation — is
+     * `null`, because the registry has to be able to name the id.
+     *
+     * @param list<array{int, string}|string> $segment
+     */
+    private function literal(array $segment, int $offset): ?string
+    {
+        $value = $segment[$offset] ?? null;
+        if (count($segment) !== $offset + 1 || !is_array($value) || $value[0] !== T_CONSTANT_ENCAPSED_STRING) {
+            return null;
+        }
+
+        // A double-quoted literal that interpolated anything would not have
+        // survived as one T_CONSTANT_ENCAPSED_STRING, so unescaping is safe.
+        return stripslashes(substr($value[1], 1, -1));
+    }
+
+    /** @param list<array{int, string}|string> $tokens */
+    private function namespaceOf(array $tokens): string
+    {
+        foreach ($tokens as $index => $token) {
+            if (!is_array($token) || $token[0] !== T_NAMESPACE) {
+                continue;
+            }
+
+            $name = $tokens[$index + 1] ?? null;
+
+            return is_array($name) ? $name[1] : '';
+        }
+
+        return '';
+    }
+
+    /**
+     * Short name (lowercased) → imported FQCN, for both `use A\B;` and
+     * `use A\B as C;`.
+     *
+     * @param list<array{int, string}|string> $tokens
+     *
+     * @return array<string, string>
+     */
+    private function importsOf(array $tokens): array
+    {
+        $imports = [];
+
+        foreach ($tokens as $index => $token) {
+            if (!is_array($token) || $token[0] !== T_USE) {
+                continue;
+            }
+
+            $name = $tokens[$index + 1] ?? null;
+            if (!is_array($name) || !in_array($name[0], [T_STRING, T_NAME_QUALIFIED, T_NAME_FULLY_QUALIFIED], true)) {
+                continue;
+            }
+
+            $fqcn = ltrim($name[1], '\\');
+            $next = $tokens[$index + 2] ?? null;
+            if (is_array($next) && $next[0] === T_AS) {
+                $alias = $tokens[$index + 3] ?? null;
+                if (is_array($alias)) {
+                    $imports[strtolower($alias[1])] = $fqcn;
+                }
+
+                continue;
+            }
+
+            $segments = explode('\\', $fqcn);
+            $imports[strtolower($segments[count($segments) - 1])] = $fqcn;
+        }
+
+        return $imports;
+    }
+
+    /**
+     * The FQCN of the first class declared in the file, so `self::` resolves.
+     *
+     * @param list<array{int, string}|string> $tokens
+     */
+    private function classOf(array $tokens, string $namespace): ?string
+    {
+        foreach ($tokens as $index => $token) {
+            if (!is_array($token) || $token[0] !== T_CLASS) {
+                continue;
+            }
+
+            $name = $tokens[$index + 1] ?? null;
+            if (is_array($name) && $name[0] === T_STRING) {
+                return $namespace === '' ? $name[1] : $namespace . '\\' . $name[1];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve a class reference the way PHP does: leading `\` is absolute,
+     * `self`/`static` is the enclosing class, a first segment matching an
+     * import is replaced by it, and anything else is namespace-relative.
+     *
+     * @param array{int, string} $token
+     * @param array<string, string> $imports
+     */
+    private function resolve(array $token, string $namespace, array $imports, ?string $selfClass): string
+    {
+        $name = $token[1];
+
+        if ($token[0] === T_NAME_FULLY_QUALIFIED) {
+            return ltrim($name, '\\');
+        }
+
+        if (in_array(strtolower($name), ['self', 'static'], true)) {
+            return $selfClass ?? '';
+        }
+
+        $segments = explode('\\', $name);
+        $head = strtolower($segments[0]);
+        if (array_key_exists($head, $imports)) {
+            $segments[0] = $imports[$head];
+
+            return implode('\\', $segments);
+        }
+
+        return $namespace === '' ? $name : $namespace . '\\' . $name;
     }
 
     /** @return array<string, mixed> */
@@ -93,11 +549,12 @@ final class DeprecationRegistryTest extends TestCase
         return $fixture['deprecations'];
     }
 
-    /** @return list<string> */
+    /** @return array<string, string> */
     private function sourceFiles(): array
     {
+        $projectRoot = dirname(__DIR__, 3);
         $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator(dirname(__DIR__, 3) . '/src'),
+            new RecursiveDirectoryIterator($projectRoot . '/src'),
         );
         $sources = [];
 
@@ -109,7 +566,7 @@ final class DeprecationRegistryTest extends TestCase
 
             $contents = file_get_contents($file->getPathname());
             $this->assertIsString($contents);
-            $sources[] = $contents;
+            $sources['src/' . $iterator->getSubPathname()] = $contents;
         }
 
         return $sources;

--- a/tests/Unit/Compatibility/DiagnosticPrefixesBaselineTest.php
+++ b/tests/Unit/Compatibility/DiagnosticPrefixesBaselineTest.php
@@ -78,7 +78,7 @@ final class DiagnosticPrefixesBaselineTest extends TestCase
     #[Test]
     public function identity_neutral_prefixes_retain_v1_9_parity(): void
     {
-        $brandedPrefixes = ['[openapi-contract-testing]', '[Gesso]'];
+        $brandedPrefixes = ['[openapi-contract-testing]', '[Gesso]', '[Gesso deprecation]'];
         $v1 = array_filter(
             $this->fixture('v1.9-diagnostic-prefixes.json'),
             static fn(string $prefix): bool => !in_array($prefix, $brandedPrefixes, true),

--- a/tests/Unit/Coverage/CoverageMergeCommandDeprecationsTest.php
+++ b/tests/Unit/Coverage/CoverageMergeCommandDeprecationsTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Coverage;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Coverage\CoverageMergeCommand;
+use Studio\Gesso\Coverage\CoverageSidecarEnvelope;
+use Studio\Gesso\Coverage\CoverageSidecarWriter;
+use Studio\Gesso\Coverage\OpenApiCoverageTracker;
+use Studio\Gesso\Coverage\SdkExerciseCoverageTracker;
+use Studio\Gesso\Internal\Deprecations;
+use Studio\Gesso\Spec\OpenApiSpecLoader;
+use Studio\Gesso\Validation\Strict\StrictAdditionalPropertiesTracker;
+use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
+
+use function dirname;
+use function file_exists;
+use function glob;
+use function is_dir;
+use function mkdir;
+use function rmdir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+/**
+ * Issue #499: a paratest worker returns from `notify()` before the end-of-run
+ * report, so the merge CLI is the only place a parallel run's residual
+ * deprecation count can surface. Without it, every parallel suite would print
+ * nothing — and printing nothing is the documented "ready for the next major"
+ * signal.
+ */
+final class CoverageMergeCommandDeprecationsTest extends TestCase
+{
+    private string $sidecarDir = '';
+    private string $outputFile = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiCoverageTracker::reset();
+        StrictRequiredTracker::reset();
+        StrictAdditionalPropertiesTracker::resetCurrent();
+        SdkExerciseCoverageTracker::resetCurrent();
+        OpenApiSpecLoader::reset();
+        Deprecations::resetForTesting();
+
+        $base = sys_get_temp_dir() . '/gesso-merge-deprecations-' . uniqid('', true);
+        $this->sidecarDir = $base . '/sidecars';
+        $this->outputFile = $base . '/coverage-report.md';
+        mkdir($this->sidecarDir, 0o755, recursive: true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ([$this->outputFile, ...(glob($this->sidecarDir . '/*.json') ?: [])] as $path) {
+            if (file_exists($path)) {
+                @unlink($path);
+            }
+        }
+        if (is_dir($this->sidecarDir)) {
+            @rmdir($this->sidecarDir);
+            @rmdir(dirname($this->sidecarDir));
+        }
+
+        OpenApiCoverageTracker::resetCurrent();
+        StrictRequiredTracker::resetCurrent();
+        StrictAdditionalPropertiesTracker::resetCurrent();
+        SdkExerciseCoverageTracker::resetCurrent();
+        OpenApiSpecLoader::reset();
+        Deprecations::resetForTesting();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function counts_from_every_worker_are_summed_into_one_line(): void
+    {
+        $this->writeSidecar('1', [
+            'laravel.config.auto_inject_dummy_bearer' => ['count' => 20, 'removed_in' => '3.0'],
+            'phpunit.enum_spec_base_path' => ['count' => 9, 'removed_in' => '3.0'],
+        ]);
+        $this->writeSidecar('2', [
+            'laravel.config.auto_inject_dummy_bearer' => ['count' => 11, 'removed_in' => '3.0'],
+        ]);
+
+        $stderr = $this->merge();
+
+        $this->assertStringContainsString(
+            '[Gesso deprecation] 2 deprecated surface(s) still in use, 40 call(s):'
+            . ' laravel.config.auto_inject_dummy_bearer (31), phpunit.enum_spec_base_path (9).'
+            . ' All are removed in Gesso 3.0.',
+            $stderr,
+        );
+    }
+
+    #[Test]
+    public function a_fleet_that_used_none_produces_no_line(): void
+    {
+        $this->writeSidecar('1', []);
+        $this->writeSidecar('2', []);
+
+        $this->assertStringNotContainsString('[Gesso deprecation]', $this->merge());
+    }
+
+    #[Test]
+    public function a_sidecar_without_the_deprecation_half_makes_a_zero_count_explicit(): void
+    {
+        // A worker on a pre-#499 Gesso stages no deprecation half, which is
+        // indistinguishable from "that worker used none". Reporting silence
+        // here would assert v3-readiness the merge cannot prove.
+        $this->writeSidecar('1', []);
+        $this->writeLegacySidecar('2');
+
+        $stderr = $this->merge();
+
+        $this->assertStringContainsString(
+            '[Gesso deprecation] NOTE: 1 of 2 worker sidecar(s) carry no deprecation state',
+            $stderr,
+        );
+        $this->assertStringContainsString(
+            'the absence of a deprecation report above does not prove the suite uses none',
+            $stderr,
+        );
+    }
+
+    #[Test]
+    public function a_sidecar_without_the_deprecation_half_makes_a_non_zero_count_a_lower_bound(): void
+    {
+        $this->writeSidecar('1', [
+            'phpunit.enum_spec_base_path' => ['count' => 4, 'removed_in' => '3.0'],
+        ]);
+        $this->writeLegacySidecar('2');
+
+        $stderr = $this->merge();
+
+        $this->assertStringContainsString('phpunit.enum_spec_base_path (4)', $stderr);
+        $this->assertStringContainsString('the counts above are a lower bound', $stderr);
+    }
+
+    #[Test]
+    public function a_malformed_deprecation_half_warns_without_failing_the_merge(): void
+    {
+        // Coverage and the gates parsed cleanly; only the migration report is
+        // unreadable. Failing the merge would be a worse outcome than saying
+        // so — but silence would read as "no deprecations".
+        $envelope = $this->envelope([]);
+        $envelope['deprecations'] = ['version' => 99, 'deprecations' => []];
+        CoverageSidecarWriter::write($this->sidecarDir, '1', $envelope);
+
+        $stderr = '';
+        $exit = $this->command($stderr)->run($this->options());
+
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString(
+            '[Gesso deprecation] WARNING: could not read the staged deprecation state',
+            $stderr,
+        );
+        $this->assertStringContainsString('Unsupported deprecation state version: got 99', $stderr);
+    }
+
+    /** @param array<string, array{count: int, removed_in: string}> $entries */
+    private function writeSidecar(string $token, array $entries): void
+    {
+        CoverageSidecarWriter::write($this->sidecarDir, $token, $this->envelope($entries));
+    }
+
+    /** A v6 envelope, as a worker predating the deprecation channel wrote it. */
+    private function writeLegacySidecar(string $token): void
+    {
+        CoverageSidecarWriter::write($this->sidecarDir, $token, CoverageSidecarEnvelope::build(
+            coverageState: (new OpenApiCoverageTracker())->exportStateOn(),
+            strictRequiredState: (new StrictRequiredTracker())->exportStateOn(),
+            strictAdditionalPropertiesState: (new StrictAdditionalPropertiesTracker())->exportStateOn(),
+            sdkExerciseState: (new SdkExerciseCoverageTracker())->exportStateOn(),
+        ));
+    }
+
+    /**
+     * @param array<string, array{count: int, removed_in: string}> $entries
+     *
+     * @return array<string, mixed>
+     */
+    private function envelope(array $entries): array
+    {
+        return CoverageSidecarEnvelope::build(
+            coverageState: (new OpenApiCoverageTracker())->exportStateOn(),
+            strictRequiredState: (new StrictRequiredTracker())->exportStateOn(),
+            strictAdditionalPropertiesState: (new StrictAdditionalPropertiesTracker())->exportStateOn(),
+            sdkExerciseState: (new SdkExerciseCoverageTracker())->exportStateOn(),
+            deprecationsState: ['version' => Deprecations::STATE_VERSION, 'deprecations' => $entries],
+        );
+    }
+
+    private function merge(): string
+    {
+        $stderr = '';
+        $this->command($stderr)->run($this->options());
+
+        return $stderr;
+    }
+
+    private function command(string &$stderr): CoverageMergeCommand
+    {
+        return new CoverageMergeCommand(
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+            stdoutWriter: static fn(string $msg): null => null,
+        );
+    }
+
+    /**
+     * @return array{sidecar_dir: string, spec_base_path: string, specs: list<string>, output_file: string}
+     */
+    private function options(): array
+    {
+        return [
+            'sidecar_dir' => $this->sidecarDir,
+            'spec_base_path' => __DIR__ . '/../../fixtures/specs',
+            'specs' => ['petstore-3.0'],
+            'output_file' => $this->outputFile,
+        ];
+    }
+}

--- a/tests/Unit/Coverage/CoverageSidecarEnvelopeTest.php
+++ b/tests/Unit/Coverage/CoverageSidecarEnvelopeTest.php
@@ -273,7 +273,9 @@ class CoverageSidecarEnvelopeTest extends TestCase
             ['envelopeVersion' => 6, ...$base, 'sdkExercise' => 'invalid'],
             ['envelopeVersion' => 4, ...$base, 'sdkExercise' => ['version' => 1, 'observations' => []]],
             ['envelopeVersion' => 7, ...$base, 'sdkExercise' => ['version' => 1, 'observations' => []]],
-            ['envelopeVersion' => 8, ...$base, 'sdkExercise' => ['version' => 1, 'observations' => []]],
+            // Still an unknown version. v8/v9 became known when the
+            // deprecation half landed, so the unknown-version row moved up.
+            ['envelopeVersion' => 10, ...$base, 'sdkExercise' => ['version' => 1, 'observations' => []]],
         ] as $payload) {
             try {
                 CoverageSidecarEnvelope::parse($payload);
@@ -294,6 +296,127 @@ class CoverageSidecarEnvelopeTest extends TestCase
             'version' => 1,
             'specs' => [],
             'sdkExercise' => ['version' => 1, 'observations' => []],
+        ]);
+    }
+
+    #[Test]
+    public function build_with_deprecations_emits_v8_and_v9_envelopes(): void
+    {
+        $coverage = ['version' => 1, 'specs' => []];
+        $strictRequired = ['version' => 2, 'observations' => []];
+        $strictAdditional = ['version' => 1, 'evaluations' => 0, 'observations' => []];
+        $sdkExercise = ['version' => 1, 'observations' => []];
+        $deprecations = ['version' => 1, 'deprecations' => []];
+
+        $plain = CoverageSidecarEnvelope::build(
+            coverageState: $coverage,
+            strictRequiredState: $strictRequired,
+            strictAdditionalPropertiesState: $strictAdditional,
+            sdkExerciseState: $sdkExercise,
+            deprecationsState: $deprecations,
+        );
+        $baseline = CoverageSidecarEnvelope::build(
+            coverageState: $coverage,
+            strictRequiredState: $strictRequired,
+            baselineDocument: ['baseline_version' => 1, 'violations' => []],
+            strictAdditionalPropertiesState: $strictAdditional,
+            sdkExerciseState: $sdkExercise,
+            deprecationsState: $deprecations,
+        );
+
+        $this->assertSame(8, $plain['envelopeVersion']);
+        $this->assertSame($deprecations, $plain['deprecations']);
+        $this->assertArrayNotHasKey('baseline', $plain);
+        $this->assertSame(9, $baseline['envelopeVersion']);
+        $this->assertSame($deprecations, $baseline['deprecations']);
+        $this->assertSame(['baseline_version' => 1, 'violations' => []], $baseline['baseline']);
+    }
+
+    #[Test]
+    public function build_rejects_deprecations_without_the_earlier_halves(): void
+    {
+        // Every version implies the halves below it, so an envelope with
+        // deprecation state but no SDK exercise state is one no reader can
+        // represent — building it would produce a v8 whose own parse() rejects.
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('require SDK exercise state');
+
+        CoverageSidecarEnvelope::build(
+            coverageState: ['version' => 1, 'specs' => []],
+            strictRequiredState: ['version' => 2, 'observations' => []],
+            strictAdditionalPropertiesState: ['version' => 1, 'evaluations' => 0, 'observations' => []],
+            deprecationsState: ['version' => 1, 'deprecations' => []],
+        );
+    }
+
+    #[Test]
+    public function parse_routes_deprecations_and_returns_null_for_legacy_versions(): void
+    {
+        $deprecations = ['version' => 1, 'deprecations' => ['a' => ['count' => 2, 'removed_in' => '3.0']]];
+        $parsed = CoverageSidecarEnvelope::parse([
+            'envelopeVersion' => 8,
+            'coverage' => ['version' => 1, 'specs' => []],
+            'strictRequired' => ['version' => 2, 'observations' => []],
+            'strictAdditionalProperties' => ['version' => 1, 'evaluations' => 0, 'observations' => []],
+            'sdkExercise' => ['version' => 1, 'observations' => []],
+            'deprecations' => $deprecations,
+        ]);
+
+        $this->assertSame($deprecations, $parsed['deprecations']);
+
+        $legacy = CoverageSidecarEnvelope::parse([
+            'envelopeVersion' => 6,
+            'coverage' => ['version' => 1, 'specs' => []],
+            'strictRequired' => ['version' => 2, 'observations' => []],
+            'strictAdditionalProperties' => ['version' => 1, 'evaluations' => 0, 'observations' => []],
+            'sdkExercise' => ['version' => 1, 'observations' => []],
+        ]);
+
+        // Null, not an empty map: the merge has to be able to tell "this worker
+        // recorded none" from "this worker could not record any".
+        $this->assertNull($legacy['deprecations']);
+    }
+
+    #[Test]
+    public function parse_rejects_missing_misplaced_or_stray_deprecation_halves(): void
+    {
+        $base = [
+            'coverage' => ['version' => 1, 'specs' => []],
+            'strictRequired' => ['version' => 2, 'observations' => []],
+            'strictAdditionalProperties' => ['version' => 1, 'evaluations' => 0, 'observations' => []],
+            'sdkExercise' => ['version' => 1, 'observations' => []],
+        ];
+        $deprecations = ['version' => 1, 'deprecations' => []];
+
+        foreach ([
+            // v8 declares the half; omitting it is malformed, not "none used".
+            ['envelopeVersion' => 8, ...$base],
+            ['envelopeVersion' => 8, ...$base, 'deprecations' => 'invalid'],
+            // v9 additionally declares the baseline half.
+            ['envelopeVersion' => 9, ...$base, 'deprecations' => $deprecations],
+            // A version that does not declare the half must not smuggle it.
+            ['envelopeVersion' => 6, ...$base, 'deprecations' => $deprecations],
+            ['envelopeVersion' => 8, ...$base, 'deprecations' => $deprecations, 'baseline' => ['baseline_version' => 1, 'violations' => []]],
+        ] as $payload) {
+            try {
+                CoverageSidecarEnvelope::parse($payload);
+                $this->fail('Malformed deprecation envelope shape must be rejected.');
+            } catch (InvalidArgumentException) {
+                $this->addToAssertionCount(1);
+            }
+        }
+    }
+
+    #[Test]
+    public function legacy_bare_payload_rejects_a_stray_deprecations_half(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('deprecations');
+
+        CoverageSidecarEnvelope::parse([
+            'version' => 1,
+            'specs' => [],
+            'deprecations' => ['version' => 1, 'deprecations' => []],
         ]);
     }
 }

--- a/tests/Unit/Internal/DeprecationsTest.php
+++ b/tests/Unit/Internal/DeprecationsTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Internal;
+
+use const E_USER_DEPRECATED;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Internal\Deprecations;
+
+use function restore_error_handler;
+use function set_error_handler;
+
+final class DeprecationsTest extends TestCase
+{
+    /** @var list<string> */
+    private array $captured = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Deprecations::resetForTesting();
+        $this->captured = [];
+        set_error_handler(function (int $errno, string $errstr): bool {
+            if ($errno !== E_USER_DEPRECATED) {
+                return false;
+            }
+
+            $this->captured[] = $errstr;
+
+            return true;
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        restore_error_handler();
+        Deprecations::resetForTesting();
+        parent::tearDown();
+    }
+
+    /** @return array<string, array{string, string, string, string, string}> */
+    public static function provideAn_empty_required_parameter_is_rejectedCases(): iterable
+    {
+        return [
+            'empty id' => ['', 'A key', 'Another key', '3.0', '$id'],
+            'empty subject' => ['x', '', 'Another key', '3.0', '$subject'],
+            'empty replacement' => ['x', 'A key', '', '3.0', '$replacement'],
+            'blank replacement' => ['x', 'A key', '   ', '3.0', '$replacement'],
+            'empty removedIn' => ['x', 'A key', 'Another key', '', '$removedIn'],
+            'blank removedIn' => ['x', 'A key', 'Another key', "\t", '$removedIn'],
+        ];
+    }
+
+    #[Test]
+    public function a_notice_names_its_replacement_and_removal_version(): void
+    {
+        Deprecations::notice(
+            id: 'laravel.config.auto_inject_dummy_bearer',
+            subject: "The Laravel config key 'auto_inject_dummy_bearer'",
+            replacement: "'auto_inject_dummy_credentials'",
+            removedIn: '3.0',
+        );
+
+        $this->assertCount(1, $this->captured);
+        $this->assertStringStartsWith('[Gesso deprecation] ', $this->captured[0]);
+        $this->assertStringContainsString("'auto_inject_dummy_credentials'", $this->captured[0]);
+        $this->assertStringContainsString('removed in Gesso 3.0', $this->captured[0]);
+    }
+
+    #[Test]
+    public function an_id_emits_once_per_process_but_keeps_counting(): void
+    {
+        for ($i = 0; $i < 3; $i++) {
+            Deprecations::notice(
+                id: 'phpunit.enum_spec_base_path',
+                subject: "The 'enum_spec_base_path' parameter",
+                replacement: "'spec_base_path'",
+                removedIn: '3.0',
+            );
+        }
+
+        $this->assertCount(1, $this->captured);
+        $this->assertSame(['phpunit.enum_spec_base_path' => 3], Deprecations::counts());
+    }
+
+    #[Test]
+    public function reset_clears_counts_and_re_arms_the_notice(): void
+    {
+        $this->notice('a');
+        Deprecations::resetForTesting();
+        $this->assertSame([], Deprecations::counts());
+
+        $this->notice('a');
+        $this->assertCount(2, $this->captured);
+    }
+
+    #[Test]
+    #[DataProvider('provideAn_empty_required_parameter_is_rejectedCases')]
+    public function an_empty_required_parameter_is_rejected(
+        string $id,
+        string $subject,
+        string $replacement,
+        string $removedIn,
+        string $expected,
+    ): void {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expected);
+
+        Deprecations::notice($id, $subject, $replacement, $removedIn);
+    }
+
+    #[Test]
+    public function no_deprecation_produces_no_summary_line(): void
+    {
+        $this->assertNull(Deprecations::summaryLine());
+    }
+
+    #[Test]
+    public function the_summary_line_lists_every_id_with_its_count(): void
+    {
+        $this->notice('b', times: 2);
+        $this->notice('a', times: 31);
+
+        $this->assertSame(
+            '[Gesso deprecation] 2 deprecated surface(s) still in use, 33 call(s): a (31), b (2).'
+            . " All are removed in Gesso 3.0.\n",
+            Deprecations::summaryLine(),
+        );
+    }
+
+    #[Test]
+    public function mixed_removal_versions_are_reported_per_id(): void
+    {
+        // The trailing "all are removed in" sentence would be false here, so
+        // each id has to carry its own version instead.
+        $this->notice('a');
+        $this->notice('b', removedIn: '4.0');
+
+        $this->assertSame(
+            '[Gesso deprecation] 2 deprecated surface(s) still in use, 2 call(s):'
+            . " a (1, removed in 3.0), b (1, removed in 4.0).\n",
+            Deprecations::summaryLine(),
+        );
+    }
+
+    private function notice(string $id, int $times = 1, string $removedIn = '3.0'): void
+    {
+        for ($i = 0; $i < $times; $i++) {
+            Deprecations::notice(
+                id: $id,
+                subject: 'The ' . $id . ' surface',
+                replacement: 'its successor',
+                removedIn: $removedIn,
+            );
+        }
+    }
+}

--- a/tests/Unit/PHPUnit/CoverageReportSubscriberBaselineTest.php
+++ b/tests/Unit/PHPUnit/CoverageReportSubscriberBaselineTest.php
@@ -166,10 +166,11 @@ class CoverageReportSubscriberBaselineTest extends TestCase
         $this->assertCount(1, $sidecars, 'the sidecar must still be written in worker mode');
         $envelope = json_decode((string) file_get_contents($sidecars[0]), true);
         $this->assertSame(
-            CoverageSidecarEnvelope::ENVELOPE_VERSION_WITH_SDK_EXERCISE_AND_BASELINE,
+            CoverageSidecarEnvelope::ENVELOPE_VERSION_WITH_DEPRECATIONS_AND_BASELINE,
             $envelope['envelopeVersion'],
         );
         $this->assertSame(1, $envelope['sdkExercise']['version']);
+        $this->assertSame(1, $envelope['deprecations']['version']);
         $this->assertSame(ViolationBaselineFile::BASELINE_VERSION, $envelope['baseline']['baseline_version']);
         $this->assertCount(1, $envelope['baseline']['violations']);
         $this->assertSame('/data/*/id', $envelope['baseline']['violations'][0]['instance_path']);

--- a/tests/Unit/PHPUnit/CoverageReportSubscriberDeprecationsTest.php
+++ b/tests/Unit/PHPUnit/CoverageReportSubscriberDeprecationsTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\PHPUnit;
+
+use const E_USER_DEPRECATED;
+
+use PHPUnit\Event\TestRunner\ExecutionFinished;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Studio\Gesso\Coverage\OpenApiCoverageTracker;
+use Studio\Gesso\Internal\Deprecations;
+use Studio\Gesso\PHPUnit\ConsoleOutput;
+use Studio\Gesso\PHPUnit\CoverageReportSubscriber;
+use Studio\Gesso\Spec\OpenApiSpecLoader;
+
+use function ob_get_clean;
+use function ob_start;
+use function restore_error_handler;
+use function set_error_handler;
+use function trigger_error;
+
+final class CoverageReportSubscriberDeprecationsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        OpenApiCoverageTracker::reset();
+        OpenApiSpecLoader::reset();
+        OpenApiSpecLoader::configure(__DIR__ . '/../../fixtures/specs');
+        Deprecations::resetForTesting();
+        set_error_handler(static fn(int $errno): bool => $errno === E_USER_DEPRECATED);
+    }
+
+    protected function tearDown(): void
+    {
+        restore_error_handler();
+        Deprecations::resetForTesting();
+        OpenApiCoverageTracker::reset();
+        OpenApiSpecLoader::reset();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function a_run_without_deprecations_writes_nothing(): void
+    {
+        $stderr = '';
+
+        $this->notify($this->subscriber($stderr));
+
+        $this->assertSame('', $stderr);
+    }
+
+    #[Test]
+    public function a_run_with_deprecations_writes_exactly_one_summary_line(): void
+    {
+        Deprecations::notice(
+            id: 'laravel.config.auto_inject_dummy_bearer',
+            subject: "The Laravel config key 'auto_inject_dummy_bearer'",
+            replacement: "'auto_inject_dummy_credentials'",
+            removedIn: '3.0',
+        );
+
+        $stderr = '';
+
+        $this->notify($this->subscriber($stderr));
+
+        $this->assertSame(
+            '[Gesso deprecation] 1 deprecated surface(s) still in use, 1 call(s):'
+            . " laravel.config.auto_inject_dummy_bearer (1). All are removed in Gesso 3.0.\n",
+            $stderr,
+        );
+    }
+
+    #[Test]
+    public function an_unrelated_e_user_deprecated_is_not_counted(): void
+    {
+        // The `#[SkipOpenApi]` advisory in ValidatesOpenApiSchema already
+        // occupies PHPUnit's deprecation tally with a non-deprecation message.
+        // The residual count reports Gesso's own channel only.
+        trigger_error('[Gesso] SkipOpenApi advisory', E_USER_DEPRECATED);
+
+        $stderr = '';
+
+        $this->notify($this->subscriber($stderr));
+
+        $this->assertSame('', $stderr);
+    }
+
+    private function subscriber(string &$stderr): CoverageReportSubscriber
+    {
+        return new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            stderrWriter: static function (string $msg) use (&$stderr): void {
+                $stderr .= $msg;
+            },
+        );
+    }
+
+    private function notify(CoverageReportSubscriber $subscriber): void
+    {
+        ob_start();
+        $subscriber->notify(
+            (new ReflectionClass(ExecutionFinished::class))->newInstanceWithoutConstructor(),
+        );
+        ob_get_clean();
+    }
+}

--- a/tests/Unit/PHPUnit/CoverageReportSubscriberWorkerModeTest.php
+++ b/tests/Unit/PHPUnit/CoverageReportSubscriberWorkerModeTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Studio\Gesso\Tests\Unit\PHPUnit;
 
+use const E_USER_DEPRECATED;
+
 use PHPUnit\Event\TestRunner\ExecutionFinished;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -12,6 +14,7 @@ use Studio\Gesso\Coverage\CoverageSidecarEnvelope;
 use Studio\Gesso\Coverage\CoverageSidecarReader;
 use Studio\Gesso\Coverage\OpenApiCoverageTracker;
 use Studio\Gesso\Coverage\SdkExerciseCoverageTracker;
+use Studio\Gesso\Internal\Deprecations;
 use Studio\Gesso\PHPUnit\ConsoleOutput;
 use Studio\Gesso\PHPUnit\CoverageReportSubscriber;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
@@ -29,7 +32,9 @@ use function mkdir;
 use function ob_get_clean;
 use function ob_start;
 use function putenv;
+use function restore_error_handler;
 use function rmdir;
+use function set_error_handler;
 use function sys_get_temp_dir;
 use function uniqid;
 use function unlink;
@@ -53,6 +58,7 @@ class CoverageReportSubscriberWorkerModeTest extends TestCase
         SdkExerciseCoverageTracker::resetCurrent();
         OpenApiSpecLoader::reset();
         OpenApiSpecLoader::configure(__DIR__ . '/../../fixtures/specs');
+        Deprecations::resetForTesting();
 
         $this->tmpDir = sys_get_temp_dir() . '/openapi-coverage-subscriber-' . uniqid('', true);
 
@@ -81,6 +87,7 @@ class CoverageReportSubscriberWorkerModeTest extends TestCase
         OpenApiCoverageTracker::reset();
         SdkExerciseCoverageTracker::resetCurrent();
         OpenApiSpecLoader::reset();
+        Deprecations::resetForTesting();
         parent::tearDown();
     }
 
@@ -136,9 +143,10 @@ class CoverageReportSubscriberWorkerModeTest extends TestCase
 
         $loaded = CoverageSidecarReader::readDir($this->tmpDir);
         $this->assertCount(1, $loaded);
-        // v6 envelope: coverage, strict trackers, and SDK exercise are nested.
+        // v8 envelope: coverage, strict trackers, SDK exercise, and the
+        // deprecation counts are nested.
         $this->assertSame(
-            CoverageSidecarEnvelope::ENVELOPE_VERSION_WITH_SDK_EXERCISE,
+            CoverageSidecarEnvelope::ENVELOPE_VERSION_WITH_DEPRECATIONS,
             $loaded[0]['envelopeVersion'],
         );
         $this->assertSame(1, $loaded[0]['coverage']['version']);
@@ -146,6 +154,58 @@ class CoverageReportSubscriberWorkerModeTest extends TestCase
         $this->assertSame(
             1,
             $loaded[0]['sdkExercise']['observations']['petstore-3.0']['GET /v1/pets'][200]['application/json'],
+        );
+        // Issue #499: staged even when empty. A missing half and "this worker
+        // used none" must stay distinguishable in the merged report.
+        $this->assertSame(
+            ['version' => 1, 'deprecations' => []],
+            $loaded[0]['deprecations'],
+        );
+    }
+
+    #[Test]
+    public function worker_mode_stages_its_deprecation_counts_in_the_sidecar(): void
+    {
+        // A worker returns before the end-of-run report, so the sidecar is the
+        // only path by which its counts can reach `gesso coverage:merge`.
+        set_error_handler(static fn(int $errno): bool => $errno === E_USER_DEPRECATED);
+
+        try {
+            for ($i = 0; $i < 2; $i++) {
+                Deprecations::notice(
+                    id: 'laravel.config.auto_inject_dummy_bearer',
+                    subject: "The Laravel config key 'auto_inject_dummy_bearer'",
+                    replacement: "'auto_inject_dummy_credentials'",
+                    removedIn: '3.0',
+                );
+            }
+        } finally {
+            restore_error_handler();
+        }
+
+        putenv('TEST_TOKEN=3');
+        $subscriber = new CoverageReportSubscriber(
+            specs: ['petstore-3.0'],
+            outputFile: null,
+            consoleOutput: ConsoleOutput::DEFAULT,
+            githubSummaryPath: null,
+            sidecarDir: $this->tmpDir,
+        );
+
+        ob_start();
+        $subscriber->notify($this->fakeExecutionFinished());
+        ob_get_clean();
+
+        $loaded = CoverageSidecarReader::readDir($this->tmpDir);
+        $this->assertCount(1, $loaded);
+        $this->assertSame(
+            [
+                'version' => 1,
+                'deprecations' => [
+                    'laravel.config.auto_inject_dummy_bearer' => ['count' => 2, 'removed_in' => '3.0'],
+                ],
+            ],
+            $loaded[0]['deprecations'],
         );
     }
 

--- a/tests/fixtures/compatibility/v2-deprecations.json
+++ b/tests/fixtures/compatibility/v2-deprecations.json
@@ -1,0 +1,4 @@
+{
+    "$comment": "Registry of every surface deprecated in v2 for removal in a later major (issue #499). One entry per Deprecations::notice() id in src/, checked by tests/Unit/Compatibility/DeprecationRegistryTest.php. A major that removes a surface deletes its entry in the same change; a removal with no entry here never shipped a deprecation and violates docs/versioning.md.",
+    "deprecations": {}
+}

--- a/tests/fixtures/compatibility/v2-diagnostic-prefixes.json
+++ b/tests/fixtures/compatibility/v2-diagnostic-prefixes.json
@@ -1,4 +1,7 @@
 {
+    "[Gesso deprecation]": {
+        "src/Internal/Deprecations.php": 1
+    },
     "[Gesso]": {
         "src/Baseline/CoverageBaselineEvaluator.php": 2,
         "src/Cli/CoverageGateCommand.php": 3,


### PR DESCRIPTION
## Summary

Adds `Internal\Deprecations`, the single emitter for a new `E_USER_DEPRECATED`
channel carrying the `[Gesso deprecation]` prefix, the one-line end-of-run
residual report in the PHPUnit extension, the registry fixture that pins each
deprecated surface to its replacement and removal version, and the standing
policy rule in `docs/versioning.md` that ties a major-release removal to a
deprecation shipped in a prior minor.

## Why

Fixes #499.

v2.4.0 has zero deprecated symbols (`grep -rn "@deprecated" src/` → 0 hits) and
no channel to announce one. The only `E_USER_DEPRECATED` emission in the library
is the `#[SkipOpenApi]` advisory, which is not a deprecation but already
occupies PHPUnit's deprecation tally. `docs/versioning.md`'s only
deprecation-staging rule was hard-wired to the v1 → v2 transition, so nothing
required a v2 → v3 removal to be preceded by a warning — and the last removal of
deprecated API in this repo (`ccbf8cb`) shipped with a docblock and no runtime
signal at all.

Every v3 rename in #501 / #502 / #503 / #504 / #507 / #508 renames something a
consumer has written down. This PR is the machinery those issues deprecate
through, and it lands now because ADR 0005 froze the names they deprecate
toward.

## Verification

- [x] `composer test` passes (3128 tests)
- [x] `composer stan` passes
- [x] `composer cs-check` passes
- Emitter: dedup per id, blank `$replacement` / `$removedIn` rejected, message
  contains the replacement and the literal removal version, `resetForTesting()`
  re-arms the notice — `tests/Unit/Internal/DeprecationsTest.php`.
- Subscriber: exactly one line when a deprecation fired, nothing when none did,
  and an unrelated `E_USER_DEPRECATED` (the `#[SkipOpenApi]` advisory's class of
  message) is not counted — `CoverageReportSubscriberDeprecationsTest`.
- Docs: VitePress build and `markdown-link-check` are clean after the
  warning-channel section rename, which changed its anchor and the one inbound
  link in `docs/setup.md`.

## Notes for reviewers

**The registry fixture starts empty, on purpose.** #499's seed inventory
(`auto_inject_dummy_bearer`, the four duplicated Laravel/PHPUnit keys,
`enum_spec_base_path`, the seven `ContractCheck*` types) says each entry is
landed by the v3 issue that owns its rename, not by this one. So this PR adds no
`Deprecations::notice()` call site, and `UPGRADING.md`'s table reads "nothing is
deprecated yet". `DeprecationRegistryTest` checks both directions from the first
real entry onward.

**Two deviations from the issue text, both small.**

1. The notice links to `UPGRADING.md#deprecations` rather than the issue's
   sketched `#v3`; the section this PR adds is version-independent and `#v3` is
   not a real anchor.
2. The summary line falls back to a per-id `removed in X` when the ids do not
   share one removal version. The issue's example ends `All are removed in Gesso
   3.0.`, which is true for the whole v3 milestone but would be a false claim on
   a mixed set. Both renderings are pinned by tests.

**Placement in `notify()`.** The summary is written before the coverage and
strict gates because `strict_required=fail` terminates the process — the
migration signal must not depend on the run passing. Worker processes return
earlier and never reach it, matching the baseline summary's existing behaviour.

**`docs/versioning.md`'s prefix line is widened, which is itself the covered
surface.** Adding `[Gesso deprecation]` to the inventory is a minor-level change
under the rule stated one line later; the same line now says so explicitly.