### PR TITLE
fix(fuzz): reuse one faker generator so GC cannot reseed a seeded run

### DIFF
--- a/src/Fuzz/SchemaDataGenerator.php
+++ b/src/Fuzz/SchemaDataGenerator.php
@@ -94,6 +94,12 @@ final class SchemaDataGenerator
     private static array $warnedFakerFormats = [];
 
     /**
+     * The one faker generator this process ever builds — see
+     * {@see self::createFaker()} for why a per-call instance is unsafe.
+     */
+    private static ?Generator $faker = null;
+
+    /**
      * @param array<string, mixed> $schema
      *
      * @return list<mixed>
@@ -150,9 +156,19 @@ final class SchemaDataGenerator
     }
 
     /**
-     * Build a faker generator when the package is installed; null otherwise.
-     * The null branch is documented and exercised by tests — see the class
-     * docblock for the determinism contract in either case.
+     * Return the process-wide faker generator when the package is installed;
+     * null otherwise. The null branch is documented and exercised by tests —
+     * see the class docblock for the determinism contract in either case.
+     *
+     * The instance is reused rather than rebuilt per call because
+     * `Faker\Generator::__destruct()` calls `seed()` with no argument, i.e.
+     * `mt_srand()` reseeding the global Mt19937 from entropy. A generator
+     * holds a reference cycle with its providers, so a discarded one is not
+     * freed at scope exit — it waits for PHP's cycle collector, which fires
+     * at a point that depends on everything that ran before it. A collection
+     * landing mid-run therefore moves the rest of that run onto a different
+     * stream and silently breaks the seeded-output contract (issue #517).
+     * Never handing out a disposable generator leaves nothing to collect.
      */
     public static function createFaker(?int $seed): ?Generator
     {
@@ -160,12 +176,12 @@ final class SchemaDataGenerator
             return null;
         }
 
-        $faker = Factory::create();
+        self::$faker ??= Factory::create();
         if ($seed !== null) {
-            $faker->seed($seed);
+            self::$faker->seed($seed);
         }
 
-        return $faker;
+        return self::$faker;
     }
 
     /**

--- a/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
+++ b/tests/Unit/Fuzz/SchemaDataGeneratorTest.php
@@ -27,6 +27,7 @@ use function array_unique;
 use function array_values;
 use function count;
 use function fmod;
+use function gc_collect_cycles;
 use function json_decode;
 use function json_encode;
 use function preg_match;
@@ -260,6 +261,41 @@ class SchemaDataGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function a_collected_faker_generator_does_not_reseed_a_seeded_run(): void
+    {
+        // `Faker\Generator::__destruct()` calls `seed()` with no argument —
+        // `mt_srand()`, reseeding the global Mt19937 from entropy — and the
+        // generator is a reference cycle, so a discarded one is freed by PHP's
+        // cycle collector at a point that depends on everything that ran
+        // before it, not at scope exit. Issue #517: a collection landing
+        // between two iterations moved the rest of the run onto a different
+        // stream, so `composer test` failed or passed depending on the
+        // `.phpunit.cache` result order.
+        gc_collect_cycles();
+
+        $schema = [
+            'type' => 'object',
+            'required' => ['name'],
+            'properties' => [
+                'name' => ['type' => 'string'],
+                'tag' => ['type' => 'string'],
+            ],
+        ];
+
+        $expected = json_encode(SchemaDataGenerator::generate($schema, 5, seed: 12345));
+
+        // Drive the loop by hand so the collector runs *inside* the run.
+        $faker = SchemaDataGenerator::createFaker(12345);
+        $values = [];
+        for ($i = 0; $i < 5; $i++) {
+            $values[] = SchemaDataGenerator::generateOne($schema, $faker, $i);
+            gc_collect_cycles();
+        }
+
+        $this->assertSame($expected, json_encode($values));
+    }
+
+    #[Test]
     public function generated_values_pass_opis_schema_validation(): void
     {
         $schema = [
@@ -321,8 +357,8 @@ class SchemaDataGeneratorTest extends TestCase
     public function different_seeds_produce_different_output(): void
     {
         // Without this test, dropping `$faker->seed($seed)` would silently
-        // pass — same_seed_produces_same_output would still hold because
-        // `Faker\Factory::create()` is only called once per generate().
+        // pass — same_seed_produces_same_output would still hold, because the
+        // generator is process-wide and both calls would read the same stream.
         $schema = ['type' => 'string', 'minLength' => 8, 'maxLength' => 8];
 
         $first = SchemaDataGenerator::generate($schema, 4, seed: 1);


### PR DESCRIPTION
## 概要

Closes #517.

`SchemaDataGeneratorTest::same_seed_produces_same_output` が `.phpunit.cache` の内容次第で落ちる件の根本原因を特定して修正した。原因はテストではなく `SchemaDataGenerator` 側にあり、シード付き fuzz 実行の決定性という**ドキュメント済みの契約が実際に壊れていた**。

## 根本原因

`Faker\Generator::__destruct()` は `seed()` を引数なしで呼ぶ（`vendor/fakerphp/faker/src/Faker/Generator.php:976-979`）。これは `mt_srand()` — グローバル Mt19937 をエントロピーで再シードする。

`Faker\Generator` は provider と相互参照する循環なので、`createFaker()` が毎回作っていたインスタンスはスコープを抜けても解放されず、PHP の循環コレクタが回るまで待つ。発火点は「それまでに何が動いたか」に依存するため、`executionOrder="depends,defects"` の下では result cache の中身が発火位置を変える。

収集が `generate()` のループの途中で起きると、そこから先が別のストリームになる。issue の症状（iteration 0 の `{"name":"i"}` は一致し、iteration 1 以降だけ毎回違う値になる）はこれで完全に説明がつく。

再現（`gc_collect_cycles()` でコレクタの発火位置を固定したもの）:

```
no leak: [{"name":"i"},{"name":"pzdszigdqrrkthqp","tag":"vviwahfxqnyifdnn",...
leaked : [{"name":"i"},{"name":"awmbjqerhfucefri","tag":"rzhnjacxvdaauojs",...
```

`fdluduxaojzcypca`（issue が記録した失敗値）がシード 12345 のストリームの先頭 200,000 draw のどこにも現れないことも確認済み。オフセットのズレではなく、別シードのストリームだった。

## 変更内容

- `SchemaDataGenerator::createFaker()` がプロセス全体で 1 個の `Faker\Generator` を使い回すようにした。回収対象のゴミを作らないので、コレクタが再シードすることがなくなる。決定性はグローバルエンジン由来なので出力は不変（既存 3167 テストが無変更で通る）。
- 回帰テスト `a_collected_faker_generator_does_not_reseed_a_seeded_run` を追加。ループを手で回して各 iteration の後に `gc_collect_cycles()` を挟み、コレクタの発火位置を固定する。
- `different_seeds_produce_different_output` の古いコメント（「`Factory::create()` は generate() ごとに 1 回だけ」）を実態に合わせた。

## 検証

| チェック | 結果 |
|---|---|
| 修正前に回帰テスト | **fail**（issue と同じ形で iteration 1 以降が発散） |
| 修正後に回帰テスト | pass |
| `composer test` | OK (3168 tests, 20351 assertions) |
| `--order-by=random` seed 1/2/3 | 3 回とも OK |
| `vendor/bin/phpstan analyse` | No errors |
| `composer cs-check` | 0 of 471 / 0 of 4 |

## 残る範囲

この修正が消せるのは Gesso 自身が作る generator だけ。利用側アプリや他ライブラリが `Faker\Generator` を捨てた場合、その回収が fuzz 実行中に起きれば同じ再シードは起こりうる。faker 1.x は静的 `mt_rand()` にしかアクセスしないため、専用エンジンへの切り替えは faker を外さない限りできない。