### PR TITLE
feat(identity): rename the env vars and artisan commands to the gesso brand

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ when upgrading from `studio-design/openapi-contract-testing` v1.10.
 - **OpenAPI 3.0, 3.1 & 3.2 support** — Explicit version detection, including 3.2 `QUERY`, custom `additionalOperations`, form `querystring`, `discriminator.defaultMapping`, and observable streaming limitations
 - **Response & request validation** — dialect-aware JSON Schema via opis/json-schema: Draft 07 compatibility for OpenAPI 3.0 and native 2020-12 semantics for OpenAPI 3.1/3.2; `application/json` and any `+json` content type
 - **Endpoint coverage tracking** — Unique PHPUnit extension that reports which spec endpoints are covered by tests, at `(method, path, status, content-type)` granularity
-- **Laravel route/spec parity** — `openapi:routes` finds documented operations without routes and registered routes without OpenAPI operations, with filters, stable JSON, and independent CI gates
+- **Laravel route/spec parity** — `gesso:routes` finds documented operations without routes and registered routes without OpenAPI operations, with filters, stable JSON, and independent CI gates
 - **Schema-driven request fuzzing** — Valid boundaries, composition branches, targeted negative cases with explicit expected status classes, deterministic replay/reduction, whole-spec filters, lifecycle/auth hooks, and explicit skip reasons
 - **Named negative contract checks** — Opt-in `ignored_auth` (does the API actually enforce declared `security`?), `missing_required_header`, and `unsupported_method` probes for the protocol-level holes schema validation cannot see, with deterministic replay and collect-then-assert reporting. See [`docs/fuzzing.md`](docs/fuzzing.md#named-contract-checks).
 - **Enum drift detection** — Static comparison between PHP backed enums and their `enum:` spec arrays, with PHPUnit-extension auto-discovery
@@ -61,8 +61,8 @@ Choose based on the workflow you need rather than on a single yes/no feature cou
 | Coverage granularity | [`method, path, status, content-type`](docs/coverage.md) | [`method, path` operation][spectator-coverage-source] | — | — | — |
 | Coverage outputs | [Markdown, JUnit XML, JSON, HTML, GitHub Step Summary](docs/coverage.md) | [Text, JSON][spectator-coverage] | — | — | — |
 | Parallel coverage merge | [Sidecar + merge CLI](docs/parallel.md) | Not documented | — | — | — |
-| Route/spec parity | [`openapi:routes`](docs/laravel-route-parity.md) with text/JSON and CI gates | [`spectator:routes`][spectator-cli] | — | — | — |
-| CLI diagnostics / scaffolding | [`doctor`](docs/doctor.md), [`openapi:routes`](docs/laravel-route-parity.md), coverage merge/gate, [`stubs` scoped to uncovered responses](docs/stubs.md) | [`validate`, `coverage`, `routes`, `stubs`][spectator-cli] | — | — | — |
+| Route/spec parity | [`gesso:routes`](docs/laravel-route-parity.md) with text/JSON and CI gates | [`spectator:routes`][spectator-cli] | — | — | — |
+| CLI diagnostics / scaffolding | [`doctor`](docs/doctor.md), [`gesso:routes`](docs/laravel-route-parity.md), coverage merge/gate, [`stubs` scoped to uncovered responses](docs/stubs.md) | [`validate`, `coverage`, `routes`, `stubs`][spectator-cli] | — | — | — |
 | Structured validation failures | [`issues()` + versioned JSON failure output](docs/validation-json-schema.md) | [JSON `{errors: [...]}`][spectator-errors] | [PHP exception hierarchy][league-errors] | [Wrapper exception][osteel-readme] | [PHPUnit failure text][kirschbaum-failure-source] |
 | Schema-driven exploration | [Deterministic endpoint + whole-spec generation](docs/fuzzing.md) | — | — | — | — |
 | Drift / under-description checks | [Enum drift](docs/enum-drift.md), [strict required](docs/strict-required.md) | — | — | — | — |
@@ -217,7 +217,7 @@ class GetPetsTest extends TestCase
 Before running tests, compare Laravel's registered routes with the spec:
 
 ```bash
-php artisan openapi:routes --fail-on-undocumented --fail-on-unimplemented
+php artisan gesso:routes --fail-on-undocumented --fail-on-unimplemented
 ```
 
 To validate every response automatically, set `'auto_assert' => true` and drop the explicit assert call. To also catch request-side drift, set `'auto_validate_request' => true`. See [`docs/setup.md`](docs/setup.md) for the full configuration and opt-out reference.
@@ -229,7 +229,7 @@ To validate every response automatically, set `'auto_assert' => true` and drop t
 | PSR-7 request / response / exchange validation and PSR-15 test recipe | [`docs/psr7.md`](docs/psr7.md) |
 | Full setup, Laravel / Symfony / framework-agnostic adapters, auto-assert, opt-out attributes, request validation, HTTP `$ref` | [`docs/setup.md`](docs/setup.md) |
 | Pre-test compatibility diagnostics (`gesso doctor`) | [`docs/doctor.md`](docs/doctor.md) |
-| Laravel route/spec parity (`openapi:routes`) | [`docs/laravel-route-parity.md`](docs/laravel-route-parity.md) |
+| Laravel route/spec parity (`gesso:routes`) | [`docs/laravel-route-parity.md`](docs/laravel-route-parity.md) |
 | Pest plugin: `expect()->toMatchOpenApiResponseSchema()` and friends | [`docs/pest-plugin.md`](docs/pest-plugin.md) |
 | Schema-driven request fuzzing & named contract checks | [`docs/fuzzing.md`](docs/fuzzing.md) |
 | Enum drift detection | [`docs/enum-drift.md`](docs/enum-drift.md) |

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -31,6 +31,51 @@ test keeps in sync with the emitters in `src/`. The `Deprecated in` column names
 the release that started warning, not the release that introduced the
 replacement.
 
+### Renamed environment variables and Artisan commands
+
+The three environment variables and two Artisan commands Gesso owns moved to the
+`gesso` brand. **The old spellings keep working through all of v3** and are
+removed in v4.0, so this is not an upgrade blocker — but a run that uses one
+prints a line like:
+
+```text
+[Gesso] WARNING: OPENAPI_BASELINE_GENERATE is deprecated and will be removed in Gesso 4.0.0. Use GESSO_BASELINE_GENERATE.
+```
+
+These do **not** raise `E_USER_DEPRECATED`, so `failOnDeprecation` suites are
+unaffected. They are absent from the deprecation table above for the same
+reason.
+
+| Old | New |
+| --- | --- |
+| `OPENAPI_VALIDATION_OUTPUT` | `GESSO_VALIDATION_FORMAT` |
+| `OPENAPI_CONSOLE_OUTPUT` | `GESSO_CONSOLE_OUTPUT` |
+| `OPENAPI_BASELINE_GENERATE` | `GESSO_BASELINE_GENERATE` |
+| `openapi:routes` | `gesso:routes` |
+| `openapi:stubs` | `gesso:stubs` |
+
+`OPENAPI_VALIDATION_OUTPUT` becomes `GESSO_VALIDATION_FORMAT`, not
+`GESSO_VALIDATION_OUTPUT`: its values are formats (`text` | `json`), and v3
+renames the matching extension parameter to `validation.format` — see
+[ADR 0005](docs/adr/0005-v3-configuration-and-cli-naming.md). The
+`validation_output` and `console_output` **extension parameters** are untouched
+by this change.
+
+To migrate CI env blocks and Artisan calls:
+
+```sh
+rg -l 'OPENAPI_(VALIDATION_OUTPUT|CONSOLE_OUTPUT|BASELINE_GENERATE)|openapi:(routes|stubs)' \
+  | xargs sed -i '' \
+    -e 's/OPENAPI_VALIDATION_OUTPUT/GESSO_VALIDATION_FORMAT/g' \
+    -e 's/OPENAPI_CONSOLE_OUTPUT/GESSO_CONSOLE_OUTPUT/g' \
+    -e 's/OPENAPI_BASELINE_GENERATE/GESSO_BASELINE_GENERATE/g' \
+    -e 's/openapi:routes/gesso:routes/g' \
+    -e 's/openapi:stubs/gesso:stubs/g'
+```
+
+(Drop the `''` after `-i` on GNU sed.) No config file, `phpunit.xml` parameter,
+or PHP code change is required.
+
 ## Within v2.x
 
 The v2.x line is covered end-to-end by SemVer (see `docs/versioning.md` for the

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -81,7 +81,7 @@ The document shape (`schema_version` 1) is a compatibility surface — see
 
 Framework adapters (Laravel, Symfony, Pest, PSR-7) can emit the same document
 in their assertion failure messages instead of the plain text shape. Select
-the mode process-wide with the `OPENAPI_VALIDATION_OUTPUT` environment
+the mode process-wide with the `GESSO_VALIDATION_FORMAT` environment
 variable (`text` | `json`), programmatically, or via the PHPUnit extension's
 `validation_output` parameter — the environment variable wins when set:
 

--- a/docs/baseline.md
+++ b/docs/baseline.md
@@ -27,7 +27,7 @@ command.
 2. Generate the baseline (full suite, no `--filter`):
 
    ```bash
-   OPENAPI_BASELINE_GENERATE=1 vendor/bin/phpunit
+   GESSO_BASELINE_GENERATE=1 vendor/bin/phpunit
    ```
 
    Every contract violation is recorded instead of failing, and the sorted,
@@ -85,7 +85,7 @@ the merge step unions them into the committed file:
 ```bash
 # 1. Run the parallel suite in generation mode — failures are demoted,
 #    fingerprints ride the worker sidecars.
-OPENAPI_BASELINE_GENERATE=1 vendor/bin/paratest --processes=4
+GESSO_BASELINE_GENERATE=1 vendor/bin/paratest --processes=4
 
 # 2. Union the worker halves and write the baseline.
 vendor/bin/gesso coverage:merge \

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -25,13 +25,13 @@ Use the `output_file` parameter to write a Markdown report to a file. This is us
 </extensions>
 ```
 
-You can also use the `OPENAPI_CONSOLE_OUTPUT` environment variable in CI to show uncovered endpoints in the job log:
+You can also use the `GESSO_CONSOLE_OUTPUT` environment variable in CI to show uncovered endpoints in the job log:
 
 ```yaml
 - name: Run tests (show uncovered endpoints)
   run: vendor/bin/phpunit
   env:
-    OPENAPI_CONSOLE_OUTPUT: uncovered_only
+    GESSO_CONSOLE_OUTPUT: uncovered_only
 ```
 
 Example GitHub Actions workflow step to post the report as a PR comment:

--- a/docs/coverage-baseline.md
+++ b/docs/coverage-baseline.md
@@ -33,7 +33,7 @@ today's gaps, fail on new ones by name, and let the ratchet show up as a diff.
 2. Generate it from a full run (no `--filter`):
 
    ```bash
-   OPENAPI_BASELINE_GENERATE=1 vendor/bin/phpunit
+   GESSO_BASELINE_GENERATE=1 vendor/bin/phpunit
    ```
 
    ```text
@@ -42,7 +42,7 @@ today's gaps, fail on new ones by name, and let the ratchet show up as a diff.
 
 3. Commit the file. Every later run compares its uncovered set against it.
 
-`OPENAPI_BASELINE_GENERATE` drives both baselines: if `baseline_file` is
+`GESSO_BASELINE_GENERATE` drives both baselines: if `baseline_file` is
 configured too, one command regenerates both. Configuring only
 `coverage_baseline_file` is fine — the violation baseline stays uninvolved.
 
@@ -91,7 +91,7 @@ An uncovered response that is **not** in the file fails the run and is named:
 [Gesso] FATAL: 2 response(s) are not covered and are not listed in the coverage baseline:
   - [front] DELETE /v1/pets/{id} status=204 content-type=*
   - [front] GET /v1/pets status=500 content-type=application/json
-  Action: cover them with a test, or accept them by regenerating the baseline with `OPENAPI_BASELINE_GENERATE=1 vendor/bin/phpunit`.
+  Action: cover them with a test, or accept them by regenerating the baseline with `GESSO_BASELINE_GENERATE=1 vendor/bin/phpunit`.
 ```
 
 Because the gate compares sets, documenting a new response in the spec does
@@ -143,8 +143,8 @@ already renders reports from:
 
 ```bash
 # Generate
-OPENAPI_BASELINE_GENERATE=1 vendor/bin/paratest --processes=4
-OPENAPI_BASELINE_GENERATE=1 vendor/bin/gesso coverage:merge \
+GESSO_BASELINE_GENERATE=1 vendor/bin/paratest --processes=4
+GESSO_BASELINE_GENERATE=1 vendor/bin/gesso coverage:merge \
     --spec-base-path=openapi/bundled \
     --coverage-baseline-file=gesso-coverage-baseline.json
 
@@ -164,7 +164,7 @@ value, or that flag without `--coverage-baseline-file`).
 On any of those failures the sidecars are **kept** instead of cleaned up, as
 the violation baseline does. Every recovery re-runs the merge, not the suite:
 fix a typo'd path, free disk space for the write, or accept the reported
-regressions by re-running with `OPENAPI_BASELINE_GENERATE=1`.
+regressions by re-running with `GESSO_BASELINE_GENERATE=1`.
 
 A generation worker that cannot write its sidecar — and cannot drop a failure
 marker either — fails the parallel run rather than letting the merge build a

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,6 +1,6 @@
 # Coverage Report
 
-After running tests, the PHPUnit extension prints a coverage report. The output format is controlled by the `console_output` parameter (or `OPENAPI_CONSOLE_OUTPUT` environment variable).
+After running tests, the PHPUnit extension prints a coverage report. The output format is controlled by the `console_output` parameter (or `GESSO_CONSOLE_OUTPUT` environment variable).
 
 Coverage is tracked at **`(method, path, statusCode, contentType)` granularity**: a `GET /v1/pets` test that only exercises `200 application/json` does not count `404` or `application/problem+json` as covered. Per-endpoint markers reflect the resolved state across all declared response definitions:
 
@@ -117,7 +117,7 @@ You can set the mode via `phpunit.xml`:
 Or via environment variable (takes priority over `phpunit.xml`):
 
 ```bash
-OPENAPI_CONSOLE_OUTPUT=uncovered_only vendor/bin/phpunit
+GESSO_CONSOLE_OUTPUT=uncovered_only vendor/bin/phpunit
 ```
 
 ## Coverage threshold gate

--- a/docs/laravel-route-parity.md
+++ b/docs/laravel-route-parity.md
@@ -1,6 +1,6 @@
 # Laravel route parity
 
-`openapi:routes` compares Laravel's registered routes with the operations in
+`gesso:routes` compares Laravel's registered routes with the operations in
 one or more OpenAPI specs. It catches drift before runtime coverage can: a
 documented operation may have no application route, or an application route
 may never have been documented.
@@ -42,13 +42,13 @@ rules, so the static result matches request/response validation.
 Use the configured `default_spec`:
 
 ```bash
-php artisan openapi:routes
+php artisan gesso:routes
 ```
 
 Select multiple specs and narrow the Laravel route collection:
 
 ```bash
-php artisan openapi:routes \
+php artisan gesso:routes \
   --spec=front \
   --spec=admin \
   --prefix=api/v2 \
@@ -94,8 +94,8 @@ By default, discovered differences are reported but the command exits `0`.
 Enable either gate independently:
 
 ```bash
-php artisan openapi:routes --fail-on-undocumented
-php artisan openapi:routes --fail-on-unimplemented
+php artisan gesso:routes --fail-on-undocumented
+php artisan gesso:routes --fail-on-unimplemented
 ```
 
 - `--fail-on-undocumented` exits `1` for registered-but-undocumented routes or
@@ -109,7 +109,7 @@ php artisan openapi:routes --fail-on-unimplemented
 Use stable machine-readable output in CI:
 
 ```bash
-php artisan openapi:routes --format=json
+php artisan gesso:routes --format=json
 ```
 
 For large applications, capture the formatted JSON as a CI artifact instead
@@ -117,7 +117,7 @@ of relying only on the job log:
 
 ```yaml
 - name: Compare Laravel routes with OpenAPI
-  run: php artisan openapi:routes --format=json > route-parity.json
+  run: php artisan gesso:routes --format=json > route-parity.json
 
 - name: Upload route parity report
   uses: actions/upload-artifact@v4

--- a/docs/migration/from-other-validators.md
+++ b/docs/migration/from-other-validators.md
@@ -4,7 +4,7 @@ Adopt this package incrementally: keep the existing validator for untouched test
 
 ## Spectator
 
-Replace Spectator response assertions with `ValidatesOpenApiSchema`. Set `default_spec` once in Laravel config. Compare route coverage using `php artisan openapi:routes`, then enable `auto_assert` only after explicit assertions pass.
+Replace Spectator response assertions with `ValidatesOpenApiSchema`. Set `default_spec` once in Laravel config. Compare route coverage using `php artisan gesso:routes`, then enable `auto_assert` only after explicit assertions pass.
 
 ## league/openapi-psr7-validator
 

--- a/docs/parallel.md
+++ b/docs/parallel.md
@@ -52,8 +52,8 @@ vendor/bin/gesso coverage:merge \
 | `--min-coverage-strict` | `false` (warn-only) | Treat threshold misses as exit non-zero |
 | `--strict-required=<mode>` | `off` | `off` / `warn` / `fail`. Assert no schema under-description drift across worker observations. See [`strict-required.md`](strict-required.md#paratest) |
 | `--strict-additional-properties=<mode>` | `off` | `off` / `warn` / `fail`. Report returned response properties absent from schema declarations. See [`strict-additional-properties.md`](strict-additional-properties.md#parallel-test-runners) |
-| `--baseline-file=<path>` | — | Union the violation-baseline halves staged by an `OPENAPI_BASELINE_GENERATE=1` parallel run and write the merged baseline. See [`baseline.md`](baseline.md#generating-under-parallel-runners) |
-| `--coverage-baseline-file=<path>` | — | Gate the merged coverage against a committed set of known-uncovered responses; writes the file instead when `OPENAPI_BASELINE_GENERATE=1` is set. See [`coverage-baseline.md`](coverage-baseline.md#parallel-runners) |
+| `--baseline-file=<path>` | — | Union the violation-baseline halves staged by an `GESSO_BASELINE_GENERATE=1` parallel run and write the merged baseline. See [`baseline.md`](baseline.md#generating-under-parallel-runners) |
+| `--coverage-baseline-file=<path>` | — | Gate the merged coverage against a committed set of known-uncovered responses; writes the file instead when `GESSO_BASELINE_GENERATE=1` is set. See [`coverage-baseline.md`](coverage-baseline.md#parallel-runners) |
 | `--coverage-baseline-stale=<mode>` | `note` | `off` / `note` / `fail`. How baseline entries that are covered now are reported |
 | `--no-cleanup` | (cleanup is on by default) | Keep sidecar files after merge |
 
@@ -81,7 +81,7 @@ report produced by `json_output`. The current writer emits an
 strict-required state `version: 2`, and strict-additional-properties state
 `version: 1`, plus SDK exercise state `version: 1` and deprecation state
 `version: 1`. A baseline-generation run
-(`OPENAPI_BASELINE_GENERATE=1`) emits `envelopeVersion: 9` and adds the violation-baseline document
+(`GESSO_BASELINE_GENERATE=1`) emits `envelopeVersion: 9` and adds the violation-baseline document
 (`baseline_version: 1`).
 
 The merge reader also accepts envelopes 2–7 and the older bare coverage state
@@ -124,7 +124,7 @@ changing a sidecar shape or filename pattern.
   `strict_required` parameter on the PHPUnit extension does not propagate
   to the merge step. See [`strict-required.md`](strict-required.md#paratest).
 - **Baseline generation aggregates across workers too.** An
-  `OPENAPI_BASELINE_GENERATE=1` parallel run stages fingerprints in the
+  `GESSO_BASELINE_GENERATE=1` parallel run stages fingerprints in the
   sidecars; pass `--baseline-file=<path>` to the merge to write the union.
   See [`baseline.md`](baseline.md#generating-under-parallel-runners).
 - **Worker counts are not exposed by paratest.** A child cannot reliably
@@ -136,7 +136,7 @@ changing a sidecar shape or filename pattern.
 - **A failed sidecar write does not fail the test run.** Workers log a
   warning to `STDERR` and let the suite finish — your contract assertions
   already passed; sidecar I/O is a CI artifact concern. The exception is a
-  baseline-generation run (`OPENAPI_BASELINE_GENERATE=1`): the worker
+  baseline-generation run (`GESSO_BASELINE_GENERATE=1`): the worker
   demoted its failures on the promise that the merge unions its sidecar, so
   losing the sidecar fails the worker — otherwise the merge could write an
   incomplete baseline from the remaining workers.

--- a/docs/quickstarts/laravel.md
+++ b/docs/quickstarts/laravel.md
@@ -7,8 +7,8 @@ php artisan vendor:publish --tag=gesso
 
 Register the extension in `phpunit.xml`. This is what configures the spec loader
 for the runtime validator; `gesso.spec_base_path` in the published
-`config/gesso.php` does not — it only feeds the `openapi:routes` and
-`openapi:stubs` Artisan commands:
+`config/gesso.php` does not — it only feeds the `gesso:routes` and
+`gesso:stubs` Artisan commands:
 
 ```xml
 <extensions>

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -76,9 +76,9 @@ Add the coverage extension to your `phpunit.xml`:
 | `junit_output` | No | — | File path to write JUnit XML coverage report (for CI dashboards — GitLab CI, Jenkins, SonarQube, Bitrise). A missing parent directory is created automatically at bootstrap (applies to `json_output` / `html_output` too); an empty value, a failed creation, or an unwritable parent directory is FATAL at bootstrap. See [Coverage output formats](ci.md#coverage-output-formats) |
 | `json_output` | No | — | File path to write machine-readable JSON coverage report (custom dashboards, analytics, scripted gating). Schema: [`coverage-json-schema.md`](coverage-json-schema.md) |
 | `html_output` | No | — | File path to write self-contained HTML coverage report (PR comments, CI artifact preview, offline review). See [`coverage-html-output.md`](coverage-html-output.md) |
-| `console_output` | No | `default` | Console output mode: `default`, `all`, `uncovered_only`, or `active_only` (overridden by `OPENAPI_CONSOLE_OUTPUT` env var) |
-| `validation_output` | No | `text` | Validation failure output format for all framework adapters: `text` or `json` (overridden by `OPENAPI_VALIDATION_OUTPUT` env var). See [Validation JSON schema](validation-json-schema.md#selecting-json-failure-output-in-adapters) |
-| `baseline_file` | No | — | Violation baseline file path (relative paths resolve from `getcwd()`). Running the suite with `OPENAPI_BASELINE_GENERATE=1` records every contract violation instead of failing and writes the sorted, versioned baseline here at run end (refused on partial runs; parallel workers stage their fingerprints in sidecars for `gesso coverage:merge --baseline-file` to union — see [Generating under parallel runners](baseline.md#generating-under-parallel-runners)). On normal runs the file is loaded (missing or malformed file is FATAL) and failures whose every violation is baselined are suppressed — only **new** violations fail. See the [baseline adoption guide](baseline.md) |
+| `console_output` | No | `default` | Console output mode: `default`, `all`, `uncovered_only`, or `active_only` (overridden by `GESSO_CONSOLE_OUTPUT` env var) |
+| `validation_output` | No | `text` | Validation failure output format for all framework adapters: `text` or `json` (overridden by `GESSO_VALIDATION_FORMAT` env var). See [Validation JSON schema](validation-json-schema.md#selecting-json-failure-output-in-adapters) |
+| `baseline_file` | No | — | Violation baseline file path (relative paths resolve from `getcwd()`). Running the suite with `GESSO_BASELINE_GENERATE=1` records every contract violation instead of failing and writes the sorted, versioned baseline here at run end (refused on partial runs; parallel workers stage their fingerprints in sidecars for `gesso coverage:merge --baseline-file` to union — see [Generating under parallel runners](baseline.md#generating-under-parallel-runners)). On normal runs the file is loaded (missing or malformed file is FATAL) and failures whose every violation is baselined are suppressed — only **new** violations fail. See the [baseline adoption guide](baseline.md) |
 | `baseline_stale` | No | `note` | How baseline entries that no longer occur during a full run are reported: `off` (not evaluated), `note` (listed as removable), or `fail` (listed and the run exits non-zero). Requires `baseline_file`; skipped on partial runs. See [Ratcheting down](baseline.md#ratcheting-down) |
 | `sidecar_dir` | No | `sys_get_temp_dir()/openapi-coverage-sidecars` | Directory paratest workers drop per-worker JSON sidecars into. Used only under parallel test runners — see [Parallel test runners](parallel.md) |
 | `min_endpoint_coverage` | No | — | Minimum fully covered endpoint percentage (`0`–`100`). See [Coverage threshold gate](coverage.md#coverage-threshold-gate) |
@@ -109,7 +109,7 @@ This creates `config/gesso.php`:
 return [
     'default_spec' => '', // e.g., 'front'
 
-    // Used by Laravel Artisan commands such as openapi:routes.
+    // Used by Laravel Artisan commands such as gesso:routes.
     'spec_base_path' => base_path('openapi'),
 
     // Keep aligned with the PHPUnit extension's strip_prefixes parameter.
@@ -140,7 +140,7 @@ return [
 Set `default_spec` to your spec name, then use the trait — no per-class override needed:
 
 The Laravel config and PHPUnit extension are separate entry points. Configure
-the same spec directory and prefixes in both so `openapi:routes` and runtime
+the same spec directory and prefixes in both so `gesso:routes` and runtime
 validation compare the same paths. See [Laravel route parity](laravel-route-parity.md)
 for filters, JSON output, and CI exit codes.
 

--- a/docs/stubs.md
+++ b/docs/stubs.md
@@ -31,7 +31,7 @@ Laravel users can run the same thing through Artisan, which takes the spec from
 `gesso.default_spec` / `gesso.spec_base_path`:
 
 ```bash
-php artisan openapi:stubs --coverage=build/coverage.json
+php artisan gesso:stubs --coverage=build/coverage.json
 ```
 
 ## Options

--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -121,6 +121,8 @@ A second channel, `trigger_error(..., E_USER_DEPRECATED)`, carries migration not
 | `[OpenAPI 3.2 $self]` | `E_USER_WARNING` | `OpenApiSpecLoader` (`$self` base URI is not applied) | spec load/cache |
 | `[Gesso deprecation]` | `E_USER_DEPRECATED` | `Internal\Deprecations` (every deprecated configuration key, CLI flag, and PHP symbol) | deprecation id |
 
+**Not on either channel:** a rename whose old spelling still works writes a plain `[Gesso] WARNING:` line to STDERR instead — going through `E_USER_DEPRECATED` would make a `failOnDeprecation` suite fail for using a name that is still supported. The three `OPENAPI_*` environment variables and the `openapi:routes` / `openapi:stubs` Artisan commands are the current members; see [renamed spellings still accepted](versioning.md#renamed-spellings-still-accepted).
+
 **Deprecation notices:** each notice names what to use instead and the version that removes the surface, because the emitter cannot represent one that does not. Under the PHPUnit extension, one summary line is written to STDERR after the run listing every deprecated surface still in use with its call count; nothing is written when the run used none. Under paratest each worker stages its counts in the sidecar and `gesso coverage:merge` writes the one summed line, so the report survives a parallel run. See [Deprecations in `UPGRADING.md`](https://github.com/studio-design/gesso/blob/main/UPGRADING.md#deprecations) for the current list and [versioning](versioning.md) for the rule that ties a removal to a prior deprecation.
 
 **How to consume:**

--- a/docs/validation-json-schema.md
+++ b/docs/validation-json-schema.md
@@ -27,7 +27,7 @@ Every framework adapter (Laravel, Symfony, Pest, PSR-7) can emit this document
 in its assertion failure message instead of the plain text shape. One
 process-wide switch selects the mode everywhere, resolved in priority order:
 
-1. the `OPENAPI_VALIDATION_OUTPUT` environment variable (`text` | `json`);
+1. the `GESSO_VALIDATION_FORMAT` environment variable (`text` | `json`);
 2. `ValidationOutput::use(ValidationOutputFormat::Json)` — call it from your
    test bootstrap, or set the `validation_output` parameter on the PHPUnit
    extension, which calls it for you:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -39,7 +39,7 @@ This library follows [Semantic Versioning 2.0](https://semver.org/). v1.0.0 is t
   bump `schema_version`).
 - The validation failure output selection: the `ValidationOutputFormat` enum
   (`text` | `json`), the `ValidationOutput` methods (`format()`, `use()`,
-  `reset()`), the `OPENAPI_VALIDATION_OUTPUT` environment variable, and the
+  `reset()`), the `GESSO_VALIDATION_FORMAT` environment variable, and the
   json-mode failure shape (one header line followed by the versioned JSON
   document; for the PSR-7 exchange assertion, one `[request]` / `[response]`
   labelled document per failing side).
@@ -57,7 +57,7 @@ This library follows [Semantic Versioning 2.0](https://semver.org/). v1.0.0 is t
   `keyword: required` (credentials absent) or `keyword: format` (present but
   unusable), and adapter body-decode failures (unparseable JSON, unreadable
   stream) carry `keyword: parse` so they stay distinct from a genuinely empty
-  body), the `OPENAPI_BASELINE_GENERATE` environment variable, and the
+  body), the `GESSO_BASELINE_GENERATE` environment variable, and the
   `baseline_file` / `baseline_stale` extension parameters (`baseline_stale`
   values: `off` | `note` | `fail`, default `note`). The enforcement semantics
   are part of the contract too: with `baseline_file` configured, a failing
@@ -75,7 +75,7 @@ This library follows [Semantic Versioning 2.0](https://semver.org/). v1.0.0 is t
   `coverage_baseline_file` / `coverage_baseline_stale` extension parameters
   (same values as `baseline_stale`), the matching
   `--coverage-baseline-file` / `--coverage-baseline-stale` merge flags, and
-  the shared `OPENAPI_BASELINE_GENERATE` generation switch are covered too.
+  the shared `GESSO_BASELINE_GENERATE` generation switch are covered too.
   The enforcement semantics are part of the contract: responses that were not
   validated — including responses skipped by `skip_response_codes` — are
   baselined, an uncovered response absent from the file fails the run, and
@@ -93,7 +93,11 @@ This library follows [Semantic Versioning 2.0](https://semver.org/). v1.0.0 is t
     `bin/gesso` entry point
   - v2.x: the `doctor`, `coverage:merge`, `coverage:gate`, and `stubs`
     subcommands of `bin/gesso`; the legacy standalone binaries are not shipped
-- The Laravel `openapi:routes` and `openapi:stubs` command surfaces (flags, exit codes, and versioned JSON output)
+- The Laravel `gesso:routes` and `gesso:stubs` command surfaces (flags, exit codes, and versioned JSON output)
+- The three environment variables Gesso owns — `GESSO_VALIDATION_FORMAT`,
+  `GESSO_CONSOLE_OUTPUT`, and `GESSO_BASELINE_GENERATE` — and the values each
+  accepts. `TEST_TOKEN` and `GITHUB_STEP_SUMMARY` are read but belong to
+  paratest and GitHub Actions; they are not Gesso's to version.
 - The `OpenApiCoverageExtension` PHPUnit configuration parameters (`spec_base_path`, `strip_prefixes`, `specs`, `output_file`, `console_output`, `validation_output`, `baseline_file`, `coverage_baseline_file`, `strict_required`, `strict_additional_properties`, `strict_additional_properties_per_call`, …)
 - The Laravel `ValidatesOpenApiSchema` trait's public methods
 - The category prefixes used in `E_USER_WARNING` messages (`[security]`, `[OpenAPI Schema]`, and the `[OpenAPI 3.2 ...]` categories) and in `E_USER_DEPRECATED` messages (`[Gesso deprecation]`). Adding a category is a minor change; renaming or removing one is major.
@@ -213,6 +217,27 @@ Conventional Commit types — so the constraint is an ordering one: every v2
 release must ship before the first breaking commit reaches `main`, because that
 commit turns the pending release into `3.0.0` and no further v2 release can be
 cut from the branch.
+
+### Renamed spellings still accepted
+
+A rename that keeps the old spelling working is not a removal, so it does not go
+through the `E_USER_DEPRECATED` channel above: a suite running PHPUnit's
+`failOnDeprecation` would fail for spelling a name that still works. These names
+warn once per process on STDERR instead, under the `[Gesso]` prefix, and each
+warning names its replacement and its removal version.
+
+| Accepted spelling | Use instead | Accepted through | Removed in |
+| --- | --- | --- | --- |
+| `OPENAPI_VALIDATION_OUTPUT` | `GESSO_VALIDATION_FORMAT` | v3.x | v4.0 |
+| `OPENAPI_CONSOLE_OUTPUT` | `GESSO_CONSOLE_OUTPUT` | v3.x | v4.0 |
+| `OPENAPI_BASELINE_GENERATE` | `GESSO_BASELINE_GENERATE` | v3.x | v4.0 |
+| `openapi:routes` | `gesso:routes` | v3.x | v4.0 |
+| `openapi:stubs` | `gesso:stubs` | v3.x | v4.0 |
+
+The current spelling wins when both are set, and setting only the accepted one
+resolves to the same value with no behaviour difference. The map lives in
+`Studio\Gesso\Internal\LegacyIdentity`; its removal is tracked by
+[#523](https://github.com/studio-design/gesso/issues/523).
 
 ## Support policy
 

--- a/src/Baseline/InvalidBaselineConfigurationException.php
+++ b/src/Baseline/InvalidBaselineConfigurationException.php
@@ -8,7 +8,7 @@ use RuntimeException;
 use Studio\Gesso\PHPUnit\OpenApiCoverageExtension;
 
 /**
- * Thrown by {@see OpenApiCoverageExtension} when `OPENAPI_BASELINE_GENERATE`
+ * Thrown by {@see OpenApiCoverageExtension} when `GESSO_BASELINE_GENERATE`
  * is set but no `baseline_file` parameter names the output path. A
  * generation run that silently produced nothing would look like "zero
  * violations", so the misconfiguration must abort bootstrap; bootstrap()

--- a/src/Baseline/ViolationBaselineCollector.php
+++ b/src/Baseline/ViolationBaselineCollector.php
@@ -11,13 +11,13 @@ use Studio\Gesso\Validation\Support\SchemaValidatorRunner;
  * Run-level recorder for baseline generation (issue #402).
  *
  * Installed by the PHPUnit extension only when the run is a baseline
- * generation run (`OPENAPI_BASELINE_GENERATE`). Unlike the tracker seams,
+ * generation run (`GESSO_BASELINE_GENERATE`). Unlike the tracker seams,
  * {@see current()} is nullable on purpose: a `null` collector means
  * "generate mode is off" and adapters take the normal assertion path, so
  * no lazy default instance may ever exist.
  *
  * @internal Implementation detail of the violation baseline; the
- *           `OPENAPI_BASELINE_GENERATE` env var and `baseline_file`
+ *           `GESSO_BASELINE_GENERATE` env var and `baseline_file`
  *           extension parameter are the supported surface.
  */
 final class ViolationBaselineCollector

--- a/src/Coverage/CoverageMergeCommand.php
+++ b/src/Coverage/CoverageMergeCommand.php
@@ -16,6 +16,7 @@ use Studio\Gesso\Baseline\ViolationBaselineFile;
 use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\Exception\SpecFileNotFoundException;
 use Studio\Gesso\Internal\Deprecations;
+use Studio\Gesso\Internal\LegacyIdentity;
 use Studio\Gesso\PHPUnit\ConsoleOutput;
 use Studio\Gesso\PHPUnit\CoverageReportSubscriber;
 use Studio\Gesso\PHPUnit\OpenApiCoverageExtension;
@@ -218,13 +219,13 @@ final class CoverageMergeCommand
                                             off | warn | fail. Report response properties
                                             absent from schema declarations. Defaults to off.
               --baseline-file=<path>        Union the violation-baseline halves staged by a
-                                            parallel `OPENAPI_BASELINE_GENERATE=1` run and
+                                            parallel `GESSO_BASELINE_GENERATE=1` run and
                                             write the merged baseline here (Issue #417).
               --coverage-baseline-file=<path>
                                             Gate the merged coverage against a committed set of
                                             known-uncovered responses: any uncovered response
                                             missing from the file fails the merge by name
-                                            (Issue #481). With OPENAPI_BASELINE_GENERATE=1 set,
+                                            (Issue #481). With GESSO_BASELINE_GENERATE=1 set,
                                             the file is (re)written instead of enforced.
               --coverage-baseline-stale=<mode>
                                             off | note | fail. How baseline entries that are
@@ -378,7 +379,7 @@ final class CoverageMergeCommand
             // failure, so returning 0 without a file would hide all of them.
             if ($baselineFile !== null) {
                 $this->writeStderr(sprintf(
-                    "[Gesso] FATAL: --baseline-file requested but no sidecars were found in %s; no baseline was written. Run the parallel suite with OPENAPI_BASELINE_GENERATE=1 first.\n",
+                    "[Gesso] FATAL: --baseline-file requested but no sidecars were found in %s; no baseline was written. Run the parallel suite with GESSO_BASELINE_GENERATE=1 first.\n",
                     $sidecarDir,
                 ));
 
@@ -605,7 +606,7 @@ final class CoverageMergeCommand
         // contract: keep the sidecars when the coverage baseline step failed.
         // Every recovery re-runs *this command*, not the suite — fixing a
         // typo'd path, freeing disk for the write, or accepting the reported
-        // regressions with `OPENAPI_BASELINE_GENERATE=1`. Deleting the
+        // regressions with `GESSO_BASELINE_GENERATE=1`. Deleting the
         // sidecars would make each of those cost a full parallel run.
         $cleanupFailure = $cleanup &&
             !$coverageBaselineFailure &&
@@ -635,7 +636,7 @@ final class CoverageMergeCommand
      */
     private static function baselineGenerationRequested(): bool
     {
-        $value = getenv('OPENAPI_BASELINE_GENERATE');
+        $value = LegacyIdentity::env('GESSO_BASELINE_GENERATE');
         if ($value === false || trim($value) === '') {
             return false;
         }
@@ -723,7 +724,7 @@ final class CoverageMergeCommand
             }
 
             $this->writeStderr(sprintf(
-                "[Gesso] FATAL: %d of %d sidecar(s) carry violation-baseline data from an OPENAPI_BASELINE_GENERATE run, but --baseline-file was not given; discarding it would silently hide the demoted violations. Re-run the merge with --baseline-file=<path>.\n",
+                "[Gesso] FATAL: %d of %d sidecar(s) carry violation-baseline data from an GESSO_BASELINE_GENERATE run, but --baseline-file was not given; discarding it would silently hide the demoted violations. Re-run the merge with --baseline-file=<path>.\n",
                 $sidecarsWithBaseline,
                 $sidecarCount,
             ));
@@ -733,7 +734,7 @@ final class CoverageMergeCommand
 
         if ($sidecarsWithoutBaseline > 0) {
             $this->writeStderr(sprintf(
-                "[Gesso] FATAL: --baseline-file requested but %d of %d sidecar(s) carry no baseline data; the union would be an incomplete baseline. Ensure every worker ran with OPENAPI_BASELINE_GENERATE=1 on a library version that stages baseline sidecars. No baseline was written.\n",
+                "[Gesso] FATAL: --baseline-file requested but %d of %d sidecar(s) carry no baseline data; the union would be an incomplete baseline. Ensure every worker ran with GESSO_BASELINE_GENERATE=1 on a library version that stages baseline sidecars. No baseline was written.\n",
                 $sidecarsWithoutBaseline,
                 $sidecarCount,
             ));
@@ -827,7 +828,7 @@ final class CoverageMergeCommand
         if ($verdict['regressions'] !== []) {
             $this->writeStderr(CoverageBaselineEvaluator::renderRegressionMessage(
                 $verdict['regressions'],
-                'OPENAPI_BASELINE_GENERATE=1 ' . $this->invocation,
+                'GESSO_BASELINE_GENERATE=1 ' . $this->invocation,
             ));
 
             return false;

--- a/src/Coverage/CoverageSidecarEnvelope.php
+++ b/src/Coverage/CoverageSidecarEnvelope.php
@@ -37,7 +37,7 @@ use function sprintf;
  * ```
  *
  * Wire shape (v3, issue #417) adds the violation-baseline half collected
- * during a parallel generation run (`OPENAPI_BASELINE_GENERATE` under
+ * during a parallel generation run (`GESSO_BASELINE_GENERATE` under
  * paratest). Its value is the baseline-file document verbatim
  * ({@see ViolationBaselineFile}), so the inner
  * `baseline_version` stays owned by the baseline format:
@@ -131,7 +131,7 @@ final class CoverageSidecarEnvelope
     /**
      * Every accepted envelope version, in the order they were introduced.
      * The pairs alternate plain / with-baseline because the baseline half is
-     * present only during an `OPENAPI_BASELINE_GENERATE` run, so it is
+     * present only during an `GESSO_BASELINE_GENERATE` run, so it is
      * orthogonal to the tracker half that raised the version.
      */
     private const ACCEPTED_VERSIONS = [

--- a/src/Internal/LegacyIdentity.php
+++ b/src/Internal/LegacyIdentity.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Internal;
+
+use const STDERR;
+
+use InvalidArgumentException;
+
+use function array_search;
+use function fwrite;
+use function getenv;
+use function in_array;
+use function sprintf;
+use function trim;
+
+/**
+ * The old→new spelling map for the two identity surfaces ADR 0001 left behind:
+ * the environment variables and Artisan commands Gesso owns.
+ *
+ * Issue #504. Every legacy spelling keeps working with identical behavior for
+ * the whole of v3; the only new output is one STDERR line per legacy name per
+ * process. Removal is {@see self::REMOVED_IN}, tracked by #523.
+ *
+ * The warning deliberately does *not* go through {@see Deprecations} and its
+ * `E_USER_DEPRECATED` channel: a PHPUnit run configured with `failOnDeprecation`
+ * would then fail purely for spelling a name that is still supported.
+ *
+ * @internal Implementation detail of the v3 rename. Not a public API: the map
+ *           disappears with the legacy names it describes.
+ */
+final class LegacyIdentity
+{
+    /**
+     * The major that removes every legacy spelling below. Tracked by
+     * https://github.com/studio-design/gesso/issues/523.
+     */
+    public const REMOVED_IN = '4.0.0';
+
+    /** Legacy environment variable name => the name to use instead. */
+    public const ENV_NAMES = [
+        'OPENAPI_VALIDATION_OUTPUT' => 'GESSO_VALIDATION_FORMAT',
+        'OPENAPI_CONSOLE_OUTPUT' => 'GESSO_CONSOLE_OUTPUT',
+        'OPENAPI_BASELINE_GENERATE' => 'GESSO_BASELINE_GENERATE',
+    ];
+
+    /** Legacy Artisan command name => the name to use instead. */
+    public const COMMAND_NAMES = [
+        'openapi:routes' => 'gesso:routes',
+        'openapi:stubs' => 'gesso:stubs',
+    ];
+
+    /** @var list<string> */
+    private static array $warnings = [];
+
+    private function __construct() {}
+
+    /**
+     * Read `$name`, falling back to its legacy spelling with a one-time
+     * warning. Returns `false` when neither name carries a non-blank value,
+     * so a caller keeps `getenv()`'s branch shape.
+     *
+     * The current name wins when both are set, and setting only the legacy
+     * name is honoured.
+     */
+    public static function env(string $name): false|string
+    {
+        $value = getenv($name);
+
+        if ($value !== false && trim($value) !== '') {
+            return $value;
+        }
+
+        $legacy = array_search($name, self::ENV_NAMES, true);
+
+        if ($legacy === false) {
+            return false;
+        }
+
+        $legacyValue = getenv($legacy);
+
+        if ($legacyValue === false || trim($legacyValue) === '') {
+            return false;
+        }
+
+        self::warn($legacy, $name);
+
+        return $legacyValue;
+    }
+
+    /**
+     * Warn when an Artisan command was invoked under its legacy alias. Takes
+     * the invoked name rather than the canonical one, because Symfony resolves
+     * the alias before the command runs and only the input still remembers
+     * which spelling the user typed.
+     */
+    public static function warnIfLegacyCommand(string $invokedName): void
+    {
+        $current = self::COMMAND_NAMES[$invokedName] ?? null;
+
+        if ($current === null) {
+            return;
+        }
+
+        self::warn($invokedName, $current);
+    }
+
+    /**
+     * The warning lines emitted this process, in order. The writes go to
+     * STDERR — which no test harness here can capture — so this is the seam
+     * that makes them assertable.
+     *
+     * @return list<string>
+     */
+    public static function warnings(): array
+    {
+        return self::$warnings;
+    }
+
+    /** Clear the once-per-process dedup. Call from tests that trigger a warning. */
+    public static function resetForTesting(): void
+    {
+        self::$warnings = [];
+    }
+
+    private static function warn(string $legacy, string $current): void
+    {
+        if (trim($legacy) === '' || trim($current) === '') {
+            throw new InvalidArgumentException('A legacy-identity warning needs both the legacy and the current name.');
+        }
+
+        $line = sprintf(
+            '[Gesso] WARNING: %s is deprecated and will be removed in Gesso %s. Use %s.',
+            $legacy,
+            self::REMOVED_IN,
+            $current,
+        );
+
+        if (in_array($line, self::$warnings, true)) {
+            return;
+        }
+
+        self::$warnings[] = $line;
+        fwrite(STDERR, $line . "\n");
+    }
+}

--- a/src/Internal/LegacyIdentity.php
+++ b/src/Internal/LegacyIdentity.php
@@ -12,6 +12,7 @@ use function array_search;
 use function fwrite;
 use function getenv;
 use function in_array;
+use function putenv;
 use function sprintf;
 use function trim;
 
@@ -121,6 +122,28 @@ final class LegacyIdentity
     /** Clear the once-per-process dedup. Call from tests that trigger a warning. */
     public static function resetForTesting(): void
     {
+        self::$warnings = [];
+    }
+
+    /**
+     * Unset `$name` *and* the spelling {@see env()} would fall back to, then
+     * clear the dedup.
+     *
+     * Test lifecycles call this instead of `putenv($name)`: clearing only the
+     * current name leaves a legacy name in the ambient environment able to
+     * steer a test that asserts default behaviour, and the leak is invisible
+     * until someone runs the suite on a machine that exports the old spelling.
+     */
+    public static function resetEnvForTesting(string $name): void
+    {
+        putenv($name);
+
+        $legacy = array_search($name, self::ENV_NAMES, true);
+
+        if ($legacy !== false) {
+            putenv($legacy);
+        }
+
         self::$warnings = [];
     }
 

--- a/src/Laravel/Commands/OpenApiRoutesCommand.php
+++ b/src/Laravel/Commands/OpenApiRoutesCommand.php
@@ -13,6 +13,7 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Routing\Router;
 use InvalidArgumentException;
 use JsonException;
+use Studio\Gesso\Internal\LegacyIdentity;
 use Studio\Gesso\Laravel\RouteParity\LaravelRouteParityAnalyzer;
 use Studio\Gesso\Laravel\RouteParity\RouteParityResult;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
@@ -34,12 +35,14 @@ use function str_starts_with;
 use function trim;
 
 /**
- * @internal Registered by GessoServiceProvider. Use the `openapi:routes`
+ * @internal Registered by GessoServiceProvider. Use the `gesso:routes`
  *           Artisan command rather than constructing this class directly.
  */
 final class OpenApiRoutesCommand extends Command
 {
-    protected $signature = 'openapi:routes
+    /** Issue #504: the pre-v3 spelling, accepted through v3 and removed in v4. */
+    protected $aliases = ['openapi:routes'];
+    protected $signature = 'gesso:routes
         {--spec=* : Spec name to compare; repeat for multiple specs}
         {--prefix= : Only include Laravel routes under this URI prefix}
         {--middleware=* : Only include routes using all of these middleware names}
@@ -57,6 +60,8 @@ final class OpenApiRoutesCommand extends Command
         Router $router,
         LaravelRouteParityAnalyzer $analyzer,
     ): int {
+        LegacyIdentity::warnIfLegacyCommand((string) $this->input->getFirstArgument());
+
         $format = trim((string) $this->option('format'));
         if (!in_array($format, ['text', 'json'], true)) {
             $this->components->error("Unsupported format '{$format}'. Use text or json.");

--- a/src/Laravel/Commands/OpenApiStubsCommand.php
+++ b/src/Laravel/Commands/OpenApiStubsCommand.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Foundation\Application;
 use InvalidArgumentException;
 use RuntimeException;
 use Studio\Gesso\Cli\StubsCommand;
+use Studio\Gesso\Internal\LegacyIdentity;
 use Studio\Gesso\Stubs\StubRenderer;
 
 use function config;
@@ -31,12 +32,14 @@ use function trim;
  * path comes from `gesso.spec_base_path` + `gesso.default_spec` so a Laravel
  * user does not have to repeat what the published config already states.
  *
- * @internal Registered by GessoServiceProvider. Use the `openapi:stubs` Artisan
+ * @internal Registered by GessoServiceProvider. Use the `gesso:stubs` Artisan
  *           command rather than constructing this class directly.
  */
 final class OpenApiStubsCommand extends Command
 {
-    protected $signature = 'openapi:stubs
+    /** Issue #504: the pre-v3 spelling, accepted through v3 and removed in v4. */
+    protected $aliases = ['openapi:stubs'];
+    protected $signature = 'gesso:stubs
         {--spec= : Spec name resolved under gesso.spec_base_path, or a path to a spec file}
         {--coverage= : Coverage JSON (schema_version 3); only uncovered responses are stubbed}
         {--adapter=laravel : Generated test idiom: phpunit, laravel, symfony or pest}
@@ -48,6 +51,8 @@ final class OpenApiStubsCommand extends Command
 
     public function handle(Application $application): int
     {
+        LegacyIdentity::warnIfLegacyCommand((string) $this->input->getFirstArgument());
+
         $adapter = trim((string) $this->option('adapter'));
         if (!in_array($adapter, StubRenderer::ADAPTERS, true)) {
             $this->components->error(sprintf(
@@ -86,7 +91,7 @@ final class OpenApiStubsCommand extends Command
         $command = new StubsCommand(
             stdoutWriter: $write,
             stderrWriter: $write,
-            invocation: 'php artisan openapi:stubs',
+            invocation: 'php artisan gesso:stubs',
         );
 
         return $command->run($options) === StubsCommand::EXIT_OK ? self::SUCCESS : self::INVALID;

--- a/src/Laravel/RouteParity/RouteParityResult.php
+++ b/src/Laravel/RouteParity/RouteParityResult.php
@@ -12,7 +12,7 @@ use function count;
  * Stable result returned by the Laravel route-parity analyzer.
  *
  * @internal Not part of the package's public API. The versioned JSON emitted
- *           by `openapi:routes` is the supported machine-readable contract.
+ *           by `gesso:routes` is the supported machine-readable contract.
  *
  * @phpstan-type MatchedEntry array{spec: string, method: string, openapi_path: string, operation_id: ?string, route_uri: string, route_name: ?string, domain: ?string}
  * @phpstan-type OpenApiOnlyEntry array{spec: string, method: string, openapi_path: string, operation_id: ?string}

--- a/src/PHPUnit/ConsoleOutput.php
+++ b/src/PHPUnit/ConsoleOutput.php
@@ -6,8 +6,9 @@ namespace Studio\Gesso\PHPUnit;
 
 use const STDERR;
 
+use Studio\Gesso\Internal\LegacyIdentity;
+
 use function fwrite;
-use function getenv;
 use function mb_strtolower;
 use function trim;
 
@@ -28,13 +29,13 @@ enum ConsoleOutput: string
      */
     public static function resolve(?string $parameterValue): self
     {
-        $envValue = getenv('OPENAPI_CONSOLE_OUTPUT');
+        $envValue = LegacyIdentity::env('GESSO_CONSOLE_OUTPUT');
 
         if ($envValue !== false && trim($envValue) !== '') {
             $resolved = self::tryFrom(mb_strtolower(trim($envValue)));
 
             if ($resolved === null) {
-                fwrite(STDERR, "[OpenAPI Coverage] WARNING: Invalid OPENAPI_CONSOLE_OUTPUT value '{$envValue}'. Valid values: default, all, uncovered_only, active_only. Falling back to 'default'.\n");
+                fwrite(STDERR, "[OpenAPI Coverage] WARNING: Invalid GESSO_CONSOLE_OUTPUT value '{$envValue}'. Valid values: default, all, uncovered_only, active_only. Falling back to 'default'.\n");
             }
 
             return $resolved ?? self::DEFAULT;

--- a/src/PHPUnit/CoverageReportSubscriber.php
+++ b/src/PHPUnit/CoverageReportSubscriber.php
@@ -101,7 +101,7 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
      * @param null|callable(int): void $exitHandler Test seam for the strict-miss exit. Defaults to native `exit()`
      *                                              so production behavior matches PHPUnit's own coverage gate.
      * @param null|string $baselineGeneratePath Issue #402: destination of a violation-baseline generation run
-     *                                          (`OPENAPI_BASELINE_GENERATE`). When non-null the subscriber writes the
+     *                                          (`GESSO_BASELINE_GENERATE`). When non-null the subscriber writes the
      *                                          collected fingerprints here at run end; partial runs refuse the write
      *                                          (an incomplete baseline would hide violations). Worker mode instead
      *                                          stages the fingerprints in the sidecar envelope for
@@ -126,7 +126,7 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
      *                                                from the set fails the run by name, independent of any
      *                                                percentage.
      * @param null|string $coverageBaselineGeneratePath Issue #481: destination of a coverage-baseline generation run
-     *                                                  (`OPENAPI_BASELINE_GENERATE`, shared with the violation
+     *                                                  (`GESSO_BASELINE_GENERATE`, shared with the violation
      *                                                  baseline). Mutually exclusive with $coverageBaseline.
      * @param BaselineStaleMode $coverageBaselineStaleMode Issue #481: how entries that are covered now — the
      *                                                     ratchet-down signal — are reported.
@@ -855,7 +855,7 @@ final readonly class CoverageReportSubscriber implements ExecutionFinishedSubscr
         if ($verdict['regressions'] !== []) {
             $this->writeStderr(CoverageBaselineEvaluator::renderRegressionMessage(
                 $verdict['regressions'],
-                'OPENAPI_BASELINE_GENERATE=1 vendor/bin/phpunit',
+                'GESSO_BASELINE_GENERATE=1 vendor/bin/phpunit',
             ));
             $this->exitNonZero();
 

--- a/src/PHPUnit/OpenApiCoverageExtension.php
+++ b/src/PHPUnit/OpenApiCoverageExtension.php
@@ -30,6 +30,7 @@ use Studio\Gesso\Exception\EnumDriftException;
 use Studio\Gesso\Exception\InvalidOpenApiSpecException;
 use Studio\Gesso\Exception\SpecFileNotFoundException;
 use Studio\Gesso\Internal\EnumScanner;
+use Studio\Gesso\Internal\LegacyIdentity;
 use Studio\Gesso\Internal\PartialRunDecision;
 use Studio\Gesso\Schema\EnumDriftAsserter;
 use Studio\Gesso\Schema\EnumDriftReport;
@@ -408,14 +409,14 @@ final class OpenApiCoverageExtension implements Extension
             // (all failures demoted) and then drop every recorded violation
             // on the floor — abort bootstrap instead.
             self::writeStderr(
-                "[Gesso] FATAL: OPENAPI_BASELINE_GENERATE is set but neither `baseline_file` nor `coverage_baseline_file` is configured.\n"
+                "[Gesso] FATAL: GESSO_BASELINE_GENERATE is set but neither `baseline_file` nor `coverage_baseline_file` is configured.\n"
                 . "  Action: add <parameter name=\"baseline_file\" value=\"gesso-baseline.json\"/> (violations) or\n"
                 . "          <parameter name=\"coverage_baseline_file\" value=\"gesso-coverage-baseline.json\"/> (coverage)\n"
                 . "          to the extension bootstrap.\n",
             );
 
             throw new InvalidBaselineConfigurationException(
-                'OPENAPI_BASELINE_GENERATE requires the baseline_file or coverage_baseline_file extension parameter.',
+                'GESSO_BASELINE_GENERATE requires the baseline_file or coverage_baseline_file extension parameter.',
             );
         }
 
@@ -453,7 +454,7 @@ final class OpenApiCoverageExtension implements Extension
             } catch (InvalidArgumentException $e) {
                 self::writeStderr(
                     "[Gesso] FATAL: baseline_file could not be loaded: {$e->getMessage()}\n"
-                    . "  Action: generate it with `OPENAPI_BASELINE_GENERATE=1 vendor/bin/phpunit`, fix the path, or remove the `baseline_file` parameter.\n",
+                    . "  Action: generate it with `GESSO_BASELINE_GENERATE=1 vendor/bin/phpunit`, fix the path, or remove the `baseline_file` parameter.\n",
                 );
 
                 throw new InvalidBaselineConfigurationException(
@@ -622,7 +623,7 @@ final class OpenApiCoverageExtension implements Extension
         } catch (InvalidArgumentException $e) {
             self::writeStderr(
                 "[Gesso] FATAL: coverage_baseline_file could not be loaded: {$e->getMessage()}\n"
-                . "  Action: generate it with `OPENAPI_BASELINE_GENERATE=1 vendor/bin/phpunit`, fix the path, or remove the `coverage_baseline_file` parameter.\n",
+                . "  Action: generate it with `GESSO_BASELINE_GENERATE=1 vendor/bin/phpunit`, fix the path, or remove the `coverage_baseline_file` parameter.\n",
             );
 
             throw new InvalidBaselineConfigurationException(
@@ -681,7 +682,7 @@ final class OpenApiCoverageExtension implements Extension
      */
     private static function baselineGenerationRequested(): bool
     {
-        $value = getenv('OPENAPI_BASELINE_GENERATE');
+        $value = LegacyIdentity::env('GESSO_BASELINE_GENERATE');
         if ($value === false || trim($value) === '') {
             return false;
         }

--- a/src/Stubs/StubGenerator.php
+++ b/src/Stubs/StubGenerator.php
@@ -58,7 +58,7 @@ use function usort;
  *     tuples: list<StubTuple>,
  * }
  *
- * @internal The `gesso stubs` / `openapi:stubs` CLI surface is the supported API.
+ * @internal The `gesso stubs` / `gesso:stubs` CLI surface is the supported API.
  */
 final class StubGenerator
 {

--- a/src/Stubs/StubRenderer.php
+++ b/src/Stubs/StubRenderer.php
@@ -62,7 +62,7 @@ use function wordwrap;
  * @phpstan-import-type StubRequestBody from StubGenerator
  * @phpstan-import-type StubTuple from StubGenerator
  *
- * @internal The `gesso stubs` / `openapi:stubs` CLI surface is the supported API.
+ * @internal The `gesso stubs` / `gesso:stubs` CLI surface is the supported API.
  */
 final class StubRenderer
 {

--- a/src/ValidationOutput.php
+++ b/src/ValidationOutput.php
@@ -6,8 +6,9 @@ namespace Studio\Gesso;
 
 use const STDERR;
 
+use Studio\Gesso\Internal\LegacyIdentity;
+
 use function fwrite;
-use function getenv;
 use function mb_strtolower;
 use function trim;
 
@@ -18,14 +19,15 @@ use function trim;
  * {@see format()} when composing an assertion failure message, so one switch
  * selects the same mode everywhere. Resolution priority:
  *
- * 1. environment variable `OPENAPI_VALIDATION_OUTPUT` (`text` | `json`);
+ * 1. environment variable `GESSO_VALIDATION_FORMAT` (`text` | `json`), or the
+ *    pre-v3 spelling {@see LegacyIdentity} still accepts for it;
  * 2. the format selected via {@see use()} (directly or through the PHPUnit
  *    extension's `validation_output` parameter);
  * 3. {@see ValidationOutputFormat::Text} (the historical default).
  *
  * An unrecognised environment value warns on STDERR once per process and
  * falls through to the next source, mirroring the coverage extension's
- * `OPENAPI_CONSOLE_OUTPUT` handling.
+ * `GESSO_CONSOLE_OUTPUT` handling.
  */
 final class ValidationOutput
 {
@@ -36,7 +38,7 @@ final class ValidationOutput
 
     public static function format(): ValidationOutputFormat
     {
-        $envValue = getenv('OPENAPI_VALIDATION_OUTPUT');
+        $envValue = LegacyIdentity::env('GESSO_VALIDATION_FORMAT');
 
         if ($envValue !== false && trim($envValue) !== '') {
             $resolved = ValidationOutputFormat::tryFrom(mb_strtolower(trim($envValue)));
@@ -47,7 +49,7 @@ final class ValidationOutput
 
             if (!self::$warnedInvalidEnv) {
                 self::$warnedInvalidEnv = true;
-                fwrite(STDERR, "[Gesso] WARNING: Invalid OPENAPI_VALIDATION_OUTPUT value '{$envValue}'. Valid values: text, json. Falling back to the configured format.\n");
+                fwrite(STDERR, "[Gesso] WARNING: Invalid GESSO_VALIDATION_FORMAT value '{$envValue}'. Valid values: text, json. Falling back to the configured format.\n");
             }
         }
 

--- a/tests/Integration/Laravel/OpenApiRoutesCommandIntegrationTest.php
+++ b/tests/Integration/Laravel/OpenApiRoutesCommandIntegrationTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\Test;
+use Studio\Gesso\Internal\LegacyIdentity;
 use Studio\Gesso\Laravel\GessoServiceProvider;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 
@@ -29,6 +30,7 @@ final class OpenApiRoutesCommandIntegrationTest extends TestCase
     {
         parent::setUp();
         OpenApiSpecLoader::reset();
+        LegacyIdentity::resetForTesting();
         config()->set('gesso.default_spec', 'route-parity');
         config()->set('gesso.spec_base_path', dirname(__DIR__, 2) . '/fixtures/specs');
         config()->set('gesso.strip_prefixes', ['/api']);
@@ -39,13 +41,39 @@ final class OpenApiRoutesCommandIntegrationTest extends TestCase
     protected function tearDown(): void
     {
         OpenApiSpecLoader::reset();
+        LegacyIdentity::resetForTesting();
         parent::tearDown();
+    }
+
+    /**
+     * Issue #504: `openapi:routes` keeps working through v3. The two paths have
+     * to be indistinguishable apart from the one deprecation line, so this
+     * compares them rather than asserting a shape twice.
+     */
+    #[Test]
+    public function the_legacy_command_name_is_an_alias_with_identical_output(): void
+    {
+        $options = ['--prefix' => 'api', '--format' => 'json'];
+
+        $currentExit = Artisan::call('gesso:routes', $options);
+        $currentOutput = Artisan::output();
+        $this->assertSame([], LegacyIdentity::warnings());
+
+        $legacyExit = Artisan::call('openapi:routes', $options);
+
+        $this->assertSame($currentExit, $legacyExit);
+        $this->assertSame($currentOutput, Artisan::output());
+        $this->assertSame(
+            ['[Gesso] WARNING: openapi:routes is deprecated and will be removed in Gesso '
+                . LegacyIdentity::REMOVED_IN . '. Use gesso:routes.'],
+            LegacyIdentity::warnings(),
+        );
     }
 
     #[Test]
     public function command_is_registered_and_renders_route_parity(): void
     {
-        $exitCode = Artisan::call('openapi:routes', [
+        $exitCode = Artisan::call('gesso:routes', [
             '--prefix' => 'api',
             '--middleware' => ['api'],
             '--domain' => ['api.example.test'],
@@ -64,7 +92,7 @@ final class OpenApiRoutesCommandIntegrationTest extends TestCase
     #[Test]
     public function json_output_is_versioned_and_supports_multiple_specs(): void
     {
-        $exitCode = Artisan::call('openapi:routes', [
+        $exitCode = Artisan::call('gesso:routes', [
             '--spec' => ['route-parity', 'route-parity-admin'],
             '--prefix' => 'api',
             '--middleware' => ['api'],
@@ -87,7 +115,7 @@ final class OpenApiRoutesCommandIntegrationTest extends TestCase
     #[Test]
     public function json_output_matches_the_v2_compatibility_fixture(): void
     {
-        $exitCode = Artisan::call('openapi:routes', [
+        $exitCode = Artisan::call('gesso:routes', [
             '--spec' => ['route-parity', 'route-parity-admin'],
             '--prefix' => 'api',
             '--middleware' => ['api'],
@@ -113,7 +141,7 @@ final class OpenApiRoutesCommandIntegrationTest extends TestCase
                 ->name("undocumented.{$index}");
         }
 
-        $exitCode = Artisan::call('openapi:routes', [
+        $exitCode = Artisan::call('gesso:routes', [
             '--format' => 'json',
         ]);
 
@@ -138,11 +166,11 @@ final class OpenApiRoutesCommandIntegrationTest extends TestCase
             '--format' => 'json',
         ];
 
-        $this->assertSame(1, Artisan::call('openapi:routes', [
+        $this->assertSame(1, Artisan::call('gesso:routes', [
             ...$options,
             '--fail-on-undocumented' => true,
         ]));
-        $this->assertSame(1, Artisan::call('openapi:routes', [
+        $this->assertSame(1, Artisan::call('gesso:routes', [
             ...$options,
             '--fail-on-unimplemented' => true,
         ]));
@@ -151,7 +179,7 @@ final class OpenApiRoutesCommandIntegrationTest extends TestCase
     #[Test]
     public function documented_side_exclusions_are_reported_and_ignored_by_the_strict_gate(): void
     {
-        $exitCode = Artisan::call('openapi:routes', [
+        $exitCode = Artisan::call('gesso:routes', [
             '--prefix' => 'api',
             '--middleware' => ['api'],
             '--domain' => ['api.example.test'],
@@ -175,7 +203,7 @@ final class OpenApiRoutesCommandIntegrationTest extends TestCase
         config()->set('gesso.route_parity.external_operation_ids', ['does-not-match']);
         config()->set('gesso.route_parity.external_openapi_paths', ['/v1/miss*']);
 
-        $exitCode = Artisan::call('openapi:routes', [
+        $exitCode = Artisan::call('gesso:routes', [
             '--prefix' => 'api',
             '--middleware' => ['api'],
             '--domain' => ['api.example.test'],
@@ -196,7 +224,7 @@ final class OpenApiRoutesCommandIntegrationTest extends TestCase
     {
         config()->set('gesso.route_parity.external_operation_ids', 'forms.*');
 
-        $this->assertSame(1, Artisan::call('openapi:routes'));
+        $this->assertSame(1, Artisan::call('gesso:routes'));
         $this->assertStringContainsString(
             'gesso.route_parity.external_operation_ids must be an array of strings',
             Artisan::output(),
@@ -206,7 +234,7 @@ final class OpenApiRoutesCommandIntegrationTest extends TestCase
     #[Test]
     public function invalid_format_returns_invalid_exit_code(): void
     {
-        $this->assertSame(2, Artisan::call('openapi:routes', ['--format' => 'xml']));
+        $this->assertSame(2, Artisan::call('gesso:routes', ['--format' => 'xml']));
         $this->assertStringContainsString('Unsupported format', Artisan::output());
     }
 

--- a/tests/Integration/Laravel/OpenApiStubsCommandIntegrationTest.php
+++ b/tests/Integration/Laravel/OpenApiStubsCommandIntegrationTest.php
@@ -7,6 +7,7 @@ namespace Studio\Gesso\Tests\Integration\Laravel;
 use Illuminate\Support\Facades\Artisan;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\Test;
+use Studio\Gesso\Internal\LegacyIdentity;
 use Studio\Gesso\Laravel\GessoServiceProvider;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 
@@ -28,6 +29,7 @@ final class OpenApiStubsCommandIntegrationTest extends TestCase
         $this->outputDir = sys_get_temp_dir() . '/gesso-artisan-stubs-' . uniqid('', true);
         parent::setUp();
         OpenApiSpecLoader::reset();
+        LegacyIdentity::resetForTesting();
         config()->set('gesso.default_spec', 'petstore-3.0');
         config()->set('gesso.spec_base_path', dirname(__DIR__, 2) . '/fixtures/specs');
     }
@@ -41,13 +43,33 @@ final class OpenApiStubsCommandIntegrationTest extends TestCase
         }
         @rmdir($this->outputDir);
         OpenApiSpecLoader::reset();
+        LegacyIdentity::resetForTesting();
         parent::tearDown();
+    }
+
+    /** Issue #504: `openapi:stubs` keeps working through v3, with one extra line. */
+    #[Test]
+    public function the_legacy_command_name_is_an_alias_with_identical_output(): void
+    {
+        $currentExit = Artisan::call('gesso:stubs', ['--output' => $this->outputDir, '--dry-run' => true]);
+        $currentOutput = Artisan::output();
+        $this->assertSame([], LegacyIdentity::warnings());
+
+        $legacyExit = Artisan::call('openapi:stubs', ['--output' => $this->outputDir, '--dry-run' => true]);
+
+        $this->assertSame($currentExit, $legacyExit);
+        $this->assertSame($currentOutput, Artisan::output());
+        $this->assertSame(
+            ['[Gesso] WARNING: openapi:stubs is deprecated and will be removed in Gesso '
+                . LegacyIdentity::REMOVED_IN . '. Use gesso:stubs.'],
+            LegacyIdentity::warnings(),
+        );
     }
 
     #[Test]
     public function command_is_registered_and_resolves_the_spec_from_config(): void
     {
-        $exitCode = Artisan::call('openapi:stubs', ['--output' => $this->outputDir]);
+        $exitCode = Artisan::call('gesso:stubs', ['--output' => $this->outputDir]);
 
         $this->assertSame(0, $exitCode);
         $this->assertStringContainsString('GetV1PetsTest.php', Artisan::output());
@@ -64,7 +86,7 @@ final class OpenApiStubsCommandIntegrationTest extends TestCase
     #[Test]
     public function a_dry_run_writes_nothing(): void
     {
-        $exitCode = Artisan::call('openapi:stubs', ['--output' => $this->outputDir, '--dry-run' => true]);
+        $exitCode = Artisan::call('gesso:stubs', ['--output' => $this->outputDir, '--dry-run' => true]);
 
         $this->assertSame(0, $exitCode);
         $this->assertStringContainsString('Would write', Artisan::output());
@@ -74,7 +96,7 @@ final class OpenApiStubsCommandIntegrationTest extends TestCase
     #[Test]
     public function an_unsupported_adapter_is_a_usage_error(): void
     {
-        $exitCode = Artisan::call('openapi:stubs', ['--adapter' => 'codeception']);
+        $exitCode = Artisan::call('gesso:stubs', ['--adapter' => 'codeception']);
 
         $this->assertSame(2, $exitCode);
         $this->assertStringContainsString('Unsupported adapter', Artisan::output());
@@ -85,7 +107,7 @@ final class OpenApiStubsCommandIntegrationTest extends TestCase
     {
         config()->set('gesso.default_spec', 'does-not-exist');
 
-        $exitCode = Artisan::call('openapi:stubs', ['--output' => $this->outputDir]);
+        $exitCode = Artisan::call('gesso:stubs', ['--output' => $this->outputDir]);
 
         $this->assertSame(2, $exitCode);
         $this->assertStringContainsString('does-not-exist.json', Artisan::output());

--- a/tests/Unit/Baseline/CoverageBaselineEvaluatorTest.php
+++ b/tests/Unit/Baseline/CoverageBaselineEvaluatorTest.php
@@ -171,13 +171,13 @@ class CoverageBaselineEvaluatorTest extends TestCase
                 ['front', 'DELETE', '/pets/{id}', '204', '*'],
                 ['front', 'GET', '/pets', '500', 'application/json'],
             ])->sorted(),
-            'OPENAPI_BASELINE_GENERATE=1 vendor/bin/phpunit',
+            'GESSO_BASELINE_GENERATE=1 vendor/bin/phpunit',
         );
 
         $this->assertStringContainsString('[Gesso] FATAL: 2 response(s) are not covered', $message);
         $this->assertStringContainsString("  - [front] DELETE /pets/{id} status=204 content-type=*\n", $message);
         $this->assertStringContainsString('  - [front] GET /pets status=500 content-type=application/json', $message);
-        $this->assertStringContainsString('OPENAPI_BASELINE_GENERATE=1 vendor/bin/phpunit', $message);
+        $this->assertStringContainsString('GESSO_BASELINE_GENERATE=1 vendor/bin/phpunit', $message);
         $this->assertStringEndsWith("\n", $message);
     }
 

--- a/tests/Unit/Coverage/CoverageMergeCommandCoverageBaselineTest.php
+++ b/tests/Unit/Coverage/CoverageMergeCommandCoverageBaselineTest.php
@@ -44,9 +44,7 @@ class CoverageMergeCommandCoverageBaselineTest extends TestCase
         OpenApiCoverageTracker::reset();
         StrictRequiredTracker::reset();
         OpenApiSpecLoader::reset();
-        putenv('GESSO_BASELINE_GENERATE');
-        putenv('OPENAPI_BASELINE_GENERATE');
-        LegacyIdentity::resetForTesting();
+        LegacyIdentity::resetEnvForTesting('GESSO_BASELINE_GENERATE');
 
         $base = sys_get_temp_dir() . '/gesso-merge-coverage-baseline-' . uniqid('', true);
         $this->sidecarDir = $base . '/sidecars';
@@ -56,9 +54,7 @@ class CoverageMergeCommandCoverageBaselineTest extends TestCase
 
     protected function tearDown(): void
     {
-        putenv('GESSO_BASELINE_GENERATE');
-        putenv('OPENAPI_BASELINE_GENERATE');
-        LegacyIdentity::resetForTesting();
+        LegacyIdentity::resetEnvForTesting('GESSO_BASELINE_GENERATE');
         foreach (glob($this->sidecarDir . '/*') ?: [] as $path) {
             @unlink($path);
         }
@@ -314,9 +310,7 @@ class CoverageMergeCommandCoverageBaselineTest extends TestCase
         putenv('GESSO_BASELINE_GENERATE=1');
         $stderr = '';
         $this->merge($stderr, $this->baselinePath);
-        putenv('GESSO_BASELINE_GENERATE');
-        putenv('OPENAPI_BASELINE_GENERATE');
-        LegacyIdentity::resetForTesting();
+        LegacyIdentity::resetEnvForTesting('GESSO_BASELINE_GENERATE');
 
         foreach (glob($this->sidecarDir . '/*') ?: [] as $path) {
             @unlink($path);

--- a/tests/Unit/Coverage/CoverageMergeCommandCoverageBaselineTest.php
+++ b/tests/Unit/Coverage/CoverageMergeCommandCoverageBaselineTest.php
@@ -12,6 +12,7 @@ use Studio\Gesso\Coverage\CoverageMergeCommand;
 use Studio\Gesso\Coverage\CoverageSidecarEnvelope;
 use Studio\Gesso\Coverage\CoverageSidecarWriter;
 use Studio\Gesso\Coverage\OpenApiCoverageTracker;
+use Studio\Gesso\Internal\LegacyIdentity;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 use Studio\Gesso\Validation\Strict\StrictRequiredTracker;
 
@@ -43,7 +44,9 @@ class CoverageMergeCommandCoverageBaselineTest extends TestCase
         OpenApiCoverageTracker::reset();
         StrictRequiredTracker::reset();
         OpenApiSpecLoader::reset();
+        putenv('GESSO_BASELINE_GENERATE');
         putenv('OPENAPI_BASELINE_GENERATE');
+        LegacyIdentity::resetForTesting();
 
         $base = sys_get_temp_dir() . '/gesso-merge-coverage-baseline-' . uniqid('', true);
         $this->sidecarDir = $base . '/sidecars';
@@ -53,7 +56,9 @@ class CoverageMergeCommandCoverageBaselineTest extends TestCase
 
     protected function tearDown(): void
     {
+        putenv('GESSO_BASELINE_GENERATE');
         putenv('OPENAPI_BASELINE_GENERATE');
+        LegacyIdentity::resetForTesting();
         foreach (glob($this->sidecarDir . '/*') ?: [] as $path) {
             @unlink($path);
         }
@@ -92,7 +97,7 @@ class CoverageMergeCommandCoverageBaselineTest extends TestCase
         // union, not either slice.
         $this->writeWorkerSidecar('1', [['GET', '/v1/pets', '200', 'application/json']]);
         $this->writeWorkerSidecar('2', [['GET', '/v1/pets/search', '200', 'application/json']]);
-        putenv('OPENAPI_BASELINE_GENERATE=1');
+        putenv('GESSO_BASELINE_GENERATE=1');
 
         $stderr = '';
         $exit = $this->merge($stderr, $this->baselinePath);
@@ -103,6 +108,25 @@ class CoverageMergeCommandCoverageBaselineTest extends TestCase
         $this->assertFalse($written->contains($this->entry('GET', '/v1/pets', '200', 'application/json')));
         $this->assertFalse($written->contains($this->entry('GET', '/v1/pets/search', '200', 'application/json')));
         $this->assertTrue($written->contains($this->entry('GET', '/v1/pets', '500', 'application/json')));
+    }
+
+    /** Issue #504: this read site goes through {@see LegacyIdentity}, not bare getenv(). */
+    #[Test]
+    public function the_legacy_generation_env_name_still_writes_the_baseline(): void
+    {
+        $this->writeWorkerSidecar('1', [['GET', '/v1/pets', '200', 'application/json']]);
+        putenv('OPENAPI_BASELINE_GENERATE=1');
+
+        $stderr = '';
+        $exit = $this->merge($stderr, $this->baselinePath);
+
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('[Gesso] Coverage baseline written:', $stderr);
+        $this->assertSame(
+            ['[Gesso] WARNING: OPENAPI_BASELINE_GENERATE is deprecated and will be removed in Gesso '
+                . LegacyIdentity::REMOVED_IN . '. Use GESSO_BASELINE_GENERATE.'],
+            LegacyIdentity::warnings(),
+        );
     }
 
     #[Test]
@@ -135,7 +159,7 @@ class CoverageMergeCommandCoverageBaselineTest extends TestCase
             '  - [petstore-3.0] GET /v1/pets status=200 content-type=application/json',
             $stderr,
         );
-        $this->assertStringContainsString('OPENAPI_BASELINE_GENERATE=1 gesso coverage:merge', $stderr);
+        $this->assertStringContainsString('GESSO_BASELINE_GENERATE=1 gesso coverage:merge', $stderr);
     }
 
     #[Test]
@@ -179,7 +203,7 @@ class CoverageMergeCommandCoverageBaselineTest extends TestCase
     {
         // Recovery from any coverage-baseline failure re-runs *this command*
         // — fix the path, free disk, or accept the regressions with
-        // OPENAPI_BASELINE_GENERATE=1. Cleaning up would make each of those
+        // GESSO_BASELINE_GENERATE=1. Cleaning up would make each of those
         // cost a full parallel suite run.
         $this->writeGeneratedBaseline([['GET', '/v1/pets', '200', 'application/json']]);
         $this->writeWorkerSidecar('1', [['GET', '/v1/pets/search', '200', 'application/json']]);
@@ -287,10 +311,12 @@ class CoverageMergeCommandCoverageBaselineTest extends TestCase
     private function writeGeneratedBaseline(array $covered): void
     {
         $this->writeWorkerSidecar('9', $covered);
-        putenv('OPENAPI_BASELINE_GENERATE=1');
+        putenv('GESSO_BASELINE_GENERATE=1');
         $stderr = '';
         $this->merge($stderr, $this->baselinePath);
+        putenv('GESSO_BASELINE_GENERATE');
         putenv('OPENAPI_BASELINE_GENERATE');
+        LegacyIdentity::resetForTesting();
 
         foreach (glob($this->sidecarDir . '/*') ?: [] as $path) {
             @unlink($path);

--- a/tests/Unit/Internal/FailureOutputTest.php
+++ b/tests/Unit/Internal/FailureOutputTest.php
@@ -9,6 +9,7 @@ use const JSON_THROW_ON_ERROR;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\Gesso\Internal\FailureOutput;
+use Studio\Gesso\Internal\LegacyIdentity;
 use Studio\Gesso\OpenApiValidationResult;
 use Studio\Gesso\ValidationIssue;
 use Studio\Gesso\ValidationOutput;
@@ -24,13 +25,13 @@ class FailureOutputTest extends TestCase
     {
         parent::setUp();
 
-        putenv('GESSO_VALIDATION_FORMAT');
+        LegacyIdentity::resetEnvForTesting('GESSO_VALIDATION_FORMAT');
         ValidationOutput::reset();
     }
 
     protected function tearDown(): void
     {
-        putenv('GESSO_VALIDATION_FORMAT');
+        LegacyIdentity::resetEnvForTesting('GESSO_VALIDATION_FORMAT');
         ValidationOutput::reset();
 
         parent::tearDown();

--- a/tests/Unit/Internal/FailureOutputTest.php
+++ b/tests/Unit/Internal/FailureOutputTest.php
@@ -24,13 +24,13 @@ class FailureOutputTest extends TestCase
     {
         parent::setUp();
 
-        putenv('OPENAPI_VALIDATION_OUTPUT');
+        putenv('GESSO_VALIDATION_FORMAT');
         ValidationOutput::reset();
     }
 
     protected function tearDown(): void
     {
-        putenv('OPENAPI_VALIDATION_OUTPUT');
+        putenv('GESSO_VALIDATION_FORMAT');
         ValidationOutput::reset();
 
         parent::tearDown();
@@ -81,7 +81,7 @@ class FailureOutputTest extends TestCase
     #[Test]
     public function json_mode_follows_the_environment_variable(): void
     {
-        putenv('OPENAPI_VALIDATION_OUTPUT=json');
+        putenv('GESSO_VALIDATION_FORMAT=json');
 
         $message = FailureOutput::compose(
             'OpenAPI request validation failed for POST /v1/pets (spec: front)',

--- a/tests/Unit/Internal/LegacyIdentityTest.php
+++ b/tests/Unit/Internal/LegacyIdentityTest.php
@@ -8,12 +8,19 @@ use const E_USER_DEPRECATED;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
 use Studio\Gesso\Internal\LegacyIdentity;
 
 use function array_keys;
+use function dirname;
+use function file_get_contents;
+use function preg_match;
 use function putenv;
 use function restore_error_handler;
 use function set_error_handler;
+use function str_replace;
 
 /**
  * Issue #504: the legacy `OPENAPI_*` / `openapi:*` spellings keep working for
@@ -178,6 +185,53 @@ final class LegacyIdentityTest extends TestCase
         LegacyIdentity::warnIfLegacyCommand('migrate');
 
         $this->assertSame([], LegacyIdentity::warnings());
+    }
+
+    /**
+     * A lifecycle that clears only the current name leaves the legacy spelling
+     * in the ambient environment able to steer a test that asserts default
+     * behaviour — a leak that stays invisible until the suite runs on a machine
+     * exporting the old name. Every clear therefore has to go through
+     * {@see LegacyIdentity::resetEnvForTesting()}, which clears both.
+     */
+    #[Test]
+    public function no_test_clears_a_renamed_variable_without_its_legacy_spelling(): void
+    {
+        $offenders = [];
+
+        foreach ($this->suiteSources() as $file => $contents) {
+            foreach (LegacyIdentity::ENV_NAMES as $current) {
+                if (preg_match('/putenv\(\s*([\'"])' . $current . '\1\s*\)/', $contents) === 1) {
+                    $offenders[] = "{$file}: putenv('{$current}')";
+                }
+            }
+        }
+
+        $this->assertSame([], $offenders, "Use LegacyIdentity::resetEnvForTesting('<name>') instead.");
+    }
+
+    /** @return array<string, string> */
+    private function suiteSources(): array
+    {
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator(dirname(__DIR__, 2)),
+        );
+        $sources = [];
+
+        /** @var SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $contents = file_get_contents($file->getPathname());
+
+            if ($contents !== false) {
+                $sources['tests/' . str_replace(dirname(__DIR__, 2) . '/', '', $file->getPathname())] = $contents;
+            }
+        }
+
+        return $sources;
     }
 
     private function clearEnv(): void

--- a/tests/Unit/Internal/LegacyIdentityTest.php
+++ b/tests/Unit/Internal/LegacyIdentityTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Studio\Gesso\Tests\Unit\Internal;
+
+use const E_USER_DEPRECATED;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Internal\LegacyIdentity;
+
+use function array_keys;
+use function putenv;
+use function restore_error_handler;
+use function set_error_handler;
+
+/**
+ * Issue #504: the legacy `OPENAPI_*` / `openapi:*` spellings keep working for
+ * the whole of v3, so the map and its one-time warning are the contract, not
+ * the individual read sites.
+ */
+final class LegacyIdentityTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->clearEnv();
+        LegacyIdentity::resetForTesting();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->clearEnv();
+        LegacyIdentity::resetForTesting();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function the_current_name_is_read_without_a_warning(): void
+    {
+        putenv('GESSO_BASELINE_GENERATE=1');
+
+        $this->assertSame('1', LegacyIdentity::env('GESSO_BASELINE_GENERATE'));
+        $this->assertSame([], LegacyIdentity::warnings());
+    }
+
+    #[Test]
+    public function the_legacy_name_still_resolves_and_names_its_replacement(): void
+    {
+        putenv('OPENAPI_BASELINE_GENERATE=1');
+
+        $this->assertSame('1', LegacyIdentity::env('GESSO_BASELINE_GENERATE'));
+        $this->assertSame(
+            ['[Gesso] WARNING: OPENAPI_BASELINE_GENERATE is deprecated and will be removed in Gesso 4.0.0. Use GESSO_BASELINE_GENERATE.'],
+            LegacyIdentity::warnings(),
+        );
+    }
+
+    #[Test]
+    public function the_warning_carries_the_removal_version_from_the_constant(): void
+    {
+        putenv('OPENAPI_CONSOLE_OUTPUT=all');
+        LegacyIdentity::env('GESSO_CONSOLE_OUTPUT');
+
+        $this->assertStringContainsString(
+            'removed in Gesso ' . LegacyIdentity::REMOVED_IN . '.',
+            LegacyIdentity::warnings()[0] ?? '',
+        );
+    }
+
+    #[Test]
+    public function the_current_name_wins_when_both_are_set_and_nothing_warns(): void
+    {
+        putenv('OPENAPI_VALIDATION_OUTPUT=text');
+        putenv('GESSO_VALIDATION_FORMAT=json');
+
+        $this->assertSame('json', LegacyIdentity::env('GESSO_VALIDATION_FORMAT'));
+        $this->assertSame([], LegacyIdentity::warnings());
+    }
+
+    #[Test]
+    public function a_blank_current_name_falls_through_to_the_legacy_one(): void
+    {
+        // Not the same as unset: an `env:` block that sets the new name to the
+        // empty string must not shadow a legacy name that carries a value.
+        putenv('GESSO_VALIDATION_FORMAT=  ');
+        putenv('OPENAPI_VALIDATION_OUTPUT=json');
+
+        $this->assertSame('json', LegacyIdentity::env('GESSO_VALIDATION_FORMAT'));
+    }
+
+    #[Test]
+    public function a_blank_legacy_value_is_not_a_value(): void
+    {
+        putenv('OPENAPI_VALIDATION_OUTPUT=  ');
+
+        $this->assertFalse(LegacyIdentity::env('GESSO_VALIDATION_FORMAT'));
+        $this->assertSame([], LegacyIdentity::warnings());
+    }
+
+    #[Test]
+    public function an_unset_pair_reads_as_false(): void
+    {
+        $this->assertFalse(LegacyIdentity::env('GESSO_BASELINE_GENERATE'));
+    }
+
+    #[Test]
+    public function a_name_outside_the_map_is_read_as_itself(): void
+    {
+        putenv('GESSO_NOT_MAPPED=x');
+
+        $this->assertSame('x', LegacyIdentity::env('GESSO_NOT_MAPPED'));
+
+        putenv('GESSO_NOT_MAPPED');
+        $this->assertFalse(LegacyIdentity::env('GESSO_NOT_MAPPED'));
+    }
+
+    #[Test]
+    public function the_warning_is_emitted_once_per_process(): void
+    {
+        putenv('OPENAPI_BASELINE_GENERATE=1');
+
+        LegacyIdentity::env('GESSO_BASELINE_GENERATE');
+        LegacyIdentity::env('GESSO_BASELINE_GENERATE');
+        LegacyIdentity::env('GESSO_BASELINE_GENERATE');
+
+        $this->assertCount(1, LegacyIdentity::warnings());
+    }
+
+    #[Test]
+    public function the_legacy_path_does_not_raise_a_php_deprecation(): void
+    {
+        // A suite running `failOnDeprecation` must not fail for spelling a
+        // name that is still supported — this is why the legacy warning does
+        // not go through Studio\Gesso\Internal\Deprecations.
+        putenv('OPENAPI_BASELINE_GENERATE=1');
+
+        $deprecations = [];
+        set_error_handler(
+            static function (int $level, string $message) use (&$deprecations): bool {
+                $deprecations[] = $message;
+
+                return true;
+            },
+            E_USER_DEPRECATED,
+        );
+
+        try {
+            LegacyIdentity::env('GESSO_BASELINE_GENERATE');
+            LegacyIdentity::warnIfLegacyCommand('openapi:stubs');
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $deprecations);
+    }
+
+    #[Test]
+    public function a_legacy_command_name_warns_and_a_current_one_does_not(): void
+    {
+        LegacyIdentity::warnIfLegacyCommand('gesso:routes');
+        $this->assertSame([], LegacyIdentity::warnings());
+
+        LegacyIdentity::warnIfLegacyCommand('openapi:routes');
+        $this->assertSame(
+            ['[Gesso] WARNING: openapi:routes is deprecated and will be removed in Gesso 4.0.0. Use gesso:routes.'],
+            LegacyIdentity::warnings(),
+        );
+    }
+
+    #[Test]
+    public function an_unknown_command_name_is_ignored(): void
+    {
+        // Symfony hands whatever the user typed to the command, including the
+        // empty string when the input carries no first argument.
+        LegacyIdentity::warnIfLegacyCommand('');
+        LegacyIdentity::warnIfLegacyCommand('migrate');
+
+        $this->assertSame([], LegacyIdentity::warnings());
+    }
+
+    private function clearEnv(): void
+    {
+        foreach (array_keys(LegacyIdentity::ENV_NAMES) as $legacy) {
+            putenv($legacy);
+        }
+        foreach (LegacyIdentity::ENV_NAMES as $current) {
+            putenv($current);
+        }
+        putenv('GESSO_NOT_MAPPED');
+    }
+}

--- a/tests/Unit/PHPUnit/ConsoleOutputTest.php
+++ b/tests/Unit/PHPUnit/ConsoleOutputTest.php
@@ -6,6 +6,7 @@ namespace Studio\Gesso\Tests\Unit\PHPUnit;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Internal\LegacyIdentity;
 use Studio\Gesso\PHPUnit\ConsoleOutput;
 
 use function putenv;
@@ -16,13 +17,17 @@ class ConsoleOutputTest extends TestCase
     {
         parent::setUp();
 
-        // Clear the environment variable before each test
+        // Clear both spellings before each test
+        putenv('GESSO_CONSOLE_OUTPUT');
         putenv('OPENAPI_CONSOLE_OUTPUT');
+        LegacyIdentity::resetForTesting();
     }
 
     protected function tearDown(): void
     {
+        putenv('GESSO_CONSOLE_OUTPUT');
         putenv('OPENAPI_CONSOLE_OUTPUT');
+        LegacyIdentity::resetForTesting();
 
         parent::tearDown();
     }
@@ -96,7 +101,7 @@ class ConsoleOutputTest extends TestCase
     #[Test]
     public function resolve_env_overrides_parameter(): void
     {
-        putenv('OPENAPI_CONSOLE_OUTPUT=uncovered_only');
+        putenv('GESSO_CONSOLE_OUTPUT=uncovered_only');
 
         $this->assertSame(ConsoleOutput::UNCOVERED_ONLY, ConsoleOutput::resolve('all'));
     }
@@ -104,7 +109,7 @@ class ConsoleOutputTest extends TestCase
     #[Test]
     public function resolve_env_is_case_insensitive(): void
     {
-        putenv('OPENAPI_CONSOLE_OUTPUT=ALL');
+        putenv('GESSO_CONSOLE_OUTPUT=ALL');
 
         $this->assertSame(ConsoleOutput::ALL, ConsoleOutput::resolve(null));
     }
@@ -112,7 +117,7 @@ class ConsoleOutputTest extends TestCase
     #[Test]
     public function resolve_returns_active_only_from_env(): void
     {
-        putenv('OPENAPI_CONSOLE_OUTPUT=active_only');
+        putenv('GESSO_CONSOLE_OUTPUT=active_only');
 
         $this->assertSame(ConsoleOutput::ACTIVE_ONLY, ConsoleOutput::resolve(null));
     }
@@ -120,7 +125,7 @@ class ConsoleOutputTest extends TestCase
     #[Test]
     public function resolve_env_trims_whitespace(): void
     {
-        putenv('OPENAPI_CONSOLE_OUTPUT=  all  ');
+        putenv('GESSO_CONSOLE_OUTPUT=  all  ');
 
         $this->assertSame(ConsoleOutput::ALL, ConsoleOutput::resolve(null));
     }
@@ -128,7 +133,7 @@ class ConsoleOutputTest extends TestCase
     #[Test]
     public function resolve_invalid_env_falls_back_to_default(): void
     {
-        putenv('OPENAPI_CONSOLE_OUTPUT=invalid');
+        putenv('GESSO_CONSOLE_OUTPUT=invalid');
 
         $this->assertSame(ConsoleOutput::DEFAULT, ConsoleOutput::resolve('all'));
     }
@@ -136,7 +141,7 @@ class ConsoleOutputTest extends TestCase
     #[Test]
     public function resolve_empty_env_uses_parameter(): void
     {
-        putenv('OPENAPI_CONSOLE_OUTPUT=');
+        putenv('GESSO_CONSOLE_OUTPUT=');
 
         $this->assertSame(ConsoleOutput::ALL, ConsoleOutput::resolve('all'));
     }
@@ -144,8 +149,32 @@ class ConsoleOutputTest extends TestCase
     #[Test]
     public function resolve_whitespace_only_env_uses_parameter(): void
     {
-        putenv('OPENAPI_CONSOLE_OUTPUT=  ');
+        putenv('GESSO_CONSOLE_OUTPUT=  ');
 
         $this->assertSame(ConsoleOutput::ALL, ConsoleOutput::resolve('all'));
+    }
+
+    /** Issue #504: this read site goes through {@see LegacyIdentity}, not bare getenv(). */
+    #[Test]
+    public function resolve_still_honours_the_legacy_env_name(): void
+    {
+        putenv('OPENAPI_CONSOLE_OUTPUT=uncovered_only');
+
+        $this->assertSame(ConsoleOutput::UNCOVERED_ONLY, ConsoleOutput::resolve('all'));
+        $this->assertSame(
+            ['[Gesso] WARNING: OPENAPI_CONSOLE_OUTPUT is deprecated and will be removed in Gesso '
+                . LegacyIdentity::REMOVED_IN . '. Use GESSO_CONSOLE_OUTPUT.'],
+            LegacyIdentity::warnings(),
+        );
+    }
+
+    #[Test]
+    public function resolve_prefers_the_current_env_name_over_the_legacy_one(): void
+    {
+        putenv('OPENAPI_CONSOLE_OUTPUT=uncovered_only');
+        putenv('GESSO_CONSOLE_OUTPUT=active_only');
+
+        $this->assertSame(ConsoleOutput::ACTIVE_ONLY, ConsoleOutput::resolve(null));
+        $this->assertSame([], LegacyIdentity::warnings());
     }
 }

--- a/tests/Unit/PHPUnit/ConsoleOutputTest.php
+++ b/tests/Unit/PHPUnit/ConsoleOutputTest.php
@@ -18,16 +18,12 @@ class ConsoleOutputTest extends TestCase
         parent::setUp();
 
         // Clear both spellings before each test
-        putenv('GESSO_CONSOLE_OUTPUT');
-        putenv('OPENAPI_CONSOLE_OUTPUT');
-        LegacyIdentity::resetForTesting();
+        LegacyIdentity::resetEnvForTesting('GESSO_CONSOLE_OUTPUT');
     }
 
     protected function tearDown(): void
     {
-        putenv('GESSO_CONSOLE_OUTPUT');
-        putenv('OPENAPI_CONSOLE_OUTPUT');
-        LegacyIdentity::resetForTesting();
+        LegacyIdentity::resetEnvForTesting('GESSO_CONSOLE_OUTPUT');
 
         parent::tearDown();
     }

--- a/tests/Unit/PHPUnit/CoverageReportSubscriberCoverageBaselineTest.php
+++ b/tests/Unit/PHPUnit/CoverageReportSubscriberCoverageBaselineTest.php
@@ -180,7 +180,7 @@ class CoverageReportSubscriberCoverageBaselineTest extends TestCase
             '  - [petstore-3.0] GET /v1/pets status=200 content-type=application/json',
             $stderr,
         );
-        $this->assertStringContainsString('OPENAPI_BASELINE_GENERATE=1 vendor/bin/phpunit', $stderr);
+        $this->assertStringContainsString('GESSO_BASELINE_GENERATE=1 vendor/bin/phpunit', $stderr);
     }
 
     #[Test]

--- a/tests/Unit/PHPUnit/OpenApiCoverageExtensionBaselineTest.php
+++ b/tests/Unit/PHPUnit/OpenApiCoverageExtensionBaselineTest.php
@@ -39,9 +39,7 @@ class OpenApiCoverageExtensionBaselineTest extends TestCase
     {
         parent::setUp();
         OpenApiSpecLoader::reset();
-        putenv('GESSO_BASELINE_GENERATE');
-        putenv('OPENAPI_BASELINE_GENERATE');
-        LegacyIdentity::resetForTesting();
+        LegacyIdentity::resetEnvForTesting('GESSO_BASELINE_GENERATE');
         ViolationBaselineCollector::resetCurrent();
         ViolationBaselineEnforcer::resetCurrent();
 
@@ -65,9 +63,7 @@ class OpenApiCoverageExtensionBaselineTest extends TestCase
             $this->stderrBuffer = null;
         }
         OpenApiSpecLoader::reset();
-        putenv('GESSO_BASELINE_GENERATE');
-        putenv('OPENAPI_BASELINE_GENERATE');
-        LegacyIdentity::resetForTesting();
+        LegacyIdentity::resetEnvForTesting('GESSO_BASELINE_GENERATE');
         ViolationBaselineCollector::resetCurrent();
         ViolationBaselineEnforcer::resetCurrent();
         if ($this->baselineFilePath !== null) {

--- a/tests/Unit/PHPUnit/OpenApiCoverageExtensionBaselineTest.php
+++ b/tests/Unit/PHPUnit/OpenApiCoverageExtensionBaselineTest.php
@@ -13,6 +13,7 @@ use Studio\Gesso\Baseline\ViolationBaselineCollector;
 use Studio\Gesso\Baseline\ViolationBaselineEnforcer;
 use Studio\Gesso\Baseline\ViolationBaselineFile;
 use Studio\Gesso\Baseline\ViolationFingerprint;
+use Studio\Gesso\Internal\LegacyIdentity;
 use Studio\Gesso\PHPUnit\OpenApiCoverageExtension;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 
@@ -38,7 +39,9 @@ class OpenApiCoverageExtensionBaselineTest extends TestCase
     {
         parent::setUp();
         OpenApiSpecLoader::reset();
+        putenv('GESSO_BASELINE_GENERATE');
         putenv('OPENAPI_BASELINE_GENERATE');
+        LegacyIdentity::resetForTesting();
         ViolationBaselineCollector::resetCurrent();
         ViolationBaselineEnforcer::resetCurrent();
 
@@ -62,7 +65,9 @@ class OpenApiCoverageExtensionBaselineTest extends TestCase
             $this->stderrBuffer = null;
         }
         OpenApiSpecLoader::reset();
+        putenv('GESSO_BASELINE_GENERATE');
         putenv('OPENAPI_BASELINE_GENERATE');
+        LegacyIdentity::resetForTesting();
         ViolationBaselineCollector::resetCurrent();
         ViolationBaselineEnforcer::resetCurrent();
         if ($this->baselineFilePath !== null) {
@@ -80,11 +85,39 @@ class OpenApiCoverageExtensionBaselineTest extends TestCase
     #[Test]
     public function generation_env_with_a_baseline_file_installs_the_collector(): void
     {
+        putenv('GESSO_BASELINE_GENERATE=1');
+
+        $this->setupExtension(['baseline_file' => 'gesso-baseline.json']);
+
+        $this->assertNotNull(ViolationBaselineCollector::current());
+    }
+
+    /** Issue #504: this read site goes through {@see LegacyIdentity}, not bare getenv(). */
+    #[Test]
+    public function the_legacy_generation_env_name_still_installs_the_collector(): void
+    {
         putenv('OPENAPI_BASELINE_GENERATE=1');
 
         $this->setupExtension(['baseline_file' => 'gesso-baseline.json']);
 
         $this->assertNotNull(ViolationBaselineCollector::current());
+        $this->assertSame(
+            ['[Gesso] WARNING: OPENAPI_BASELINE_GENERATE is deprecated and will be removed in Gesso '
+                . LegacyIdentity::REMOVED_IN . '. Use GESSO_BASELINE_GENERATE.'],
+            LegacyIdentity::warnings(),
+        );
+    }
+
+    #[Test]
+    public function the_current_generation_env_name_beats_the_legacy_one(): void
+    {
+        putenv('OPENAPI_BASELINE_GENERATE=1');
+        putenv('GESSO_BASELINE_GENERATE=0');
+
+        $this->setupExtension(['baseline_file' => $this->writeBaselineFixture()]);
+
+        $this->assertNull(ViolationBaselineCollector::current());
+        $this->assertSame([], LegacyIdentity::warnings());
     }
 
     #[Test]
@@ -100,7 +133,7 @@ class OpenApiCoverageExtensionBaselineTest extends TestCase
     #[Test]
     public function a_falsy_generation_env_value_installs_no_collector(): void
     {
-        putenv('OPENAPI_BASELINE_GENERATE=0');
+        putenv('GESSO_BASELINE_GENERATE=0');
 
         $this->setupExtension(['baseline_file' => $this->writeBaselineFixture()]);
 
@@ -110,7 +143,7 @@ class OpenApiCoverageExtensionBaselineTest extends TestCase
     #[Test]
     public function generation_env_without_a_baseline_file_is_fatal(): void
     {
-        putenv('OPENAPI_BASELINE_GENERATE=1');
+        putenv('GESSO_BASELINE_GENERATE=1');
 
         try {
             $this->setupExtension([]);
@@ -129,7 +162,7 @@ class OpenApiCoverageExtensionBaselineTest extends TestCase
         // sequential run — the subscriber's worker branch stages the
         // collected fingerprints in the sidecar envelope for
         // `gesso coverage:merge --baseline-file` instead of writing a file.
-        putenv('OPENAPI_BASELINE_GENERATE=1');
+        putenv('GESSO_BASELINE_GENERATE=1');
         putenv('TEST_TOKEN=3');
 
         try {
@@ -172,7 +205,7 @@ class OpenApiCoverageExtensionBaselineTest extends TestCase
         } catch (InvalidBaselineConfigurationException) {
             $this->assertStringContainsString('[Gesso] FATAL', $this->capturedStderr());
             $this->assertStringContainsString('baseline_file', $this->capturedStderr());
-            $this->assertStringContainsString('OPENAPI_BASELINE_GENERATE', $this->capturedStderr());
+            $this->assertStringContainsString('GESSO_BASELINE_GENERATE', $this->capturedStderr());
             $this->assertNull(ViolationBaselineEnforcer::current());
         }
     }
@@ -196,7 +229,7 @@ class OpenApiCoverageExtensionBaselineTest extends TestCase
     #[Test]
     public function a_generation_run_never_installs_the_enforcer(): void
     {
-        putenv('OPENAPI_BASELINE_GENERATE=1');
+        putenv('GESSO_BASELINE_GENERATE=1');
         $path = $this->writeBaselineFixture();
 
         $this->setupExtension(['baseline_file' => $path]);

--- a/tests/Unit/PHPUnit/OpenApiCoverageExtensionCoverageBaselineTest.php
+++ b/tests/Unit/PHPUnit/OpenApiCoverageExtensionCoverageBaselineTest.php
@@ -41,9 +41,7 @@ class OpenApiCoverageExtensionCoverageBaselineTest extends TestCase
     {
         parent::setUp();
         OpenApiSpecLoader::reset();
-        putenv('GESSO_BASELINE_GENERATE');
-        putenv('OPENAPI_BASELINE_GENERATE');
-        LegacyIdentity::resetForTesting();
+        LegacyIdentity::resetEnvForTesting('GESSO_BASELINE_GENERATE');
 
         $buffer = fopen('php://memory', 'w+');
         if ($buffer === false) {
@@ -65,9 +63,7 @@ class OpenApiCoverageExtensionCoverageBaselineTest extends TestCase
         }
         $this->tempFiles = [];
         OpenApiSpecLoader::reset();
-        putenv('GESSO_BASELINE_GENERATE');
-        putenv('OPENAPI_BASELINE_GENERATE');
-        LegacyIdentity::resetForTesting();
+        LegacyIdentity::resetEnvForTesting('GESSO_BASELINE_GENERATE');
         parent::tearDown();
     }
 

--- a/tests/Unit/PHPUnit/OpenApiCoverageExtensionCoverageBaselineTest.php
+++ b/tests/Unit/PHPUnit/OpenApiCoverageExtensionCoverageBaselineTest.php
@@ -11,6 +11,7 @@ use Studio\Gesso\Baseline\CoverageBaseline;
 use Studio\Gesso\Baseline\CoverageBaselineEntry;
 use Studio\Gesso\Baseline\CoverageBaselineFile;
 use Studio\Gesso\Baseline\InvalidBaselineConfigurationException;
+use Studio\Gesso\Internal\LegacyIdentity;
 use Studio\Gesso\PHPUnit\OpenApiCoverageExtension;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 
@@ -40,7 +41,9 @@ class OpenApiCoverageExtensionCoverageBaselineTest extends TestCase
     {
         parent::setUp();
         OpenApiSpecLoader::reset();
+        putenv('GESSO_BASELINE_GENERATE');
         putenv('OPENAPI_BASELINE_GENERATE');
+        LegacyIdentity::resetForTesting();
 
         $buffer = fopen('php://memory', 'w+');
         if ($buffer === false) {
@@ -62,7 +65,9 @@ class OpenApiCoverageExtensionCoverageBaselineTest extends TestCase
         }
         $this->tempFiles = [];
         OpenApiSpecLoader::reset();
+        putenv('GESSO_BASELINE_GENERATE');
         putenv('OPENAPI_BASELINE_GENERATE');
+        LegacyIdentity::resetForTesting();
         parent::tearDown();
     }
 
@@ -106,7 +111,7 @@ class OpenApiCoverageExtensionCoverageBaselineTest extends TestCase
     {
         // The file is about to be overwritten; a missing or stale one must
         // not abort the very run that would fix it.
-        putenv('OPENAPI_BASELINE_GENERATE=1');
+        putenv('GESSO_BASELINE_GENERATE=1');
 
         $this->setupExtension([
             'coverage_baseline_file' => sys_get_temp_dir() . '/gesso-missing-' . uniqid() . '.json',
@@ -118,10 +123,10 @@ class OpenApiCoverageExtensionCoverageBaselineTest extends TestCase
     #[Test]
     public function generation_with_only_a_coverage_baseline_file_is_allowed(): void
     {
-        // Issue #481: `OPENAPI_BASELINE_GENERATE` drives both baselines, so
+        // Issue #481: `GESSO_BASELINE_GENERATE` drives both baselines, so
         // configuring only the coverage half must not trip the violation
         // baseline's "nowhere to write" guard.
-        putenv('OPENAPI_BASELINE_GENERATE=1');
+        putenv('GESSO_BASELINE_GENERATE=1');
 
         $this->setupExtension(['coverage_baseline_file' => 'gesso-coverage-baseline.json']);
 
@@ -131,7 +136,7 @@ class OpenApiCoverageExtensionCoverageBaselineTest extends TestCase
     #[Test]
     public function generation_without_either_baseline_file_is_fatal(): void
     {
-        putenv('OPENAPI_BASELINE_GENERATE=1');
+        putenv('GESSO_BASELINE_GENERATE=1');
 
         try {
             $this->setupExtension([]);

--- a/tests/Unit/PHPUnit/OpenApiCoverageExtensionValidationOutputTest.php
+++ b/tests/Unit/PHPUnit/OpenApiCoverageExtensionValidationOutputTest.php
@@ -27,7 +27,7 @@ class OpenApiCoverageExtensionValidationOutputTest extends TestCase
     {
         parent::setUp();
         OpenApiSpecLoader::reset();
-        putenv('OPENAPI_VALIDATION_OUTPUT');
+        putenv('GESSO_VALIDATION_FORMAT');
         ValidationOutput::reset();
 
         $buffer = fopen('php://memory', 'w+');
@@ -46,7 +46,7 @@ class OpenApiCoverageExtensionValidationOutputTest extends TestCase
             $this->stderrBuffer = null;
         }
         OpenApiSpecLoader::reset();
-        putenv('OPENAPI_VALIDATION_OUTPUT');
+        putenv('GESSO_VALIDATION_FORMAT');
         ValidationOutput::reset();
         parent::tearDown();
     }
@@ -101,7 +101,7 @@ class OpenApiCoverageExtensionValidationOutputTest extends TestCase
     #[Test]
     public function environment_variable_still_wins_over_the_parameter(): void
     {
-        putenv('OPENAPI_VALIDATION_OUTPUT=text');
+        putenv('GESSO_VALIDATION_FORMAT=text');
 
         $this->setupExtension(['validation_output' => 'json']);
 

--- a/tests/Unit/PHPUnit/OpenApiCoverageExtensionValidationOutputTest.php
+++ b/tests/Unit/PHPUnit/OpenApiCoverageExtensionValidationOutputTest.php
@@ -7,6 +7,7 @@ namespace Studio\Gesso\Tests\Unit\PHPUnit;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Runner\Extension\ParameterCollection;
+use Studio\Gesso\Internal\LegacyIdentity;
 use Studio\Gesso\PHPUnit\OpenApiCoverageExtension;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 use Studio\Gesso\ValidationOutput;
@@ -27,7 +28,7 @@ class OpenApiCoverageExtensionValidationOutputTest extends TestCase
     {
         parent::setUp();
         OpenApiSpecLoader::reset();
-        putenv('GESSO_VALIDATION_FORMAT');
+        LegacyIdentity::resetEnvForTesting('GESSO_VALIDATION_FORMAT');
         ValidationOutput::reset();
 
         $buffer = fopen('php://memory', 'w+');
@@ -46,7 +47,7 @@ class OpenApiCoverageExtensionValidationOutputTest extends TestCase
             $this->stderrBuffer = null;
         }
         OpenApiSpecLoader::reset();
-        putenv('GESSO_VALIDATION_FORMAT');
+        LegacyIdentity::resetEnvForTesting('GESSO_VALIDATION_FORMAT');
         ValidationOutput::reset();
         parent::tearDown();
     }

--- a/tests/Unit/Psr7/OpenApiAssertionsJsonOutputTest.php
+++ b/tests/Unit/Psr7/OpenApiAssertionsJsonOutputTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\Gesso\Coverage\OpenApiCoverageTracker;
+use Studio\Gesso\Internal\LegacyIdentity;
 use Studio\Gesso\Psr7\OpenApiAssertions;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 use Studio\Gesso\ValidationOutput;
@@ -31,7 +32,7 @@ final class OpenApiAssertionsJsonOutputTest extends TestCase
         parent::setUp();
         OpenApiSpecLoader::reset();
         OpenApiCoverageTracker::reset();
-        putenv('GESSO_VALIDATION_FORMAT');
+        LegacyIdentity::resetEnvForTesting('GESSO_VALIDATION_FORMAT');
         ValidationOutput::reset();
         OpenApiSpecLoader::configure(__DIR__ . '/../../fixtures/specs');
     }
@@ -40,7 +41,7 @@ final class OpenApiAssertionsJsonOutputTest extends TestCase
     {
         OpenApiSpecLoader::reset();
         OpenApiCoverageTracker::reset();
-        putenv('GESSO_VALIDATION_FORMAT');
+        LegacyIdentity::resetEnvForTesting('GESSO_VALIDATION_FORMAT');
         ValidationOutput::reset();
         parent::tearDown();
     }

--- a/tests/Unit/Psr7/OpenApiAssertionsJsonOutputTest.php
+++ b/tests/Unit/Psr7/OpenApiAssertionsJsonOutputTest.php
@@ -31,7 +31,7 @@ final class OpenApiAssertionsJsonOutputTest extends TestCase
         parent::setUp();
         OpenApiSpecLoader::reset();
         OpenApiCoverageTracker::reset();
-        putenv('OPENAPI_VALIDATION_OUTPUT');
+        putenv('GESSO_VALIDATION_FORMAT');
         ValidationOutput::reset();
         OpenApiSpecLoader::configure(__DIR__ . '/../../fixtures/specs');
     }
@@ -40,7 +40,7 @@ final class OpenApiAssertionsJsonOutputTest extends TestCase
     {
         OpenApiSpecLoader::reset();
         OpenApiCoverageTracker::reset();
-        putenv('OPENAPI_VALIDATION_OUTPUT');
+        putenv('GESSO_VALIDATION_FORMAT');
         ValidationOutput::reset();
         parent::tearDown();
     }
@@ -78,7 +78,7 @@ final class OpenApiAssertionsJsonOutputTest extends TestCase
     #[Test]
     public function json_mode_is_selected_by_the_environment_variable(): void
     {
-        putenv('OPENAPI_VALIDATION_OUTPUT=json');
+        putenv('GESSO_VALIDATION_FORMAT=json');
         $request = new Request('GET', 'https://example.test/body/scalar');
         $response = new Response(200, ['Content-Type' => 'application/json'], '"wrong"');
 

--- a/tests/Unit/Symfony/OpenApiAssertionsJsonOutputTest.php
+++ b/tests/Unit/Symfony/OpenApiAssertionsJsonOutputTest.php
@@ -33,7 +33,7 @@ final class OpenApiAssertionsJsonOutputTest extends TestCase
         OpenApiSpecLoader::reset();
         OpenApiSpecLoader::configure(__DIR__ . '/../../fixtures/specs');
         OpenApiCoverageTracker::reset();
-        putenv('OPENAPI_VALIDATION_OUTPUT');
+        putenv('GESSO_VALIDATION_FORMAT');
         ValidationOutput::reset();
     }
 
@@ -41,7 +41,7 @@ final class OpenApiAssertionsJsonOutputTest extends TestCase
     {
         OpenApiSpecLoader::reset();
         OpenApiCoverageTracker::reset();
-        putenv('OPENAPI_VALIDATION_OUTPUT');
+        putenv('GESSO_VALIDATION_FORMAT');
         ValidationOutput::reset();
         parent::tearDown();
     }
@@ -76,7 +76,7 @@ final class OpenApiAssertionsJsonOutputTest extends TestCase
     #[Test]
     public function request_assertion_failure_renders_the_json_document_after_the_header(): void
     {
-        putenv('OPENAPI_VALIDATION_OUTPUT=json');
+        putenv('GESSO_VALIDATION_FORMAT=json');
         $request = Request::create('/v1/pets/search?limit=not-an-integer', 'GET');
 
         try {

--- a/tests/Unit/Symfony/OpenApiAssertionsJsonOutputTest.php
+++ b/tests/Unit/Symfony/OpenApiAssertionsJsonOutputTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\Gesso\Attribute\OpenApiSpec;
 use Studio\Gesso\Coverage\OpenApiCoverageTracker;
+use Studio\Gesso\Internal\LegacyIdentity;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 use Studio\Gesso\Symfony\OpenApiAssertions;
 use Studio\Gesso\ValidationOutput;
@@ -33,7 +34,7 @@ final class OpenApiAssertionsJsonOutputTest extends TestCase
         OpenApiSpecLoader::reset();
         OpenApiSpecLoader::configure(__DIR__ . '/../../fixtures/specs');
         OpenApiCoverageTracker::reset();
-        putenv('GESSO_VALIDATION_FORMAT');
+        LegacyIdentity::resetEnvForTesting('GESSO_VALIDATION_FORMAT');
         ValidationOutput::reset();
     }
 
@@ -41,7 +42,7 @@ final class OpenApiAssertionsJsonOutputTest extends TestCase
     {
         OpenApiSpecLoader::reset();
         OpenApiCoverageTracker::reset();
-        putenv('GESSO_VALIDATION_FORMAT');
+        LegacyIdentity::resetEnvForTesting('GESSO_VALIDATION_FORMAT');
         ValidationOutput::reset();
         parent::tearDown();
     }

--- a/tests/Unit/ValidatesOpenApiSchemaJsonOutputTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaJsonOutputTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Studio\Gesso\Coverage\OpenApiCoverageTracker;
 use Studio\Gesso\HttpMethod;
+use Studio\Gesso\Internal\LegacyIdentity;
 use Studio\Gesso\Laravel\ValidatesOpenApiSchema;
 use Studio\Gesso\Spec\OpenApiSpecLoader;
 use Studio\Gesso\Tests\Helpers\CreatesTestResponse;
@@ -35,7 +36,7 @@ class ValidatesOpenApiSchemaJsonOutputTest extends TestCase
         OpenApiSpecLoader::reset();
         OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs');
         OpenApiCoverageTracker::reset();
-        putenv('GESSO_VALIDATION_FORMAT');
+        LegacyIdentity::resetEnvForTesting('GESSO_VALIDATION_FORMAT');
         ValidationOutput::reset();
     }
 
@@ -44,7 +45,7 @@ class ValidatesOpenApiSchemaJsonOutputTest extends TestCase
         self::resetValidatorCache();
         OpenApiSpecLoader::reset();
         OpenApiCoverageTracker::reset();
-        putenv('GESSO_VALIDATION_FORMAT');
+        LegacyIdentity::resetEnvForTesting('GESSO_VALIDATION_FORMAT');
         ValidationOutput::reset();
         parent::tearDown();
     }

--- a/tests/Unit/ValidatesOpenApiSchemaJsonOutputTest.php
+++ b/tests/Unit/ValidatesOpenApiSchemaJsonOutputTest.php
@@ -35,7 +35,7 @@ class ValidatesOpenApiSchemaJsonOutputTest extends TestCase
         OpenApiSpecLoader::reset();
         OpenApiSpecLoader::configure(__DIR__ . '/../fixtures/specs');
         OpenApiCoverageTracker::reset();
-        putenv('OPENAPI_VALIDATION_OUTPUT');
+        putenv('GESSO_VALIDATION_FORMAT');
         ValidationOutput::reset();
     }
 
@@ -44,7 +44,7 @@ class ValidatesOpenApiSchemaJsonOutputTest extends TestCase
         self::resetValidatorCache();
         OpenApiSpecLoader::reset();
         OpenApiCoverageTracker::reset();
-        putenv('OPENAPI_VALIDATION_OUTPUT');
+        putenv('GESSO_VALIDATION_FORMAT');
         ValidationOutput::reset();
         parent::tearDown();
     }
@@ -83,7 +83,7 @@ class ValidatesOpenApiSchemaJsonOutputTest extends TestCase
     #[Test]
     public function json_mode_is_selected_by_the_environment_variable(): void
     {
-        putenv('OPENAPI_VALIDATION_OUTPUT=json');
+        putenv('GESSO_VALIDATION_FORMAT=json');
         $body = (string) json_encode(['wrong_key' => 'value'], JSON_THROW_ON_ERROR);
         $response = $this->makeTestResponse($body, 200);
 

--- a/tests/Unit/ValidationOutputTest.php
+++ b/tests/Unit/ValidationOutputTest.php
@@ -6,6 +6,7 @@ namespace Studio\Gesso\Tests\Unit;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Studio\Gesso\Internal\LegacyIdentity;
 use Studio\Gesso\ValidationOutput;
 use Studio\Gesso\ValidationOutputFormat;
 
@@ -17,13 +18,17 @@ class ValidationOutputTest extends TestCase
     {
         parent::setUp();
 
+        putenv('GESSO_VALIDATION_FORMAT');
         putenv('OPENAPI_VALIDATION_OUTPUT');
+        LegacyIdentity::resetForTesting();
         ValidationOutput::reset();
     }
 
     protected function tearDown(): void
     {
+        putenv('GESSO_VALIDATION_FORMAT');
         putenv('OPENAPI_VALIDATION_OUTPUT');
+        LegacyIdentity::resetForTesting();
         ValidationOutput::reset();
 
         parent::tearDown();
@@ -56,7 +61,7 @@ class ValidationOutputTest extends TestCase
     public function env_overrides_the_programmatically_selected_format(): void
     {
         ValidationOutput::use(ValidationOutputFormat::Text);
-        putenv('OPENAPI_VALIDATION_OUTPUT=json');
+        putenv('GESSO_VALIDATION_FORMAT=json');
 
         $this->assertSame(ValidationOutputFormat::Json, ValidationOutput::format());
     }
@@ -65,7 +70,7 @@ class ValidationOutputTest extends TestCase
     public function env_text_overrides_a_programmatic_json_selection(): void
     {
         ValidationOutput::use(ValidationOutputFormat::Json);
-        putenv('OPENAPI_VALIDATION_OUTPUT=text');
+        putenv('GESSO_VALIDATION_FORMAT=text');
 
         $this->assertSame(ValidationOutputFormat::Text, ValidationOutput::format());
     }
@@ -73,7 +78,7 @@ class ValidationOutputTest extends TestCase
     #[Test]
     public function env_is_case_insensitive(): void
     {
-        putenv('OPENAPI_VALIDATION_OUTPUT=JSON');
+        putenv('GESSO_VALIDATION_FORMAT=JSON');
 
         $this->assertSame(ValidationOutputFormat::Json, ValidationOutput::format());
     }
@@ -81,7 +86,7 @@ class ValidationOutputTest extends TestCase
     #[Test]
     public function env_trims_whitespace(): void
     {
-        putenv('OPENAPI_VALIDATION_OUTPUT=  json  ');
+        putenv('GESSO_VALIDATION_FORMAT=  json  ');
 
         $this->assertSame(ValidationOutputFormat::Json, ValidationOutput::format());
     }
@@ -90,7 +95,7 @@ class ValidationOutputTest extends TestCase
     public function empty_env_falls_through_to_the_programmatic_selection(): void
     {
         ValidationOutput::use(ValidationOutputFormat::Json);
-        putenv('OPENAPI_VALIDATION_OUTPUT=');
+        putenv('GESSO_VALIDATION_FORMAT=');
 
         $this->assertSame(ValidationOutputFormat::Json, ValidationOutput::format());
     }
@@ -99,7 +104,7 @@ class ValidationOutputTest extends TestCase
     public function whitespace_only_env_falls_through_to_the_programmatic_selection(): void
     {
         ValidationOutput::use(ValidationOutputFormat::Json);
-        putenv('OPENAPI_VALIDATION_OUTPUT=  ');
+        putenv('GESSO_VALIDATION_FORMAT=  ');
 
         $this->assertSame(ValidationOutputFormat::Json, ValidationOutput::format());
     }
@@ -108,7 +113,7 @@ class ValidationOutputTest extends TestCase
     public function invalid_env_falls_through_to_the_programmatic_selection(): void
     {
         ValidationOutput::use(ValidationOutputFormat::Json);
-        putenv('OPENAPI_VALIDATION_OUTPUT=yaml');
+        putenv('GESSO_VALIDATION_FORMAT=yaml');
 
         $this->assertSame(ValidationOutputFormat::Json, ValidationOutput::format());
     }
@@ -116,8 +121,33 @@ class ValidationOutputTest extends TestCase
     #[Test]
     public function invalid_env_without_a_programmatic_selection_falls_back_to_text(): void
     {
-        putenv('OPENAPI_VALIDATION_OUTPUT=yaml');
+        putenv('GESSO_VALIDATION_FORMAT=yaml');
 
         $this->assertSame(ValidationOutputFormat::Text, ValidationOutput::format());
+    }
+
+    /** Issue #504: this read site goes through {@see LegacyIdentity}, not bare getenv(). */
+    #[Test]
+    public function the_legacy_env_name_still_selects_the_format(): void
+    {
+        ValidationOutput::use(ValidationOutputFormat::Text);
+        putenv('OPENAPI_VALIDATION_OUTPUT=json');
+
+        $this->assertSame(ValidationOutputFormat::Json, ValidationOutput::format());
+        $this->assertSame(
+            ['[Gesso] WARNING: OPENAPI_VALIDATION_OUTPUT is deprecated and will be removed in Gesso '
+                . LegacyIdentity::REMOVED_IN . '. Use GESSO_VALIDATION_FORMAT.'],
+            LegacyIdentity::warnings(),
+        );
+    }
+
+    #[Test]
+    public function the_current_env_name_beats_the_legacy_one(): void
+    {
+        putenv('OPENAPI_VALIDATION_OUTPUT=text');
+        putenv('GESSO_VALIDATION_FORMAT=json');
+
+        $this->assertSame(ValidationOutputFormat::Json, ValidationOutput::format());
+        $this->assertSame([], LegacyIdentity::warnings());
     }
 }

--- a/tests/Unit/ValidationOutputTest.php
+++ b/tests/Unit/ValidationOutputTest.php
@@ -18,17 +18,13 @@ class ValidationOutputTest extends TestCase
     {
         parent::setUp();
 
-        putenv('GESSO_VALIDATION_FORMAT');
-        putenv('OPENAPI_VALIDATION_OUTPUT');
-        LegacyIdentity::resetForTesting();
+        LegacyIdentity::resetEnvForTesting('GESSO_VALIDATION_FORMAT');
         ValidationOutput::reset();
     }
 
     protected function tearDown(): void
     {
-        putenv('GESSO_VALIDATION_FORMAT');
-        putenv('OPENAPI_VALIDATION_OUTPUT');
-        LegacyIdentity::resetForTesting();
+        LegacyIdentity::resetEnvForTesting('GESSO_VALIDATION_FORMAT');
         ValidationOutput::reset();
 
         parent::tearDown();

--- a/tests/fixtures/compatibility/v2-diagnostic-prefixes.json
+++ b/tests/fixtures/compatibility/v2-diagnostic-prefixes.json
@@ -8,6 +8,7 @@
         "src/Cli/StubsCommand.php": 4,
         "src/Coverage/CoverageMergeCommand.php": 15,
         "src/Fuzz/SchemaDataGenerator.php": 1,
+        "src/Internal/LegacyIdentity.php": 1,
         "src/Laravel/ValidatesOpenApiSchema.php": 1,
         "src/PHPUnit/CoverageReportSubscriber.php": 19,
         "src/PHPUnit/OpenApiCoverageExtension.php": 7,


### PR DESCRIPTION
## Summary

Renames the three environment variables and two Artisan commands Gesso owns to
the `gesso` brand. Every old spelling keeps working through all of v3 — this is
**not breaking**, and no consumer has to change anything to upgrade.

| Old | New |
| --- | --- |
| `OPENAPI_VALIDATION_OUTPUT` | `GESSO_VALIDATION_FORMAT` |
| `OPENAPI_CONSOLE_OUTPUT` | `GESSO_CONSOLE_OUTPUT` |
| `OPENAPI_BASELINE_GENERATE` | `GESSO_BASELINE_GENERATE` |
| `openapi:routes` | `gesso:routes` |
| `openapi:stubs` | `gesso:stubs` |

`OPENAPI_VALIDATION_OUTPUT` becomes `GESSO_VALIDATION_FORMAT`, not
`GESSO_VALIDATION_OUTPUT`: [ADR 0005](docs/adr/0005-v3-configuration-and-cli-naming.md)
rules that the value is a format and #502 renames the matching parameter to
`validation.format`, so both spellings move on one deprecation entry.

## Why

Fixes #504. ADR 0001 made Gesso the identity of the package, namespace, CLI
binary, config file, and provider — but not of the two surfaces a user types
every day. The naming was inverted: variables Gesso owns were `OPENAPI_*` while
the user-owned remote-spec token was already documented as `GESSO_SPEC_TOKEN`.

`src/Internal/LegacyIdentity.php` is the single old→new map; all four env read
sites and both commands consult it, and nothing else duplicates it. The current
name wins when both are set, and setting only the legacy name is honoured.

The legacy warning is a plain `[Gesso] WARNING:` STDERR line, **not**
`E_USER_DEPRECATED` — a suite running `failOnDeprecation` would otherwise fail
purely for spelling a name that still works. That is also why these do not
appear in the `UPGRADING.md` deprecation table, which is that channel's index.

Independent of the rename: `OPENAPI_CONSOLE_OUTPUT` was missing from
`docs/versioning.md` entirely while `docs/ci.md`, `docs/coverage.md`, and
`docs/setup.md` all told users to set it. All three variables are now listed as
covered surfaces.

## Verification

- [x] `composer test` passes (3167 tests, 20349 assertions)
- [x] `composer stan` passes (needs `--memory-limit=1G` locally; the default
      128M crashes a parallel worker, unrelated to this change)
- [x] `composer cs-check` passes
- Legacy path proven at each read site, not only on the map: one test per
  surface asserts the old name resolves to the same value and that the warning
  names the replacement and `LegacyIdentity::REMOVED_IN`
- Precedence and silence: a test per surface asserts `GESSO_*` wins when both
  are set and that nothing warns in that case
- `failOnDeprecation` safety: a test installs an `E_USER_DEPRECATED` handler and
  asserts the legacy env and command paths raise nothing
- Artisan aliases: both integration tests invoke the old and new names and
  compare exit code and output byte-for-byte, so "identical behaviour" is
  asserted rather than described. `protected $aliases` verified present on the
  dependency floor (`orchestra/testbench ^9.0` → laravel/framework 11.x,
  `src/Illuminate/Console/Command.php:85,116`), not only the installed 13.x
- Ambient-environment independence: the Unit suite passes with all three legacy
  names exported, with all three current names exported, and with
  `--order-by=random`
- `npm run docs:build`, `docs:links`, and `docs:verify-accessibility` pass

## Review rounds

**Round 1 — [P2] test lifecycles cleared only the new spelling.** Confirmed and
fixed in 07ba439. Five `setUp()`/`tearDown()` pairs unset `GESSO_VALIDATION_FORMAT`
but not `OPENAPI_VALIDATION_OUTPUT`, so an ambient legacy name steered tests
asserting default behaviour (`OPENAPI_VALIDATION_OUTPUT=json vendor/bin/phpunit
tests/Unit/Internal/FailureOutputTest.php` → 1 failure, reproduced).

Rather than add two lines to each lifecycle — which leaves the identical trap
for the next test that touches a renamed variable — `LegacyIdentity::resetEnvForTesting()`
now clears the current name, whatever spelling `env()` falls back to, and the
dedup, as one call replacing the bare `putenv()`. It cannot drift when a name
joins the map. Every lifecycle in the suite was converted, not just the five.

A scanner test (`no_test_clears_a_renamed_variable_without_its_legacy_spelling`)
fails on any `putenv('<mapped name>')` left under `tests/`, so the omission
cannot come back silently. Verified by reintroducing the bare clear and watching
the guard fail with the offending file and line.

## Notes for reviewers

**One acceptance criterion was deliberately not implemented.** #504 also asked
for `src/PHPUnit/ConsoleOutput.php`'s `[OpenAPI Coverage] WARNING:` prefix to
become `[Gesso] WARNING:`. #504 checked `docs/versioning.md:99` (where
`[OpenAPI Coverage]` is indeed absent, so no documented contract is touched) but
not `DiagnosticPrefixesBaselineTest::identity_neutral_prefixes_retain_v1_9_parity`,
which pins every non-branded prefix byte-for-byte against the v1.9 fixture.
Making the change pass would mean adding `[OpenAPI Coverage]` — 35 emissions
across 6 files — to `$brandedPrefixes`, gutting the guard for a cosmetic fix, in
a **v2 minor**. Filed as #524 for v3, where #502 renames the setting itself to
`console_report` and the prefix can move with it.

**Removal version.** `LegacyIdentity::REMOVED_IN` is `4.0.0`, per #504, tracked
by #523 on a new v4.0 milestone. Worth a second look: since this lands in a v2
minor rather than in v3, the deprecation ships in v2 and `docs/versioning.md`'s
standing rule would already permit removal in **3.0**. v4 is the conservative
read (a user jumping 2.5 → 3.0 never sees the warning); say the word and #523
moves to the v3 milestone.

The `validation_output` and `console_output` **extension parameters** are
untouched — only the environment variables moved. Class names
(`OpenApiRoutesCommand`, `OpenApiStubsCommand`) are unchanged: they are
`@internal` and describe the OpenAPI domain, which ADR 0001 keeps.

`docs/migration/v2-compatibility-inventory.md` and the v1→v2 section of
`UPGRADING.md` still say `OPENAPI_*` on purpose — both are records of what
v1.9/v2 shipped, not instructions.