### PR TITLE
build(docs): bump js-yaml to 4.3.1 so npm audit stops failing every pr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2489,9 +2489,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

Bumps the resolved transitive `js-yaml` in `package-lock.json` from 4.3.0 to
4.3.1 so `npm audit --audit-level=high` exits 0 again. Three lines, lockfile
only.

## Why

Fixes #526. [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj)
reports quadratic CPU consumption in js-yaml's `!!omap` resolution. `npm audit`
is a step of the required `Documentation site` job, so every PR started failing
on it — first seen on #525, whose diff is a PHP rename.

The advisory's **title** says the CVE-2026-59870 fix was not backported, but its
structured data disagrees:

```json
{ "package": "js-yaml", "vulnerable_version_range": ">= 4.0.0, < 4.3.1", "first_patched_version": "4.3.1" }
{ "package": "js-yaml", "vulnerable_version_range": ">= 3.0.0, < 3.15.1", "first_patched_version": "3.15.1" }
```

4.3.1 was published 2026-07-31 and sits inside the `js-yaml: ^4.1.1` that
`xmlbuilder2` declares, so npm resolves it with no constraint change. Our
lockfile was simply pinned to 4.3.0 from before that release.

`js-yaml` reaches this repo only through `markdown-link-check → xmlbuilder2`, a
docs devDependency. Nothing in `composer.json` and nothing shipped to consumers
is involved.

## Verification

- [x] `npm ci`, then every step of the `Documentation site` job in order:
      `audit` (0 vulnerabilities), `verify-tombo`, `build`, `verify-version`,
      `verify-accessibility`, `verify-base`, `links` — all exit 0
- [x] `docs:links` reports the same **351** links as before
- [x] `npm ls js-yaml` → `js-yaml@4.3.1`

## Notes for reviewers

**An earlier revision of this PR added `"js-yaml": "5.2.3"` to `overrides`.**
That was wrong and has been dropped: it was written off the advisory's title
without reading `first_patched_version`, and it would have forced a major
outside the range `xmlbuilder2` declares — working today only because nothing
here reaches js-yaml's `load()`, and silently breaking the day something did.
The current diff touches no `package.json`.

Only the lockfile's `js-yaml` entry changed. A full `npm install` would also
strip `libc` metadata from 13 rollup optional deps, because this machine runs
npm 10 while CI runs Node 24 / npm 11 — that churn is deliberately not here, and
`npm ci` was re-run to confirm the lockfile is installable as written.

#525 is red on this exact check and should go green once this merges.